### PR TITLE
Index custom properties in Solr as dynamic fields

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Add dossier_type field for dossiertemplates. [phgross]
 - Index custom properties in searchable text. [buchi]
+- Index custom properties in Solr dynamic fields. [buchi]
 
 
 2021.7.0 (2021-04-01)

--- a/opengever/propertysheets/configure.zcml
+++ b/opengever/propertysheets/configure.zcml
@@ -60,4 +60,15 @@
       template="templates/propertysheet.pt"
       />
 
+  <adapter
+      for="opengever.dossier.behaviors.dossier.IDossierMarker
+           ftw.solr.interfaces.ISolrConnectionManager"
+      factory=".solr.DossierIndexHandler"
+      />
+  <adapter
+      for="opengever.document.behaviors.IBaseDocument
+           ftw.solr.interfaces.ISolrConnectionManager"
+      factory=".solr.DocumentIndexHandler"
+      />
+
 </configure>

--- a/opengever/propertysheets/solr.py
+++ b/opengever/propertysheets/solr.py
@@ -1,0 +1,81 @@
+from ftw.solr.handlers import DefaultIndexHandler
+from ftw.solr.handlers import DexterityItemIndexHandler
+from opengever.document.behaviors.customproperties import IDocumentCustomProperties
+from opengever.dossier.behaviors.customproperties import IDossierCustomProperties
+from opengever.propertysheets.storage import PropertySheetSchemaStorage
+from zope.schema import getFields
+from zope.schema import Text
+
+
+SOLR_TYPES = {
+    'unicode': 'string',
+    'str': 'string',
+    'bool': 'boolean',
+    'int': 'int',
+}
+
+
+class CustomPropertiesIndexHandler(DefaultIndexHandler):
+    """Indexes custom properties in Solr dynamic fields"""
+
+    behavior = None
+
+    def get_data(self, attributes):
+        data = super(CustomPropertiesIndexHandler, self).get_data(attributes)
+        if not attributes:
+            data.update(self.get_custom_properties())
+        return data
+
+    def get_custom_properties(self):
+        data = {}
+
+        adapted = self.behavior(self.context, None)
+        if not adapted:
+            return data
+
+        custom_properties = adapted.custom_properties
+        if not custom_properties:
+            return data
+
+        field = getFields(self.behavior).get('custom_properties')
+        active_slot = field.get_active_assignment_slot(self.context)
+        for slot in [active_slot, field.default_slot]:
+            if slot not in custom_properties:
+                continue
+
+            definition = PropertySheetSchemaStorage().query(slot)
+            if not definition:
+                continue
+
+            for name, custom_field in definition.get_fields():
+                # Custom properties are indexed for filtering and sorting.
+                # This doesn't make sense for multiline text.
+                if type(custom_field) == Text:
+                    continue
+                if name in custom_properties[slot]:
+                    value = custom_properties[slot][name]
+                    solr_type = SOLR_TYPES.get(type(value).__name__, 'string')
+                    data['{}_custom_field_{}'.format(name, solr_type)] = value
+
+        return data
+
+
+class DossierIndexHandler(CustomPropertiesIndexHandler):
+
+    behavior = IDossierCustomProperties
+
+
+class DocumentIndexHandler(CustomPropertiesIndexHandler, DexterityItemIndexHandler):
+
+    behavior = IDocumentCustomProperties
+
+    def get_data(self, attributes):
+        data = super(DocumentIndexHandler, self).get_data(attributes)
+        # DexterityItems request excplicitly all attributes without
+        # SearchableText when no attributes are specified for indexing.
+        # If this is the case, we need to add the custom properties.
+        if attributes:
+            all_fields = set(self.manager.schema.fields.keys())
+            if set(attributes) | set([u'SearchableText']) == all_fields:
+                data.update(self.get_custom_properties())
+        return data

--- a/opengever/propertysheets/tests/test_solr.py
+++ b/opengever/propertysheets/tests/test_solr.py
@@ -1,0 +1,84 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.document.behaviors.customproperties import IDocumentCustomProperties
+from opengever.dossier.behaviors.customproperties import IDossierCustomProperties
+from opengever.testing import solr_data_for
+from opengever.testing import SolrIntegrationTestCase
+
+
+class TestCustomPropertiesIndexHandler(SolrIntegrationTestCase):
+
+    def test_index_custom_properties_from_default_and_active_slot(self):
+        self.login(self.manager)
+        create(
+            Builder("property_sheet_schema")
+            .named("default_doc_schema")
+            .assigned_to_slots(u"IDocument.default")
+            .with_field("textline", u"f1", u"Field 1", u"", False)
+        )
+        self.document.document_type = u'directive'
+        IDocumentCustomProperties(self.document).custom_properties = {
+            "IDocumentMetadata.document_type.directive": {
+                "textline": u"indexme-directive",
+            },
+            "IDocumentMetadata.document_type.regulations": {
+                "textline": u"noindex-regulations",
+            },
+            "IDocument.default": {"f1": "indexme-default"},
+        }
+        self.document.reindexObject()
+        self.commit_solr()
+
+        solr_doc = solr_data_for(self.document)
+        self.assertEqual(solr_doc.get(u'f1_custom_field_string'), u'indexme-default')
+        self.assertEqual(solr_doc.get(u'textline_custom_field_string'), u'indexme-directive')
+
+    def test_index_custom_properties_with_all_types(self):
+        self.login(self.regular_user)
+
+        self.document.document_type = u'regulations'
+        IDocumentCustomProperties(self.document).custom_properties = {
+            "IDocumentMetadata.document_type.regulations": {
+                "yesorno": False,
+                "choose": u"gr\xfcn",
+                "num": 122333,
+                "text": u"K\xe4fer\nJ\xe4ger",
+                "textline": u"Kr\xe4he",
+            }
+        }
+        self.document.reindexObject()
+        self.commit_solr()
+
+        solr_doc = solr_data_for(self.document)
+        self.assertEqual(
+            solr_doc.get(u'yesorno_custom_field_boolean'), False)
+        self.assertEqual(
+            solr_doc.get(u'choose_custom_field_string'), u"gr\xfcn")
+        self.assertEqual(
+            solr_doc.get(u'num_custom_field_int'), 122333)
+        self.assertNotIn(u'text_custom_field_string', solr_doc)
+        self.assertEqual(
+            solr_doc.get(u'textline_custom_field_string'), u"Kr\xe4he")
+
+    def test_index_custom_properties_of_dossiers(self):
+        self.login(self.manager)
+
+        create(
+            Builder("property_sheet_schema")
+            .named("businesscase_dossier_schema")
+            .assigned_to_slots(u"IDossier.dossier_type.businesscase")
+            .with_field("textline", u"f1", u"Field 1", u"", False)
+        )
+        self.dossier.dossier_type = u"businesscase"
+        IDossierCustomProperties(self.dossier).custom_properties = {
+            "IDossier.dossier_type.businesscase": {"f1": "indexme-businesscase"},
+            "IDossier.default": {"additional_title": "indexme-default"},
+        }
+        self.dossier.reindexObject()
+        self.commit_solr()
+
+        solr_doc = solr_data_for(self.dossier)
+        self.assertEqual(
+            solr_doc.get(u'f1_custom_field_string'), u'indexme-businesscase')
+        self.assertEqual(
+            solr_doc.get(u'additional_title_custom_field_string'), u'indexme-default')

--- a/solr-conf/managed-schema
+++ b/solr-conf/managed-schema
@@ -182,6 +182,10 @@
     <copyField source="path" dest="path_parent"/>
     <copyField source="sequence_number" dest="sequence_number_string"/>
 
+    <dynamicField name="*_custom_field_string" type="string" indexed="true" stored="false"/>
+    <dynamicField name="*_custom_field_int" type="pint" indexed="true" stored="false"/>
+    <dynamicField name="*_custom_field_boolean" type="boolean" indexed="true" stored="false"/>
+
     <dynamicField name="ignored_*" type="ignored"/>
 
     <!-- Field to use to determine and enforce document uniqueness.


### PR DESCRIPTION
This allows filtering and sorting by custom properties in Solr. However there's no UI integration so far.

Properties are indexed using the corresponding Solr type (string, int, boolean) in dynamic fields.
Text (multiline) properties are not indexed as it doesn't make sense to filter/sort on multiline text.
Only properties of the active and the default assignment are indexed.

The name patterns for dynamic fields are:
- `*_custom_field_string`
- `*_custom_field_int`
- `*_custom_field_boolean`

E.g. a custom property with id `supplier` and type `TextLine` would be indexed in the dynamic field `supplier_custom_field_string`. The assignment is not part of the Solr field name, which could potentially lead to conflicts in case of having the same id in the default and the active assignment. However this can be neglected as it doesn't make sense to do this and it would be difficult to represent that in the UI anyway.

JIRA: https://4teamwork.atlassian.net/browse/CA-1285

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

