### PR TITLE
Fix oc_checkout endpoint

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,7 +11,7 @@ Changelog
 - Allow overriding task and subtask title and text in `@trigger-task-template` endpoint. [deiferni]
 - Implement group_by_type parameter in @solrsearch endpoint. [tinagerber]
 - Add repository_folders and template_folders to @listing endpoint. [tinagerber]
-
+- Fix oc_checkout endpoint to work with shadow documents that don't have a content-type. [buchi]
 
 
 2021.6.0 (2021-03-18)

--- a/opengever/officeconnector/service.py
+++ b/opengever/officeconnector/service.py
@@ -221,7 +221,7 @@ class OfficeConnectorCheckoutPayload(OfficeConnectorPayload):
             if authorized:
                 if document.is_shadow_document():
                     # Oneoffixx is only used for .docx files in opengever.core
-                    payload['content-type'] = IAnnotations(document)["content-type"]
+                    payload['content-type'] = IAnnotations(document).get("content-type")
                 else:
                     payload['content-type'] = document.get_file().contentType
 


### PR DESCRIPTION
Make it work with shadow documents that don't have a content type stored in annotations. This is the case for Docugate as we don't know yet the content type.

JIRA: https://4teamwork.atlassian.net/browse/CA-1411


## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

