### PR TITLE
Open Office Online in new tab

### DIFF
--- a/changes/6975.other
+++ b/changes/6975.other
@@ -1,0 +1,1 @@
+Open Office Online in new tab. [buchi]

--- a/opengever/document/browser/templates/macros.pt
+++ b/opengever/document/browser/templates/macros.pt
@@ -86,7 +86,7 @@
         </tal:checkout_and_edit_discreet>
 
         <tal:edit_in_office_online tal:condition="view/is_office_online_edit_action_available">
-            <a class="function-edit" id="office-online-edit"
+            <a class="function-edit" id="office-online-edit" target="_blank"
                 tal:attributes="href view/get_office_online_edit_url"
                 i18n:translate="label_edit_in_office_online">
                 Edit in Office Online


### PR DESCRIPTION
Microsoft has removed the close action from Word and has announced to do the same for Excel and PowerPoint in the future. The user now needs to close the tab to finish editing. Thus we open Office Online in a new tab.

JIRA: https://4teamwork.atlassian.net/browse/CA-1940

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
