### PR TITLE
Fix broken task template responsibles

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2021.7.1 (unreleased)
 ---------------------
 
+- Fix broken task template responsibles [elioschmutz]
 - Add dossier_type field for dossiertemplates. [phgross]
 
 

--- a/opengever/core/upgrades/20210401195218_fix_task_template_responsibles/upgrade.py
+++ b/opengever/core/upgrades/20210401195218_fix_task_template_responsibles/upgrade.py
@@ -1,0 +1,13 @@
+from ftw.upgrade import UpgradeStep
+
+
+class FixTaskTemplateResponsibles(UpgradeStep):
+    """Fix task template responsibles.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()
+        query = {'responsible': 'interactive_actor:None'}
+        for obj in self.objects(query, 'Fix task template responsible'):
+            obj.responsible = None
+            obj.reindexObject(idxs=['responsible'])


### PR DESCRIPTION
Jira: https://4teamwork.atlassian.net/browse/CA-1997

This PR fixes an issue where it is possible, that the responsible of a tasktemplate is `interactive_actor:None`. 

This bug was introduced in the PR: https://github.com/4teamwork/opengever.core/pull/6804 (v2021.3.0.) by the upgradestep: https://github.com/4teamwork/opengever.core/pull/6804/files#diff-5ab0af610f807e6e371deb6d77e40033f44c2a9abdb3c1cf88d8c4aeaabb3c46

Before v2021.3.0, if you removed a tasktemplate responsible, the `responsible_client` have not been removed. But the upgradestep in https://github.com/4teamwork/opengever.core/pull/6804/files#diff-5ab0af610f807e6e371deb6d77e40033f44c2a9abdb3c1cf88d8c4aeaabb3c46 assumed, that it is: https://github.com/4teamwork/opengever.core/pull/6804/files#diff-5ab0af610f807e6e371deb6d77e40033f44c2a9abdb3c1cf88d8c4aeaabb3c46R22

Means, all tasktemplates which have had an interactive user set and then been removed, are broken now. This PR fixes this tasktemplates with an upgradestep and will set the broken responsible to `None` again. 

There is also a script in the `opengever.maintenance` which can be used to post-fix a site without upgrading to a new version: https://github.com/4teamwork/opengever.maintenance/pull/257

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
