### PR TITLE
Add is_remote_task to task serialization.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Fix in-progress to close transition (API), for multi adminunit tasks. [phgross]
+- Add is_remote_task to task serialization. [njohner]
 - Add policyless deployment. [lgraf]
 - Add TTW bundle import. [lgraf]
 - Add support for configuration import via bundle. [lgraf]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,6 +11,11 @@ Breaking Changes
 
 - Deserialization: Years before 1900 will now get rejected for date and datetime fields.
 
+Other Changes
+^^^^^^^^^^^^^
+
+- Task serialization now also returns is_remote_task.
+
 
 2021.7.0 (2021-04-01)
 ---------------------

--- a/opengever/api/task.py
+++ b/opengever/api/task.py
@@ -40,6 +40,7 @@ class SerializeTaskToJson(GeverSerializeFolderToJson):
         result = super(SerializeTaskToJson, self).__call__(*args, **kwargs)
         result[u'containing_dossier'] = self._get_containing_dossier_summary()
         result[u'sequence_type'] = self._get_sequence_type()
+        result[u'is_remote_task'] = self.context.get_sql_object().is_remote_task
         return result
 
     def _get_containing_dossier_summary(self):

--- a/opengever/api/tests/test_task.py
+++ b/opengever/api/tests/test_task.py
@@ -241,6 +241,13 @@ class TestTaskSerialization(SolrIntegrationTestCase):
         self.assertEqual({u'title': u'Paralleler Ablauf', u'token': u'parallel'},
                          browser.json['sequence_type'])
 
+    @browsing
+    def test_contains_is_remote_task(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.task, method="GET", headers=self.api_headers)
+        self.assertIn('is_remote_task', browser.json)
+        self.assertFalse(browser.json['is_remote_task'])
+
 
 class TestTaskCommentSync(FunctionalTestCase):
 


### PR DESCRIPTION
The frontend needs to know whether a task is a cross client task so that it can present the correct options for the workflow transitions.

For https://4teamwork.atlassian.net/browse/CA-2064

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/


## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- API change:
  - [ ] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed