### PR TITLE
Index agenda items in the workspace meeting searchable text.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2021.6.0 (unreleased)
 ---------------------
 
+- Index agenda items in the workspace meeting searchable text. [njohner]
 - Show add_task_from_document action also for documents within tasks. [tinagerber]
 - Add containing_subdossier_url to document serializer. [tinagerber]
 - Implement a new content-type: opengever.workspace.meetingagendaitem. [elioschmutz]

--- a/opengever/workspace/configure.zcml
+++ b/opengever/workspace/configure.zcml
@@ -53,6 +53,18 @@
       handler=".subscribers.response_added"
       />
 
+  <subscriber
+      for="opengever.workspace.interfaces.IWorkspaceMeetingAgendaItem
+           zope.lifecycleevent.interfaces.IObjectAddedEvent"
+      handler=".subscribers.workspace_meeting_agendaitem_added"
+      />
+
+  <subscriber
+      for="opengever.workspace.interfaces.IWorkspaceMeetingAgendaItem
+           zope.lifecycleevent.interfaces.IObjectModifiedEvent"
+      handler=".subscribers.workspace_meeting_agendaitem_modified"
+      />
+
   <utility
       factory=".vocabularies.RolesVocabulary"
       name="opengever.workspace.RolesVocabulary"
@@ -66,6 +78,11 @@
   <adapter
       factory=".indexers.external_reference"
       name="external_reference"
+      />
+
+  <adapter
+      factory=".indexers.WorkspaceMeetingSearchableTextExtender"
+      name="IWorkspaceMeeting"
       />
 
   <plone:service

--- a/opengever/workspace/indexers.py
+++ b/opengever/workspace/indexers.py
@@ -21,6 +21,8 @@ INDEXED_IN_MEETING_SEARCHABLE_TEXT = ['title', 'text', 'decision']
 
 def to_safe_utf8(obj, fieldname):
     value = getattr(obj, fieldname)
+    if value is None:
+        return
     if isinstance(value, RichTextValue):
         value = api.portal.get_tool(name='portal_transforms').convertTo(
             'text/plain', value.output, mimetype='text/html').getData()
@@ -57,4 +59,4 @@ class WorkspaceMeetingSearchableTextExtender(object):
                 [to_safe_utf8(agendaitem, fieldname) for fieldname
                  in INDEXED_IN_MEETING_SEARCHABLE_TEXT])
 
-        return ' '.join(searchable)
+        return ' '.join(filter(None, searchable))

--- a/opengever/workspace/indexers.py
+++ b/opengever/workspace/indexers.py
@@ -1,5 +1,12 @@
+from collective import dexteritytextindexer
+from opengever.workspace.interfaces import IWorkspaceMeeting
 from opengever.workspace.workspace import IWorkspaceSchema
+from plone import api
+from plone.app.textfield.value import RichTextValue
 from plone.indexer import indexer
+from Products.CMFDiffTool.utils import safe_utf8
+from zope.component import adapter
+from zope.interface import implementer
 
 
 @indexer(IWorkspaceSchema)
@@ -7,3 +14,47 @@ def external_reference(obj):
     if obj.external_reference:
         return obj.external_reference
     return ''
+
+
+INDEXED_IN_MEETING_SEARCHABLE_TEXT = ['title', 'text', 'decision']
+
+
+def to_safe_utf8(obj, fieldname):
+    value = getattr(obj, fieldname)
+    if isinstance(value, RichTextValue):
+        value = api.portal.get_tool(name='portal_transforms').convertTo(
+            'text/plain', value.output, mimetype='text/html').getData()
+    return safe_utf8(value)
+
+
+@implementer(dexteritytextindexer.IDynamicTextIndexExtender)
+@adapter(IWorkspaceMeeting)
+class WorkspaceMeetingSearchableTextExtender(object):
+    """This extender includes the WorkspaceMeetingAgendaItems in the
+    WorkspaceMeeting SearchableText.
+
+    The searchable text gets updated when WorkspaceMeetingAgendaItems are added
+    or modified via event handles (see workspace_meeting_agendaitem_added, and
+    workspace_meeting_agendaitem_modified)."""
+
+    def __init__(self, context):
+        self.context = context
+
+    def __call__(self):
+        searchable = []
+
+        # We include the WorkspaceMeetingAgendaItems in the the searchable text
+        # of the meeting.
+        catalog = api.portal.get_tool('portal_catalog')
+        path = '/'.join(self.context.getPhysicalPath())
+        brains = catalog.unrestrictedSearchResults(
+            path=path,
+            portal_type='opengever.workspace.meetingagendaitem')
+
+        for brain in brains:
+            agendaitem = brain.getObject()
+            searchable.extend(
+                [to_safe_utf8(agendaitem, fieldname) for fieldname
+                 in INDEXED_IN_MEETING_SEARCHABLE_TEXT])
+
+        return ' '.join(searchable)

--- a/opengever/workspace/tests/test_workspace_meeting_agenda_item.py
+++ b/opengever/workspace/tests/test_workspace_meeting_agenda_item.py
@@ -2,6 +2,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from opengever.testing import IntegrationTestCase
+from opengever.testing import solr_data_for
 from opengever.testing import SolrIntegrationTestCase
 from zExceptions import BadRequest
 import json
@@ -130,6 +131,7 @@ class TestWorkspaceMeetingAgendaItem(IntegrationTestCase):
 
 
 class TestWorkspaceMeetingAgendaItemSolr(SolrIntegrationTestCase):
+
     @browsing
     def test_members_can_change_order(self, browser):
         self.login(self.workspace_member, browser)
@@ -180,3 +182,90 @@ class TestWorkspaceMeetingAgendaItemSolr(SolrIntegrationTestCase):
         with browser.expect_http_error(401):
             browser.open(self.workspace_meeting, method='PATCH',
                          headers=self.api_headers, data=json.dumps(data))
+
+    @browsing
+    def test_workspace_agendaitems_are_indexed_in_meeting_searchable_text(self, browser):
+        self.login(self.workspace_member, browser)
+        # builder of workspace_meeting_agendaitem does not reindex
+        # the workspace meeting
+        self.workspace_meeting.reindexObject()
+        self.commit_solr()
+
+        searchable_text = solr_data_for(self.workspace_meeting).get('SearchableText')
+
+        self.assertEqual(
+            u'Genehmigung des Lageberichts',
+            self.workspace_meeting_agenda_item.title)
+        self.assertIn(
+            u'Genehmigung des Lageberichts',
+            searchable_text)
+
+        self.assertEqual(
+            u'Der Lagebericht 2018 steht zur Verf\xfcgung und muss genehmigt werden',
+            self.workspace_meeting_agenda_item.text.raw)
+        self.assertIn(
+            u'Der Lagebericht 2018 steht zur Verf\xfcgung und muss genehmigt werden',
+            searchable_text)
+
+        self.assertEqual(
+            u'Die <a href="http://example.com">Gener\xe4lversammlung</a> '
+            'genehmigt den <b>Lagebericht</b> 2018',
+            self.workspace_meeting_agenda_item.decision.raw)
+        self.assertIn(
+            u'Die  Gener\xe4lversammlung  genehmigt den Lagebericht 2018',
+            searchable_text)
+
+    @browsing
+    def test_workspace_meeting_gets_reindexed_when_agendaitem_is_modified(self, browser):
+        self.login(self.workspace_member, browser)
+        # builder of workspace_meeting_agendaitem does not reindex
+        # the workspace meeting
+        self.workspace_meeting.reindexObject()
+        self.commit_solr()
+
+        searchable_text = solr_data_for(self.workspace_meeting).get('SearchableText')
+        self.assertNotIn("Danger text", searchable_text)
+        self.assertNotIn("Danger decision", searchable_text)
+
+        headers = self.api_headers.copy()
+        headers.update({'Prefer': 'return=representation'})
+        browser.open(self.workspace_meeting_agenda_item, method='PATCH',
+                     headers=headers,
+                     data=json.dumps({
+                         'text': u'Danger<script>alert("foo")</script> text',
+                         'decision': u'Danger<script>alert("foo")</script> decision'}))
+
+        self.commit_solr()
+        searchable_text = solr_data_for(self.workspace_meeting).get('SearchableText')
+        self.assertIn("Danger text", searchable_text)
+        self.assertIn("Danger decision", searchable_text)
+
+    @browsing
+    def test_workspace_meeting_gets_reindexed_when_agendaitem_is_added(self, browser):
+        self.login(self.workspace_member, browser)
+        # builder of workspace_meeting_agendaitem does not reindex
+        # the workspace meeting
+        self.workspace_meeting.reindexObject()
+        self.commit_solr()
+
+        searchable_text = solr_data_for(self.workspace_meeting).get('SearchableText')
+        self.assertNotIn(u'\xc4 new title', searchable_text)
+        self.assertNotIn(u'My <b>bold</b> text', searchable_text)
+        self.assertNotIn(u'My <b>bold</b> decision', searchable_text)
+
+        data = {
+            '@type': u'opengever.workspace.meetingagendaitem',
+            'title': u'\xc4 new title',
+            'text': u'My <b>bold</b> text',
+            'decision': u'My <b>bold</b> decision',
+        }
+        browser.open(self.workspace_meeting,
+                     method='POST',
+                     headers=self.api_headers,
+                     data=json.dumps(data))
+
+        self.commit_solr()
+        searchable_text = solr_data_for(self.workspace_meeting).get('SearchableText')
+        self.assertIn(u'\xc4 new title', searchable_text)
+        self.assertIn(u'My bold text', searchable_text)
+        self.assertIn(u'My bold decision', searchable_text)

--- a/opengever/workspace/tests/test_workspace_meeting_agenda_item.py
+++ b/opengever/workspace/tests/test_workspace_meeting_agenda_item.py
@@ -257,7 +257,7 @@ class TestWorkspaceMeetingAgendaItemSolr(SolrIntegrationTestCase):
             '@type': u'opengever.workspace.meetingagendaitem',
             'title': u'\xc4 new title',
             'text': u'My <b>bold</b> text',
-            'decision': u'My <b>bold</b> decision',
+            'decision': None,
         }
         browser.open(self.workspace_meeting,
                      method='POST',
@@ -268,4 +268,4 @@ class TestWorkspaceMeetingAgendaItemSolr(SolrIntegrationTestCase):
         searchable_text = solr_data_for(self.workspace_meeting).get('SearchableText')
         self.assertIn(u'\xc4 new title', searchable_text)
         self.assertIn(u'My bold text', searchable_text)
-        self.assertIn(u'My bold decision', searchable_text)
+        self.assertNotIn(u'None', searchable_text)

--- a/opengever/workspace/workspace_meeting_agenda_item.py
+++ b/opengever/workspace/workspace_meeting_agenda_item.py
@@ -1,3 +1,5 @@
+from Acquisition import aq_inner
+from Acquisition import aq_parent
 from collective import dexteritytextindexer
 from opengever.base.source import WorkspacePathSourceBinder
 from opengever.document import _
@@ -53,3 +55,8 @@ class IWorkspaceMeetingAgendaItemSchema(model.Schema):
 
 class WorkspaceMeetingAgendaItem(Item):
     implements(IWorkspaceMeetingAgendaItem)
+
+    def get_containing_meeting(self):
+        """Return the workspace meeting containing the agendaitem.
+        """
+        return aq_parent(aq_inner(self))


### PR DESCRIPTION
As we do not want to display `WorkspaceMeetingAgendaItem`s as separate objects (no detail view), but we want their content to be searchable, we need to add their content to the `SearchableText` of the `WorkspaceMeeting`. For this:
- We define a `SearchableTextExtender`
- We add event handlers to reindex the `WorkspaceMeeting` when an `WorkspaceMeetingAgendaItem` is added or modified.

For https://4teamwork.atlassian.net/browse/CA-1734

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)