### PR TITLE
Deployment no longer fails if ldap is not in authentication plugins.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2021.6.1 (unreleased)
 ---------------------
 
+- No longer fail during deployment if ldap is not in authentication plugins. [njohner]
 - Add id field to the @listing endpoint. [elioschmutz]
 
 

--- a/opengever/setup/deploy.py
+++ b/opengever/setup/deploy.py
@@ -138,7 +138,10 @@ class GeverDeployment(object):
         if not self.is_development_setup:
             # Deactivate 'Authentication' capability for LDAP plugin
             # In production, auth will always be performed by CAS portal
-            plugins.deactivatePlugin(IAuthenticationPlugin, 'ldap')
+            try:
+                plugins.deactivatePlugin(IAuthenticationPlugin, 'ldap')
+            except KeyError:
+                pass
 
     def sync_ogds(self):
         if not self.has_ogds_sync:


### PR DESCRIPTION
With [this PR](https://github.com/4teamwork/opengever.core/pull/6903), we removed LDAP from the Authentication plugins in the policy templates, as it anyway gets deactivated during setup. Problem is that the deployment script fails while trying to deactivate the plugin.

For https://4teamwork.atlassian.net/browse/CA-1801

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)