### PR TITLE
Extend document propertysheets with a default slot.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2021.6.1 (unreleased)
 ---------------------
 
+- Introduce customproperties default slots which is enabled for every document. [phgross]
 - No longer fail during deployment if ldap is not in authentication plugins. [njohner]
 - Add id field to the @listing endpoint. [elioschmutz]
 

--- a/docs/public/dev-manual/api/propertysheets.rst
+++ b/docs/public/dev-manual/api/propertysheets.rst
@@ -82,9 +82,13 @@ Einzelne Felder werden in folgendem Format erwartet:
 - ``values``: Auswahlmöglichkeiten für das Feld, nur für ``choice`` Feldtyp
 
 Die für das Assigmnet verwendeten Assignment-Slots müssen aus dem Vokabular
-``opengever.propertysheets.PropertySheetAssignmentsVocabulary`` stammen. Zudem
-müssen Assignments eindeutig sein, mehrere Property Sheets dem gleichen
-Assignment-Slot zuzuweisen ist im Moment nicht unterstützt.
+``opengever.propertysheets.PropertySheetAssignmentsVocabulary`` stammen. Ein
+Spezifalfall ist dabei der Default-Slot ``IDocument.default``, welcher
+unabhängig vom Dokumenttyp Feld immer dargestellt wird.
+
+Zudem müssen Assignments
+eindeutig sein, mehrere Property Sheets dem gleichen Assignment-Slot zuzuweisen
+ist im Moment nicht unterstützt.
 
 
 **Beispiel-Request**:
@@ -145,7 +149,9 @@ Serialisierung/Deserialisierung von Custom Properties
 
 Im Moment sind Custom Properties auf Dokumenten und Mails unterstützt. Die
 Auswahl des zu validerenden Property Sheets basiert auf dem Wert des Feldes
-`document_type`. Ist für den Assignment-Slot
+`document_type`. Ausnahme ist dabei der Default-Slot ``IDocument.default``
+welcher unabhängig des Feldwertes von ``document_type`` immer dargestellt wird.
+Ist für den Assignment-Slot
 ``IDocumentMetadata.document_type.<document_type_value>`` ein Property Sheet
 registriert, so werden Feldwerte dieses Property Sheets validiert. Hat das
 Property Sheet also obligatorische Felder, so müssen die Custom Properties
@@ -223,7 +229,3 @@ Slots nicht überschrieben.
 
     HTTP/1.1 204 No content
     Content-Type: application/json
-
-
-
-

--- a/opengever/document/behaviors/customproperties.py
+++ b/opengever/document/behaviors/customproperties.py
@@ -1,5 +1,6 @@
 from opengever.document import _
 from opengever.propertysheets.assignment import get_document_assignment_slots
+from opengever.propertysheets.assignment import DOCUMENT_DEFAULT_ASSIGNMENT_SLOT
 from opengever.propertysheets.field import PropertySheetField
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.supermodel import model
@@ -13,6 +14,7 @@ class IDocumentCustomProperties(model.Schema):
         attribute_name='document_type',
         assignemnt_prefix='IDocumentMetadata.document_type',
         valid_assignment_slots_factory=get_document_assignment_slots,
+        default_slot=DOCUMENT_DEFAULT_ASSIGNMENT_SLOT,
     )
 
     model.fieldset(

--- a/opengever/propertysheets/assignment.py
+++ b/opengever/propertysheets/assignment.py
@@ -6,6 +6,7 @@ from zope.schema.vocabulary import SimpleVocabulary
 
 
 DOCUMENT_TYPE_ASSIGNMENT_SLOT_PREFIX = "IDocumentMetadata.document_type"
+DOCUMENT_DEFAULT_ASSIGNMENT_SLOT = "IDocument.default"
 
 
 @implementer(IVocabularyFactory)
@@ -21,16 +22,18 @@ class PropertySheetAssignmentVocabulary(object):
 def get_document_assignment_slots():
     """"Return a list of all valid assignment slots for documents.
 
-    Currently this is limited to one slot per possible value of the
-    `document_type` field.
+    This is limited to one slot per possible value of the
+    `document_type` field and the default document slot.
     """
     vocabulary_factory = getUtility(
         IVocabularyFactory, name="opengever.document.document_types"
     )
-    return [
+    terms = [
         document_type_assignment_slot_name(term.value)
         for term in vocabulary_factory(None)
     ]
+
+    return [DOCUMENT_DEFAULT_ASSIGNMENT_SLOT] + terms
 
 
 def document_type_assignment_slot_name(value):

--- a/opengever/propertysheets/tests/fixture.py
+++ b/opengever/propertysheets/tests/fixture.py
@@ -1,5 +1,9 @@
+from opengever.propertysheets.assignment import DOCUMENT_DEFAULT_ASSIGNMENT_SLOT
+
+
 def fixture_assignment_factory():
     return [
+        DOCUMENT_DEFAULT_ASSIGNMENT_SLOT,
         u"IDocumentMetadata.document_type.contract",
         u"IDocumentMetadata.document_type.question",
     ]

--- a/opengever/propertysheets/tests/test_annotation.py
+++ b/opengever/propertysheets/tests/test_annotation.py
@@ -1,6 +1,7 @@
 from opengever.propertysheets.annotation import CustomPropertiesStorage
 from opengever.propertysheets.annotation import CustomPropertiesStorageImpl
 from opengever.propertysheets.assignment import DOCUMENT_TYPE_ASSIGNMENT_SLOT_PREFIX
+from opengever.propertysheets.assignment import DOCUMENT_DEFAULT_ASSIGNMENT_SLOT
 from opengever.propertysheets.exceptions import BadCustomPropertiesFactoryConfiguration
 from opengever.propertysheets.field import PropertySheetField
 from opengever.testing.test_case import FunctionalTestCase
@@ -24,6 +25,7 @@ class ITestFixtureWithCustomProperties(model.Schema):
         attribute_name='some_attribute',
         assignemnt_prefix=DOCUMENT_TYPE_ASSIGNMENT_SLOT_PREFIX,
         valid_assignment_slots_factory=fixture_assignment_factory,
+        default_slot=DOCUMENT_DEFAULT_ASSIGNMENT_SLOT
     )
 
 

--- a/opengever/propertysheets/tests/test_assignment.py
+++ b/opengever/propertysheets/tests/test_assignment.py
@@ -15,6 +15,10 @@ EXPECTED_DOCUMENT_ASSIGNMENT_SLOTS = [
     u"IDocumentMetadata.document_type.request",
 ]
 
+EXPECTED_DOCUMENT_DEFAULT_SLOT = [
+    u"IDocument.default",
+]
+
 
 class TestPropertySheetAssignmentVocabulary(FunctionalTestCase):
 
@@ -25,7 +29,7 @@ class TestPropertySheetAssignmentVocabulary(FunctionalTestCase):
         )(self.portal)
 
         self.assertItemsEqual(
-            EXPECTED_DOCUMENT_ASSIGNMENT_SLOTS,
+            EXPECTED_DOCUMENT_DEFAULT_SLOT + EXPECTED_DOCUMENT_ASSIGNMENT_SLOTS,
             [term.value for term in vocabulary],
         )
 
@@ -34,6 +38,6 @@ class TestPropertySheetDocumentAssignmentSlots(FunctionalTestCase):
 
     def test_assignemnt_vocabulary_contains_document_types(self):
         self.assertItemsEqual(
-            EXPECTED_DOCUMENT_ASSIGNMENT_SLOTS,
+            EXPECTED_DOCUMENT_DEFAULT_SLOT + EXPECTED_DOCUMENT_ASSIGNMENT_SLOTS,
             get_document_assignment_slots(),
         )

--- a/opengever/propertysheets/tests/test_field_schema_provider.py
+++ b/opengever/propertysheets/tests/test_field_schema_provider.py
@@ -1,6 +1,7 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from jsonschema import Draft4Validator
+from opengever.propertysheets.assignment import DOCUMENT_DEFAULT_ASSIGNMENT_SLOT
 from opengever.propertysheets.assignment import DOCUMENT_TYPE_ASSIGNMENT_SLOT_PREFIX
 from opengever.propertysheets.field import PropertySheetField
 from opengever.propertysheets.tests.fixture import fixture_assignment_factory
@@ -21,6 +22,7 @@ class TestPropertySheetFieldSchemaProvider(FunctionalTestCase):
             "unused_attribute",
             DOCUMENT_TYPE_ASSIGNMENT_SLOT_PREFIX,
             fixture_assignment_factory,
+            DOCUMENT_DEFAULT_ASSIGNMENT_SLOT
         )
 
     @property


### PR DESCRIPTION
Introduce customproperties default slots which is enabled for every document. So it's possible to add custom fields which are available regardless of which document type is selected.

First part of https://4teamwork.atlassian.net/browse/CA-1493 - Dossier Support will follow in a separate PR

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
- New functionality:
  - [X] for `document` also works for `mail`