### PR TITLE
Fix in-progress to close transition (API), for multi adminunit tasks.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2021.9.0 (unreleased)
 ---------------------
 
+- Fix in-progress to close transition (API), for multi adminunit tasks. [phgross]
 - Add policyless deployment. [lgraf]
 - Add TTW bundle import. [lgraf]
 - Add support for configuration import via bundle. [lgraf]

--- a/opengever/task/response_syncer/workflow.py
+++ b/opengever/task/response_syncer/workflow.py
@@ -34,6 +34,7 @@ class WorkflowResponseSyncerSender(BaseResponseSyncerSender):
     def _is_synced_transition(self, transition):
         return transition in [
             'task-transition-in-progress-resolved',
+            'task-transition-in-progress-tested-and-closed',
             'task-transition-resolved-in-progress',
             'task-transition-resolved-tested-and-closed',
             'task-transition-reassign',

--- a/opengever/task/tests/test_response_syncer.py
+++ b/opengever/task/tests/test_response_syncer.py
@@ -238,6 +238,20 @@ class TestWorkflowResponseSyncerSender(FunctionalTestCase):
             [task.get_sql_object()],
             sender.get_related_tasks_to_sync(transition='task-transition-reassign'))
 
+    def test_in_progress_to_close_is_synced(self):
+        task = create(Builder('task')
+                      .having(task_type='direct-execution')
+                      .in_state('task-state-in-progress'))
+        successor = create(Builder('task')
+                           .having(task_type='direct-execution')
+                           .in_state('task-state-in-progress')
+                           .successor_from(task))
+
+        sender = WorkflowResponseSyncerSender(successor, self.request)
+        self.assertEqual(
+            [task.get_sql_object()],
+            sender.get_related_tasks_to_sync(transition='task-transition-in-progress-tested-and-closed'))
+
 
 class TestModifyDeadlineResponseSyncerSender(FunctionalTestCase):
 


### PR DESCRIPTION
Add `task-transition-in-progress-tested-and-closed` transition to synced transitions, to make sure closing a multi admin unit direct-execution tasks, is synced correctly to the predecessor.

https://4teamwork.atlassian.net/browse/CA-2047


## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
