### PR TITLE
Properly reset the responsible watcher if a user accepts a task assigned to a team.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 - Fix broken task template responsibles [elioschmutz]
 - Provide dossier_reference_number mergefield value also for ad-hoc proposals. [phgross]
 - Fix plone site deletion by skipping certain event handlers. [njohner]
+- Properly reset the responsible watcher if a user accepts a task assigned to a team. [elioschmutz]
 - Add dossier_type field for dossiertemplates. [phgross]
 - Index custom properties in searchable text. [buchi]
 - Index custom properties in Solr dynamic fields. [buchi]

--- a/opengever/task/transition.py
+++ b/opengever/task/transition.py
@@ -189,7 +189,13 @@ class AcceptTransitionExtender(DefaultTransitionExtender):
 
     def reassign_team_task(self, response):
         old_responsible = ITask(self.context).responsible
-        ITask(self.context).responsible = api.user.get_current().getId()
+        current_user_id = api.user.get_current().getId()
+
+        center = notification_center()
+        center.add_task_responsible(self.context, current_user_id)
+        center.remove_task_responsible(self.context, old_responsible)
+
+        ITask(self.context).responsible = current_user_id
         response.add_change(
             'responsible',
             old_responsible, ITask(self.context).responsible,


### PR DESCRIPTION
This PR properly handles watchers for team tasks accepted by a user.

With this change, if a user accepts a task assigned to a group, the group will be removed as a watcher of the resource and the user will be added. 

Jira: https://4teamwork.atlassian.net/browse/CA-1953

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
