### PR TITLE
When delegating tasks via API, informed_principals can be set.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2021.7.0 (unreleased)
 ---------------------
 
+- When delegating tasks via API, informed_principals can be set. [tinagerber]
 - Add a new field `attendees` for workspace meetings. [elioschmutz]
 - Dispatch notification for documents added to tasks. [lgraf]
 - Introduce a new field dossier_type and customproperty slots for dossiers. [phgross]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -9,7 +9,8 @@ API Changelog
 Other Changes
 ^^^^^^^^^^^^^
 
-- ``@solrsearch``: Add ``group_by_type`` paramerter (see :ref:`group-by-type`)
+- ``@workflow/task-transition-delegate``: Allow to set ``informed_principals``.
+- ``@solrsearch``: Add ``group_by_type`` parameter (see :ref:`group-by-type`)
 - ``@listing``: Add ``repository_folders`` and ``template_folders`` listing (see :ref:`docs <listing-names>`)
 - ``@listing`` endpoint whitelists the ``id`` field.
 - The endpoint ``@trigger-task-template`` supports overriding ``title`` and ``text`` for each task (see :ref:`trigger_task_template` for updated examples).

--- a/opengever/task/transition.py
+++ b/opengever/task/transition.py
@@ -3,6 +3,7 @@ from opengever.activity.roles import TASK_RESPONSIBLE_ROLE
 from opengever.base.source import DossierPathSourceBinder
 from opengever.base.transition import ITransitionExtender
 from opengever.base.transition import TransitionExtender
+from opengever.ogds.base.sources import AllUsersAndGroupsSourceBinder
 from opengever.ogds.base.sources import AllUsersInboxesAndTeamsSourceBinder
 from opengever.task import _
 from opengever.task.activities import TaskAddedActivity
@@ -70,6 +71,20 @@ class INewDeadline(Schema):
     new_deadline = schema.Date(
         title=_(u"label_new_deadline", default=u"New Deadline"),
         required=True)
+
+
+class INewInformedPrincipals(Schema):
+
+    informed_principals = schema.List(
+        title=_(u"label_informed_principals", default=u"Info at"),
+        description=_(u"help_informed_principals", default=u""),
+        value_type=schema.Choice(
+            source=AllUsersAndGroupsSourceBinder(),
+            ),
+        required=False,
+        missing_value=[],
+        default=[]
+    )
 
 
 class INewResponsibleSchema(Schema):
@@ -329,7 +344,7 @@ class RejectTransitionExtender(DefaultTransitionExtender):
 @adapter(ITask, IBrowserRequest)
 class DelegateTransitionExtender(DefaultTransitionExtender):
 
-    schemas = [IUpdateMetadata, ISelectRecipientsSchema]
+    schemas = [IUpdateMetadata, ISelectRecipientsSchema, INewInformedPrincipals]
 
     def after_transition_hook(self, transition, disable_sync, transition_params):
         create_subtasks(self.context,


### PR DESCRIPTION
It should now be possible to notify additional principals when delegating a task, just like when creating a task.

Jira: https://4teamwork.atlassian.net/browse/NE-671

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
- New functionality:
  - [ ] for `task` also works for `forwarding`