### PR TITLE
Add support for policyless deployments

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1306,6 +1306,60 @@ LDAP profiles can be selected in the setup wizard. They are used to install an L
 
 See https://github.com/4teamwork/opengever.core/blob/master/opengever/setup/meta.py for a list of all possible options.
 
+Policyless Deployments
+^^^^^^^^^^^^^^^^^^^^^^
+
+For policyless deployments, the Plone site can be created with a stock profile, and most settings and content will be set up in a second step, via the import of a Bundle with a ``configuration.json``.
+
+Select "Policyless Deployment" and "Policyless LDAP" on the setup screen to create a minimal policyless Plone site. OGDS sync will not be performed yet during Plone site creation, since LDAP settings will be imported later.
+
+Then, using the ``@@import-bundle`` view, import a Bundle containing the appropriate content as well as a ``configuration.json``.
+
+LDAP credentials can be specified via the classic ``~/.opengever/ldap/<hostname>.json``, or through environment variables ``PLONE_LDAP_BIND_UID`` and ``PLONE_LDAP_BIND_PWD`` (these always take precedence, if set). These credentials will be read and configured once during the import of the bundle configuration.
+
+Example for a ``configuration.json``:
+
+.. code:: json
+
+    {
+      "units": {
+        "admin_units": [
+          {
+            "unit_id": "musterstadt",
+            "title": "Musterstadt",
+            "ip_address": "127.0.0.1",
+            "site_url": "http://localhost:8080/ogsite",
+            "public_url": "http://localhost:8080/ogsite",
+            "abbreviation": "MS"
+          }
+        ],
+        "org_units": [
+          {
+            "unit_id": "musterstadt",
+            "title": "Musterstadt",
+            "admin_unit_id": "musterstadt",
+            "users_group_id": "users_group",
+            "inbox_group_id": "inbox_group"
+          }
+        ]
+      },
+      "registry": {
+        "opengever.workspace.interfaces.IWorkspaceSettings.is_feature_enabled": true
+      },
+      "ldap": {
+        "users_base": "ou=Users,dc=example,dc=org",
+        "groups_base": "ou=Groups,dc=example,dc=org",
+        "servers": [
+            {
+                "host": "ldap.example.org",
+                "protocol": "ldaps",
+                "port": 636,
+                "conn_timeout": 5,
+                "op_timeout": -1
+            }
+        ]
+      }
+    }
 
 Content creation
 ~~~~~~~~~~~~~~~~

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 2021.9.0 (unreleased)
 ---------------------
 
+- Add policyless deployment. [lgraf]
+- Add TTW bundle import. [lgraf]
+- Add support for configuration import via bundle. [lgraf]
 - API: Reject years before 1900 for date and datetime fields. [lgraf]
 
 

--- a/opengever/base/casauth.py
+++ b/opengever/base/casauth.py
@@ -19,6 +19,10 @@ def get_cluster_base_url():
     """
     admin_unit = get_current_admin_unit()
 
+    if admin_unit is None:
+        # Policyless deployment - cas_url will be set via bundle config
+        return 'http://NOT-CONFIGURED-YET.local/'
+
     base_url = admin_unit.public_url
     if not base_url.endswith('/'):
         base_url = base_url + '/'

--- a/opengever/base/favorite.py
+++ b/opengever/base/favorite.py
@@ -72,8 +72,12 @@ class FavoriteManager(object):
         return Favorite.query.by_userid(userid=userid).all()
 
     def list_all_repository_favorites(self, userid):
+        current_au = get_current_admin_unit()
+        if not current_au:
+            return []
+
         favorites = Favorite.query.only_repository_favorites(
-            userid, get_current_admin_unit().id()).all()
+            userid, current_au.id()).all()
         return favorites
 
     def get_favorite(self, obj, user):

--- a/opengever/bundle/browser/configure.zcml
+++ b/opengever/bundle/browser/configure.zcml
@@ -1,0 +1,13 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser">
+
+  <browser:page
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      name="import-bundle"
+      class=".import_bundle.ImportBundleForm"
+      permission="zope2.ViewManagementScreens"
+      template="import_bundle.pt"
+      />
+
+</configure>

--- a/opengever/bundle/browser/configure.zcml
+++ b/opengever/bundle/browser/configure.zcml
@@ -2,6 +2,8 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:browser="http://namespaces.zope.org/browser">
 
+  <include file="widget.zcml" />
+
   <browser:page
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"
       name="import-bundle"

--- a/opengever/bundle/browser/import_bundle.pt
+++ b/opengever/bundle/browser/import_bundle.pt
@@ -1,0 +1,23 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      lang="en"
+      metal:use-macro="context/main_template/macros/master"
+      i18n:domain="opengever.bundle">
+<body>
+
+<metal:main fill-slot="main">
+
+<h1 class="documentFirstHeading">Import GEVER Bundle</h1>
+
+    <h2>Configuration</h2>
+
+    <div id="content-core">
+        <metal:block use-macro="context/@@ploneform-macros/titlelessform" />
+    </div>
+
+</metal:main>
+
+</body>
+</html>

--- a/opengever/bundle/browser/import_bundle.py
+++ b/opengever/bundle/browser/import_bundle.py
@@ -1,0 +1,62 @@
+from opengever.bundle.config.importer import ConfigImporter
+from plone import api
+from plone.autoform.form import AutoExtensibleForm
+from plone.supermodel import model
+from z3c.form import button
+from z3c.form.form import Form
+from zope import schema
+from zope.globalrequest import getRequest
+import json
+import os
+
+
+class IImportBundleSchema(model.Schema):
+
+    development_mode = schema.Bool(
+        title=u'Development Mode',
+        description=u'Development Mode',
+        defaultFactory=lambda: bool(os.environ.get('IS_DEVELOPMENT_MODE')),
+        required=True)
+
+    config_file = schema.Bytes(
+        title=u'Config File',
+        description=u'Select configuration.json from OGGBundle to import',
+        required=True)
+
+
+class ImportBundleForm(AutoExtensibleForm, Form):
+
+    schema = IImportBundleSchema
+
+    ignoreContext = True
+    _finished = False
+
+    @button.buttonAndHandler(u'Import', name='save')
+    def handle_import(self, action):
+        data, errors = self.extractData()
+        if errors:
+            self.status = self.formErrorsMessage
+            return
+
+        json_data = json.loads(data['config_file'])
+        importer = ConfigImporter(json_data)
+        result = importer.run(development_mode=data['development_mode'])
+
+        if result is not None:
+            self._finished = True
+            api.portal.show_message(
+                u'Units imported.', request=getRequest(), type='info')
+
+    @button.buttonAndHandler(u'Cancel', name='cancel')
+    def handle_cancel(self, action):
+        return self.request.response.redirect(self.next_url())
+
+    def next_url(self):
+        return self.context.absolute_url()
+
+    def render(self):
+        self.request.set('disable_border', True)
+        if self._finished:
+            return self.request.response.redirect(self.next_url())
+
+        return self.index()

--- a/opengever/bundle/browser/import_bundle.py
+++ b/opengever/bundle/browser/import_bundle.py
@@ -33,6 +33,12 @@ class IImportBundleSchema(model.Schema):
         description=u'Select JSON files from OGGBundle to import (e.g. configuration.json)',
         required=True)
 
+    allow_skip_units = schema.Bool(
+        title=u'Skip import of existing AdminUnits or OrgUnits',
+        description=u'Skip import of units if they already exist',
+        default=True,
+        required=True)
+
 
 class ImportBundleForm(AutoExtensibleForm, Form):
 
@@ -54,7 +60,9 @@ class ImportBundleForm(AutoExtensibleForm, Form):
             uploaded_files[upload['filename']] = upload
 
         config_data = json.loads(uploaded_files['configuration.json']['data'])
-        importer = ConfigImporter(config_data)
+        importer = ConfigImporter(
+            config_data,
+            allow_skip_units=data['allow_skip_units'])
         result = importer.run(development_mode=data['development_mode'])
 
         bundle_dir = mkdtemp(prefix='ttw-bundle-', suffix='.oggbundle')

--- a/opengever/bundle/browser/multi_file_display.pt
+++ b/opengever/bundle/browser/multi_file_display.pt
@@ -1,0 +1,22 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      tal:omit-tag="">
+<span id="" class=""
+      tal:attributes="id view/id;
+                      class view/klass;
+                      style view/style;
+                      title view/title;
+                      lang view/lang;
+                      onclick view/onclick;
+                      ondblclick view/ondblclick;
+                      onmousedown view/onmousedown;
+                      onmouseup view/onmouseup;
+                      onmouseover view/onmouseover;
+                      onmousemove view/onmousemove;
+                      onmouseout view/onmouseout;
+                      onkeypress view/onkeypress;
+                      onkeydown view/onkeydown;
+                      onkeyup view/onkeyup"><tal:block
+      condition="view/value" content="view/value"
+/></span>
+</html>

--- a/opengever/bundle/browser/multi_file_input.pt
+++ b/opengever/bundle/browser/multi_file_input.pt
@@ -1,0 +1,52 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      tal:omit-tag="">
+
+
+<script type="text/javascript">
+    updateFileList = function() {
+    var input = document.getElementById('${view/id}');
+    var output = document.getElementById('fileList-${view/id}');
+    var children = "";
+    for (var i = 0; i < input.files.length; ++i) {
+        children += '<li>' + input.files.item(i).name + '</li>';
+    }
+    output.innerHTML = '<ul>'+children+'</ul>';
+}
+</script>
+
+<input type="file" id="" name="" class="" title="" lang="" disabled=""
+       readonly="" alt="" tabindex="" accesskey="" size="" maxlength=""
+       accept="" multiple="" onchange="javascript:updateFileList()"
+       tal:attributes="id view/id;
+                       name view/name;
+                       class view/klass;
+                       accept view/accept;
+                       style view/style;
+                       title view/title;
+                       lang view/lang;
+                       onclick view/onclick;
+                       ondblclick view/ondblclick;
+                       onmousedown view/onmousedown;
+                       onmouseup view/onmouseup;
+                       onmouseover view/onmouseover;
+                       onmousemove view/onmousemove;
+                       onmouseout view/onmouseout;
+                       onkeypress view/onkeypress;
+                       onkeydown view/onkeydown;
+                       onkeyup view/onkeyup;
+                       disabled view/disabled;
+                       tabindex view/tabindex;
+                       onfocus view/onfocus;
+                       onblur view/onblur;
+                       readonly view/readonly;
+                       alt view/alt;
+                       accesskey view/accesskey;
+                       onselect view/onselect;
+                       size view/size;
+                       maxlength view/maxlength" />
+
+<div id="fileList-${view/id}">
+</div>
+
+</html>

--- a/opengever/bundle/browser/multiuploadwidget.py
+++ b/opengever/bundle/browser/multiuploadwidget.py
@@ -1,0 +1,83 @@
+from z3c.form import widget
+from z3c.form.browser.file import FileWidget
+from z3c.form.converter import FileUploadDataConverter
+from z3c.form.i18n import MessageFactory as _
+from z3c.form.interfaces import IFieldWidget
+from z3c.form.interfaces import IFileWidget
+from z3c.form.interfaces import IFormLayer
+from zope import schema
+from zope.component import adapter
+from zope.component import adapts
+from zope.interface import implementer
+from zope.interface import implementer_only
+from zope.schema.interfaces import IFromUnicode
+from zope.schema.interfaces import ITuple
+from ZPublisher.HTTPRequest import FileUpload
+from zope.schema._bootstrapinterfaces import RequiredMissing
+
+
+class IMultiFileUploadWidget(IFileWidget):
+    pass
+
+
+class IMultiFileUploadField(ITuple):
+    pass
+
+
+@implementer(IMultiFileUploadField, IFromUnicode)
+class MultiFileUploadField(schema.Tuple):
+
+    def validate(self, value):
+        if not value and self.required:
+            raise RequiredMissing(self.__name__)
+
+
+@implementer_only(IMultiFileUploadWidget)
+class MultiFileUploadWidget(FileWidget):
+
+    accept = '.json'
+
+    def json_data(self):
+        raise NotImplementedError
+
+
+class MultiFileUploadDataConverter(FileUploadDataConverter):
+
+    adapts(
+        IMultiFileUploadField, IMultiFileUploadWidget)
+
+    def toFieldValue(self, value):
+        """See interfaces.IDataConverter"""
+
+        if isinstance(value, list):
+            return tuple([self.convert_upload(upload) for upload in value])
+        return ()
+
+    def convert_upload(self, upload):
+        if not isinstance(upload, FileUpload):
+            return None
+
+        headers = upload.headers
+        filename = upload.filename
+        try:
+            seek = upload.seek
+            read = upload.read
+        except AttributeError as e:
+            raise ValueError(_('Bytes data are not a file object'), e)
+        else:
+            seek(0)
+            data = read()
+            if data or getattr(upload, 'filename', ''):
+                return {
+                    'filename': filename,
+                    'headers': headers,
+                    'data': data,
+                }
+            else:
+                return self.field.missing_value
+
+
+@adapter(IMultiFileUploadField, IFormLayer)
+@implementer(IFieldWidget)
+def MultiFileUploadFieldWidget(field, request):
+    return widget.FieldWidget(field, MultiFileUploadWidget(request))

--- a/opengever/bundle/browser/widget.zcml
+++ b/opengever/bundle/browser/widget.zcml
@@ -1,0 +1,35 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:z3c="http://namespaces.zope.org/z3c"
+    i18n_domain="z3c.form">
+
+  <class class=".multiuploadwidget.MultiFileUploadWidget">
+    <require
+        permission="zope.Public"
+        interface=".multiuploadwidget.IMultiFileUploadWidget"
+        />
+  </class>
+
+  <adapter
+      factory=".multiuploadwidget.MultiFileUploadFieldWidget"
+      for=".multiuploadwidget.IMultiFileUploadField
+           z3c.form.interfaces.IFormLayer"
+      />
+
+  <z3c:widgetTemplate
+      mode="display"
+      widget=".multiuploadwidget.IMultiFileUploadWidget"
+      layer="z3c.form.interfaces.IFormLayer"
+      template="multi_file_display.pt"
+      />
+
+  <z3c:widgetTemplate
+      mode="input"
+      widget=".multiuploadwidget.IMultiFileUploadWidget"
+      layer="z3c.form.interfaces.IFormLayer"
+      template="multi_file_input.pt"
+      />
+
+  <adapter factory=".multiuploadwidget.MultiFileUploadDataConverter" />
+
+</configure>

--- a/opengever/bundle/config/importer.py
+++ b/opengever/bundle/config/importer.py
@@ -15,8 +15,9 @@ log.setLevel(logging.INFO)
 
 class ConfigImporter(object):
 
-    def __init__(self, json_data):
+    def __init__(self, json_data, allow_skip_units=False):
         self.configuration = json_data
+        self.allow_skip_units = allow_skip_units
 
     def run(self, development_mode=False):
         self.development_mode = development_mode
@@ -35,7 +36,9 @@ class ConfigImporter(object):
         admin_unit_id = admin_units[0]['unit_id'].decode('utf-8')
 
         admin_units = StringIO(json.dumps(admin_units))
-        AdminUnitCreator(is_development=self.development_mode).run(admin_units)
+        AdminUnitCreator(
+            is_development=self.development_mode,
+            skip_if_exists=self.allow_skip_units).run(admin_units)
 
         api.portal.set_registry_record(
             'current_unit_id', admin_unit_id,
@@ -44,7 +47,9 @@ class ConfigImporter(object):
     def create_org_units(self, units_config):
         org_units = units_config['org_units']
         org_units = StringIO(json.dumps(org_units))
-        OrgUnitCreator(is_development=self.development_mode).run(org_units)
+        OrgUnitCreator(
+            is_development=self.development_mode,
+            skip_if_exists=self.allow_skip_units).run(org_units)
 
     def import_registry_settings(self):
         registry = getUtility(IRegistry)

--- a/opengever/bundle/config/importer.py
+++ b/opengever/bundle/config/importer.py
@@ -1,16 +1,25 @@
 from opengever.ogds.base.interfaces import IAdminUnitConfiguration
+from opengever.ogds.base.sync.ogds_updater import sync_ogds
 from opengever.setup.creation.adminunit import AdminUnitCreator
 from opengever.setup.creation.orgunit import OrgUnitCreator
+from opengever.setup.ldap_creds import get_ldap_credentials
+from opengever.setup.ldap_creds import update_credentials
 from plone import api
 from plone.registry.interfaces import IRegistry
 from StringIO import StringIO
 from zope.component import getUtility
+from ZPublisher.HTTPRequest import default_encoding
 import json
 import logging
+import os
 
 
 log = logging.getLogger('opengever.bundle')
 log.setLevel(logging.INFO)
+
+
+class ConfigImportException(Exception):
+    pass
 
 
 class ConfigImporter(object):
@@ -18,12 +27,17 @@ class ConfigImporter(object):
     def __init__(self, json_data, allow_skip_units=False):
         self.configuration = json_data
         self.allow_skip_units = allow_skip_units
+        self.portal = api.portal.get()
 
     def run(self, development_mode=False):
         self.development_mode = development_mode
+        self.import_ldap_settings()
         self.import_units()
         self.import_registry_settings()
         return True
+
+    def import_ldap_settings(self):
+        LDAPSettingsImporter(self.portal, self.configuration).run()
 
     def import_units(self):
         units_config = self.configuration['units']
@@ -63,3 +77,107 @@ class ConfigImporter(object):
             record.field.validate(value)
             record.value = value
             log.info('Set registry record %r to %r' % (key, value))
+
+
+class LDAPSettingsImporter(object):
+
+    SUPPORTED_PROPERTIES = (
+        'users_base',
+        'groups_base',
+        '_binduid',
+        '_bindpwd',
+        'servers',
+    )
+
+    PLUGIN_ID = 'ldap'
+
+    def __init__(self, portal, configuration):
+        self.portal = portal
+        self.configuration = configuration
+
+    def run(self):
+        """Import LDAP settings from bundle configuration.json.
+
+        Loosely based on Products.LDAPUserFolder.exportimport.
+        """
+        ldap_config = self.configuration['ldap']
+        uf = self.get_ldap_user_folder()
+
+        for key, value in ldap_config.items():
+
+            if key == 'servers':
+                servers = value
+                if len(servers) > 1:
+                    raise ConfigImportException(
+                        'Import of multiple servers not supported yet')
+
+                server = servers[0]
+
+                host = server['host']
+                protocol = server.get('protocol', 'ldap')
+                port = int(server.get('port', 389))
+                conn_timeout = int(server.get('conn_timeout', 5))
+                op_timeout = int(server.get('op_timeout', -1))
+
+                if protocol.lower() == 'ldaps':
+                    use_ssl = 1
+                elif protocol.lower() == 'ldapi':
+                    use_ssl = 2
+                else:
+                    use_ssl = 0
+
+                uf.manage_addServer(
+                    host.encode(default_encoding),
+                    port=port,
+                    use_ssl=use_ssl,
+                    conn_timeout=conn_timeout,
+                    op_timeout=op_timeout,
+                )
+
+                self.configure_bind_credentials(uf, ldap_config, host)
+                continue
+
+            if key not in self.SUPPORTED_PROPERTIES:
+                raise ConfigImportException(
+                    'LDAP property not supported: %r' % key)
+
+            if key in ('_binduid', '_bindpwd'):
+                continue
+
+            uf._setProperty(key, value)
+
+        sync_ogds(self.portal)
+
+    def configure_bind_credentials(self, uf, ldap_config, host):
+        """Determine and set LDAP credentials.
+
+        Order of precedence:
+        - Environment variables
+        - ~/.opengever/ldap/<hostname>.json
+        - configuration.json from Bundle
+        """
+        # Consume possible credentials from bundle config first.
+        # Shouldn't be used in production, but it's here if we need it.
+        _binduid = ldap_config.get('_binduid')
+        _bindpwd = ldap_config.get('_bindpwd')
+
+        # If present, override with credentials from ~/.opengever/ldap
+        creds_from_file = get_ldap_credentials(host)
+        if creds_from_file:
+            creds = creds_from_file[self.PLUGIN_ID]
+            _binduid = creds['user'].encode('utf-8')
+            _bindpwd = creds['password'].encode('utf-8')
+
+        # Environment variables - highest precedence
+        _binduid = os.environ.get('PLONE_LDAP_BIND_UID', _binduid)
+        _bindpwd = os.environ.get('PLONE_LDAP_BIND_PWD', _bindpwd)
+
+        if all([_binduid, _bindpwd]):
+            update_credentials(uf, _binduid, _bindpwd)
+
+    def get_ldap_user_folder(self):
+        if self.PLUGIN_ID not in self.portal.acl_users:
+            raise ConfigImportException(
+                "LDAP Plugin not found. An LDAP plugin with ID %r must "
+                "exist to import LDAP settings via bundle." % self.PLUGIN_ID)
+        return self.portal.acl_users.ldap.acl_users

--- a/opengever/bundle/config/importer.py
+++ b/opengever/bundle/config/importer.py
@@ -38,6 +38,7 @@ class ConfigImporter(object):
         admin_units = StringIO(json.dumps(admin_units))
         AdminUnitCreator(
             is_development=self.development_mode,
+            is_policyless=True,
             skip_if_exists=self.allow_skip_units).run(admin_units)
 
         api.portal.set_registry_record(
@@ -49,6 +50,7 @@ class ConfigImporter(object):
         org_units = StringIO(json.dumps(org_units))
         OrgUnitCreator(
             is_development=self.development_mode,
+            is_policyless=True,
             skip_if_exists=self.allow_skip_units).run(org_units)
 
     def import_registry_settings(self):

--- a/opengever/bundle/config/importer.py
+++ b/opengever/bundle/config/importer.py
@@ -1,0 +1,58 @@
+from opengever.ogds.base.interfaces import IAdminUnitConfiguration
+from opengever.setup.creation.adminunit import AdminUnitCreator
+from opengever.setup.creation.orgunit import OrgUnitCreator
+from plone import api
+from plone.registry.interfaces import IRegistry
+from StringIO import StringIO
+from zope.component import getUtility
+import json
+import logging
+
+
+log = logging.getLogger('opengever.bundle')
+log.setLevel(logging.INFO)
+
+
+class ConfigImporter(object):
+
+    def __init__(self, json_data):
+        self.configuration = json_data
+
+    def run(self, development_mode=False):
+        self.development_mode = development_mode
+        self.import_units()
+        self.import_registry_settings()
+        return True
+
+    def import_units(self):
+        units_config = self.configuration['units']
+        self.create_admin_units(units_config)
+        self.create_org_units(units_config)
+
+    def create_admin_units(self, units_config):
+        admin_units = units_config['admin_units']
+        assert len(admin_units) == 1
+        admin_unit_id = admin_units[0]['unit_id'].decode('utf-8')
+
+        admin_units = StringIO(json.dumps(admin_units))
+        AdminUnitCreator(is_development=self.development_mode).run(admin_units)
+
+        api.portal.set_registry_record(
+            'current_unit_id', admin_unit_id,
+            interface=IAdminUnitConfiguration)
+
+    def create_org_units(self, units_config):
+        org_units = units_config['org_units']
+        org_units = StringIO(json.dumps(org_units))
+        OrgUnitCreator(is_development=self.development_mode).run(org_units)
+
+    def import_registry_settings(self):
+        registry = getUtility(IRegistry)
+
+        settings_to_import = self.configuration.get('registry', {})
+        for key, value in sorted(settings_to_import.items()):
+            # TODO: Might need to do some typecasting for some field types
+            record = registry.records[key]
+            record.field.validate(value)
+            record.value = value
+            log.info('Set registry record %r to %r' % (key, value))

--- a/opengever/bundle/config/importer.py
+++ b/opengever/bundle/config/importer.py
@@ -177,7 +177,7 @@ class LDAPSettingsImporter(object):
 
             uf._setProperty(key, value)
 
-        sync_ogds(self.portal)
+        sync_ogds(self.portal, update_remote_timestamps=False)
 
     def configure_bind_credentials(self, uf, ldap_config, host):
         """Determine and set LDAP credentials.

--- a/opengever/bundle/configure.zcml
+++ b/opengever/bundle/configure.zcml
@@ -3,5 +3,6 @@
     xmlns="http://namespaces.zope.org/zope">
 
   <include file="transmogrifier.zcml" />
+  <include package=".browser" />
 
 </configure>

--- a/opengever/bundle/importer.py
+++ b/opengever/bundle/importer.py
@@ -1,0 +1,105 @@
+from collective.indexing.monkey import unpatch as unpatch_collective_indexing
+from collective.transmogrifier.transmogrifier import Transmogrifier
+from ftw.solr.interfaces import ISolrConnectionManager
+from opengever.base.interfaces import INoSeparateConnectionForSequenceNumbers
+from opengever.bundle.ldap import DisabledLDAP
+from opengever.bundle.loader import GUID_INDEX_NAME
+from opengever.bundle.sections.bundlesource import BUNDLE_KEY
+from opengever.bundle.sections.bundlesource import BUNDLE_PATH_KEY
+from opengever.bundle.sections.commit import INTERMEDIATE_COMMITS_KEY
+from plone import api
+from zope.annotation import IAnnotations
+from zope.component import getUtility
+from zope.interface import alsoProvides
+import logging
+
+
+log = logging.getLogger('opengever.bundle')
+log.setLevel(logging.INFO)
+
+
+class BundleImporter(object):
+
+    def __init__(self, site, bundle_path, disable_ldap=True,
+                 create_guid_index=True, no_intermediate_commits=False,
+                 possibly_unpatch_collective_indexing=True,
+                 no_separate_connection_for_sequence_numbers=True):
+        self.site = site
+        self.bundle_path = bundle_path
+
+        self.disable_ldap = disable_ldap
+        self.create_guid_index = create_guid_index
+        self.no_intermediate_commits = no_intermediate_commits
+        self.possibly_unpatch_collective_indexing = possibly_unpatch_collective_indexing
+        self.no_separate_connection_for_sequence_numbers = no_separate_connection_for_sequence_numbers
+
+    def run(self):
+        log.info("Importing OGGBundle %s" % self.bundle_path)
+
+        # Don't use a separate ZODB connection to issue sequence numbers in
+        # order to avoid conflict errors during OGGBundle import
+        if self.no_separate_connection_for_sequence_numbers:
+            alsoProvides(self.site.REQUEST, INoSeparateConnectionForSequenceNumbers)
+
+        # Add index to track imported GUIDs (if it doesn't exist yet)
+        if self.create_guid_index:
+            add_guid_index()
+
+        transmogrifier = Transmogrifier(self.site)
+
+        ann = IAnnotations(transmogrifier)
+        ann[BUNDLE_PATH_KEY] = self.bundle_path
+        ann[INTERMEDIATE_COMMITS_KEY] = not self.no_intermediate_commits
+
+        solr_enabled = api.portal.get_registry_record(
+            'opengever.base.interfaces.ISearchSettings.use_solr',
+            default=False)
+
+        if solr_enabled:
+            # Check if solr is running
+            conn = getUtility(ISolrConnectionManager).connection
+            if conn.get('/schema').status == -1:
+                # XXX: The --skip-solr flag doesn't exist any more
+                raise Exception(
+                    "Solr isn't running, but solr reindexing is enabled. "
+                    "Skipping solr reindexing via `--skip-solr`.")
+        else:
+            # TODO: In order to also allow this for TTW imports, we would
+            # need to make sure to apply c.indexing patches again with
+            # a context manager.
+            if self.possibly_unpatch_collective_indexing:
+                # Disable collective indexing as it can lead to too many
+                # subtransactions
+                unpatch_collective_indexing()
+
+        if self.disable_ldap:
+            with DisabledLDAP(self.site):
+                transmogrifier(u'opengever.bundle.oggbundle')
+        else:
+            transmogrifier(u'opengever.bundle.oggbundle')
+
+        bundle = IAnnotations(transmogrifier)[BUNDLE_KEY]
+        timings = bundle.stats['timings']
+
+        if 'migration_finished' in timings:
+            duration = timings['migration_finished'] - timings['start_loading']
+            log.info("Duration: %.2fs" % duration.total_seconds())
+
+
+def add_guid_index():
+    """Adds a FieldIndex 'bundle_guid' if it doesn't exist yet.
+
+    This index is only used by OGGBundle imports, and is used to track GUIDs
+    of already imported objects and efficiently query them. This is necessary
+    to enable partial / delta imports, and to accurately query the catalog to
+    build reports about imported objects.
+
+    This index will likely be removed after successful migrations, so code
+    outside the bundle import MUST NOT rely on it being present.
+    """
+    catalog = api.portal.get_tool('portal_catalog')
+    if GUID_INDEX_NAME not in catalog.indexes():
+        log.info("Adding GUID index %r" % GUID_INDEX_NAME)
+        catalog.addIndex(GUID_INDEX_NAME, 'FieldIndex')
+    else:
+        log.info("GUID index %r already exists" % GUID_INDEX_NAME)

--- a/opengever/bundle/tests/assets/policyless_gever.oggbundle/configuration.json
+++ b/opengever/bundle/tests/assets/policyless_gever.oggbundle/configuration.json
@@ -1,0 +1,35 @@
+{
+  "units": {
+    "admin_units": [
+      {
+        "unit_id": "musterstadt",
+        "title": "Musterstadt",
+        "ip_address": "127.0.0.1",
+        "site_url": "http://musterstadt.local",
+        "public_url": "http://musterstadt.local",
+        "abbreviation": "MS"
+      }
+    ],
+    "org_units": [
+      {
+        "unit_id": "finanzdepartement",
+        "title": "Finanzdepartement",
+        "admin_unit_id": "musterstadt",
+        "users_group_id": "og_demo-ftw_users",
+        "inbox_group_id": "og_demo-ftw_users"
+      },
+      {
+        "unit_id": "baudepartement",
+        "title": "Baudepartement",
+        "admin_unit_id": "musterstadt",
+        "users_group_id": "og_demo-ftw_users",
+        "inbox_group_id": "og_demo-ftw_users"
+      }
+    ]
+  },
+  "registry": {
+    "opengever.dossier.interfaces.IDossierContainerTypes.maximum_dossier_depth": 2,
+    "opengever.base.interfaces.IBaseCustodyPeriods.custody_periods": ["0", "30", "100"],
+    "opengever.bumblebee.interfaces.IGeverBumblebeeSettings.open_pdf_in_a_new_window": false
+  }
+}

--- a/opengever/bundle/tests/assets/policyless_gever.oggbundle/configuration.json
+++ b/opengever/bundle/tests/assets/policyless_gever.oggbundle/configuration.json
@@ -31,5 +31,18 @@
     "opengever.dossier.interfaces.IDossierContainerTypes.maximum_dossier_depth": 2,
     "opengever.base.interfaces.IBaseCustodyPeriods.custody_periods": ["0", "30", "100"],
     "opengever.bumblebee.interfaces.IGeverBumblebeeSettings.open_pdf_in_a_new_window": false
+  },
+  "ldap": {
+    "users_base": "ou=Users,ou=Dev,ou=OneGovGEVER,dc=4teamwork,dc=ch",
+    "groups_base": "ou=Groups,ou=Dev,ou=OneGovGEVER,dc=4teamwork,dc=ch",
+    "servers": [
+        {
+            "host": "ldap.4teamwork.ch",
+            "protocol": "ldaps",
+            "port": 636,
+            "conn_timeout": 5,
+            "op_timeout": -1
+        }
+    ]
   }
 }

--- a/opengever/bundle/tests/assets/policyless_gever.oggbundle/repofolders.json
+++ b/opengever/bundle/tests/assets/policyless_gever.oggbundle/repofolders.json
@@ -1,0 +1,85 @@
+[
+  {
+    "guid": "aed9f3db7b3b4713b61a7d7295362ea4",
+    "parent_guid": "e3718c24d4284b319639057187d86c0e",
+    "archival_value": "prompt",
+    "custody_period": 100,
+    "classification": "confidential",
+    "description": "",
+    "former_reference": "",
+    "privacy_layer": "privacy_layer_yes",
+    "public_trial": "private",
+    "public_trial_statement": "Enthält vertrauliche Personaldossiers.",
+    "reference_number_prefix": "3",
+    "referenced_activity": "",
+    "retention_period": 10,
+    "retention_period_annotation": "",
+    "review_state": "repositoryfolder-state-active",
+    "title_de": "Personal",
+    "title_fr": "Personnel",
+    "valid_from": "2005-01-01",
+    "valid_until": "2050-01-01",
+    "_permissions": {
+      "block_inheritance": true,
+      "read": [
+        "gever_admins"
+      ],
+      "add": [
+        "gever_admins"
+      ],
+      "edit": [
+        "gever_admins"
+      ],
+      "close": [
+        "gever_admins"
+      ],
+      "reactivate": [
+        "gever_admins"
+      ],
+      "manage_dossiers": [
+        "gever_admins"
+      ]
+    }
+  }, {
+    "guid": "xed7f3db7b3b4713b61a7d729536abcd",
+    "parent_guid": "e3718c24d4284b319639057187d86c0e",
+    "custody_period": 30,
+    "description": "",
+    "former_reference": "",
+    "privacy_layer": "privacy_layer_no",
+    "public_trial": "unchecked",
+    "public_trial_statement": "",
+    "reference_number_prefix": "0",
+    "referenced_activity": "",
+    "retention_period": 5,
+    "retention_period_annotation": "",
+    "review_state": "repositoryfolder-state-active",
+    "title_de": "Organigramm, Prozesse",
+    "title_en": "Organigrams and processes",
+    "valid_from": "2005-01-01",
+    "valid_until": "2020-01-01"
+  }, {
+    "guid": "e3718c24d4284b319639057187d86c0e",
+    "parent_guid": "754daf80623f45659004a8c38c78dc3e",
+    "archival_value": "unchecked",
+    "archival_value_annotation": "",
+    "classification": "unprotected",
+    "custody_period": 30,
+    "date_of_cassation": "2016-10-1",
+    "date_of_submission": "2016-10-2",
+    "description": "",
+    "location": "Aktenschrank 123",
+    "privacy_layer": "privacy_layer_no",
+    "public_trial": "unchecked",
+    "public_trial_statement": "",
+    "reference_number_prefix": "0",
+    "referenced_activity": "",
+    "retention_period": 5,
+    "review_state": "repositoryfolder-state-active",
+    "title_de": "Organisation",
+    "title_fr": "Organisation",
+    "title_en": "Organisation",
+    "valid_from": "2005-01-01",
+    "valid_until": "2030-01-01"
+  }
+]

--- a/opengever/bundle/tests/assets/policyless_gever.oggbundle/reporoots.json
+++ b/opengever/bundle/tests/assets/policyless_gever.oggbundle/reporoots.json
@@ -1,0 +1,28 @@
+[
+  {
+    "guid": "754daf80623f45659004a8c38c78dc3e",
+    "review_state": "repositoryroot-state-active",
+    "title_de": "Ordnungssystem",
+    "title_fr": "Système de classement",
+    "valid_from": "2000-01-01",
+    "valid_until": "2099-12-31",
+    "version": "",
+    "_permissions": {
+      "read": [
+        "og_demo-ftw_users"
+      ],
+      "add": [
+        "og_demo-ftw_users"
+      ],
+      "edit": [
+        "og_demo-ftw_users"
+      ],
+      "close": [
+        "og_demo-ftw_users"
+      ],
+      "reactivate": [
+        "gever_admins"
+      ]
+    }
+  }
+]

--- a/opengever/bundle/tests/assets/policyless_teamraum.oggbundle/configuration.json
+++ b/opengever/bundle/tests/assets/policyless_teamraum.oggbundle/configuration.json
@@ -1,0 +1,26 @@
+{
+  "units": {
+    "admin_units": [
+      {
+        "unit_id": "musterstadt",
+        "title": "Musterstadt",
+        "ip_address": "127.0.0.1",
+        "site_url": "http://musterstadt.local",
+        "public_url": "http://musterstadt.local",
+        "abbreviation": "MS"
+      }
+    ],
+    "org_units": [
+      {
+        "unit_id": "musterstadt",
+        "title": "Musterstadt",
+        "admin_unit_id": "musterstadt",
+        "users_group_id": "og_demo-ftw_users",
+        "inbox_group_id": "og_demo-ftw_users"
+      }
+    ]
+  },
+  "registry": {
+    "opengever.workspace.interfaces.IWorkspaceSettings.is_feature_enabled": true
+  }
+}

--- a/opengever/bundle/tests/assets/policyless_teamraum.oggbundle/configuration.json
+++ b/opengever/bundle/tests/assets/policyless_teamraum.oggbundle/configuration.json
@@ -22,5 +22,18 @@
   },
   "registry": {
     "opengever.workspace.interfaces.IWorkspaceSettings.is_feature_enabled": true
+  },
+  "ldap": {
+    "users_base": "ou=Users,ou=Dev,ou=OneGovGEVER,dc=4teamwork,dc=ch",
+    "groups_base": "ou=Groups,ou=Dev,ou=OneGovGEVER,dc=4teamwork,dc=ch",
+    "servers": [
+        {
+            "host": "ldap.4teamwork.ch",
+            "protocol": "ldaps",
+            "port": 636,
+            "conn_timeout": 5,
+            "op_timeout": -1
+        }
+    ]
   }
 }

--- a/opengever/bundle/tests/assets/policyless_teamraum.oggbundle/workspaceroots.json
+++ b/opengever/bundle/tests/assets/policyless_teamraum.oggbundle/workspaceroots.json
@@ -1,0 +1,17 @@
+[
+  {
+    "guid": "4c2afa47bdeb47d689f675d123369dcf",
+    "review_state": "opengever_workspace_root--STATUS--active",
+    "title_de": "Teamr\u00e4ume",
+    "title_fr": "Espace partag\u00e9",
+    "title_en": "Workspaces",
+    "_permissions": {
+      "workspaces_creator": [
+        "og_demo-ftw_users"
+      ],
+      "workspaces_user": [
+        "og_demo-ftw_users"
+      ]
+    }
+  }
+]

--- a/opengever/examplecontent/profiles/default/propertiestool.xml
+++ b/opengever/examplecontent/profiles/default/propertiestool.xml
@@ -4,6 +4,6 @@
       <element value="Topic" />
       <element value="Topic" />
     </property>
-    <property name="default_language" type="string">de</property>
+    <property name="default_language" type="string">de-ch</property>
   </object>
 </object>

--- a/opengever/ogds/base/sync/ogds_updater.py
+++ b/opengever/ogds/base/sync/ogds_updater.py
@@ -44,7 +44,8 @@ logger = logging.getLogger('opengever.ogds.base')
 logger.setLevel(logging.INFO)
 
 
-def sync_ogds(plone, users=True, groups=True, local_groups=False):
+def sync_ogds(plone, users=True, groups=True, local_groups=False,
+              update_remote_timestamps=True):
     """Syncronize OGDS users and groups by importing users, groups and
     group membership information from LDAP into the respective OGDS SQL tables.
 
@@ -81,8 +82,9 @@ def sync_ogds(plone, users=True, groups=True, local_groups=False):
     elapsed = time.time() - start
     logger.info(u"Done in {:0.1f} seconds.".format(elapsed))
 
-    logger.info(u"Updating LDAP SYNC importstamp...")
-    set_remote_import_stamp(plone)
+    if update_remote_timestamps:
+        logger.info(u"Updating LDAP SYNC importstamp...")
+        set_remote_import_stamp(plone)
 
     logger.info(u"Synchronization Done.")
 

--- a/opengever/ogds/base/tests/test_utils.py
+++ b/opengever/ogds/base/tests/test_utils.py
@@ -1,0 +1,27 @@
+from opengever.ogds.base.interfaces import IAdminUnitConfiguration
+from opengever.ogds.base.utils import get_current_admin_unit
+from opengever.ogds.models.service import ogds_service
+from opengever.testing import IntegrationTestCase
+from plone.registry.interfaces import IRegistry
+from zope.component import getUtility
+
+
+class TestGetCurrentOrgUnit(IntegrationTestCase):
+
+    def setUp(self):
+        super(TestGetCurrentOrgUnit, self).setUp()
+        registry = getUtility(IRegistry)
+        self.au_config = registry.forInterface(IAdminUnitConfiguration)
+
+    def test_get_current_admin_unit_returns_unit_configured_in_registry(self):
+        unit_id = self.au_config.current_unit_id
+        self.assertEqual('plone', unit_id)
+
+        self.assertEqual(
+            ogds_service().fetch_admin_unit(unit_id),
+            get_current_admin_unit())
+
+    def test_get_current_admin_unit_returns_none_if_unit_not_configured(self):
+        self.au_config.current_unit_id = None
+
+        self.assertEqual(None, get_current_admin_unit())

--- a/opengever/ogds/base/utils.py
+++ b/opengever/ogds/base/utils.py
@@ -65,7 +65,11 @@ def get_ou_selector(ignore_anonymous=False):
     else:
         users_units = ogds_service().assigned_org_units(member.getId())
 
-    admin_unit_units = get_current_admin_unit().org_units
+    admin_unit = get_current_admin_unit()
+    if not admin_unit:
+        admin_unit_units = []
+    else:
+        admin_unit_units = admin_unit.org_units
 
     if not admin_unit_units:
         return NoAssignedUnitsOrgUnitSelector()
@@ -98,6 +102,11 @@ def get_current_org_unit():
 def get_current_admin_unit():
     registry = getUtility(IRegistry)
     proxy = registry.forInterface(IAdminUnitConfiguration)
+
+    if not proxy.current_unit_id:
+        # AdminUnit might not be configured yet immediately after Plone setup
+        return None
+
     return ogds_service().fetch_admin_unit(proxy.current_unit_id)
 
 

--- a/opengever/setup/browser/adddeployment.pt
+++ b/opengever/setup/browser/adddeployment.pt
@@ -141,7 +141,10 @@
 
     <div id="setup-completed">
         Setup successful!
-        <a href="#">open deployment ...</a>
+        <a class="open-deployment" href="#">open deployment ...</a><br/>
+        For policyless setup style, continue with
+        <a href="http://localhost:8080/ogsite/@@import-bundle">OGGBundle Import</a>
     </div>
+
   </body>
 </html>

--- a/opengever/setup/browser/admin.py
+++ b/opengever/setup/browser/admin.py
@@ -182,7 +182,7 @@ class CreateDeployment(BrowserView):
             '<script type="text/javascript">'
             '    var iframe = $("#deploy-output", window.parent.document);'
             '    iframe.contents().scrollTop(iframe.contents().height());'
-            '    $("#setup-completed a", window.parent.document)'
+            '    $("#setup-completed a.open-deployment", window.parent.document)'
             '        .attr("href", "{}")'
             '        .html("Open deployment {}");'
             '    $("#setup-completed", window.parent.document).show();'

--- a/opengever/setup/configure.zcml
+++ b/opengever/setup/configure.zcml
@@ -8,6 +8,7 @@
   <include package=".creation" />
   <include file="profiles.zcml" />
   <include package=".upgrades" />
+  <include package=".policyless" />
   <include file="transmogrifier.zcml" />
 
 </configure>

--- a/opengever/setup/creation/adminunit.py
+++ b/opengever/setup/creation/adminunit.py
@@ -13,10 +13,14 @@ class AdminUnitCreator(UnitCreator):
                            'public_url', 'abbreviation')
 
     def apply_development_config(self, item):
-        admin_unit_id = item['unit_id']
+        if self.is_policyless:
+            plone_site_id = 'gever'
+        else:
+            plone_site_id = item['unit_id']
+
         url = 'http://{}:{}/{}'.format(DEVELOPMENT_SERVER_HOSTNAME,
                                        DEVELOPMENT_SERVER_PORT,
-                                       admin_unit_id)
+                                       plone_site_id)
         item['site_url'] = url
         item['public_url'] = url
         item['ip_address'] = DEVELOPMENT_IP_ADDRESS

--- a/opengever/setup/creation/adminunit.py
+++ b/opengever/setup/creation/adminunit.py
@@ -3,6 +3,7 @@ from opengever.setup import DEVELOPMENT_IP_ADDRESS
 from opengever.setup import DEVELOPMENT_SERVER_HOSTNAME
 from opengever.setup import DEVELOPMENT_SERVER_PORT
 from opengever.setup.creation.unit import UnitCreator
+from opengever.setup.deploy import POLICYLESS_SITE_ID
 
 
 class AdminUnitCreator(UnitCreator):
@@ -14,7 +15,7 @@ class AdminUnitCreator(UnitCreator):
 
     def apply_development_config(self, item):
         if self.is_policyless:
-            plone_site_id = 'gever'
+            plone_site_id = POLICYLESS_SITE_ID
         else:
             plone_site_id = item['unit_id']
 

--- a/opengever/setup/creation/unit.py
+++ b/opengever/setup/creation/unit.py
@@ -11,9 +11,10 @@ class UnitCreator(object):
     required_attributes = tuple()
     key_mapping = {}
 
-    def __init__(self, is_development=False, skip_if_exists=False):
+    def __init__(self, is_development=False, skip_if_exists=False, is_policyless=False):
         self.session = create_session()
         self.is_development = is_development
+        self.is_policyless = is_policyless
         self.skip_if_exists = skip_if_exists
 
     def get_json_data(self, jsonfile):

--- a/opengever/setup/creation/unit.py
+++ b/opengever/setup/creation/unit.py
@@ -11,9 +11,10 @@ class UnitCreator(object):
     required_attributes = tuple()
     key_mapping = {}
 
-    def __init__(self, is_development=False):
+    def __init__(self, is_development=False, skip_if_exists=False):
         self.session = create_session()
         self.is_development = is_development
+        self.skip_if_exists = skip_if_exists
 
     def get_json_data(self, jsonfile):
         data = json.loads(jsonfile.read())
@@ -48,4 +49,10 @@ class UnitCreator(object):
                 raise GeverSetupException(msg)
 
     def create_unit(self, item):
+        if self.skip_if_exists:
+            existing = self.item_class.query.filter_by(
+                unit_id=item['unit_id']).one_or_none()
+            if existing:
+                return
+
         self.session.add(self.item_class(**item))

--- a/opengever/setup/deploy.py
+++ b/opengever/setup/deploy.py
@@ -49,6 +49,7 @@ class GeverDeployment(object):
         self.config = config
         self.db_session = db_session
         self.is_development_setup = is_development_setup
+        self.is_policyless = config.get('is_policyless', False)
         self.has_purge_sql = has_purge_sql
         self.ldap_profile = ldap_profile
         self.has_ogds_sync = has_ogds_sync
@@ -78,9 +79,16 @@ class GeverDeployment(object):
         ext_profiles = list(EXTENSION_PROFILES)
         ext_profiles.extend(BASE_PROFILES)
 
+        if self.is_policyless:
+            # For policyless deployments, admin unit will be set up later,
+            # and the Plone site ID won't be tied to it.
+            plone_site_id = 'gever'
+        else:
+            plone_site_id = config.get('admin_unit_id').encode('utf-8')
+
         return addPloneSite(
             self.context,
-            config['admin_unit_id'].encode('utf-8'),
+            plone_site_id,
             title=config['title'],
             profile_id=_DEFAULT_PROFILE,
             extension_ids=ext_profiles,
@@ -153,9 +161,20 @@ class GeverDeployment(object):
         print '===== Done SYNCING LDAP ===='
 
     def configure_admin_unit(self):
-        registry = getUtility(IRegistry)
-        proxy = registry.forInterface(IAdminUnitConfiguration)
-        proxy.current_unit_id = self.config['admin_unit_id'].decode('utf-8')
+        """With classic installations, the admin unit will be created during
+        Plone site setup, and the registry  `current_unit_id` will be
+        set accordingly. The admin unit's ID will be used as the Plone site ID
+        as well.
+
+        In policyless setup style however, the admin unit ID should be omitted
+        from the registerDeployment directive, since it will be created later.
+        """
+        admin_unit_id = self.config.get('admin_unit_id')
+
+        if admin_unit_id:
+            registry = getUtility(IRegistry)
+            proxy = registry.forInterface(IAdminUnitConfiguration)
+            proxy.current_unit_id = admin_unit_id.decode('utf-8')
 
     def install_policy_profile(self):
         # import the default generic setup profiles if needed

--- a/opengever/setup/deploy.py
+++ b/opengever/setup/deploy.py
@@ -154,7 +154,9 @@ class GeverDeployment(object):
                 pass
 
     def sync_ogds(self):
-        if not self.has_ogds_sync:
+        if not self.has_ogds_sync or self.is_policyless:
+            # TODO: Disable "Sync OGDS" checkbox in setup form for policyless
+            # deployments, since it won't have an effect.
             return
 
         print '===== SYNC LDAP ===='

--- a/opengever/setup/deploy.py
+++ b/opengever/setup/deploy.py
@@ -37,6 +37,8 @@ BASE_PROFILES = (
     'opengever.policy.base:mimetype',
 )
 
+POLICYLESS_SITE_ID = 'ogsite'
+
 
 class GeverDeployment(object):
 
@@ -82,7 +84,7 @@ class GeverDeployment(object):
         if self.is_policyless:
             # For policyless deployments, admin unit will be set up later,
             # and the Plone site ID won't be tied to it.
-            plone_site_id = 'gever'
+            plone_site_id = POLICYLESS_SITE_ID
         else:
             plone_site_id = config.get('admin_unit_id').encode('utf-8')
 

--- a/opengever/setup/meta.py
+++ b/opengever/setup/meta.py
@@ -44,7 +44,7 @@ class IDeploymentDirective(Interface):
         title=u'Additional profiles',
         description=u'Generic setup profile names (without profile- prefix)',
         default=None,
-        required=True,
+        required=False,
         value_type=TextLine()
     )
 

--- a/opengever/setup/policyless/configure.zcml
+++ b/opengever/setup/policyless/configure.zcml
@@ -1,0 +1,39 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:five="http://namespaces.zope.org/five"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    xmlns:opengever="http://namespaces.zope.org/opengever"
+    xmlns:profilehook="http://namespaces.zope.org/profilehook"
+    xmlns:transmogrifier="http://namespaces.plone.org/transmogrifier"
+    i18n_domain="opengever.setup">
+
+  <include package="ftw.profilehook" />
+
+  <opengever:registerDeployment
+      title="Policyless Deployment"
+      policy_profile="opengever.setup.policyless:default"
+      is_policyless="True"
+      />
+
+  <opengever:registerLDAP
+      title="Policyless LDAP"
+      ldap_profile="opengever.setup.policyless:policyless-ldap"
+      />
+
+  <genericsetup:registerProfile
+      name="default"
+      title="opengever.setup.policyless: default"
+      directory="profiles/default"
+      description="Policyless default profile"
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      />
+
+  <genericsetup:registerProfile
+      name="policyless-ldap"
+      title="opengever.setup.policyless: Policyless LDAP"
+      directory="profiles/policyless-ldap"
+      description="Policyless LDAP configuration"
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      />
+
+</configure>

--- a/opengever/setup/policyless/configure.zcml
+++ b/opengever/setup/policyless/configure.zcml
@@ -13,6 +13,7 @@
       title="Policyless Deployment"
       policy_profile="opengever.setup.policyless:default"
       is_policyless="True"
+      additional_profiles="opengever.setup:casauth_ianus_portal"
       />
 
   <opengever:registerLDAP

--- a/opengever/setup/policyless/profiles/default/metadata.xml
+++ b/opengever/setup/policyless/profiles/default/metadata.xml
@@ -1,0 +1,2 @@
+<metadata>
+</metadata>

--- a/opengever/setup/policyless/profiles/default/portal_languages.xml
+++ b/opengever/setup/policyless/profiles/default/portal_languages.xml
@@ -1,0 +1,7 @@
+<object>
+  <supported_langs>
+    <element value="fr-ch" />
+    <element value="de-ch" />
+    <element value="en-us" />
+  </supported_langs>
+</object>

--- a/opengever/setup/policyless/profiles/default/propertiestool.xml
+++ b/opengever/setup/policyless/profiles/default/propertiestool.xml
@@ -1,5 +1,5 @@
 <object name="portal_properties" meta_type="Plone Properties Tool">
   <object name="site_properties" meta_type="Plone Property Sheet">
-    <property name="default_language" type="string">de</property>
+    <property name="default_language" type="string">de-ch</property>
   </object>
 </object>

--- a/opengever/setup/policyless/profiles/default/propertiestool.xml
+++ b/opengever/setup/policyless/profiles/default/propertiestool.xml
@@ -1,0 +1,5 @@
+<object name="portal_properties" meta_type="Plone Properties Tool">
+  <object name="site_properties" meta_type="Plone Property Sheet">
+    <property name="default_language" type="string">de</property>
+  </object>
+</object>

--- a/opengever/setup/policyless/profiles/default/registry.xml
+++ b/opengever/setup/policyless/profiles/default/registry.xml
@@ -1,0 +1,50 @@
+<registry>
+  <!-- TODO: This has been copied from opengever/examplecontent -->
+  <!-- These defaults might not all be sensible for production -->
+  <records interface="opengever.meeting.interfaces.IMeetingSettings">
+    <value key="is_feature_enabled">True</value>
+  </records>
+
+  <records interface="opengever.base.interfaces.IReferenceNumberSettings">
+    <value key="reference_prefix_starting_point">0</value>
+  </records>
+
+  <records interface="opengever.dossier.interfaces.ITemplateFolderProperties">
+    <value key="create_doc_properties">True</value>
+  </records>
+
+  <records interface="opengever.bumblebee.interfaces.IGeverBumblebeeSettings">
+    <value key="is_feature_enabled">True</value>
+  </records>
+
+  <records interface="opengever.contact.interfaces.IContactSettings">
+    <value key="is_feature_enabled">True</value>
+  </records>
+
+  <records interface="opengever.officeatwork.interfaces.IOfficeatworkSettings">
+    <value key="is_feature_enabled">True</value>
+  </records>
+
+  <records interface="opengever.dossier.dossiertemplate.interfaces.IDossierTemplateSettings">
+    <value key="is_feature_enabled">True</value>
+  </records>
+
+  <records interface="opengever.ech0147.interfaces.IECH0147Settings">
+    <value key="ech0147_export_enabled">True</value>
+    <value key="ech0147_import_enabled">True</value>
+  </records>
+
+  <records interface="opengever.officeconnector.interfaces.IOfficeConnectorSettings">
+    <value key="attach_to_outlook_enabled">True</value>
+    <value key="direct_checkout_and_edit_enabled">True</value>
+  </records>
+
+  <records interface="opengever.ogds.base.interfaces.IOGDSSyncConfiguration">
+    <value key="group_title_ldap_attribute">description</value>
+  </records>
+
+  <records interface="opengever.base.interfaces.ISearchSettings">
+    <value key="use_solr">True</value>
+  </records>
+
+</registry>

--- a/opengever/setup/policyless/profiles/policyless-ldap/ldap_plugin.xml
+++ b/opengever/setup/policyless/profiles/policyless-ldap/ldap_plugin.xml
@@ -1,0 +1,200 @@
+<ldapplugins>
+  <!-- TODO: This has been copied from opengever/examplecontent -->
+  <!-- These defaults might not all be sensible for production -->
+
+  <ldapplugin
+      title="LDAP"
+      id="ldap"
+      meta_type="Plone LDAP plugin"
+      update="False">
+    <cache value="RAMCache" />
+    <interface value="IAuthenticationPlugin" />
+    <interface value="ICredentialsResetPlugin" />
+    <interface value="IGroupEnumerationPlugin" />
+    <interface value="IGroupIntrospection" />
+    <interface value="IGroupsPlugin" />
+    <interface value="IPropertiesPlugin" />
+    <interface value="IUserAdderPlugin" />
+    <interface value="IUserEnumerationPlugin" />
+    <interface value="IUserManagement" />
+    <plugin_property
+        id="prefix"
+        type="string"
+        mode="w"
+        value=""
+        />
+    <plugin_property
+        id="title"
+        type="string"
+        mode="wd"
+        value="LDAP"
+        />
+    <property id="_login_attr" type="str">
+      <item value="uid" />
+    </property>
+    <property id="_uid_attr" type="str">
+      <item value="uid" />
+    </property>
+    <property id="_rdnattr" type="str">
+      <item value="cn" />
+    </property>
+    <property id="users_base" type="str">
+      <item value="" />
+    </property>
+    <property id="users_scope" type="int">
+      <item value="2" />
+    </property>
+    <property id="_local_groups" type="bool">
+      <item value="False" />
+    </property>
+    <property id="_implicit_mapping" type="int">
+      <item value="0" />
+    </property>
+    <property id="groups_base" type="str">
+      <item value="" />
+    </property>
+    <property id="groups_scope" type="int">
+      <item value="2" />
+    </property>
+    <property id="_binduid" type="str">
+      <item value="REPLACEME" />
+    </property>
+    <property id="_bindpwd" type="str">
+      <item value="REPLACEME" />
+    </property>
+    <property id="_binduid_usage" type="int">
+      <item value="1" />
+    </property>
+    <property id="read_only" type="bool">
+      <item value="False" />
+    </property>
+    <property id="_user_objclasses" type="list">
+      <item value="inetOrgPerson" />
+      <item value="organizationalPerson" />
+      <item value="person" />
+    </property>
+    <property id="_extra_user_filter" type="str">
+      <item value="" />
+    </property>
+    <property id="_pwd_encryption" type="str">
+      <item value="SHA" />
+    </property>
+    <property id="_roles" type="list">
+      <item value="Authenticated" />
+    </property>
+    <schema>
+      <attr id="mail">
+        <item
+            id="public_name"
+            value="email"
+            />
+        <item
+            id="binary"
+            value="False"
+            />
+        <item
+            id="ldap_name"
+            value="mail"
+            />
+        <item
+            id="friendly_name"
+            value="Email address"
+            />
+        <item
+            id="multivalued"
+            value="False"
+            />
+      </attr>
+      <attr id="cn">
+        <item
+            id="public_name"
+            value="fullname"
+            />
+        <item
+            id="binary"
+            value="False"
+            />
+        <item
+            id="ldap_name"
+            value="cn"
+            />
+        <item
+            id="friendly_name"
+            value="Canonical Name"
+            />
+        <item
+            id="multivalued"
+            value="False"
+            />
+      </attr>
+      <attr id="sn">
+        <item
+            id="public_name"
+            value="lastname"
+            />
+        <item
+            id="binary"
+            value="False"
+            />
+        <item
+            id="ldap_name"
+            value="sn"
+            />
+        <item
+            id="friendly_name"
+            value="Last Name"
+            />
+        <item
+            id="multivalued"
+            value="False"
+            />
+      </attr>
+      <attr id="uid">
+        <item
+            id="public_name"
+            value="userid"
+            />
+        <item
+            id="binary"
+            value="False"
+            />
+        <item
+            id="ldap_name"
+            value="uid"
+            />
+        <item
+            id="friendly_name"
+            value="User id"
+            />
+        <item
+            id="multivalued"
+            value="False"
+            />
+      </attr>
+      <attr id="givenName">
+        <item
+            id="public_name"
+            value="firstname"
+            />
+        <item
+            id="binary"
+            value="False"
+            />
+        <item
+            id="ldap_name"
+            value="givenName"
+            />
+        <item
+            id="friendly_name"
+            value="First name"
+            />
+        <item
+            id="multivalued"
+            value="False"
+            />
+      </attr>
+    </schema>
+
+  </ldapplugin>
+
+</ldapplugins>

--- a/opengever/setup/registry.py
+++ b/opengever/setup/registry.py
@@ -18,7 +18,7 @@ class BaseConfigurationRegistry(object):
 
     def _list_entries(self):
         results = []
-        for key, values in self.configs.items():
+        for key, values in sorted(self.configs.items()):
             if values['is_default']:
                 results.insert(0, key)
             else:

--- a/opengever/setup/tests/test_creation.py
+++ b/opengever/setup/tests/test_creation.py
@@ -1,8 +1,13 @@
 from ftw.builder import Builder
 from ftw.builder import create
+from opengever.base.model import create_session
 from opengever.ogds.models.service import ogds_service
+from opengever.setup.creation.adminunit import AdminUnitCreator
+from opengever.setup.creation.orgunit import OrgUnitCreator
 from opengever.testing import FunctionalTestCase
 from plone.app.testing import applyProfile
+from StringIO import StringIO
+import json
 
 
 class TestUnitCreation(FunctionalTestCase):
@@ -13,6 +18,25 @@ class TestUnitCreation(FunctionalTestCase):
         super(TestUnitCreation, self).setUp()
         create(Builder('ogds_group').id('users'))
         applyProfile(self.portal, 'opengever.setup.tests:units')
+        self.session = create_session()
+
+        self.au_data = StringIO(json.dumps([{
+            'unit_id': 'admin',
+            'title': 'AdminUnit',
+            'ip_address': '127.0.0.1',
+            'site_url': 'http://admin.local',
+            'public_url': 'http://admin.local',
+            'abbreviation': 'A',
+        }]))
+
+        self.ou_data = StringIO(json.dumps([{
+            'unit_id': 'org',
+            'title': 'OrgUnit',
+            'admin_unit_id': 'admin',
+            'users_group_id': 'users',
+            'inbox_group_id': 'users',
+
+        }]))
 
     def test_admin_unit_created(self):
         self.assertEqual(1, len(ogds_service().all_admin_units()))
@@ -26,3 +50,12 @@ class TestUnitCreation(FunctionalTestCase):
         self.assertIsNotNone(org_unit.admin_unit)
         self.assertIsNotNone(org_unit.users_group)
         self.assertIsNotNone(org_unit.inbox_group)
+
+    def test_allows_skipping_of_already_existing_units(self):
+        au_creator = AdminUnitCreator(skip_if_exists=True)
+        au_creator.run(self.au_data)
+        self.session.flush()
+
+        ou_creator = OrgUnitCreator(skip_if_exists=True)
+        ou_creator.run(self.ou_data)
+        self.session.flush()

--- a/opengever/tabbedview/browser/personal_overview.py
+++ b/opengever/tabbedview/browser/personal_overview.py
@@ -153,6 +153,14 @@ class PersonalOverview(TabbedView):
         """
         try:
             current_user = ogds_service().fetch_current_user()
+
+            admin_unit = get_current_admin_unit()
+            if not admin_unit:
+                # No AdminUnit configured yet - this might be the case
+                # immediately after Plone site setup with in "policyless"
+                # style, and should be a temporary situation
+                return True
+
             if get_current_admin_unit().is_user_assigned(current_user):
                 return True
             elif self._is_user_admin():

--- a/opengever/tabbedview/tests/test_personaloverview.py
+++ b/opengever/tabbedview/tests/test_personaloverview.py
@@ -2,7 +2,10 @@ from datetime import date
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from opengever.ogds.base.interfaces import IAdminUnitConfiguration
 from opengever.testing import IntegrationTestCase
+from plone.registry.interfaces import IRegistry
+from zope.component import getUtility
 
 
 class TestPersonalOverview(IntegrationTestCase):
@@ -35,10 +38,25 @@ class TestPersonalOverview(IntegrationTestCase):
 
         browser.open(view='personal_overview')
 
-        self.assertEquals(
+        self.assertEqual(
             u'Personal Overview: B\xe4rfuss K\xe4thi',
             browser.css('h1.documentFirstHeading').first.text,
             )
+
+    @browsing
+    def test_personal_overview_doesnt_fail_when_missing_admin_unit(self, browser):
+        registry = getUtility(IRegistry)
+        config = registry.forInterface(IAdminUnitConfiguration)
+        config.current_unit_id = None
+
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(view='personal_overview')
+
+        self.assertEquals(
+            u'Personal Overview: B\xe4rfuss K\xe4thi',
+            browser.css('h1.documentFirstHeading').first.text,
+        )
 
     @browsing
     def test_additional_tabs_are_shown_for_admins(self, browser):

--- a/opengever/tabbedview/tests/test_personaloverview.py
+++ b/opengever/tabbedview/tests/test_personaloverview.py
@@ -53,7 +53,7 @@ class TestPersonalOverview(IntegrationTestCase):
 
         browser.open(view='personal_overview')
 
-        self.assertEquals(
+        self.assertEqual(
             u'Personal Overview: B\xe4rfuss K\xe4thi',
             browser.css('h1.documentFirstHeading').first.text,
         )
@@ -259,7 +259,7 @@ class TestGlobalTaskListings(IntegrationTestCase):
             for row in browser.css('.listing').first.dicts()
             ]
 
-        self.assertEquals(expected_tasks, found_tasks)
+        self.assertEqual(expected_tasks, found_tasks)
 
     @browsing
     def test_my_tasks_list_task_issued_by_the_current_user(self, browser):
@@ -276,7 +276,7 @@ class TestGlobalTaskListings(IntegrationTestCase):
             u're: Diskr\xe4te Dinge',
             ]
         found_tasks = [row.get('Title') for row in browser.css('.listing').first.dicts()]
-        self.assertEquals(expected_tasks, found_tasks)
+        self.assertEqual(expected_tasks, found_tasks)
         self.task.get_sql_object().issuer = 'kathi.barfuss'
         browser.open(view='tabbedview_view-myissuedtasks')
         expected_tasks = [
@@ -289,7 +289,7 @@ class TestGlobalTaskListings(IntegrationTestCase):
             u're: Diskr\xe4te Dinge',
             ]
         found_tasks = [row.get('Title') for row in browser.css('.listing').first.dicts()]
-        self.assertEquals(expected_tasks, found_tasks)
+        self.assertEqual(expected_tasks, found_tasks)
 
     @browsing
     def test_all_task_list_all_task_assigned_to_current_org_unit(self, browser):


### PR DESCRIPTION
This adds support for policyless deployments:

- Plone site creation with a fixed, bare-bones **"Policyless Deployment" profile**
- Support for **configuration import via bundle**:
  - AdminUnits, OrgUnits
  - Registry Settings
  - LDAP configuration
- **TTW bundle import**

#### Notes / Caveats

- The Policyless Deployment LDAP profile currently only contains an ldap_plugin.xml that sets up a 'Plone LDAP plugin'.
  An 'Plone ActiveDirectory plugin' profile would have to be created in addition to also support AD.

- The MultiFileUploadWidget used in the @@import-bundle form currently has a bug:
  It actually *requires* multiple files to be selected, just selecting a single file doesn't work

- bin/instance import <bundle> will now also import a configuration.json, if present.
  This may possibly have an effect on data migrations.

- The @@import-bundle form currently always imports everything from every file selected.
  In the future it might be desirable to uncheck certain steps (like content, or individual config subsections)

- The "Install OneGov GEVER" screen isn't optimized for policyless setup:
  The "Sync OGDS" checkbox will be ignored, and selecting an LDAP profile other than the policyless one(s) would result in an undefined outcome.

- Config import via bundle is currently optimized for the "one-time initial setup" use case.
  Re-applying a config import should work, but wasn't my primary focus, and therefore hasn't been tested extensively.

- There currently is no support yet for:
  - Creating initial content like inboxes, contact folders, etc..
  - Setting optional functional groups like reader group, records manager group, ...

Jira: https://4teamwork.atlassian.net/browse/ROAD-1655

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
