### PR TITLE
Allow to create tasks from document within task

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2021.6.0 (unreleased)
 ---------------------
 
+- Show add_task_from_document action also for documents within tasks. [tinagerber]
 - Add containing_subdossier_url to document serializer. [tinagerber]
 - Implement a new content-type: opengever.workspace.meetingagendaitem. [elioschmutz]
 - Add edit_items folder action. [tinagerber]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2021.6.0 (unreleased)
 ---------------------
 
+- Add containing_subdossier_url to document serializer. [tinagerber]
 - Implement a new content-type: opengever.workspace.meetingagendaitem. [elioschmutz]
 - Add edit_items folder action. [tinagerber]
 - Update .gitignore of policytemplates for deployment on CentOS 8. [njohner]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -8,7 +8,10 @@ API Changelog
 2021.6.0 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+Other Changes
+^^^^^^^^^^^^^
+
+- Add ``containing_subdossier_url`` to the document serializer.
 
 
 2021.5.0 (2021-03-04)

--- a/opengever/api/document.py
+++ b/opengever/api/document.py
@@ -47,6 +47,7 @@ class SerializeDocumentToJson(GeverSerializeToJson):
             'is_locked': obj.is_locked(),
             'containing_dossier': obj.containing_dossier_title(),
             'containing_subdossier': obj.containing_subdossier_title(),
+            'containing_subdossier_url': obj.containing_subdossier_url(),
             'trashed': obj.is_trashed,
             'is_shadow_document': obj.is_shadow_document(),
             'current_version_id': obj.get_current_version_id(

--- a/opengever/api/tests/test_actions.py
+++ b/opengever/api/tests/test_actions.py
@@ -642,7 +642,7 @@ class TestNewTaskFromDocumentAction(FileActionsTestBase):
                          self.get_file_actions(browser, self.resolvable_document))
 
     @browsing
-    def test_task_from_doc_not_available_for_doc_in_task(self, browser):
+    def test_task_from_doc_available_for_doc_in_task(self, browser):
         self.login(self.regular_user, browser)
         expected_file_actions = [
             {u'id': u'oc_direct_checkout',
@@ -659,6 +659,9 @@ class TestNewTaskFromDocumentAction(FileActionsTestBase):
              u'icon': u''},
             {u'id': u'trash_document',
              u'title': u'Trash document',
+             u'icon': u''},
+            {u'id': u'new_task_from_document',
+             u'title': u'New task from document',
              u'icon': u''},
             ]
         self.assertEqual(expected_file_actions,

--- a/opengever/api/tests/test_document.py
+++ b/opengever/api/tests/test_document.py
@@ -70,6 +70,7 @@ class TestDocumentSerializer(IntegrationTestCase):
         self.assertEqual(u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
                          browser.json['containing_dossier'])
         self.assertEqual(u'2016', browser.json['containing_subdossier'])
+        self.assertEqual(self.subdossier.absolute_url(), browser.json['containing_subdossier_url'])
         self.assertFalse(browser.json['trashed'])
         self.assertFalse(browser.json['is_shadow_document'])
         self.assertFalse(0, browser.json['current_version_id'])

--- a/opengever/api/tests/test_mail.py
+++ b/opengever/api/tests/test_mail.py
@@ -25,6 +25,7 @@ class TestGetMail(IntegrationTestCase):
         self.assertEqual(u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
                          browser.json['containing_dossier'])
         self.assertIsNone(browser.json['containing_subdossier'])
+        self.assertIsNone(browser.json['containing_subdossier_url'])
         self.assertFalse(browser.json['trashed'])
         self.assertFalse(browser.json['is_shadow_document'])
         self.assertFalse(0, browser.json['current_version_id'])

--- a/opengever/document/base.py
+++ b/opengever/document/base.py
@@ -289,6 +289,18 @@ class BaseDocumentMixin(object):
 
         return dossier.title
 
+    def containing_subdossier_url(self):
+        """"Returns the url of the subdossier which the document is placed in.
+        Returns None when the object is placed directly inside a main dossier.
+        """
+        dossier = self.get_parent_dossier()
+
+        # Return None if the dossier is a main dossier
+        if not IDossierMarker.providedBy(aq_parent(dossier)):
+            return None
+
+        return dossier.absolute_url()
+
 
 def mimetype_lookup(mtr, contenttype):
     """Reimplemented as case insensitive from Products.MimetypesRegistry."""

--- a/opengever/document/fileactions.py
+++ b/opengever/document/fileactions.py
@@ -1,5 +1,3 @@
-from Acquisition import aq_inner
-from Acquisition import aq_parent
 from ftw.bumblebee.mimetypes import is_mimetype_supported
 from opengever.api.lock import can_unlock_obj
 from opengever.bumblebee import is_bumblebee_feature_enabled
@@ -114,10 +112,10 @@ class BaseDocumentFileActions(object):
         return trasher.verify_may_untrash(raise_on_violations=False)
 
     def is_new_task_from_document_available(self):
-        parent = aq_parent(aq_inner(self.context))
-        is_inside_dossier = IDossierMarker.providedBy(parent)
-        may_add_task = api.user.has_permission('opengever.task: Add task', obj=parent)
-        return is_inside_dossier and may_add_task
+        dossier = self.context.get_parent_dossier()
+        if not IDossierMarker.providedBy(dossier):
+            return False
+        return api.user.has_permission('opengever.task: Add task', obj=dossier)
 
     def is_unlock_available(self):
         lockable = ILockable(self.context)

--- a/opengever/document/tests/test_base.py
+++ b/opengever/document/tests/test_base.py
@@ -39,10 +39,22 @@ class TestBaseDocument(IntegrationTestCase):
             u'2016',
             self.subdocument.containing_subdossier_title())
 
+    def test_containing_subdossier_url_returns_subdossier_url(self):
+        self.login(self.regular_user)
+
+        self.assertEqual(
+            self.subdossier.absolute_url(),
+            self.subdocument.containing_subdossier_url())
+
     def test_containing_subdossier_title_returns_None_for_document_inside_main_dossier(self):
         self.login(self.regular_user)
 
         self.assertIsNone(self.document.containing_subdossier_title())
+
+    def test_containing_subdossier_url_returns_None_for_document_inside_main_dossier(self):
+        self.login(self.regular_user)
+
+        self.assertIsNone(self.document.containing_subdossier_url())
 
 
 class TestBaseDocumentMails(TestBaseDocument):


### PR DESCRIPTION
The action `new_task_from_document` should now also be available for documents within tasks.
To determine in the frontend where the new task should be created, the field `containing_subdossier_url` must also be serialised for documents.

Jira: https://4teamwork.atlassian.net/browse/NE-677


## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
- New functionality:
  - [x] for `document` also works for `mail`