### PR TITLE
Remove daterange restriction in spv meeting end date.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2021.7.1 (unreleased)
 ---------------------
 
+- Remove daterange restriction in spv meeting end date. [elioschmutz]
 - Add attendees solr index for workspace meetings. [tinagerber]
 - Fix broken task template responsibles [elioschmutz]
 - Provide dossier_reference_number mergefield value also for ad-hoc proposals. [phgross]

--- a/opengever/meeting/browser/resources/datetimepicker.js
+++ b/opengever/meeting/browser/resources/datetimepicker.js
@@ -12,8 +12,6 @@
       }
     }, options);
 
-    var self = this;
-
     this.start = options.target.start;
     this.end = options.target.end;
 
@@ -34,34 +32,6 @@
       this.startwidget.setCurrentTime(roundedStartDateTime);
       this.start.val(this.startwidget.str());
     }
-
-    self.getMinTime = function () {
-      var start = self.startwidget.getCurrentTime();
-      var end = self.endwidget.getCurrentTime();
-      if (end.getYear() <= start.getYear() &&
-          end.getMonth() <= start.getMonth() &&
-          end.getDay() <= start.getDay()) {
-        return self.startwidget.getCurrentTime();
-      } else {
-        return false;
-      }
-    };
-
-    // make sure no date is selected before the start of the range by looking
-    // up the earliest valid time in the startwidget
-    self.end.datetimepicker({
-      onShow: function (current_time, input) {
-                this.setOptions({
-                  minDate: self.startwidget.getCurrentTime(),
-                  minTime: self.getMinTime()
-                });
-              },
-      onSelectDate: function(current_time, input) {
-                      this.setOptions({
-                        minTime: self.getMinTime()
-                      });
-                    }
-    });
 
     // avoid ftw.datetimepicker destroying our end datetime picker
     $(document).off('change', '.datetimepicker-widget');


### PR DESCRIPTION
This PR removes the daterange restriction in the spv meeting end date.

Jira:https://4teamwork.atlassian.net/browse/CA-1459

Because the JS code in the old ui is hard to maintain and legacy anyway, we just remove this restriction.

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
