### PR TITLE
Allow overriding task and subtask title and text in `@trigger-task-template` endpoint.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - No longer fail during deployment if ldap is not in authentication plugins. [njohner]
 - Add id field to the @listing endpoint. [elioschmutz]
 - Add action to download meeting minutes as PDF. [buchi]
+- Allow overriding task and subtask title and text in `@trigger-task-template` endpoint. [deiferni]
 
 
 2021.6.0 (2021-03-18)

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -6,7 +6,11 @@ API Changelog
 2021.7.0 (unreleased)
 ---------------------
 
+Other Changes
+^^^^^^^^^^^^^
+
 - ``@listing`` endpoint whitelists the ``id`` field.
+- The endpoint ``@trigger-task-template`` supports overriding ``title`` and ``text`` for each task (see :ref:`trigger_task_template` for updated examples).
 
 
 2021.6.0 (2021-03-18)

--- a/docs/public/dev-manual/api/trigger_task_template.rst
+++ b/docs/public/dev-manual/api/trigger_task_template.rst
@@ -70,3 +70,44 @@ werden. Es gibt dabei folgende Möglichkeiten:
             ],
             "start_immediately": false
         }
+
+
+Titel und Beschreibung setzen
+-----------------------------
+
+Sowohl für die Hauptaufgabe wie auch für jede der ausgewählten Aufgabenvorlage
+kann Titel und Beschreibung der Aufgabe überschrieben werden. Dafür stehen
+folgende Felder zur Verfügung:
+
+- ``title``: Setzt den Titel der Aufgabe (Default: Titel der Vorlage)
+- ``text``:  Setzt die Beschreibung der Aufgabe (Default: Beschreibung
+  der Vorlage, oder Leer für die Hauptaufgabe)
+
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+        POST /ordnungssystem/fuehrung/dossier-23/@trigger-task-template HTTP/1.1
+        Accept: application/json
+
+        {
+            "tasktemplatefolder": "67a25fc941354568950439f08f7af3ed",
+            "title": "Meine Aufgabe",
+            "text": "Bitte sofort erledigen!",
+            "tasktemplates": [
+                {
+                    "@id": "http://localhost:8080/fd/vorlagen/tasktemplatefolder-1/tasktemplate-1",
+                    "responsible": "stv:david.erni",
+                    "title": "Unteraufgabe",
+                    "text": "Noch schneller erledigen!"
+                }
+            ],
+            "related_documents": [
+                {
+                    "@id": "http://localhost:8080/fd/ordnungssystem/fuehrung/dossier-23/document-23515"
+                }
+            ],
+
+            "start_immediately": true
+        }


### PR DESCRIPTION
Allow overriding task and subtask title and text (description) fields in the `@trigger-task-template` endpoint, so that users can set these attributes in a batch add form in the new UI.

We extend the existing `@trigger-task-template` endpoint so that new, optional attributes can be provided. 

This will provide more convenience in the new UI. The functionality is available in the classic UI, but only when editing the content after creation.

Corresponding UI PR: https://github.com/4teamwork/gever-ui/pull/1673
Jira: https://4teamwork.atlassian.net/browse/HG-1041

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
