### PR TITLE
Create initial version upon document checkin.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Implement a new content-type: opengever.workspace.meetingagendaitem. [elioschmutz]
+- Create initial version upon checkin. [njohner]
 - Add edit_items folder action. [tinagerber]
 - Update .gitignore of policytemplates for deployment on CentOS 8. [njohner]
 - Change p7m extension to eml (or extension configured in the registry) in mail download. [njohner]

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -152,6 +152,13 @@
       permission="opengever.trash.UntrashContent"
       />
 
+  <plone:service
+      method="GET"
+      name="@history"
+      for="opengever.document.document.IDocumentSchema"
+      factory=".history.GeverHistoryGet"
+      permission="CMFEditions.AccessPreviousVersions"
+      />
 
   <plone:service
       method="PATCH"

--- a/opengever/api/history.py
+++ b/opengever/api/history.py
@@ -1,8 +1,11 @@
+from opengever.document.interfaces import ICheckinCheckoutManager
+from opengever.ogds.base.actor import Actor
 from plone.restapi.deserializer import json_body
 from plone.restapi.serializer.converters import json_compatible
 from plone.restapi.services import Service
-from opengever.document.interfaces import ICheckinCheckoutManager
+from plone.restapi.services.history.get import HistoryGet
 from zope.component import getMultiAdapter
+from zope.component.hooks import getSite
 
 
 class HistoryPatch(Service):
@@ -24,3 +27,38 @@ class HistoryPatch(Service):
         msg = u"{} has been reverted to revision {}.".format(title, version)
 
         return json_compatible({"message": msg})
+
+
+class GeverHistoryGet(HistoryGet):
+    """ We overwrite the history endpoint to always use the creator as the
+    actor of the initial version. There were situations in the past where the
+    creator of the initial version was not set correctly, or where the initial
+    version is missing altogether (see
+    https://github.com/4teamwork/opengever.core/pull/4632 and
+    https://github.com/4teamwork/opengever.core/pull/6935).
+    """
+    def reply(self):
+        if self.version:
+            return super(GeverHistoryGet, self).reply()
+
+        history = super(GeverHistoryGet, self).reply()
+        versions = [entry for entry in history if entry['type'] == 'versioning']
+        if not versions:
+            return history
+
+        initial_version = versions[-1]
+        if initial_version['actor']['id'] == self.context.Creator():
+            return history
+
+        site_url = getSite().absolute_url()
+        actorid = self.context.Creator()
+        actor = Actor.lookup(actorid)
+
+        initial_version['actor'] = {
+                "@id": "{}/@users/{}".format(site_url, actorid),
+                "id": actorid,
+                "fullname": actor.get_label(with_principal=False),
+                "username": None,
+            }
+
+        return json_compatible(history)

--- a/opengever/document/checkout/manager.py
+++ b/opengever/document/checkout/manager.py
@@ -208,6 +208,12 @@ class CheckinCheckoutManager(object):
                   mapping={'collaborators': collaborator_list}),
                 target_language=site_language.split('-')[0])
 
+        # In case the document was checked-out and in without having ever
+        # been modified, the initial version will be missing and needs
+        # to be created, as it will not be created by the file setter.
+        # In all other scenarios the initial version should already exist.
+        self.versioner.create_initial_version()
+
         # create new version in CMFEditions
         self.versioner.create_version(comment)
 

--- a/opengever/document/tests/test_checkout.py
+++ b/opengever/document/tests/test_checkout.py
@@ -176,7 +176,7 @@ class TestCheckinIntegration(IntegrationTestCase):
                              u'B\xe4rfuss K\xe4thi (kathi.barfuss), '
                              u'Ziegler Robert (robert.ziegler)')
 
-        version_metadata = Versioner(self.document).get_version_metadata(0)
+        version_metadata = Versioner(self.document).get_version_metadata(1)
         version_comment = version_metadata['sys_metadata']['comment']
         self.assertEqual(collaborator_note, version_comment)
 

--- a/opengever/document/tests/test_copy_document.py
+++ b/opengever/document/tests/test_copy_document.py
@@ -39,7 +39,7 @@ class TestCopyDocuments(IntegrationTestCase):
         self.checkout_document(self.document)
         self.checkin_document(self.document)
         old_history = self.portal.portal_repository.getHistory(self.document)
-        self.assertEqual(len(old_history), 1)
+        self.assertEqual(len(old_history), 2)
 
         cb = self.dossier.manage_copyObjects(self.document.id)
         self.dossier.manage_pasteObjects(cb)

--- a/opengever/document/tests/test_versioner.py
+++ b/opengever/document/tests/test_versioner.py
@@ -38,6 +38,22 @@ class TestInitialVersionCreation(IntegrationTestCase):
         self.assertEquals(
             1, versioner.get_history_metadata().getLength(countPurged=False))
 
+    def test_checkin_creates_initial_version(self):
+        self.login(self.regular_user)
+        versioner = Versioner(self.document)
+
+        self.assertFalse(versioner.has_initial_version())
+        self.assertEquals([], versioner.get_history_metadata())
+
+        self.checkout_document(self.document)
+        self.assertFalse(versioner.has_initial_version())
+        self.assertEquals([], versioner.get_history_metadata())
+
+        self.checkin_document(self.document)
+        self.assertTrue(versioner.has_initial_version())
+        self.assertEquals(
+            2, versioner.get_history_metadata().getLength(countPurged=False))
+
     @browsing
     def test_initial_version_date_is_documents_creation_date(self, browser):
         self.login(self.manager)

--- a/opengever/trash/tests/test_trash.py
+++ b/opengever/trash/tests/test_trash.py
@@ -364,8 +364,6 @@ class TestTrashWithBumblebee(IntegrationTestCase):
         # Ensure we have two versions of the document
         self.checkout_document(self.subdocument)
         self.checkin_document(self.subdocument)
-        self.checkout_document(self.subdocument)
-        self.checkin_document(self.subdocument)
         browser.open(
             self.dossier,
             view='trashed',


### PR DESCRIPTION
In case the document was checked-out and in without having ever been modified, the initial version will be missing and needs to be created, as it will not be created by the file setter. In all other scenarios the initial version should already exist.

I don't see any way we could identify concerned documents and recreate the initial version though. It's also not that important, as the missing version has the same file as the first version. It also seems that we have wrong creators[ for the initial version of older documents](https://github.com/4teamwork/opengever.core/pull/4632), so we overwrite the `@history` endpoint to return the correct creator for the initial versions. This also ensures that the same creators are displayed in the new frontend as in the classic UI [without having to fix it in the frontend](https://github.com/4teamwork/gever-ui/pull/1654).

I did not document this change in the API changelog, because it's simply a fix of what is returned by the API, not a real change in the API.

For https://4teamwork.atlassian.net/browse/CA-1842

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide])
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed