### PR TITLE
Fix searching for group descriptions with umlauts in search terms.

### DIFF
--- a/changes/CA-2012.bugfix
+++ b/changes/CA-2012.bugfix
@@ -1,0 +1,1 @@
+Fix searching for group descriptions with umlauts in search terms.

--- a/opengever/sharing/browser/sharing.py
+++ b/opengever/sharing/browser/sharing.py
@@ -387,7 +387,9 @@ class OpengeverSharingView(SharingView):
 
             fields = ['id', 'title']
             if group_attribute:
-                fields.append(group_attribute)
+                # search fields need to be utf-8 otherwise it leads to empty
+                # search results with silent encoding errors.
+                fields.append(group_attribute.encode('utf-8'))
 
             return merge_search_results(
                 chain(*[hunter.searchGroups(**{field: search_term}) for field in fields]), 'groupid')

--- a/opengever/sharing/tests/test_sharing.py
+++ b/opengever/sharing/tests/test_sharing.py
@@ -365,9 +365,9 @@ class TestOpengeverSharing(IntegrationTestCase):
         self.login(self.administrator, browser=browser)
 
         group = api.group.get('rk_inbox_users')
-        group.setGroupProperties({'description': 'grouptest'})
+        group.setGroupProperties({'description': 'K%C3%B6nizer Schulen'})
 
-        browser.open(self.empty_dossier, view='@sharing?search=grouptest',
+        browser.open(self.empty_dossier, view='@sharing?search=K%C3%B6niz',
                      method='Get', headers={'Accept': 'application/json'})
 
         self.assertNotIn('rk_inbox_users',
@@ -377,7 +377,7 @@ class TestOpengeverSharing(IntegrationTestCase):
             name='group_title_ldap_attribute',
             value=u'description', interface=IOGDSSyncConfiguration)
 
-        browser.open(self.empty_dossier, view='@sharing?search=grouptest',
+        browser.open(self.empty_dossier, view='@sharing?search=K%C3%B6niz',
                      method='Get', headers={'Accept': 'application/json'})
 
         self.assertIn('rk_inbox_users',


### PR DESCRIPTION
Currently when searching for a group, via the @sharing endpoint and the search_terms contains umlaut, the search for the additional group_title attribute (`description`) failed silently with a UnicodeWarning. Because combining the attribute and the search_term raised an UnicodeDecodeError.

Fixes https://4teamwork.atlassian.net/browse/CA-2012

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/


## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
