### PR TITLE
Change wrong i18n domain for workspace agenda item schema

### DIFF
--- a/docs/schema-dumps/opengever.workspace.meetingagendaitem.schema.json
+++ b/docs/schema-dumps/opengever.workspace.meetingagendaitem.schema.json
@@ -18,13 +18,13 @@
         },
         "decision": {
             "type": "object",
-            "title": "Decision",
+            "title": "Beschluss",
             "description": "",
             "_zope_schema_type": "RichText"
         },
         "relatedItems": {
             "type": "array",
-            "title": "Related items",
+            "title": "Verweise",
             "description": "",
             "_zope_schema_type": "RelationList",
             "default": []

--- a/opengever/workspace/workspace_meeting_agenda_item.py
+++ b/opengever/workspace/workspace_meeting_agenda_item.py
@@ -1,6 +1,6 @@
 from collective import dexteritytextindexer
 from opengever.base.source import WorkspacePathSourceBinder
-from opengever.document import _
+from opengever.workspace import _
 from opengever.workspace.interfaces import IWorkspaceMeetingAgendaItem
 from plone.app.textfield import RichText
 from plone.autoform.interfaces import IFormFieldProvider


### PR DESCRIPTION
Jira: https://4teamwork.atlassian.net/browse/CA-1734

This PR fixes a wrong i18n domain for the workspace agenda item schema. There is no need to update the translations because all the translation strings are already translated. The `opengever.document` translations have not been update in the meantime, thus, there is also no need to rebuild them.

A changelog is not required because it's a fix of a feature introduced in this PR: #6925 

## Before
<img width="275" alt="Bildschirmfoto 2021-03-15 um 14 11 10" src="https://user-images.githubusercontent.com/557005/111159094-037dd200-8599-11eb-9795-e46a05140143.png">

## After
<img width="236" alt="Bildschirmfoto 2021-03-15 um 14 02 20" src="https://user-images.githubusercontent.com/557005/111159099-05e02c00-8599-11eb-905b-3ecd1a2e3c07.png">

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
