### PR TITLE
Add new @versions endpoint

### DIFF
--- a/changes/1912.feature
+++ b/changes/1912.feature
@@ -1,0 +1,1 @@
+Add new @versions endpoint for documents. [njohner]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -15,7 +15,7 @@ Other Changes
 ^^^^^^^^^^^^^
 
 - Task serialization now also returns is_remote_task and responsible_admin_unit_url.
-
+- New ``@version`` that returns the historical versions of a document.
 
 2021.7.0 (2021-04-01)
 ---------------------

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -25,6 +25,7 @@ Inhalt:
    documents_from_template.rst
    extract_attachments.rst
    trash.rst
+   versions.rst
    workflow.rst
    vocabularies.rst
    scanin.rst

--- a/docs/public/dev-manual/api/schemas/opengever.dossier.businesscasedossier.inc
+++ b/docs/public/dev-manual/api/schemas/opengever.dossier.businesscasedossier.inc
@@ -174,6 +174,16 @@
        
 
 
+   .. py:attribute:: dossier_type
+
+       :Feldname: :field-title:`Dossiertyp`
+       :Datentyp: ``Choice``
+       
+       
+       
+       :Wertebereich: ["businesscase"]
+
+
    .. py:attribute:: classification
 
        :Feldname: :field-title:`Klassifikation`
@@ -281,4 +291,14 @@
        
        
        
+       
+
+
+   .. py:attribute:: custom_properties
+
+       :Feldname: :field-title:`Benutzerdefinierte Felder`
+       :Datentyp: ``PropertySheetField``
+       
+       
+       :Beschreibung: Enthält die Daten für die benutzerdefinierten Felder.
        

--- a/docs/public/dev-manual/api/schemas/opengever.workspace.meeting.inc
+++ b/docs/public/dev-manual/api/schemas/opengever.workspace.meeting.inc
@@ -54,6 +54,16 @@
        
 
 
+   .. py:attribute:: attendees
+
+       :Feldname: :field-title:`Teilnehmer`
+       :Datentyp: ``List``
+       
+       :Default: []
+       
+       
+
+
    .. py:attribute:: title
 
        :Feldname: :field-title:`Titel`

--- a/docs/public/dev-manual/api/versions.rst
+++ b/docs/public/dev-manual/api/versions.rst
@@ -1,0 +1,75 @@
+Versionen
+=========
+
+Der ``@versions`` Endpoint liefert ähnliche Information wie der ``@history`` Endpoint (siehe `plone.restapi Dokumentation <https://plonerestapi.readthedocs.io/en/latest/history.html>`_.) aber eingeschränkt nur auf Versionen, ohne historische Statusveränderunginformationen. Dieser Endpoint is performanter als der ``@history`` Endpoint.
+
+Versionen Auflistung:
+---------------------
+Mittels eines GET Request können die Versionen eines Dokuments aufgelistet werden. Dieser Endpoint ist paginiert.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       GET /ordnungssystem/dossier-23/document-123/@versions HTTP/1.1
+       Accept: application/json
+
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+        "@id": "http://example.org/ordnungssystem/dossier-23/document-123/@versions",
+        "items": [
+            {
+                "@id": "http://example.org/ordnungssystem/dossier-23/document-123/@versions/2",
+                "actor": {
+                    "@id": "http://example.org/ordnungssystem/@actors/niklaus.johner",
+                    "identifier": "niklaus.johner",
+                },
+                "comments": "",
+                "may_revert": true,
+                "time": "2021-04-14T11:31:10.205146",
+                "version": 2
+            },
+            {
+                "@id": "http://example.org/ordnungssystem/dossier-23/document-123/@versions/1",
+                "...": "..."
+            }
+        ],
+        "items_total": 3
+      }
+
+
+Spezifische Version:
+--------------------
+
+Die Daten einer spezifischen Version können mit der Versionsnummer als zusätzliches Pfad-Argument abgefragt werden:
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       GET /ordnungssystem/dossier-23/document-123/@versions/1 HTTP/1.1
+       Accept: application/json
+
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+        "@id": "/ordnungssystem/dossier-23/document-123",
+        "@type": "opengever.document.document",
+        "UID": "cf8bcd04db1443e7a83bee77ff169476",
+        "current_version_id": 2,
+        "version": "1",
+        "...": "..."
+      }

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -171,6 +171,14 @@
       />
 
   <plone:service
+      method="GET"
+      name="@versions"
+      for="opengever.document.document.IDocumentSchema"
+      factory=".history.VersionsGet"
+      permission="CMFEditions.AccessPreviousVersions"
+      />
+
+  <plone:service
       method="POST"
       name="@scan-in"
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"

--- a/opengever/document/browser/versions_tab.py
+++ b/opengever/document/browser/versions_tab.py
@@ -98,23 +98,30 @@ class VersionDataProxy(object):
         return self._version_data['version_id']
 
     @property
+    def actor_id(self):
+        if self.version == 0:
+            # Always return document's original creator for initial version
+            return self._context.Creator()
+        return self.sys_metadata['principal']
+
+    @property
     def actor(self):
         """Returns a formatted link to the actor that created this version.
         """
-        if self.version == 0:
-            # Always return document's original creator for initial version
-            return Actor.user(self._context.Creator()).get_link()
-
-        principal = self.sys_metadata['principal']
-        actor = Actor.user(principal)
+        actor = Actor.user(self.actor_id)
         return actor.get_link()
+
+    @property
+    def raw_timestamp(self):
+        """Creation timestamp of this version.
+        """
+        return self.sys_metadata['timestamp']
 
     @property
     def timestamp(self):
         """Creation timestamp of this version, formatted as localized time.
         """
-        ts = self.sys_metadata['timestamp']
-        dt = datetime.fromtimestamp(ts)
+        dt = datetime.fromtimestamp(self.raw_timestamp)
         return api.portal.get_localized_time(datetime=dt, long_format=True)
 
     @property
@@ -281,11 +288,21 @@ class InitialVersionDataProxy(object):
         return 0
 
     @property
+    def actor_id(self):
+        return self.obj.Creator()
+
+    @property
     def actor(self):
         """Returns the creator of the document, which we'll be also the
         creator of the initial version.
         """
-        return Actor.user(self.obj.Creator()).get_link()
+        return Actor.user(self.actor_id).get_link()
+
+    @property
+    def raw_timestamp(self):
+        """Returns the creation date of the document as timestamp
+        """
+        return self.obj.created().timeTime()
 
     @property
     def timestamp(self):


### PR DESCRIPTION
We add a new `@versions` endpoint to retrieve the list of versions of a document. This endpoint is basically a copy of the `@history` endpoint with a few modifications:
- It only returns versioning entries (whereas the `@history` endpoint also returns workflow modification entries).
- It is batched
- It always returns the initial version, even when it has not been created now. Because we delay the creation of the initial version in Gever to avoid wasting storage space, we make sure to return the correct information for the initial version in the @versions endpoint even when it wasn't created yet.
- Use the creator as the actor of the initial version in `@versions.` This is necessary because certain initial versions in Gever have the wrong actor. This was already [corrected in the `@history` endpoint](https://github.com/4teamwork/opengever.core/pull/6935)
- It is lazy (uses the shadow history, and does not materialise the whole history as does the `@history` endpoint)
- It only returns relevant data

Note that the `@versions` endpoint is only defined for documents, not for mails. As a side note the `@history` endpoint is broken for mails. But neither endpoint is necessary for mails, so IMO we do not need the `versions` endpoint for mails and we do not need to fix the `@history` endpoint

For https://4teamwork.atlassian.net/browse/CA-1912

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail` -> not defined for mails