### PR TITLE
Fix plone site deletion by skipping certain event handlers.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Fix broken task template responsibles [elioschmutz]
 - Provide dossier_reference_number mergefield value also for ad-hoc proposals. [phgross]
+- Fix plone site deletion by skipping certain event handlers. [njohner]
 - Add dossier_type field for dossiertemplates. [phgross]
 - Index custom properties in searchable text. [buchi]
 - Index custom properties in Solr dynamic fields. [buchi]


### PR DESCRIPTION
Plone site deletion fails when attachments have been extracted to new documents. This is because of event handlers on the `IObjectRemovedEvent` which fail due to deletion order. I did not dig too deeply, but it seems that the behaviors can get deleted before the objects, so that adapting the document to `IRelatedDocuments` in `extracted_attachment_deleted` will fail.

I also skip a second event handler (`mail_deleted`), although I did not see any failure due to this one, but it might happen, so it's safer to also check for plone site deletion there.

For https://4teamwork.atlassian.net/browse/CA-1947

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)