### PR TITLE
Include team tasks in globalindex

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,7 @@ Changelog
 - Filter out trash and untrash folder buttons in @actions on repository root and folders. [njohner]
 - Don't resolve or deactivate a dossier if it has linked workspaces without view permission. [elioschmutz]
 - Reset value of NamedFileWidget in DocumentAddForm when validation fails. [njohner]
+- When filtering by responsible in globalindex also return tasks assigned to a team the responsible belongs to. [buchi]
 
 
 2021.5.1 (2021-03-09)


### PR DESCRIPTION
When filtering by responsible using the `@globalindex` endpoint, also return tasks assigned to a team the responsible belongs to. Ensures the same behavior we have in the classic UI.

JIRA: https://4teamwork.atlassian.net/browse/CA-1454


## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

