### PR TITLE
Meeting minutes pdf

### DIFF
--- a/development.cfg
+++ b/development.cfg
@@ -62,6 +62,7 @@ environment-vars +=
     MSGCONVERT_URL http://localhost:8090/
     SABLON_URL http://localhost:8091/
     PDFLATEX_URL http://localhost:8092/
+    WEASYPRINT_URL http://localhost:8093/
 
 zcml +=
   opengever.core
@@ -74,12 +75,14 @@ initialization +=
     os.environ['MSGCONVERT_URL'] = 'http://localhost:8090/'
     os.environ['SABLON_URL'] = 'http://localhost:8091/'
     os.environ['PDFLATEX_URL'] = 'http://localhost:8092/'
+    os.environ['WEASYPRINT_URL'] = 'http://localhost:8093/'
 
 [testserver]
 initialization +=
     os.environ.setdefault('MSGCONVERT_URL', 'http://localhost:8090/')
     os.environ.setdefault('SABLON_URL', 'http://localhost:8091/')
     os.environ.setdefault('PDFLATEX_URL', 'http://localhost:8092/')
+    os.environ.setdefault('WEASYPRINT_URL', 'http://localhost:8093/')
 
 [docxcompose]
 recipe = zc.recipe.egg:script

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,4 +13,7 @@ services:
     image: 4teamwork/pdflatex:latest
     ports:
       - 8092:8080
-
+  weasyprint:
+    image: 4teamwork/weasyprint:latest
+    ports:
+      - 8093:8080

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 - Introduce customproperties default slots which is enabled for every document. [phgross]
 - No longer fail during deployment if ldap is not in authentication plugins. [njohner]
 - Add id field to the @listing endpoint. [elioschmutz]
+- Add action to download meeting minutes as PDF. [buchi]
 
 
 2021.6.0 (2021-03-18)

--- a/opengever/core/docker_testing.py
+++ b/opengever/core/docker_testing.py
@@ -82,6 +82,13 @@ class SablonServiceLayer(DockerServiceLayer):
     service_url_env = 'SABLON_URL'
 
 
+class WeasyPrintServiceLayer(DockerServiceLayer):
+    port_env = 'PORT8'
+    image_name = '4teamwork/weasyprint:latest'
+    service_url_env = 'WEASYPRINT_URL'
+
+
 MSGCONVERT_SERVICE_FIXTURE = MSGConvertServiceLayer()
 PDFLATEX_SERVICE_FIXTURE = PDFLatexServiceLayer()
 SABLON_SERVICE_FIXTURE = SablonServiceLayer()
+WEASYPRINT_SERVICE_FIXTURE = WeasyPrintServiceLayer()

--- a/opengever/core/locales/de/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/de/LC_MESSAGES/opengever.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-03-11 08:43+0000\n"
+"POT-Creation-Date: 2021-03-19 17:03+0000\n"
 "PO-Revision-Date: 2017-09-18 15:21+0200\n"
 "Last-Translator: Philippe Gross <p.gross@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -122,6 +122,11 @@ msgstr "Dokument"
 #: ./opengever/core/profiles/default/types/opengever.dossier.dossiertemplate.xml
 msgid "Dossier template"
 msgstr "Dossiervorlage"
+
+#: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20210319175529_add_meeting_minutes_pdf_action/actions.xml
+msgid "Download meeting minutes PDF"
+msgstr "Protokoll als PDF herunterladen"
 
 #: ./opengever/core/profiles/default/actions.xml
 msgid "Download protocol json"

--- a/opengever/core/locales/en/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/en/LC_MESSAGES/opengever.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-03-11 08:43+0000\n"
+"POT-Creation-Date: 2021-03-19 17:03+0000\n"
 "PO-Revision-Date: 2017-09-18 15:21+0200\n"
 "Last-Translator: Philippe Gross <p.gross@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -148,6 +148,11 @@ msgstr "Document"
 #: ./opengever/core/profiles/default/types/opengever.dossier.dossiertemplate.xml
 msgid "Dossier template"
 msgstr "Dossier template"
+
+#: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20210319175529_add_meeting_minutes_pdf_action/actions.xml
+msgid "Download meeting minutes PDF"
+msgstr "Download meeting minutes as PDF"
 
 #. German translation: JSON Sitzungsdaten herunterladen
 #: ./opengever/core/profiles/default/actions.xml

--- a/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-03-11 08:43+0000\n"
+"POT-Creation-Date: 2021-03-19 17:03+0000\n"
 "PO-Revision-Date: 2013-03-27 10:44+0100\n"
 "Last-Translator: Philippe Gross <p.gross@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -119,6 +119,11 @@ msgstr "Document"
 #: ./opengever/core/profiles/default/types/opengever.dossier.dossiertemplate.xml
 msgid "Dossier template"
 msgstr "Modèle de dossier"
+
+#: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20210319175529_add_meeting_minutes_pdf_action/actions.xml
+msgid "Download meeting minutes PDF"
+msgstr "Télécharger le procès-verbal en PDF"
 
 #: ./opengever/core/profiles/default/actions.xml
 msgid "Download protocol json"

--- a/opengever/core/locales/opengever.core.pot
+++ b/opengever/core/locales/opengever.core.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-11 08:43+0000\n"
+"POT-Creation-Date: 2021-03-19 17:03+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -121,6 +121,11 @@ msgstr ""
 
 #: ./opengever/core/profiles/default/types/opengever.dossier.dossiertemplate.xml
 msgid "Dossier template"
+msgstr ""
+
+#: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20210319175529_add_meeting_minutes_pdf_action/actions.xml
+msgid "Download meeting minutes PDF"
 msgstr ""
 
 #: ./opengever/core/profiles/default/actions.xml

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -936,6 +936,18 @@
       <property name="visible">True</property>
     </object>
 
+    <object name="meeting_minutes_pdf" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Download meeting minutes PDF</property>
+      <property name="description" i18n:translate="" />
+      <property name="url_expr">string:@@meeting_minutes_pdf</property>
+      <property name="icon_expr" />
+      <property name="available_expr">python:here.restrictedTraverse('@@plone_interface_info').provides('opengever.workspace.interfaces.IWorkspaceMeeting')</property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
   </object>
 
 

--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -21,6 +21,7 @@ from opengever.core.cached_testing import CACHED_COMPONENT_REGISTRY_ISOLATION
 from opengever.core.cached_testing import CACHED_COMPONENT_REGISTRY_ISOLATION_SOLR
 from opengever.core.docker_testing import MSGCONVERT_SERVICE_FIXTURE
 from opengever.core.docker_testing import PDFLATEX_SERVICE_FIXTURE
+from opengever.core.docker_testing import WEASYPRINT_SERVICE_FIXTURE
 from opengever.core.solr_testing import SolrReplicationAPIClient
 from opengever.core.solr_testing import SolrServer
 from opengever.dossier.dossiertemplate.interfaces import IDossierTemplateSettings  # noqa
@@ -680,6 +681,10 @@ PDFLATEX_SERVICE_INTEGRATION_TESTING = GEVERIntegrationTesting(
 MSGCONVERT_SERVICE_INTEGRATION_TESTING = GEVERIntegrationTesting(
     bases=(MSGCONVERT_SERVICE_FIXTURE, OPENGEVER_FIXTURE),
     name="opengever.core:msgconvert-service-integration")
+
+WEASYPRINT_SERVICE_INTEGRATION_TESTING = GEVERIntegrationTesting(
+    bases=(ContentFixtureLayer(), TRAVERSAL_BROWSER_FIXTURE, WEASYPRINT_SERVICE_FIXTURE),
+    name="opengever.core:weasyprint-service-integration")
 
 
 class OpengeverFixtureWithSolr(SolrTestingBase, OpengeverFixture):

--- a/opengever/core/upgrades/20210319175529_add_meeting_minutes_pdf_action/actions.xml
+++ b/opengever/core/upgrades/20210319175529_add_meeting_minutes_pdf_action/actions.xml
@@ -1,0 +1,19 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="portal_actions" meta_type="Plone Actions Tool">
+
+  <object name="object_buttons" meta_type="CMF Action Category">
+
+    <object name="meeting_minutes_pdf" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Download meeting minutes PDF</property>
+      <property name="description" i18n:translate="" />
+      <property name="url_expr">string:@@meeting_minutes_pdf</property>
+      <property name="icon_expr" />
+      <property name="available_expr">python:here.restrictedTraverse('@@plone_interface_info').provides('opengever.workspace.interfaces.IWorkspaceMeeting')</property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
+  </object>
+
+</object>

--- a/opengever/core/upgrades/20210319175529_add_meeting_minutes_pdf_action/upgrade.py
+++ b/opengever/core/upgrades/20210319175529_add_meeting_minutes_pdf_action/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddMeetingMinutesPDFAction(UpgradeStep):
+    """Add meeting minutes pdf action.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/deployment-+base.server_name+-+base.deployment_number+-+base.domain+.cfg.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/deployment-+base.server_name+-+base.deployment_number+-+base.domain+.cfg.bob
@@ -42,6 +42,9 @@ environment-vars +=
     SABLON_URL http://localhost:8091/
     PDFLATEX_URL http://localhost:8092/
 {{% endif %}}
+{{% if setup.enable_workspace_meeting_feature %}}
+    WEASYPRINT_URL http://localhost:8093/
+{{% endif %}}
 
 {{% if is_teamraum %}}
     WORKSPACE_SECRET {{{base.workspace_secret}}}

--- a/opengever/workspace/browser/configure.zcml
+++ b/opengever/workspace/browser/configure.zcml
@@ -71,6 +71,13 @@
       permission="cmf.ModifyPortalContent"
       />
 
+  <browser:page
+      name="meeting_minutes_pdf"
+      for="opengever.workspace.interfaces.IWorkspaceMeeting"
+      class=".meeting_pdf.MeetingMinutesPDFView"
+      permission="zope2.View"
+      />
+
   <!-- WorkspaceRoot add form: only show translated title fields for active languages  -->
   <adapter
       factory=".forms.WorkspaceRootAddView"

--- a/opengever/workspace/browser/meeting_pdf.py
+++ b/opengever/workspace/browser/meeting_pdf.py
@@ -1,0 +1,61 @@
+from DateTime import DateTime
+from logging import getLogger
+from opengever.base.helpers import display_name
+from os import environ
+from Products.Five.browser import BrowserView
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from zope.component import getMultiAdapter
+import requests
+
+
+logger = getLogger('opengever.workspace')
+
+
+class MeetingMinutesPDFView(BrowserView):
+
+    template = ViewPageTemplateFile("templates/meeting_minutes.pt")
+
+    def __call__(self):
+        weasyprint_url = environ.get('WEASYPRINT_URL')
+        if not weasyprint_url:
+            logger.error('Weasyprint url not configured.')
+            self.request.response.setStatus(500)
+            return 'PDF generation failed.'
+
+        resp = None
+        try:
+            resp = requests.post(
+                weasyprint_url, files={'html': self.meeting_minutes_html()})
+            resp.raise_for_status()
+        except requests.exceptions.RequestException:
+            details = resp.content[:200] if resp is not None else ''
+            logger.exception('PDF generation failed. %s', details)
+            self.request.response.setStatus(500)
+            return 'PDF generation failed.'
+        else:
+            self.request.response.setHeader('Content-Type', 'application/pdf')
+            return resp.content
+
+    def meeting_minutes_html(self):
+        data = {}
+        portal_state = getMultiAdapter((self.context, self.request),
+                                       name=u'plone_portal_state')
+        data['generator'] = portal_state.portal_title()
+        data['print_date'] = DateTime()
+        data['responsible'] = display_name(self.context.responsible)
+
+        data['agenda_items'] = []
+        agenda_items = self.context.getFolderContents(
+            {'portal_type': 'opengever.workspace.meetingagendaitem'})
+        for i, item in enumerate(agenda_items):
+            obj = item.getObject()
+            text = obj.text.output if obj.text else ''
+            decision = obj.decision.output if obj.decision else ''
+            data['agenda_items'].append({
+                'number': '{}. '.format(i + 1),
+                'title': obj.Title(),
+                'text': text,
+                'decision': decision,
+            })
+
+        return self.template(self, **data)

--- a/opengever/workspace/browser/templates/meeting_minutes.pt
+++ b/opengever/workspace/browser/templates/meeting_minutes.pt
@@ -1,0 +1,111 @@
+<html
+    xmlns:tal="http://xml.zope.org/namespaces/tal"
+    xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+    i18n:domain="opengever.workspace"
+    tal:define="toLocalizedTime nocall: context/@@plone/toLocalizedTime">
+<head>
+<meta charset="utf-8">
+<meta name="generator" tal:attributes="content options/generator">
+<title i18n:translate="heading_meeting_minutes">Meeting Minutes: <span i18n:name="title" tal:replace="context/title">Title</span></title>
+
+<style>
+body {
+  font-family: Helvetica, Arial, Sans-serif;
+  font-size: 10pt;
+  line-height: 120%;
+}
+h1 {
+  font-size: 14pt;
+  line-height: 100%;
+  page-break-before: always;
+}
+h2 {
+  font-size: 11pt;
+}
+h3 {
+  font-size: 10pt;
+  margin: 0;
+}
+h1, h2, h3, h4, h5 {
+  page-break-after: avoid;
+}
+p {
+  margin: 0.5em 0;
+}
+ol, ul {
+  padding-left: 22pt;
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+}
+li > p {
+  margin-top: 0.25em;
+  margin-bottom: 0.25em;
+}
+table, figure {
+  page-break-inside: avoid;
+}
+th {
+  text-align: left;
+}
+td, th {
+  padding-right: 10pt;
+}
+a {
+  text-decoration: none;
+  color: black;
+}
+@page {
+  size: A4;
+  margin-left: 2.5cm;
+  margin-right: 2.5cm;
+  font-family: Helvetica, Arial, Sans-serif;
+  font-size: 10pt;
+  @bottom-right {
+    content: counter(page) "/" counter(pages);
+  }
+  @bottom-left {
+    content: "${python:toLocalizedTime(options['print_date'], long_format=True)}";
+  }
+}
+h1 {
+
+</style>
+</head>
+
+<body>
+
+  <h1 i18n:translate="heading_meeting_minutes">Meeting Minutes: <span i18n:name="title" tal:replace="context/title">Title</span></h1>
+
+  <table>
+    <tr tal:condition="context/location">
+      <th><span i18n:translate="label_location">Location</span>:</th>
+      <td tal:content="context/location"></td>
+    </tr>
+    <tr>
+      <th><span i18n:translate="label_date">Date</span>:</th>
+      <td tal:content="python: toLocalizedTime(context.start, long_format=True)"></td>
+    </tr>
+    <tr tal:condition="options/responsible">
+      <th><span i18n:translate="label_responsible">Responsible</span>:</th>
+      <td tal:content="options/responsible"></td>
+    </tr>
+  </table>
+  <h2 i18n:translate="heading_agenda_items">Agenda Items</h2>
+    <ol>
+    <tal:repeat tal:repeat="agenda_item options/agenda_items">
+      <li><a href="" tal:content="agenda_item/title" tal:attributes="href python: '#agenda-item-%s' % repeat['agenda_item'].index"></a></li>
+    </tal:repeat>
+    </ol>
+  <tal:repeat tal:repeat="agenda_item options/agenda_items">
+    <h2 tal:attributes="id python: 'agenda-item-%s' % repeat['agenda_item'].index">
+      <span tal:content="agenda_item/number"></span><span tal:content="agenda_item/title"></span>
+    </h2>
+    <div tal:condition="nocall: agenda_item/text" tal:content="structure agenda_item/text"></div>
+    <div tal:condition="nocall: agenda_item/decision">
+      <h3><span i18n:translate="label_decision">Decision</span>:</h3>
+      <p tal:replace="structure agenda_item/decision"></p>
+    </div>
+  </tal:repeat>
+
+</body>
+</html>

--- a/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-03 15:27+0000\n"
+"POT-Creation-Date: 2021-03-19 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -98,6 +98,16 @@ msgstr "Teammitglied"
 msgid "fieldset_common"
 msgstr "Allgemein"
 
+#. Default: "Agenda Items"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
+msgid "heading_agenda_items"
+msgstr "Traktanden"
+
+#. Default: "Meeting Minutes: ${title}"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
+msgid "heading_meeting_minutes"
+msgstr "Protokoll: ${title}"
+
 #. Default: "URL for videoconferencing link"
 #: ./opengever/workspace/workspace.py
 msgid "help_videoconferencing_url"
@@ -139,12 +149,18 @@ msgstr ""
 msgid "label_completed"
 msgstr "Erledigt"
 
+#. Default: "Date"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
+msgid "label_date"
+msgstr "Datum"
+
 #. Default: "Deadline"
 #: ./opengever/workspace/todo.py
 msgid "label_deadline"
 msgstr "Zu erledigen bis"
 
 #. Default: "Decision"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
 #: ./opengever/workspace/workspace_meeting_agenda_item.py
 msgid "label_decision"
 msgstr "Beschluss"
@@ -180,6 +196,7 @@ msgid "label_linked_dossier"
 msgstr "Verknüpftes Dossier"
 
 #. Default: "Location"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
 #: ./opengever/workspace/workspace_meeting.py
 msgid "label_location"
 msgstr "Ort"
@@ -196,6 +213,7 @@ msgid "label_related_items"
 msgstr "Verweise"
 
 #. Default: "Responsible"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
 #: ./opengever/workspace/todo.py
 msgid "label_responsible"
 msgstr "Verantwortlich"

--- a/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-03 15:27+0000\n"
+"POT-Creation-Date: 2021-03-19 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -118,6 +118,16 @@ msgstr "Member"
 msgid "fieldset_common"
 msgstr "Common"
 
+#. Default: "Agenda Items"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
+msgid "heading_agenda_items"
+msgstr "Agenda Items"
+
+#. Default: "Meeting Minutes: ${title}"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
+msgid "heading_meeting_minutes"
+msgstr "Meeting Minutes: ${title}"
+
 #. German translation: Verwendete URL um eine Videokonferenz für diesen Teamraum zu starten.
 #. Default: "URL for videoconferencing link"
 #: ./opengever/workspace/workspace.py
@@ -166,6 +176,11 @@ msgstr ""
 msgid "label_completed"
 msgstr "Completed"
 
+#. Default: "Date"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
+msgid "label_date"
+msgstr "Date"
+
 #. German translation: Zu erledigen bis
 #. Default: "Deadline"
 #: ./opengever/workspace/todo.py
@@ -173,6 +188,7 @@ msgid "label_deadline"
 msgstr "Deadline"
 
 #. Default: "Decision"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
 #: ./opengever/workspace/workspace_meeting_agenda_item.py
 msgid "label_decision"
 msgstr "Decision"
@@ -215,6 +231,7 @@ msgstr "Linked dossier"
 
 #. German translation: Ort
 #. Default: "Location"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
 #: ./opengever/workspace/workspace_meeting.py
 msgid "label_location"
 msgstr "Location"
@@ -233,6 +250,7 @@ msgstr "Related items"
 
 #. German translation: Verantwortlich
 #. Default: "Responsible"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
 #: ./opengever/workspace/todo.py
 msgid "label_responsible"
 msgstr "Responsible"

--- a/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-03 15:27+0000\n"
+"POT-Creation-Date: 2021-03-19 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -98,6 +98,16 @@ msgstr "Membre du team"
 msgid "fieldset_common"
 msgstr "Général"
 
+#. Default: "Agenda Items"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
+msgid "heading_agenda_items"
+msgstr "Points à l'ordre du jour"
+
+#. Default: "Meeting Minutes: ${title}"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
+msgid "heading_meeting_minutes"
+msgstr "Procès-verbal de réunion: ${title}"
+
 #. Default: "URL for videoconferencing link"
 #: ./opengever/workspace/workspace.py
 msgid "help_videoconferencing_url"
@@ -139,12 +149,18 @@ msgstr ""
 msgid "label_completed"
 msgstr "Accompli"
 
+#. Default: "Date"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
+msgid "label_date"
+msgstr "Date"
+
 #. Default: "Deadline"
 #: ./opengever/workspace/todo.py
 msgid "label_deadline"
 msgstr "A compléter d'ici le"
 
 #. Default: "Decision"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
 #: ./opengever/workspace/workspace_meeting_agenda_item.py
 msgid "label_decision"
 msgstr "Décision"
@@ -180,6 +196,7 @@ msgid "label_linked_dossier"
 msgstr "Dossier lié"
 
 #. Default: "Location"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
 #: ./opengever/workspace/workspace_meeting.py
 msgid "label_location"
 msgstr "Lieu"
@@ -196,6 +213,7 @@ msgid "label_related_items"
 msgstr "Renvois"
 
 #. Default: "Responsible"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
 #: ./opengever/workspace/todo.py
 msgid "label_responsible"
 msgstr "Responsable"

--- a/opengever/workspace/locales/opengever.workspace.pot
+++ b/opengever/workspace/locales/opengever.workspace.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-03 15:27+0000\n"
+"POT-Creation-Date: 2021-03-19 15:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -101,6 +101,16 @@ msgstr ""
 msgid "fieldset_common"
 msgstr ""
 
+#. Default: "Agenda Items"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
+msgid "heading_agenda_items"
+msgstr ""
+
+#. Default: "Meeting Minutes: ${title}"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
+msgid "heading_meeting_minutes"
+msgstr ""
+
 #. Default: "URL for videoconferencing link"
 #: ./opengever/workspace/workspace.py
 msgid "help_videoconferencing_url"
@@ -136,12 +146,18 @@ msgstr ""
 msgid "label_completed"
 msgstr ""
 
+#. Default: "Date"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
+msgid "label_date"
+msgstr ""
+
 #. Default: "Deadline"
 #: ./opengever/workspace/todo.py
 msgid "label_deadline"
 msgstr ""
 
 #. Default: "Decision"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
 #: ./opengever/workspace/workspace_meeting_agenda_item.py
 msgid "label_decision"
 msgstr ""
@@ -177,6 +193,7 @@ msgid "label_linked_dossier"
 msgstr ""
 
 #. Default: "Location"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
 #: ./opengever/workspace/workspace_meeting.py
 msgid "label_location"
 msgstr ""
@@ -193,6 +210,7 @@ msgid "label_related_items"
 msgstr ""
 
 #. Default: "Responsible"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
 #: ./opengever/workspace/todo.py
 msgid "label_responsible"
 msgstr ""

--- a/opengever/workspace/tests/test_meeting_minutes.py
+++ b/opengever/workspace/tests/test_meeting_minutes.py
@@ -1,0 +1,16 @@
+from ftw.testbrowser import browsing
+from opengever.core.testing import WEASYPRINT_SERVICE_INTEGRATION_TESTING
+from opengever.testing import IntegrationTestCase
+
+
+class TestMeetingMinutes(IntegrationTestCase):
+
+    layer = WEASYPRINT_SERVICE_INTEGRATION_TESTING
+
+    @browsing
+    def test_meeting_minutes_pdf_view_returns_a_pdf(self, browser):
+        self.login(self.workspace_member, browser)
+        browser.open(self.workspace_meeting, view="meeting_minutes_pdf")
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual(browser.headers['Content-Type'], 'application/pdf')
+        self.assertEqual(browser.contents[:8], '%PDF-1.5')


### PR DESCRIPTION
Provides the functionality to create a PDF with the meeting minutes from a workspace meeting.

Uses WeasyPrint for PDF generation from HTML, which is integrated as dockerized a web service.
The reason for not using the already available PDFLaTeX, is its poor support for handling HTML tables.

JIRA: https://4teamwork.atlassian.net/browse/CA-1743


## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade steps (changes in profile):
  - [x] Make it deferrable if possible
  - [x] Execute as much as possible conditionally
- New translations
  - [x] All msg-strings are unicode

