### PR TITLE
Add dossier_type field for dossier templates.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2021.7.1 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Add dossier_type field for dossiertemplates. [phgross]
 
 
 2021.7.0 (2021-04-01)

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -374,6 +374,7 @@ DOSSIER_TEMPLATE_DEFAULTS = {
 DOSSIER_TEMPLATE_FORM_DEFAULTS = {
 }
 DOSSIER_TEMPLATE_MISSING_VALUES = {
+    'dossier_type': None,
     'comments': None,
     'filing_prefix': None,
 }

--- a/opengever/dossier/dossiertemplate/behaviors.py
+++ b/opengever/dossier/dossiertemplate/behaviors.py
@@ -83,6 +83,7 @@ class IDossierTemplate(model.Schema):
         label=base_mf(u'fieldset_common', default=u'Common'),
         fields=[
             u'keywords',
+            u'dossier_type',
             u'comments',
         ],
     )
@@ -97,6 +98,14 @@ class IDossierTemplate(model.Schema):
         required=False,
         missing_value=(),
         default=(),
+    )
+
+    dossier_type = schema.Choice(
+        title=_(u'label_dossier_type', default='Dossier type'),
+        source=wrap_vocabulary(
+            'opengever.dossier.dossier_types',
+            hidden_terms_from_registry='opengever.dossier.interfaces.IDossierType.hidden_dossier_types'),
+        required=False,
     )
 
     comments = schema.Text(

--- a/opengever/dossier/tests/test_dossier_template.py
+++ b/opengever/dossier/tests/test_dossier_template.py
@@ -177,6 +177,7 @@ class TestDossierTemplate(IntegrationTestCase):
             u'Keywords',
             u'Prefill keywords',
             u'Restrict keywords',
+            u'Dossier type',
             u'Comments',
             u'Filing number prefix'],
             browser.css('#content fieldset label').text
@@ -194,6 +195,7 @@ class TestDossierTemplate(IntegrationTestCase):
             u'Keywords',
             u'Prefill keywords',
             u'Restrict keywords',
+            u'Dossier type',
             u'Comments',
             u'Filing number prefix'],
             browser.css('#content fieldset label').text
@@ -391,6 +393,7 @@ class TestDossierTemplateAddWizard(IntegrationTestCase):
         self.assertEqual((u'secret', u'special'), IDossier(dossier).keywords)
         self.assertEqual('this is very special', IDossier(dossier).comments)
         self.assertEqual('department', IDossier(dossier).filing_prefix)
+        self.assertEqual('businesscase', IDossier(dossier).dossier_type)
 
     @browsing
     def test_dossiertemplate_do_not_copy_keywords(self, browser):

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -780,6 +780,7 @@ class OpengeverContentFixture(object):
                 'keywords': (u'secret', u'special'),
                 'comments': 'this is very special',
                 'filing_prefix': 'department',
+                'dossier_type': 'businesscase'
             })
             .within(self.templates)
         ))

--- a/opengever/testing/profiles/testing/registry.xml
+++ b/opengever/testing/profiles/testing/registry.xml
@@ -1,0 +1,5 @@
+<records interface="opengever.dossier.interfaces.IDossierType">
+  <value key="hidden_dossier_types">
+    <element>no_hidden_type</element>
+  </value>
+</records>


### PR DESCRIPTION
Add the new dossier_type field to dossier templates. 

The PR also enables the dossier_type `businesscase` in our testsetup, this allows the gever-ui to tests dossier_type specific customproperties.

https://4teamwork.atlassian.net/browse/CA-1292

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)