### PR TITLE
Update .gitignore of policytemplates for deployment on CentOS 8.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Add edit_items folder action. [tinagerber]
+- Update .gitignore of policytemplates for deployment on CentOS 8. [njohner]
 - Fixed automatic start of a next task inside a sequential task process. [phgross]
 - Only show "add task to process" link, if next task is not yet started. [phgross]
 - Fix adding sequential task process on first position. [phgross]

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/.gitignore
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/.gitignore
@@ -14,3 +14,7 @@ eggs/
 parts/
 src/
 var/
+include/
+lib/
+lib64
+pip-selfcheck.json


### PR DESCRIPTION
We use python virtual environments on CentOS 8. For this we need to ignore a few more files and folders, otherwise deployments will get marked as dirty.

For https://4teamwork.atlassian.net/browse/CA-1792

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)