### PR TITLE
Provide dossier_reference_number mergefield value also for ad-hoc proposals 

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Fix broken task template responsibles [elioschmutz]
+- Provide dossier_reference_number mergefield value also for ad-hoc proposals. [phgross]
 - Add dossier_type field for dossiertemplates. [phgross]
 - Index custom properties in searchable text. [buchi]
 - Index custom properties in Solr dynamic fields. [buchi]

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -7,6 +7,7 @@ from opengever.base.oguid import Oguid
 from opengever.base.types import UnicodeCoercingText
 from opengever.base.utils import to_html_xweb_intelligent
 from opengever.document.interfaces import ICheckinCheckoutManager
+from opengever.dossier.utils import get_main_dossier
 from opengever.meeting import _
 from opengever.meeting.exceptions import MissingMeetingDossierPermissions
 from opengever.meeting.exceptions import WrongAgendaItemState
@@ -184,6 +185,11 @@ class AgendaItem(Base):
     def get_dossier_reference_number(self):
         if self.has_proposal:
             return self.proposal.dossier_reference_number
+
+        if self.ad_hoc_document_int_id:
+            dossier = get_main_dossier(self.resolve_document())
+            return dossier.get_reference_number()
+
         return None
 
     def get_excerpt_header_template(self):

--- a/opengever/meeting/tests/test_agendaitem_adhoc.py
+++ b/opengever/meeting/tests/test_agendaitem_adhoc.py
@@ -306,3 +306,11 @@ class TestAdHocAgendaItem(IntegrationTestCase):
         self.assertIn(
             'href="{}"'.format(excerpt.absolute_url()),
             excerpt_links[0]['link'])
+
+    @browsing
+    def test_dossier_reference_number_is_meeting_dossiers_reference_number(self, browser):
+        self.login(self.committee_responsible, browser)
+        agenda_item = self.schedule_ad_hoc(self.meeting, u'ad-hoc')
+
+        self.assertEquals('Client1 1.1 / 6',
+                          agenda_item.get_dossier_reference_number())

--- a/opengever/meeting/tests/test_agendaitem_list.py
+++ b/opengever/meeting/tests/test_agendaitem_list.py
@@ -149,7 +149,7 @@ class TestAgendaItemList(IntegrationTestCase):
              u'description': u'F\xfcr weitere Bearbeitung bewilligen'},
             {u'decision_number': None,
              u'description': None,
-             u'dossier_reference_number': None,
+             u'dossier_reference_number': u'Client1 1.1 / 6',
              u'is_paragraph': False,
              u'number': '2.',
              u'number_raw': 2,


### PR DESCRIPTION
For ad-hoc proposals, the `dossier_reference_number` mergefield contains now the reference_number of the meeting dossier instead of None.

https://4teamwork.atlassian.net/browse/CA-1374

The dossier_reference_number is fetched on the fly. Since the IntId Catalog and Acquisition are used for this, I consider this procedure as not performance critical and have decieded do not persist the file number in the SQL model.

Documentation needs no update, the `dossier_reference_number` is already documented.

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)