### PR TITLE
Properly override inflator import step

### DIFF
--- a/opengever/setup/creation/configure.zcml
+++ b/opengever/setup/creation/configure.zcml
@@ -15,23 +15,6 @@
       handler="opengever.setup.creation.setuphandler.unit_creation">
     </genericsetup:importStep>
 
-  <include package="ftw.inflator" />
-  <configure package="ftw.inflator.creation">
-    <genericsetup:importStep
-        name="ftw.inflator.content_creation"
-        title="ftw.inflator: content creation"
-        description="Generic content creation from content_creation/*.json files."
-        handler="ftw.inflator.creation.setuphandler.content_creation">
-      <depends name="opengever.setup.unit_creation" />
-      <depends name="typeinfo" />
-      <depends name="workflow" />
-      <depends
-          name="languagetool"
-          zcml:condition="installed plone.app.multilingual"
-          />
-    </genericsetup:importStep>
-  </configure>
-
   <genericsetup:importStep
       name="opengever.setup.opengever_content"
       title="opengever.setup: opengever content"

--- a/opengever/setup/overrides.zcml
+++ b/opengever/setup/overrides.zcml
@@ -1,7 +1,9 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
-    xmlns:five="http://namespaces.zope.org/five"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     xmlns:transmogrifier="http://namespaces.plone.org/transmogrifier"
+    xmlns:i18n="http://namespaces.zope.org/i18n"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="opengever.setup">
 
   <utility
@@ -13,5 +15,19 @@
       component=".sections.reindexobject.GeverReindexObjectSection"
       name="plone.app.transmogrifier.reindexobject"
       />
+
+  <genericsetup:importStep
+      name="ftw.inflator.content_creation"
+      title="ftw.inflator: content creation"
+      description="Generic content creation from content_creation/*.json files."
+      handler="ftw.inflator.creation.setuphandler.content_creation">
+    <depends name="opengever.setup.unit_creation" />
+    <depends name="typeinfo" />
+    <depends name="workflow" />
+    <depends
+        name="languagetool"
+        zcml:condition="installed plone.app.multilingual"
+        />
+  </genericsetup:importStep>
 
 </configure>

--- a/opengever/setup/tests/test_inflator_config_overwrite.py
+++ b/opengever/setup/tests/test_inflator_config_overwrite.py
@@ -27,7 +27,7 @@ class TestInflatorConfig(TestCase):
         inflator_setup = xpath(inflator_config, XPATH_INFLATOR)
 
         gever_path = resource_filename(
-            'opengever.setup.creation', 'configure.zcml')
+            'opengever.setup', 'overrides.zcml')
         gever_config = etree.parse(gever_path, parser)
         gever_setup = xpath(gever_config, XPATH_GEVER)
         additional_element = xpath(gever_config, XPATH_DEPENDS)


### PR DESCRIPTION
Redeclaring it in `configure.zcml` may result in a `ConfigurationConflictError` depending on the order the packages are
loaded.

I'm not sure why, but sometimes I get a different order of the package paths included in the instance script. Seems to happen particularly after running buildout for the first time. Running buildout again usually "fixes" the order.
We also had the issue with deployments on a server, so it seems not to depend on the local dev environment.

E.g. if the grokcore packages are added first to the path then it probably doesn't work:

```
sys.path[0:0] = [
  '/apps/eggs/grokcore.annotation-1.3-py2.7.egg',
  '/apps/eggs/grokcore.site-1.6.1-py2.7.egg',
  '/apps/eggs/grokcore.viewlet-1.11-py2.7.egg',
  '/apps/eggs/grokcore.component-2.5.1-py2.7.egg',
  '/apps/eggs/grokcore.security-1.6.3-py2.7.egg',
```

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)
