### PR TITLE
Add responsible_admin_unit_url to task serialization.

### DIFF
--- a/changes/6977.other
+++ b/changes/6977.other
@@ -1,1 +1,1 @@
-Add is_remote_task to task serialization. [njohner]
+Add is_remote_task and responsible_admin_unit_url to task serialization. [njohner]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -14,7 +14,7 @@ Breaking Changes
 Other Changes
 ^^^^^^^^^^^^^
 
-- Task serialization now also returns is_remote_task.
+- Task serialization now also returns is_remote_task and responsible_admin_unit_url.
 
 
 2021.7.0 (2021-04-01)

--- a/opengever/api/task.py
+++ b/opengever/api/task.py
@@ -40,7 +40,10 @@ class SerializeTaskToJson(GeverSerializeFolderToJson):
         result = super(SerializeTaskToJson, self).__call__(*args, **kwargs)
         result[u'containing_dossier'] = self._get_containing_dossier_summary()
         result[u'sequence_type'] = self._get_sequence_type()
-        result[u'is_remote_task'] = self.context.get_sql_object().is_remote_task
+
+        model = self.context.get_sql_object()
+        result[u'is_remote_task'] = model.is_remote_task
+        result[u'responsible_admin_unit_url'] = model.get_assigned_org_unit().admin_unit.public_url
         return result
 
     def _get_containing_dossier_summary(self):

--- a/opengever/api/tests/test_task.py
+++ b/opengever/api/tests/test_task.py
@@ -248,6 +248,13 @@ class TestTaskSerialization(SolrIntegrationTestCase):
         self.assertIn('is_remote_task', browser.json)
         self.assertFalse(browser.json['is_remote_task'])
 
+    @browsing
+    def test_contains_responsible_admin_unit_public_url(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.task, method="GET", headers=self.api_headers)
+        self.assertIn('responsible_admin_unit_url', browser.json)
+        self.assertEqual('http://nohost/plone', browser.json['responsible_admin_unit_url'])
+
 
 class TestTaskCommentSync(FunctionalTestCase):
 


### PR DESCRIPTION
The frontend also needs to find out the URL of the admin unit of the responsible for a given task. We thought of fetching this from the portal, but we cannot rely on the URLs being configured correctly on the portal. Instead we now also add that URL to the task serialization.

For https://4teamwork.atlassian.net/browse/CA-2064

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/


## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- API change:
  - [ ] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed