### PR TITLE
Introduce a new field dossier_type and customproperty slots for dossiers.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2021.6.1 (unreleased)
 ---------------------
 
+- Introduce a new field dossier_type and customproperty slots for dossiers. [phgross]
 - Introduce customproperties default slots which is enabled for every document. [phgross]
 - No longer fail during deployment if ldap is not in authentication plugins. [njohner]
 - Add id field to the @listing endpoint. [elioschmutz]

--- a/docs/public/dev-manual/api/propertysheets.rst
+++ b/docs/public/dev-manual/api/propertysheets.rst
@@ -83,8 +83,9 @@ Einzelne Felder werden in folgendem Format erwartet:
 
 Die für das Assigmnet verwendeten Assignment-Slots müssen aus dem Vokabular
 ``opengever.propertysheets.PropertySheetAssignmentsVocabulary`` stammen. Ein
-Spezifalfall ist dabei der Default-Slot ``IDocument.default``, welcher
-unabhängig vom Dokumenttyp Feld immer dargestellt wird.
+Spezialfall ist dabei der Default-Slot ``IDocument.default`` bzw.
+``IDossier.default``, welcher unabhängig vom Dokument- oder Dossiertyp Feld
+immer dargestellt wird.
 
 Zudem müssen Assignments
 eindeutig sein, mehrere Property Sheets dem gleichen Assignment-Slot zuzuweisen
@@ -147,10 +148,11 @@ ist im Moment nicht unterstützt.
 Serialisierung/Deserialisierung von Custom Properties
 -----------------------------------------------------
 
-Im Moment sind Custom Properties auf Dokumenten und Mails unterstützt. Die
-Auswahl des zu validerenden Property Sheets basiert auf dem Wert des Feldes
-`document_type`. Ausnahme ist dabei der Default-Slot ``IDocument.default``
-welcher unabhängig des Feldwertes von ``document_type`` immer dargestellt wird.
+Im Moment sind Custom Properties auf Dokumenten, Mails und Dossiers unterstützt.
+Die Auswahl des zu validierenden Property Sheets basiert auf dem Wert des Feldes
+`document_type` bzw. `dossier_type`. Ausnahme ist dabei der Default-Slot
+``IDocument.default`` bzw. ``IDossier.default`` welcher unabhängig des Typen
+Feldwertes immer dargestellt wird.
 Ist für den Assignment-Slot
 ``IDocumentMetadata.document_type.<document_type_value>`` ein Property Sheet
 registriert, so werden Feldwerte dieses Property Sheets validiert. Hat das

--- a/docs/schema-dumps/opengever.dossier.businesscasedossier.schema.json
+++ b/docs/schema-dumps/opengever.dossier.businesscasedossier.schema.json
@@ -125,6 +125,15 @@
             "description": "",
             "_zope_schema_type": "TextLine"
         },
+        "dossier_type": {
+            "type": "string",
+            "title": "Dossiertyp",
+            "description": "",
+            "_zope_schema_type": "Choice",
+            "enum": [
+                "businesscase"
+            ]
+        },
         "classification": {
             "type": "string",
             "title": "Klassifikation",
@@ -234,6 +243,12 @@
             "format": "date",
             "description": "",
             "_zope_schema_type": "Date"
+        },
+        "custom_properties": {
+            "type": "object",
+            "title": "Benutzerdefinierte Felder",
+            "description": "Enth\u00e4lt die Daten f\u00fcr die benutzerdefinierten Felder.",
+            "_zope_schema_type": "PropertySheetField"
         }
     },
     "required": [
@@ -258,6 +273,7 @@
         "relatedDossier",
         "former_reference_number",
         "reference_number",
+        "dossier_type",
         "classification",
         "privacy_layer",
         "public_trial",
@@ -268,6 +284,7 @@
         "archival_value_annotation",
         "custody_period",
         "date_of_cassation",
-        "date_of_submission"
+        "date_of_submission",
+        "custom_properties"
     ]
 }

--- a/opengever/api/schema/adapters.py
+++ b/opengever/api/schema/adapters.py
@@ -1,5 +1,6 @@
 from opengever.api.schema.schema import TYPE_TO_BE_ADDED_KEY
 from opengever.base.interfaces import IOpengeverBaseLayer
+from opengever.base.vocabulary import WrapperBase
 from plone.restapi.types.adapters import ChoiceJsonSchemaProvider
 from plone.restapi.types.adapters import CollectionJsonSchemaProvider
 from plone.restapi.types.adapters import ListJsonSchemaProvider
@@ -47,11 +48,17 @@ class GEVERChoiceJsonSchemaProvider(ChoiceJsonSchemaProvider):
                                                                parent_field=parent_field)
 
         if 'vocabulary' in result:
-            # Extract vocab_name from URL
-            # (it's not always just self.field.vocabularyName)
-            vocab_url = result['vocabulary']['@id']
-            vocab_name = vocab_url.split('/')[-1]
-            result['vocabulary']['@id'] = get_vocabulary_url(vocab_name, self.context, self.request)
+            vocabulary = getattr(self.field, "vocabulary", None)
+            # Handle elephantvocabularies as sources
+            if isinstance(vocabulary, WrapperBase):
+                result['vocabulary']['@id'] = get_source_url(
+                    self.field, self.context, self.request)
+            else:
+                # Extract vocab_name from URL
+                # (it's not always just self.field.vocabularyName)
+                vocab_url = result['vocabulary']['@id']
+                vocab_name = vocab_url.split('/')[-1]
+                result['vocabulary']['@id'] = get_vocabulary_url(vocab_name, self.context, self.request)
 
         return result
 

--- a/opengever/api/tests/test_vocabularies.py
+++ b/opengever/api/tests/test_vocabularies.py
@@ -34,6 +34,7 @@ NON_SENSITIVE_VOCABUALRIES = [
     'opengever.dossier.container_types',
     'opengever.dossier.DocumentTemplatesVocabulary',
     'opengever.dossier.DossierTemplatesVocabulary',
+    'opengever.dossier.dossier_types',
     'opengever.dossier.participation_roles',
     'opengever.dossier.type_prefixes',
     'opengever.dossier.ValidResolverNamesVocabulary',

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -109,6 +109,8 @@ DOSSIER_DEFAULTS = {
     'reading_and_writing': [],
     'dossier_manager': None,
     'touched': FROZEN_TODAY,
+    'custom_properties': None,
+    'dossier_type': None,
 }
 DOSSIER_FORM_DEFAULTS = {
     'responsible': 'kathi.barfuss',

--- a/opengever/bundle/schemas/dossiers.schema.json
+++ b/opengever/bundle/schemas/dossiers.schema.json
@@ -178,6 +178,19 @@
                     "description": "",
                     "_zope_schema_type": "TextLine"
                 },
+                "dossier_type": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "title": "Dossiertyp",
+                    "description": "",
+                    "_zope_schema_type": "Choice",
+                    "enum": [
+                        null,
+                        "businesscase"
+                    ]
+                },
                 "classification": {
                     "type": [
                         "null",
@@ -327,6 +340,15 @@
                     "description": "",
                     "_zope_schema_type": "Date"
                 },
+                "custom_properties": {
+                    "type": [
+                        "null",
+                        "object"
+                    ],
+                    "title": "Benutzerdefinierte Felder",
+                    "description": "Enth\u00e4lt die Daten f\u00fcr die benutzerdefinierten Felder.",
+                    "_zope_schema_type": "PropertySheetField"
+                },
                 "review_state": {
                     "type": "string",
                     "enum": [
@@ -407,6 +429,7 @@
                 "relatedDossier",
                 "former_reference_number",
                 "reference_number",
+                "dossier_type",
                 "classification",
                 "privacy_layer",
                 "public_trial",
@@ -417,7 +440,8 @@
                 "archival_value_annotation",
                 "custody_period",
                 "date_of_cassation",
-                "date_of_submission"
+                "date_of_submission",
+                "custom_properties"
             ]
         },
         "permission": {

--- a/opengever/core/profiles/default/registry.xml
+++ b/opengever/core/profiles/default/registry.xml
@@ -80,6 +80,7 @@
   <records interface="opengever.dossier.interfaces.ITemplateFolderProperties" />
   <records interface="opengever.dossier.interfaces.IDossierResolveProperties" />
   <records interface="opengever.dossier.dossiertemplate.interfaces.IDossierTemplateSettings" />
+  <records interface="opengever.dossier.interfaces.IDossierType" />
 
   <!-- ECH-0147 -->
   <records interface="opengever.ech0147.interfaces.IECH0147Settings" />

--- a/opengever/core/profiles/default/types/opengever.dossier.businesscasedossier.xml
+++ b/opengever/core/profiles/default/types/opengever.dossier.businesscasedossier.xml
@@ -42,6 +42,7 @@
     <element value="plone.app.lockingbehavior.behaviors.ILocking" />
     <element value="opengever.mail.behaviors.ISendableDocsContainer" />
     <element value="opengever.dossier.behaviors.protect_dossier.IProtectDossier" />
+    <element value="opengever.dossier.behaviors.customproperties.IDossierCustomProperties" />
   </property>
 
   <!-- View information -->

--- a/opengever/core/profiles/default/types/opengever.meeting.meetingdossier.xml
+++ b/opengever/core/profiles/default/types/opengever.meeting.meetingdossier.xml
@@ -41,6 +41,7 @@
     <element value="opengever.sharing.behaviors.IDossier" />
     <element value="plone.app.lockingbehavior.behaviors.ILocking" />
     <element value="opengever.mail.behaviors.ISendableDocsContainer" />
+    <element value="opengever.dossier.behaviors.customproperties.IDossierCustomProperties" />
   </property>
 
   <!-- View information -->

--- a/opengever/core/upgrades/20210322222234_add_dossier_types_configuration_setting/registry.xml
+++ b/opengever/core/upgrades/20210322222234_add_dossier_types_configuration_setting/registry.xml
@@ -1,0 +1,5 @@
+<registry>
+
+  <records interface="opengever.dossier.interfaces.IDossierType" />
+
+</registry>

--- a/opengever/core/upgrades/20210322222234_add_dossier_types_configuration_setting/upgrade.py
+++ b/opengever/core/upgrades/20210322222234_add_dossier_types_configuration_setting/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddDossierTypesConfigurationSetting(UpgradeStep):
+    """Add dossier_types configuration setting.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/core/upgrades/20210323080047_enable_custom_properties_for_dossiers/types/opengever.dossier.businesscasedossier.xml
+++ b/opengever/core/upgrades/20210323080047_enable_custom_properties_for_dossiers/types/opengever.dossier.businesscasedossier.xml
@@ -1,0 +1,7 @@
+<object name="opengever.dossier.businesscasedossier" meta_type="Dexterity FTI">
+
+  <property name="behaviors" purge="False">
+    <element value="opengever.dossier.behaviors.customproperties.IDossierCustomProperties" />
+  </property>
+
+</object>

--- a/opengever/core/upgrades/20210323080047_enable_custom_properties_for_dossiers/types/opengever.meeting.meetingdossier.xml
+++ b/opengever/core/upgrades/20210323080047_enable_custom_properties_for_dossiers/types/opengever.meeting.meetingdossier.xml
@@ -1,0 +1,7 @@
+<object name="opengever.meeting.meetingdossier" meta_type="Dexterity FTI" >
+
+  <property name="behaviors" purge="False">
+    <element value="opengever.dossier.behaviors.customproperties.IDossierCustomProperties" />
+  </property>
+
+</object>

--- a/opengever/core/upgrades/20210323080047_enable_custom_properties_for_dossiers/upgrade.py
+++ b/opengever/core/upgrades/20210323080047_enable_custom_properties_for_dossiers/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class EnableCustomPropertiesForDossiers(UpgradeStep):
+    """Enable custom properties for dossiers.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/dossier/behaviors.zcml
+++ b/opengever/dossier/behaviors.zcml
@@ -88,4 +88,13 @@
       for="plone.dexterity.interfaces.IDexterityContent"
       />
 
+  <!-- customproperties -->
+  <plone:behavior
+      title="Dossier property sheet integration"
+      description="Property sheets for dossier like objects"
+      provides="opengever.dossier.behaviors.customproperties.IDossierCustomProperties"
+      for="opengever.dossier.behaviors.dossier.IDossierMarker"
+      factory="opengever.propertysheets.annotation.CustomPropertiesStorage"
+      />
+
 </configure>

--- a/opengever/dossier/behaviors/customproperties.py
+++ b/opengever/dossier/behaviors/customproperties.py
@@ -1,0 +1,29 @@
+from opengever.dossier import _
+from opengever.propertysheets.assignment import get_dossier_assignment_slots
+from opengever.propertysheets.assignment import DOSSIER_DEFAULT_ASSIGNMENT_SLOT
+from opengever.propertysheets.field import PropertySheetField
+from plone.autoform.interfaces import IFormFieldProvider
+from plone.supermodel import model
+from zope.interface import alsoProvides
+
+
+class IDossierCustomProperties(model.Schema):
+
+    custom_properties = PropertySheetField(
+        request_key='form.widgets.IDossier.dossier_type',
+        attribute_name='dossier_type',
+        assignemnt_prefix='IDossier.dossier_type',
+        valid_assignment_slots_factory=get_dossier_assignment_slots,
+        default_slot=DOSSIER_DEFAULT_ASSIGNMENT_SLOT,
+    )
+
+    model.fieldset(
+        u'custom_properties',
+        label=_(u'Custom properties'),
+        fields=[
+            u'custom_properties',
+            ],
+        )
+
+
+alsoProvides(IDossierCustomProperties, IFormFieldProvider)

--- a/opengever/dossier/behaviors/dossier.py
+++ b/opengever/dossier/behaviors/dossier.py
@@ -51,6 +51,7 @@ class IDossier(model.Schema):
             u'external_reference',
             u'responsible',
             u'relatedDossier',
+            u'dossier_type',
         ],
     )
 
@@ -197,6 +198,15 @@ class IDossier(model.Schema):
         required=False,
         readonly=True,
     )
+
+    dossier_type = schema.Choice(
+        title=_(u'label_dossier_type', default='Dossier type'),
+        source=wrap_vocabulary(
+            'opengever.dossier.dossier_types',
+            hidden_terms_from_registry='opengever.dossier.interfaces.IDossierType.hidden_dossier_types'),
+        required=False,
+    )
+
 
     @invariant
     def validate_start_end(data):

--- a/opengever/dossier/interfaces.py
+++ b/opengever/dossier/interfaces.py
@@ -250,3 +250,16 @@ class IDossierTasksPdfMarker(Interface):
 
 class IDossierJournalPdfMarker(Interface):
     """Deprecated marker Interface for dossier journal document."""
+
+
+class IDossierType(Interface):
+    """plone.app.registry schema for the dossier types setting."""
+
+    hidden_dossier_types = schema.List(
+        title=u"Dossier Type",
+        value_type=schema.Choice(
+            title=u"Name",
+            vocabulary=u'opengever.dossier.dossier_types',
+        ),
+        default=['businesscase']
+    )

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-03-02 18:53+0000\n"
+"POT-Creation-Date: 2021-03-23 14:26+0000\n"
 "PO-Revision-Date: 2017-05-23 04:53+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -48,6 +48,10 @@ msgstr "Dossier hinzufügen"
 #: ./opengever/dossier/move_items.py
 msgid "Can only move objects from open dossiers!"
 msgstr "Es können nur Objekte aus aktiven Dossiers verschoben werden!"
+
+#: ./opengever/dossier/behaviors/customproperties.py
+msgid "Custom properties"
+msgstr "Benutzerdefinierte Felder"
 
 #: ./opengever/dossier/browser/overview.py
 msgid "Description"
@@ -626,6 +630,11 @@ msgstr "Dossier überfällig"
 #: ./opengever/dossier/browser/tabbed.py
 msgid "label_dossier_templates"
 msgstr "Dossiervorlagen"
+
+#. Default: "Dossier type"
+#: ./opengever/dossier/behaviors/dossier.py
+msgid "label_dossier_type"
+msgstr "Dossiertyp"
 
 #. Default: "Edit after creation"
 #: ./opengever/dossier/templatefolder/form.py

--- a/opengever/dossier/locales/en/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/en/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-03-02 18:53+0000\n"
+"POT-Creation-Date: 2021-03-23 14:26+0000\n"
 "PO-Revision-Date: 2017-05-23 04:53+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -56,6 +56,10 @@ msgstr "Add dossier"
 #: ./opengever/dossier/move_items.py
 msgid "Can only move objects from open dossiers!"
 msgstr "Can only move objects from open dossiers!"
+
+#: ./opengever/dossier/behaviors/customproperties.py
+msgid "Custom properties"
+msgstr "Custom properties"
 
 #. German translation: Beschreibung
 #: ./opengever/dossier/browser/overview.py
@@ -770,6 +774,11 @@ msgstr "Overdue dossier"
 #: ./opengever/dossier/browser/tabbed.py
 msgid "label_dossier_templates"
 msgstr "Dossier templates"
+
+#. Default: "Dossier type"
+#: ./opengever/dossier/behaviors/dossier.py
+msgid "label_dossier_type"
+msgstr "Dossier type"
 
 #. German translation: Nach dem Hinzufügen bearbeiten
 #. Default: "Edit after creation"

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-02 18:53+0000\n"
+"POT-Creation-Date: 2021-03-23 14:26+0000\n"
 "PO-Revision-Date: 2017-12-03 11:16+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/fr/>\n"
@@ -47,6 +47,10 @@ msgstr "Ajouter le dossier"
 #: ./opengever/dossier/move_items.py
 msgid "Can only move objects from open dossiers!"
 msgstr "Seuls les objets de dossiers actifs peuvent être déplacés!"
+
+#: ./opengever/dossier/behaviors/customproperties.py
+msgid "Custom properties"
+msgstr ""
 
 #: ./opengever/dossier/browser/overview.py
 msgid "Description"
@@ -624,6 +628,11 @@ msgstr "Dossier en souffrance"
 #: ./opengever/dossier/browser/tabbed.py
 msgid "label_dossier_templates"
 msgstr "Modèles de dossier"
+
+#. Default: "Dossier type"
+#: ./opengever/dossier/behaviors/dossier.py
+msgid "label_dossier_type"
+msgstr ""
 
 #. Default: "Edit after creation"
 #: ./opengever/dossier/templatefolder/form.py

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-02 18:53+0000\n"
+"POT-Creation-Date: 2021-03-23 14:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -47,6 +47,10 @@ msgstr ""
 
 #: ./opengever/dossier/move_items.py
 msgid "Can only move objects from open dossiers!"
+msgstr ""
+
+#: ./opengever/dossier/behaviors/customproperties.py
+msgid "Custom properties"
 msgstr ""
 
 #: ./opengever/dossier/browser/overview.py
@@ -622,6 +626,11 @@ msgstr ""
 #. Default: "Dossier templates"
 #: ./opengever/dossier/browser/tabbed.py
 msgid "label_dossier_templates"
+msgstr ""
+
+#. Default: "Dossier type"
+#: ./opengever/dossier/behaviors/dossier.py
+msgid "label_dossier_type"
 msgstr ""
 
 #. Default: "Edit after creation"

--- a/opengever/dossier/tests/test_dossier_types.py
+++ b/opengever/dossier/tests/test_dossier_types.py
@@ -1,0 +1,58 @@
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import factoriesmenu
+from ftw.testbrowser.pages.statusmessages import info_messages
+from opengever.dossier.behaviors.dossier import IDossier
+from opengever.dossier.interfaces import IDossierType
+from opengever.testing import IntegrationTestCase
+from plone import api
+
+
+class TestDossierType(IntegrationTestCase):
+
+    @browsing
+    def test_field_is_not_available_in_add_form_when_no_dossier_types_active(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(self.leaf_repofolder)
+        factoriesmenu.add('Business Case Dossier')
+
+        self.assertIsNone(browser.forms['form'].find_field('Dossier type'))
+
+        # By default the only type `businesscase` is hidden by registry entry
+        api.portal.set_registry_record(
+            name='hidden_dossier_types', interface=IDossierType, value=[])
+
+        browser.open(self.leaf_repofolder)
+        factoriesmenu.add('Business Case Dossier')
+        self.assertIsNotNone(browser.forms['form'].find_field('Dossier type'))
+
+    @browsing
+    def test_field_is_not_available_in_edit_form_when_no_dossier_types_active(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(self.dossier, view='edit')
+        self.assertIsNone(browser.forms['form'].find_field('Dossier type'))
+
+        # By default the only type `businesscase` is hidden by registry entry
+        api.portal.set_registry_record(
+            name='hidden_dossier_types', interface=IDossierType, value=[])
+
+        browser.open(self.dossier, view='edit')
+        self.assertIsNotNone(browser.forms['form'].find_field('Dossier type'))
+
+    @browsing
+    def test_fill_dossier_type(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        # By default the only type `businesscase` is hidden by registry entry
+        api.portal.set_registry_record(
+            name='hidden_dossier_types', interface=IDossierType, value=[])
+        # Reset cached hidden_terms in the vocabulary
+        IDossier['dossier_type'].vocabulary.hidden_terms = []
+
+        browser.open(self.dossier, view='edit')
+        browser.fill({'Dossier type': 'businesscase'})
+        browser.click_on('Save')
+
+        self.assertEquals(['Changes saved'], info_messages())
+        self.assertEquals('businesscase', IDossier(self.dossier).dossier_type)

--- a/opengever/dossier/vdexvocabs/dossier_types.vdex
+++ b/opengever/dossier/vdexvocabs/dossier_types.vdex
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vdex xmlns="http://www.imsglobal.org/xsd/imsvdex_v1p0"
+      orderSignificant="false" language="en">
+    <vocabIdentifier>opengever.dossier.dossier_types</vocabIdentifier>
+    <term>
+        <termIdentifier>businesscase</termIdentifier>
+        <caption>
+            <langstring language="en">Business case</langstring>
+            <langstring language="en-us">Business case</langstring>
+            <langstring language="de-ch">Geschäftsfall</langstring>
+            <langstring language="de">Geschäftsfall</langstring>
+            <langstring language="fr">Commercial</langstring>
+            <langstring language="fr-ch">Commercial</langstring>
+        </caption>
+    </term>
+
+</vdex>

--- a/opengever/propertysheets/assignment.py
+++ b/opengever/propertysheets/assignment.py
@@ -8,6 +8,9 @@ from zope.schema.vocabulary import SimpleVocabulary
 DOCUMENT_TYPE_ASSIGNMENT_SLOT_PREFIX = "IDocumentMetadata.document_type"
 DOCUMENT_DEFAULT_ASSIGNMENT_SLOT = "IDocument.default"
 
+DOSSIER_TYPE_ASSIGNMENT_SLOT_PREFIX = "IDossier.dossier_type"
+DOSSIER_DEFAULT_ASSIGNMENT_SLOT = "IDossier.default"
+
 
 @implementer(IVocabularyFactory)
 class PropertySheetAssignmentVocabulary(object):
@@ -16,6 +19,10 @@ class PropertySheetAssignmentVocabulary(object):
         assignment_terms = []
         for slot_name in get_document_assignment_slots():
             assignment_terms.append(SimpleTerm(slot_name))
+
+        for slot_name in get_dossier_assignment_slots():
+            assignment_terms.append(SimpleTerm(slot_name))
+
         return SimpleVocabulary(assignment_terms)
 
 
@@ -41,3 +48,24 @@ def document_type_assignment_slot_name(value):
         DOCUMENT_TYPE_ASSIGNMENT_SLOT_PREFIX,
         value
     )
+
+
+def get_dossier_assignment_slots():
+    """"Return a list of all valid assignment slots for dossiers.
+
+    This is limited to one slot per possible value of the
+    `dossier_type` field and the default dossier slot.
+    """
+    vocabulary_factory = getUtility(
+        IVocabularyFactory, name="opengever.dossier.dossier_types"
+    )
+    terms = [
+        dossier_type_assignment_slot_name(term.value)
+        for term in vocabulary_factory(None)
+    ]
+
+    return [DOSSIER_DEFAULT_ASSIGNMENT_SLOT] + terms
+
+
+def dossier_type_assignment_slot_name(value):
+    return u"{}.{}".format(DOSSIER_TYPE_ASSIGNMENT_SLOT_PREFIX, value)

--- a/opengever/propertysheets/tests/test_assignment.py
+++ b/opengever/propertysheets/tests/test_assignment.py
@@ -1,4 +1,5 @@
 from opengever.propertysheets.assignment import get_document_assignment_slots
+from opengever.propertysheets.assignment import get_dossier_assignment_slots
 from opengever.testing.test_case import FunctionalTestCase
 from zope.component import getUtility
 from zope.schema.interfaces import IVocabularyFactory
@@ -19,6 +20,14 @@ EXPECTED_DOCUMENT_DEFAULT_SLOT = [
     u"IDocument.default",
 ]
 
+EXPECTED_DOSSIER_DEFAULT_SLOT = [
+    u"IDossier.default",
+]
+
+EXPECTED_DOSSIER_ASSIGNMENT_SLOTS = [
+    u"IDossier.dossier_type.businesscase",
+]
+
 
 class TestPropertySheetAssignmentVocabulary(FunctionalTestCase):
 
@@ -28,10 +37,12 @@ class TestPropertySheetAssignmentVocabulary(FunctionalTestCase):
             name="opengever.propertysheets.PropertySheetAssignmentsVocabulary",
         )(self.portal)
 
-        self.assertItemsEqual(
-            EXPECTED_DOCUMENT_DEFAULT_SLOT + EXPECTED_DOCUMENT_ASSIGNMENT_SLOTS,
-            [term.value for term in vocabulary],
-        )
+        expected = EXPECTED_DOCUMENT_DEFAULT_SLOT + \
+            EXPECTED_DOCUMENT_ASSIGNMENT_SLOTS + \
+            EXPECTED_DOSSIER_DEFAULT_SLOT + \
+            EXPECTED_DOSSIER_ASSIGNMENT_SLOTS
+
+        self.assertItemsEqual(expected, [term.value for term in vocabulary])
 
 
 class TestPropertySheetDocumentAssignmentSlots(FunctionalTestCase):
@@ -40,4 +51,13 @@ class TestPropertySheetDocumentAssignmentSlots(FunctionalTestCase):
         self.assertItemsEqual(
             EXPECTED_DOCUMENT_DEFAULT_SLOT + EXPECTED_DOCUMENT_ASSIGNMENT_SLOTS,
             get_document_assignment_slots(),
+        )
+
+
+class TestPropertySheetDossierAssignmentSlots(FunctionalTestCase):
+
+    def test_assignemnt_vocabulary_contains_dossier_types(self):
+        self.assertItemsEqual(
+            EXPECTED_DOSSIER_DEFAULT_SLOT + EXPECTED_DOSSIER_ASSIGNMENT_SLOTS,
+            get_dossier_assignment_slots(),
         )

--- a/opengever/propertysheets/tests/test_dossier_custom_properties.py
+++ b/opengever/propertysheets/tests/test_dossier_custom_properties.py
@@ -1,0 +1,207 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.dossier.behaviors.customproperties import IDossierCustomProperties
+from opengever.testing import IntegrationTestCase
+import json
+
+
+class TestDossierCustomPropertiesPatch(IntegrationTestCase):
+
+    @browsing
+    def test_correctly_stores_custom_properties_with_all_field_types(self, browser):
+        self.login(self.manager, browser)
+
+        choices = ["one", u"zw\xf6i", "three"]
+        create(
+            Builder("property_sheet_schema")
+            .named("schema1")
+            .assigned_to_slots(u"IDossier.dossier_type.businesscase")
+            .with_field("choice", u"choose", u"Choose", u"", True, values=choices)
+            .with_field("textline", u"textline", u"A line of text", u"", True)
+        )
+        self.dossier.dossier_type = u"businesscase"
+
+        self.login(self.regular_user, browser)
+        good_data = {
+            "custom_properties": {
+                "IDossier.dossier_type.businesscase": {
+                    "choose": u"zw\xf6i".encode("unicode_escape"),
+                    "textline": u"bl\xe4",
+                },
+            }
+        }
+        browser.open(self.dossier, method="PATCH",
+                     data=json.dumps(good_data), headers=self.api_headers)
+
+        expected_properties = {
+            "IDossier.dossier_type.businesscase": {
+                "choose": u"zw\xf6i",
+                "textline": u"bl\xe4",
+            },
+        }
+        self.assertEqual(
+            expected_properties,
+            IDossierCustomProperties(self.dossier).custom_properties)
+
+    @browsing
+    def test_raises_validation_error_when_selected_assignment_validation_fails(self, browser):
+        self.login(self.manager, browser)
+
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(u"IDossier.dossier_type.businesscase")
+            .with_field("text", u"foo", u"some input", u"", True)
+        )
+        self.dossier.dossier_type = u"businesscase"
+
+        self.login(self.regular_user, browser)
+        bad_data = {
+            "custom_properties": {
+                "IDossier.dossier_type.businesscase": {"qux": "123"}
+            }
+        }
+        with browser.expect_http_error(400):
+            browser.open(
+                self.dossier,
+                method="PATCH",
+                data=json.dumps(bad_data),
+                headers=self.api_headers,
+            )
+
+        self.assertDictContainsSubset({"type": "BadRequest"}, browser.json)
+
+    @browsing
+    def test_validates_required_field_in_selected_assignment(
+        self, browser
+    ):
+        self.login(self.manager, browser)
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(u"IDossier.dossier_type.businesscase")
+            .with_field("text", u"foo", u"some input", u"", True)
+            .with_field("choice", u"choose", u"Choose", u"", True, values=["A1", "A2", "A3"])
+        )
+        self.dossier.dossier_type = u"businesscase"
+
+        self.login(self.regular_user, browser)
+
+        bad_data = {
+            "custom_properties": {
+                "IDossier.dossier_type.businesscase": {"foo": "blabla"}
+            }
+        }
+
+        with browser.expect_http_error(400):
+            browser.open(
+                self.dossier,
+                method="PATCH",
+                data=json.dumps(bad_data),
+                headers=self.api_headers,
+            )
+
+        self.assertDictContainsSubset({"type": "BadRequest"}, browser.json)
+
+
+    @browsing
+    def test_allows_empty_data_if_only_non_required_fields_in_selected_assignment(self, browser):
+        self.login(self.manager, browser)
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(u"IDossier.dossier_type.businesscase")
+            .with_field("text", u"foo", u"some input", u"", False)
+        )
+        self.dossier.dossier_type = u"businesscase"
+
+        self.login(self.regular_user, browser)
+        good_data = {"custom_properties": {}}
+        browser.open(
+            self.dossier,
+            method="PATCH",
+            data=json.dumps(good_data),
+            headers=self.api_headers,
+        )
+        self.assertEqual(
+            {},
+            IDossierCustomProperties(self.dossier).custom_properties,
+        )
+
+
+class TestDossierCustomPropertiesPost(IntegrationTestCase):
+
+    @browsing
+    def test_stores_custom_properties_when_no_document_type_selected(self, browser):
+        self.login(self.manager, browser)
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(u"IDossier.dossier_type.businesscase")
+            .with_field("text", u"foo", u"some input", u"", False)
+        )
+
+        self.login(self.regular_user, browser)
+        property_data = {
+            "IDossier.dossier_type.businesscase": {
+                "foo": u"f\xfc"
+            }
+        }
+        data = {
+            "@type": "opengever.dossier.businesscasedossier",
+            "title": "New Dossier",
+            "responsible": self.regular_user.id,
+            "file": {
+                "data": "foo bar",
+                "filename": "test.txt",
+            },
+            "custom_properties": property_data,
+        }
+
+        with self.observe_children(self.leaf_repofolder) as children:
+            browser.open(self.leaf_repofolder, data=json.dumps(data), method="POST",
+                         headers=self.api_headers)
+
+        self.assertEqual(property_data, browser.json['custom_properties'])
+        self.assertEqual(1, len(children['added']))
+        new_dossier = children['added'].pop()
+        self.assertEqual(
+            property_data,
+            IDossierCustomProperties(new_dossier).custom_properties,
+        )
+
+    @browsing
+    def test_validates_custom_properties_when_dossier_type_selected(self, browser):
+        self.login(self.manager, browser)
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(u"IDossier.dossier_type.businesscase")
+            .with_field("text", u"foo", u"some input", u"", False)
+        )
+
+        self.login(self.regular_user, browser)
+        bad_data = {
+            "IDossier.dossier_type.businesscase": {
+                "qux": u"i am invalid"
+            }
+        }
+        data = {
+            "@type": "opengever.dossier.businesscasedossier",
+            "title": "New Dossier",
+            "responsible": self.regular_user.id,
+            "file": {
+                "data": "foo bar",
+                "filename": "test.txt",
+            },
+            "document_type": "question",
+            "custom_properties": bad_data,
+        }
+
+        with browser.expect_http_error(400):
+            browser.open(self.dossier, data=json.dumps(data), method="POST",
+                         headers=self.api_headers)
+
+        self.assertIn("'field': 'custom_properties'", browser.json["message"])
+        self.assertDictContainsSubset({u"type": u"BadRequest"}, browser.json)


### PR DESCRIPTION
This PR introduces a customproperty field for dossier, including a new field `dossier_type`, similar to the `document_type` field for documents and mails. I made the following decisions:
- For the dossier_type values I introduced new vdexvocabulary, which can be customized by a GEVER policy. By default there is only one value, which is also hidden by the registry entry.                                                                                                                                                                 
- If there are no values for the field available, the field is hidden in the add and edit forms.
- The customproperty field provides a default slot and slots for each dossier_type.

I also had to fix the vocabulary_url for unnamed vocabularies in the @schema representation, for example dossier_type or document_type.

https://4teamwork.atlassian.net/browse/CA-1493


## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- API change:
  - [x] Documentation is updated
- Upgrade steps (changes in profile)