### PR TITLE
Remove workspace meeting agendaitem from search

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2021.6.0 (unreleased)
 ---------------------
 
+- Exclude opengever.workspace.meetingagendaitem from search results. [njohner]
 - Index agenda items in the workspace meeting searchable text. [njohner]
 - Show add_task_from_document action also for documents within tasks. [tinagerber]
 - Add containing_subdossier_url to document serializer. [tinagerber]

--- a/opengever/api/tests/test_solrsearch.py
+++ b/opengever/api/tests/test_solrsearch.py
@@ -3,6 +3,7 @@ from opengever.dossier.behaviors.dossier import IDossier
 from opengever.testing import IntegrationTestCase
 from opengever.testing.integration_test_case import SolrIntegrationTestCase
 from plone.uuid.interfaces import IUUID
+from Products.CMFCore.utils import getToolByName
 from unittest import skip
 
 
@@ -27,6 +28,35 @@ class TestMockSolrSearchGet(IntegrationTestCase):
         browser.open(url, method='GET', headers=self.api_headers)
 
         self.assertEqual(self.solr.search.call_args[1]['sort'], None)
+
+    @browsing
+    def test_default_portal_type_filter(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        self.solr = self.mock_solr(response_json={})
+
+        url = u'{}/@solrsearch?q=Foo&fl=UID,Title'.format(
+            self.portal.absolute_url())
+        browser.open(url, method='GET', headers=self.api_headers)
+
+        plone_utils = getToolByName(self.portal, 'plone_utils')
+        types = plone_utils.getUserFriendlyTypes()
+        self.assertIn('portal_type:({})'.format(' OR '.join(types)),
+                      self.solr.search.call_args[1]['filters'])
+
+    @browsing
+    def test_respects_portal_type_filter_if_provided(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        self.solr = self.mock_solr(response_json={})
+
+        url = u'{}/@solrsearch?fq=portal_type:opengever.workspace.meetingagendaitem'.format(
+            self.portal.absolute_url())
+        browser.open(url, method='GET', headers=self.api_headers)
+
+        self.assertEqual(['portal_type:opengever.workspace.meetingagendaitem',
+                          u'path_parent:\\/plone'],
+                         self.solr.search.call_args[1]['filters'])
 
 
 class TestSolrSearchGet(SolrIntegrationTestCase):

--- a/opengever/base/browser/search.py
+++ b/opengever/base/browser/search.py
@@ -107,7 +107,15 @@ class OpengeverSearch(Search):
         filters = []
 
         # Avoid mutating nested values in self.request.form
-        for key, value in deepcopy(self.request.form).items():
+        query = deepcopy(self.request.form)
+
+        # respect `types_not_searched` setting
+        types = query.get('portal_type', [])
+        if not isinstance(types, (list, tuple)):
+            types = [types]
+        query['portal_type'] = self.filter_types(types)
+
+        for key, value in query.items():
             if key == 'SearchableText':
                 continue
             if key not in schema.fields:

--- a/opengever/base/tests/test_search.py
+++ b/opengever/base/tests/test_search.py
@@ -1,14 +1,11 @@
 from ftw.testbrowser import browsing
-from opengever.base.interfaces import ISearchSettings
 from opengever.testing import IntegrationTestCase
 from opengever.testing import obj2brain
 from opengever.testing import SolrIntegrationTestCase
 from plone import api
 from plone.app.contentlisting.interfaces import IContentListing
-from plone.registry.interfaces import IRegistry
 from plone.uuid.interfaces import IUUID
 from zope.component import getMultiAdapter
-from zope.component import getUtility
 
 
 class TestOpengeverSearch(IntegrationTestCase):
@@ -69,6 +66,13 @@ class TestOpengeverSearch(IntegrationTestCase):
                         '/advanced_search?SearchableText=M%C3%BCller+and+%7Bco%29')
 
         self.assertEqual(expected_url, advanced_search.get("href"))
+
+    @browsing
+    def test_workspace_meeting_agendaitems_are_excluded_from_search(self, browser):
+        self.login(self.workspace_member, browser)
+        browser.open(self.portal, view='@@search?UID={}'.format(
+            self.workspace_meeting_agenda_item.UID()))
+        self.assertEqual(0, len(browser.css('dl.searchResults dt')))
 
 
 class TestOpengeverSearchSolr(SolrIntegrationTestCase):

--- a/opengever/base/tests/test_search.py
+++ b/opengever/base/tests/test_search.py
@@ -5,6 +5,7 @@ from opengever.testing import SolrIntegrationTestCase
 from plone import api
 from plone.app.contentlisting.interfaces import IContentListing
 from plone.uuid.interfaces import IUUID
+from Products.CMFCore.utils import getToolByName
 from zope.component import getMultiAdapter
 
 
@@ -132,6 +133,14 @@ class TestOpengeverSearchSolr(SolrIntegrationTestCase):
 
         self.assertEqual(expected_url, advanced_search.get("href"))
 
+    @browsing
+    def test_workspace_meeting_agendaitems_are_excluded_from_search(self, browser):
+        self.login(self.workspace_member, browser)
+
+        browser.open(self.portal, view='@@search?UID={}'.format(
+            self.workspace_meeting_agenda_item.UID()))
+        self.assertEqual(0, len(browser.css('dl.searchResults dt')))
+
 
 class TestBumblebeePreview(SolrIntegrationTestCase):
 
@@ -224,13 +233,28 @@ class TestSolrSearch(IntegrationTestCase):
         self.search = self.portal.unrestrictedTraverse('@@search')
         self.solr = self.mock_solr('solr_search.json')
 
+    def default_portal_types_filter(self):
+        plone_utils = getToolByName(self.portal, 'plone_utils')
+        types = plone_utils.getUserFriendlyTypes()
+        types = ['"{}"'.format(el) if ' ' in el else el for el in types]
+        return 'portal_type:({})'.format(' OR '.join(types))
+
+    def remove_portal_types_filter(self, filters):
+        """portal_type filter gets added by default to exclude certain portal_types
+        from the search results. Here we filter it out to make testing easier"""
+        filters = self.search.solr_filters()
+        filters.remove(self.default_portal_types_filter())
+        return filters
+
     def test_solr_filters_ignores_searchabletext(self):
         self.request.form.update({'SearchableText': 'foo'})
-        self.assertEqual(self.search.solr_filters(), [])
+        self.assertEqual(
+            self.remove_portal_types_filter(self.search.solr_filters()), [])
 
     def test_solr_filters_ignores_fields_not_in_schema(self):
         self.request.form.update({'myfield': 'foo'})
-        self.assertEqual(self.search.solr_filters(), [])
+        self.assertEqual(
+            self.remove_portal_types_filter(self.search.solr_filters()), [])
 
     def test_solr_filters_handles_date_min_records(self):
         self.request.environ['QUERY_STRING'] = (
@@ -238,7 +262,7 @@ class TestSolrSearch(IntegrationTestCase):
             'created.range:record=min')
         self.request.processInputs()
         self.assertEqual(
-            self.search.solr_filters(),
+            self.remove_portal_types_filter(self.search.solr_filters()),
             [u'created:[2018\\-01\\-20T00\\:00\\:00Z TO *]'])
 
     def test_solr_filters_handles_date_max_records(self):
@@ -247,7 +271,7 @@ class TestSolrSearch(IntegrationTestCase):
             'created.range:record=max')
         self.request.processInputs()
         self.assertEqual(
-            self.search.solr_filters(),
+            self.remove_portal_types_filter(self.search.solr_filters()),
             [u'created:[* TO 2018\\-01\\-20T00\\:00\\:00Z]'])
 
     def test_solr_filters_handles_date_range_records(self):
@@ -257,7 +281,7 @@ class TestSolrSearch(IntegrationTestCase):
             'created.range:record=minmax')
         self.request.processInputs()
         self.assertEqual(
-            self.search.solr_filters(),
+            self.remove_portal_types_filter(self.search.solr_filters()),
             [u'created:[2018\\-01\\-20T00\\:00\\:00Z TO 2018\\-01\\-25T00\\:00\\:00Z]'])
 
     def test_solr_filters_handles_lists(self):
@@ -267,15 +291,15 @@ class TestSolrSearch(IntegrationTestCase):
         self.request.processInputs()
         self.assertEqual(
             self.search.solr_filters(),
-            [u'portal_type:(opengever.document.document OR '
-             u'opengever.dossier.businesscasedossier)'])
+            [u'portal_type:(opengever.dossier.businesscasedossier OR '
+             u'opengever.document.document)'])
 
     def test_solr_filters_handles_simple_values(self):
         self.request.environ['QUERY_STRING'] = (
             'sequence_number:int=123&responsible=hans.muster')
         self.request.processInputs()
         self.assertEqual(
-            self.search.solr_filters(),
+            self.remove_portal_types_filter(self.search.solr_filters()),
             [u'responsible:hans.muster', u'sequence_number:123'])
 
     def test_solr_filters_switch_path_to_parent_path(self):
@@ -283,7 +307,7 @@ class TestSolrSearch(IntegrationTestCase):
             'sequence_number:int=123&path=/fd/ordnungssystem')
         self.request.processInputs()
         self.assertEqual(
-            self.search.solr_filters(),
+            self.remove_portal_types_filter(self.search.solr_filters()),
             [u'path_parent:\\/fd\\/ordnungssystem', u'sequence_number:123'])
 
     def test_solr_sort_on_date(self):
@@ -313,7 +337,7 @@ class TestSolrSearch(IntegrationTestCase):
                    u'Title:foo^100 OR Title:foo*^20 OR SearchableText:foo^5 '
                    u'OR SearchableText:foo* OR metadata:foo^10 '
                    u'OR metadata:foo*^2 OR sequence_number_string:foo^2000'),
-            filters=[u'trashed:false'],
+            filters=[self.default_portal_types_filter(), u'trashed:false'],
             start=0,
             rows=10,
             sort=None,
@@ -335,7 +359,9 @@ class TestSolrSearch(IntegrationTestCase):
         self.search.solr_results()
         self.solr.search.assert_called_with(
             query=u'*:*',
-            filters=[u'responsible:hans.muster', u'trashed:false'],
+            filters=[self.default_portal_types_filter(),
+                     u'responsible:hans.muster',
+                     u'trashed:false'],
             start=0,
             rows=10,
             sort=None,
@@ -350,6 +376,16 @@ class TestSolrSearch(IntegrationTestCase):
                 'hl.encoder': 'html',
                 'hl.snippets': 3,
             })
+
+    def test_search_filters_portal_types_by_default(self):
+        self.assertEqual(
+            self.search.solr_filters(), [self.default_portal_types_filter()])
+
+    def test_search_respects_portal_types_filters_if_provided(self):
+        self.request.form.update({'portal_type': ['opengever.document.document']})
+        self.assertEqual(
+            self.search.solr_filters(),
+            [u'portal_type:opengever.document.document'])
 
     def test_search_uses_solr_if_enabled(self):
         self.request.environ['QUERY_STRING'] = ('SearchableText=foo')

--- a/opengever/core/profiles/default/propertiestool.xml
+++ b/opengever/core/profiles/default/propertiestool.xml
@@ -3,6 +3,28 @@
   <!-- SITE PROPERTIES -->
   <object name="site_properties" meta_type="Plone Property Sheet">
     <property name="icon_visibility" type="string">enabled</property>
+
+    <property name="types_not_searched" type="lines">
+      <element value="ATBooleanCriterion" />
+      <element value="ATDateCriteria" />
+      <element value="ATDateRangeCriterion" />
+      <element value="ATListCriterion" />
+      <element value="ATPortalTypeCriterion" />
+      <element value="ATReferenceCriterion" />
+      <element value="ATSelectionCriterion" />
+      <element value="ATSimpleIntCriterion" />
+      <element value="ATSimpleStringCriterion" />
+      <element value="ATSortCriterion" />
+      <element value="ChangeSet" />
+      <element value="Discussion Item" />
+      <element value="Plone Site" />
+      <element value="TempFolder" />
+      <element value="ATCurrentAuthorCriterion" />
+      <element value="ATPathCriterion" />
+      <element value="ATRelativePathCriterion" />
+      <element value="opengever.workspace.meetingagendaitem" />
+    </property>
+
   </object>
 
   <!-- NAVTREE PROPERTIES -->

--- a/opengever/core/upgrades/20210315115831_remove_workspace_agendaitem_from_search/propertiestool.xml
+++ b/opengever/core/upgrades/20210315115831_remove_workspace_agendaitem_from_search/propertiestool.xml
@@ -1,0 +1,12 @@
+<object name="portal_properties" meta_type="Plone Properties Tool">
+
+  <!-- SITE PROPERTIES -->
+  <object name="site_properties" meta_type="Plone Property Sheet">
+
+    <property name="types_not_searched" type="lines" purge="False">
+     <element value="opengever.workspace.meetingagendaitem"/>
+    </property>
+
+  </object>
+
+</object>

--- a/opengever/core/upgrades/20210315115831_remove_workspace_agendaitem_from_search/upgrade.py
+++ b/opengever/core/upgrades/20210315115831_remove_workspace_agendaitem_from_search/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class RemoveWorkspaceAgendaitemFromSearch(UpgradeStep):
+    """Remove workspace agendaitem from search.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/workspace/tests/test_workspace_meeting_agenda_item.py
+++ b/opengever/workspace/tests/test_workspace_meeting_agenda_item.py
@@ -142,7 +142,8 @@ class TestWorkspaceMeetingAgendaItemSolr(SolrIntegrationTestCase):
 
         self.commit_solr()
         browser.open(self.workspace_meeting,
-                     view='@solrsearch?sort=getObjPositionInParent asc&depth=1&fl=id',
+                     view='@solrsearch?sort=getObjPositionInParent asc&depth=1'
+                          '&fl=id&fq=portal_type:opengever.workspace.meetingagendaitem',
                      headers=self.api_headers)
 
         self.assertEqual(['agendaitem-1', 'agendaitem-2'],
@@ -159,7 +160,8 @@ class TestWorkspaceMeetingAgendaItemSolr(SolrIntegrationTestCase):
         self.commit_solr()
         self.assertEqual(204, browser.status_code)
         browser.open(self.workspace_meeting,
-                     view='@solrsearch?sort=getObjPositionInParent asc&depth=1&fl=id',
+                     view='@solrsearch?sort=getObjPositionInParent asc&depth=1'
+                          '&fl=id&fq=portal_type:opengever.workspace.meetingagendaitem',
                      headers=self.api_headers)
 
         self.assertEqual(['agendaitem-2', 'agendaitem-1'],
@@ -269,3 +271,12 @@ class TestWorkspaceMeetingAgendaItemSolr(SolrIntegrationTestCase):
         self.assertIn(u'\xc4 new title', searchable_text)
         self.assertIn(u'My bold text', searchable_text)
         self.assertNotIn(u'None', searchable_text)
+
+    @browsing
+    def test_workspace_meeting_agendaitems_are_excluded_from_search(self, browser):
+        self.login(self.workspace_member, browser)
+        url = u'{}/@solrsearch?fq=UID:{}'.format(
+            self.portal.absolute_url(), self.workspace_meeting_agenda_item.UID())
+        browser.open(url, method='GET', headers=self.api_headers)
+
+        self.assertEqual(0, browser.json["items_total"])


### PR DESCRIPTION
`WorkspaceMeetingAgendaItem` are only meant to be represented on the the `WorkspaceMeeting` and should therefore not be findable in searches. Instead their content gets indexed in the `SearchableText` of the `WorkspaceMeeting`. So here we make sure that they get filtered out of the different search views and endpoints.

The `@solrsearch` endpoint is implemented in such a way that by default it filters out the blacklisted portal_types (notably `WorkspaceMeetingAgendaItem`), but if a `portal_type` filter is specified, it will be respected, so that it is possible to search for `WorkspaceMeetingAgendaItem`.

As `WorkspaceMeetingAgendaItem` get introduced in this version, this is not an API change and I did not adapt the documentation. I don't think that we need to describe in the documentation that the blacklisted `portal_types` are retrievable.

For https://4teamwork.atlassian.net/browse/CA-1734

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- API change: 
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed