### PR TITLE
Fix catalog inconsistency when creating a dossier from a dossiertemplate. 

### DIFF
--- a/changes/1361.bugfix
+++ b/changes/1361.bugfix
@@ -1,0 +1,1 @@
+Fix catalog inconsistency when creating a dossier from a dossiertemplate. [njohner]

--- a/opengever/base/monkey/patches/__init__.py
+++ b/opengever/base/monkey/patches/__init__.py
@@ -1,5 +1,4 @@
 from .action_info import PatchActionInfo
-from .cmf_catalog_aware import PatchCMFCatalogAware
 from .cmf_catalog_aware import PatchCMFCatalogAwareHandlers
 from .default_values import PatchBuilderCreate
 from .default_values import PatchDeserializeFromJson
@@ -45,7 +44,6 @@ PatchBaseOrderedViewletManagerExceptions()()
 PatchBuilderCreate()()
 PatchCASAuthSetLoginTimes()()
 PatchCatalogToFilterTrashedDocs()()
-PatchCMFCatalogAware()()
 PatchCMFCatalogAwareHandlers()()
 PatchCMFEditonsHistoryHandlerTool()()
 PatchContentRulesHandlerOnLogin()()

--- a/opengever/dossier/dossiertemplate/form.py
+++ b/opengever/dossier/dossiertemplate/form.py
@@ -195,6 +195,9 @@ class CreateDossierContentFromTemplateMixin(object):
         self.recursive_reindex(container)
 
     def recursive_reindex(self, obj):
+        # because we have created objects inside the obj, we also
+        # need to reindex obj, not only its children.
+        obj.reindexObject()
         for child_obj in obj.listFolderContents():
             child_obj.reindexObject()
 


### PR DESCRIPTION
When creating a dossier from a dossier template, the children of the main dossier get created with `DeactivatedCatalogIndexing`. This does not work as expected as we Monkey patch the same indexing methods than `collective.indexing`. Because our patch gets applied first, the patch from `collective.indexing` will still be adding indexing operations to the indexing queue, and our patched methods will only be used when the queue is processed. This is why we need to make sure to process the queue when entering this context manager so that items already in the queue get processed correctly, and before exiting the context manager so that indexing of queued items really gets skipped.

Moreover we need to make sure to reindex the main dossier after creation of the child objects (because adding children modifies the container).

This issue was discovered while looking at https://4teamwork.atlassian.net/browse/CA-1361

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)