### PR TITLE
Add attendees solr index for workspace meetings.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2021.7.1 (unreleased)
 ---------------------
 
+- Add attendees solr index for workspace meetings. [tinagerber]
 - Fix broken task template responsibles [elioschmutz]
 - Provide dossier_reference_number mergefield value also for ad-hoc proposals. [phgross]
 - Fix plone site deletion by skipping certain event handlers. [njohner]

--- a/opengever/core/upgrades/20210409160907_index_attendees_in_solr/upgrade.py
+++ b/opengever/core/upgrades/20210409160907_index_attendees_in_solr/upgrade.py
@@ -1,0 +1,13 @@
+from ftw.upgrade import UpgradeStep
+from opengever.workspace.interfaces import IWorkspaceMeeting
+
+
+class IndexAttendeesInSolr(UpgradeStep):
+    """Index attendees in solr.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()
+        query = {'object_provides': IWorkspaceMeeting.__identifier__}
+        for meeting in self.objects(query, 'Reindex meeting attendees'):
+            meeting.reindexObject(idxs=['UID', 'attendees'])

--- a/opengever/workspace/configure.zcml
+++ b/opengever/workspace/configure.zcml
@@ -86,6 +86,11 @@
       />
 
   <adapter
+      factory=".indexers.attendees"
+      name="attendees"
+      />
+
+  <adapter
       factory=".indexers.WorkspaceMeetingSearchableTextExtender"
       name="IWorkspaceMeeting"
       />

--- a/opengever/workspace/indexers.py
+++ b/opengever/workspace/indexers.py
@@ -60,3 +60,8 @@ class WorkspaceMeetingSearchableTextExtender(object):
                  in INDEXED_IN_MEETING_SEARCHABLE_TEXT])
 
         return ' '.join(filter(None, searchable))
+
+
+@indexer(IWorkspaceMeeting)
+def attendees(obj):
+    return obj.attendees

--- a/solr-conf/managed-schema
+++ b/solr-conf/managed-schema
@@ -128,6 +128,7 @@
     <field name="is_folderish" type="boolean" indexed="true" stored="true"/>
 
     <!-- GEVER specific fields -->
+    <field name="attendees" type="string" indexed="true" stored="false" multiValued="true"/>
     <field name="blocked_local_roles" type="boolean" indexed="true" stored="false" />
     <field name="bumblebee_checksum" type="string" indexed="false" stored="false" />
     <field name="changed" type="pdate" indexed="true" stored="false" />


### PR DESCRIPTION
With this PR, attendees for workspace meetings are indexed in Solr. This is necessary to display a meetings card on the teamraum dashboard.
Based on: https://github.com/4teamwork/opengever.core/pull/6858

Jira: [NE-678]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [x] Execute as much as possible conditionally
 
  [NE-678]: https://4teamwork.atlassian.net/browse/NE-678