### PR TITLE
Add id field to the @listing endpoint.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2021.6.1 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Add id field to the @listing endpoint. [elioschmutz]
 
 
 2021.6.0 (2021-03-18)

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -6,7 +6,7 @@ API Changelog
 2021.7.0 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- ``@listing`` endpoint whitelists the ``id`` field.
 
 
 2021.6.0 (2021-03-18)

--- a/docs/public/dev-manual/api/listings.rst
+++ b/docs/public/dev-manual/api/listings.rst
@@ -92,6 +92,7 @@ werden. Folgende Felder stehen zur Verfügung:
 - ``is_sutask``: Ob die Aufgabe eine Unteraufgabe ist.
 - ``issuer_fullname``: Auftraggeber (Anzeigename)
 - ``issuer``: Auftraggeber (Benutzername)
+- ``id``: ID des Inhalts
 - ``keywords``: Schlagwörter
 - ``lastname``: Nachname
 - ``mimetype``: Mimetype

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -35,6 +35,7 @@ OTHER_ALLOWED_FIELDS = set([
     'has_sametype_children',
     'is_subdossier',
     'is_subtask',
+    'id',
     'lastname',
     'language',
     'location',


### PR DESCRIPTION
This whitelists the `id` for the `@listing` endpoint. The ID is required to for manual ordering in the task template listing.

Currently, we extract the `id` from the `@id` attribute. With this PR this is no longer necessary. That's part of a small refactoring.

Jira: https://4teamwork.atlassian.net/browse/CA-1737

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
