### PR TITLE
API: Reject years before 1900 for date and datetime fields.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2021.9.0 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- API: Reject years before 1900 for date and datetime fields. [lgraf]
 
 
 2021.8.0 (2021-04-15)

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -6,7 +6,11 @@ API Changelog
 2021.8.0 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+Breaking Changes
+^^^^^^^^^^^^^^^^
+
+- Deserialization: Years before 1900 will now get rejected for date and datetime fields.
+
 
 2021.7.0 (2021-04-01)
 ---------------------

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -53,6 +53,8 @@
   <adapter factory=".serializer.long_converter" />
   <adapter factory=".field_deserializers.PersistentDefaultFieldDeserializer" />
   <adapter factory=".field_deserializers.PersistentDatetimeFieldDeserializer" />
+  <adapter factory=".field_deserializers.DateFieldDeserializer" />
+  <adapter factory=".field_deserializers.DatetimeFieldDeserializer" />
   <adapter
       factory=".local_roles.GeverSerializeLocalRolesToJson"
       name="local_roles"

--- a/opengever/api/field_deserializers.py
+++ b/opengever/api/field_deserializers.py
@@ -1,11 +1,16 @@
 # -*- coding: utf-8 -*-
+from datetime import date
+from datetime import datetime
+from opengever.base.interfaces import IOpengeverBaseLayer
+from persistent.interfaces import IPersistent
+from plone.dexterity.interfaces import IDexterityContent
 from plone.restapi.deserializer.dxfields import DatetimeFieldDeserializer
 from plone.restapi.deserializer.dxfields import DefaultFieldDeserializer
 from plone.restapi.interfaces import IFieldDeserializer
-from persistent.interfaces import IPersistent
 from zope.component import adapter
 from zope.interface import implementer
 from zope.publisher.interfaces.browser import IBrowserRequest
+from zope.schema.interfaces import IDate
 from zope.schema.interfaces import IDatetime
 from zope.schema.interfaces import IField
 
@@ -20,3 +25,30 @@ class PersistentDefaultFieldDeserializer(DefaultFieldDeserializer):
 @adapter(IDatetime, IPersistent, IBrowserRequest)
 class PersistentDatetimeFieldDeserializer(DatetimeFieldDeserializer):
     """Datetime field deserializer for persisten objects"""
+
+
+@implementer(IFieldDeserializer)
+@adapter(IDate, IDexterityContent, IOpengeverBaseLayer)
+class DateFieldDeserializer(DefaultFieldDeserializer):
+    def __call__(self, value):
+        value = super(DateFieldDeserializer, self).__call__(value)
+        reject_year_before_1900(value)
+        return value
+
+
+@implementer(IFieldDeserializer)
+@adapter(IDatetime, IDexterityContent, IOpengeverBaseLayer)
+class DatetimeFieldDeserializer(DatetimeFieldDeserializer):
+    def __call__(self, value):
+        value = super(DatetimeFieldDeserializer, self).__call__(value)
+        reject_year_before_1900(value)
+        return value
+
+
+def reject_year_before_1900(value):
+    """Because strftime() methods don't support years before 1900, we can't
+    represent them. We therefore reject them here.
+    """
+    if isinstance(value, (date, datetime)) and value.year < 1900:
+        raise ValueError(
+            'year=%s is invalid. Year must be >= 1900.' % value.year)


### PR DESCRIPTION
Because the Python `strftime` methods can't represent dates earlier than 1900, we reject them in the API by using custom field serializers.

I didn't override the `PersistentDatetimeFieldDeserializer` that we also have (in the same file), because that only gets used for system-generated timestamps, like entries in task or proposal histories. These should never get set to anything earlier than 1900 ;-) 

Jira: https://4teamwork.atlassian.net/browse/CA-1882

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- API change:
  - [ ] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [x] api-change label added
    - [x] #delivery channel notified about breaking change
    - [x] Scrum master is informed