### PR TITLE
No longer export meeting.json in meeting zip export of original files.

### DIFF
--- a/changes/CA-1732.other
+++ b/changes/CA-1732.other
@@ -1,0 +1,1 @@
+No longer include `meetings.json` metadata file in ZIP download of original files. [deiferni]

--- a/opengever/meeting/tests/test_meeting_json_serializer.py
+++ b/opengever/meeting/tests/test_meeting_json_serializer.py
@@ -1,0 +1,64 @@
+from ftw.testing import freeze
+from opengever.meeting.zipexport import MeetingDocumentZipper
+from opengever.meeting.zipexport import MeetingJSONSerializer
+from opengever.testing import IntegrationTestCase
+from opengever.testing import set_preferred_language
+from opengever.testing.helpers import localized_datetime
+
+
+class TestMeetingJSONSerializer(IntegrationTestCase):
+    features = ('meeting',)
+    maxDiff = None
+
+    def test_meeting_data_for_zip_export_json(self):
+        set_preferred_language(self.portal.REQUEST, 'de-ch')
+        self.login(self.committee_responsible)
+        self.schedule_paragraph(self.meeting, u'A Gesch\xfcfte')
+        with freeze(localized_datetime(2017, 12, 13)):
+            self.schedule_ad_hoc(self.meeting, u'Ad-hoc Traktand\xfem')
+        self.schedule_proposal(self.meeting, self.submitted_proposal)
+
+        serializer = MeetingJSONSerializer(
+            self.meeting.model,
+            MeetingDocumentZipper(self.meeting.model, None))
+        serializer.traverse()
+        expected_agenda_items = {
+            'agenda_items': [
+                {'opengever_id': 2, 'sort_order': 1, 'title': u'A Gesch\xfcfte'},
+                {
+                    'number': '1.', 'number_raw': 1, 'opengever_id': 3, 'proposal': {
+                        'checksum': 'e00d6c8fb32c30d3ca3a3f8e5d873565482567561023016d9ca18243ff1cfa14',
+                        'file': 'Traktandum 1/Ad-hoc Traktandthm.docx',
+                        'modified': u'2017-12-13T00:00:00+01:00',
+                    },
+                    'sort_order': 2,
+                    'title': u'Ad-hoc Traktand\xfem'
+                },
+                {
+                    'attachments': [{
+                        'checksum': '51d6317494eccc4a73154625a6820cb6b50dc1455eb4cf26399299d4f9ce77b2',
+                        'file': 'Traktandum 2/Beilage/1_Vertraegsentwurf.docx',
+                        'modified': u'2016-08-31T16:09:33+02:00',
+                        'title': u'Vertr\xe4gsentwurf',
+                    }],
+                    'number': '2.',
+                    'number_raw': 2,
+                    'opengever_id': 4,
+                    'proposal': {
+                        'checksum': '114e7a059dc34c7459dab90904685584e331089d80bb6310183a0de009b66c3b',
+                        'file': 'Traktandum 2/Vertraege.docx',
+                        'modified': u'2016-08-31T16:09:33+02:00',
+                    },
+                    'sort_order': 3,
+                    'title': u'Vertr\xe4ge',
+                },
+            ],
+            'committee': {'oguid': u'plone:1010073300', 'title': u'Rechnungspr\xfcfungskommission'},
+            'end': u'2016-09-12T17:00:00+00:00',
+            'location': u'B\xfcren an der Aare',
+            'opengever_id': 1,
+            'start': u'2016-09-12T15:30:00+00:00',
+            'title': u'9. Sitzung der Rechnungspr\xfcfungskommission',
+        }
+
+        self.assertEquals(expected_agenda_items, serializer.data)

--- a/opengever/meeting/tests/test_meeting_zipdemand.py
+++ b/opengever/meeting/tests/test_meeting_zipdemand.py
@@ -1,9 +1,15 @@
 from ftw.testbrowser import browsing
+from ftw.testing import freeze
+from ftw.zipexport.zipfilestream import ZipFile
 from opengever.meeting.zipexport import MeetingZipExporter
 from opengever.meeting.zipexport import ZipJobManager
 from opengever.testing import IntegrationTestCase
+from opengever.testing import set_preferred_language
+from opengever.testing.helpers import localized_datetime
 from plone.namedfile.file import NamedBlobFile
 from plone.uuid.interfaces import IUUID
+from StringIO import StringIO
+import json
 
 
 class TestPollMeetingZip(IntegrationTestCase):
@@ -78,3 +84,131 @@ class TestDownloadMeetingZip(IntegrationTestCase):
             self.meeting,
             view='download_meeting_zip?job_id={}'.format(exporter.zip_job.job_id))
         self.assertEquals('application/zip', browser.contenttype)
+
+        zip_file = ZipFile(StringIO(browser.contents), 'r')
+        self.assertEquals(
+            ['meeting.json'],
+            zip_file.namelist())
+
+    @browsing
+    def test_exported_meeting_json_has_correct_file_names(self, browser):
+        set_preferred_language(self.portal.REQUEST, 'de-ch')
+        browser.append_request_header('Accept-Language', 'de-ch')
+        self.login(self.committee_responsible, browser)
+
+        docs = []
+
+        self.meeting.model.title = u'9. Sitzung der Rechnungspr\xfcfungs' \
+                                   u'kommission, ordentlich'
+        self.schedule_paragraph(self.meeting, u'A Gesch\xfcfte')
+        with freeze(localized_datetime(2017, 12, 13)):
+            ad_hoc_agenda_item = self.schedule_ad_hoc(
+                self.meeting, u'Ad-hoc Traktand\xfem'
+            )
+            ad_hoc_agenda_item.decide()
+            docs.append(ad_hoc_agenda_item.resolve_document())
+
+        agenda_item = self.schedule_proposal(self.meeting, self.submitted_proposal)
+        self.decide_agendaitem_generate_and_return_excerpt(agenda_item)
+
+        proposal = agenda_item.proposal.resolve_submitted_proposal()
+        docs.append(proposal.get_proposal_document())
+        docs.append(proposal.get_excerpt())
+        docs.extend(proposal.get_documents())
+
+        with freeze(localized_datetime(2017, 12, 14)):
+            docs.append(self.generate_agenda_item_list(self.meeting))
+            self.meeting.model.close()
+
+        docs.append(self.meeting.model.protocol_document.resolve_document())
+
+        # fake pdf conversion, make sure files for the ZIP are available
+        exporter = MeetingZipExporter(self.meeting.model)
+        exporter.zip_job = exporter.job_manager.create_job()
+        for doc in docs:
+            exporter.zip_job.add_doc_status(IUUID(doc), {'status': 'converting'})
+            doc_in_job_id = exporter.zip_job._get_doc_in_job_id(doc)
+            exporter.receive_pdf(doc_in_job_id, 'application/pdf', 'apdf.')
+        exporter.generate_zipfile()
+
+        browser.open(
+            self.meeting,
+            view='download_meeting_zip?job_id={}'.format(exporter.zip_job.job_id))
+        self.assertEquals('application/zip', browser.contenttype)
+
+        zip_file = ZipFile(StringIO(browser.contents), 'r')
+
+        meeting_json = json.loads(zip_file.read('meeting.json'))
+
+        # the protocol and agenda_item_list are generated during the tests and
+        # their checksums cannot be predicted
+        meeting_json['meetings'][0]['protocol']['checksum'] = 'unpredictable'
+        meeting_json['meetings'][0]['documents'][0]['checksum'] = 'unpredictable'
+        meeting_json['meetings'][0].pop('opengever_id')
+        for agenda_item in meeting_json['meetings'][0]['agenda_items']:
+            agenda_item.pop('opengever_id')
+
+        expected_meeting_json = {
+            u'meetings': [{
+                u'agenda_items': [
+                    {u'sort_order': 1, u'title': u'A Gesch\xfcfte'},
+                    {
+                        u'number': u'1.',
+                        u'number_raw': 1,
+                        u'proposal': {
+                            u'checksum': u'e00d6c8fb32c30d3ca3a3f8e5d873565482567561023016d9ca18243ff1cfa14',
+                            u'file': u'Traktandum 1/Ad-hoc Traktandthm.pdf',
+                            u'modified': u'2017-12-13T00:00:00+01:00',
+                        },
+                        u'sort_order': 2,
+                        u'title': u'Ad-hoc Traktand\xfem',
+                    },
+                    {
+                        u'attachments': [{
+                            u'checksum': u'51d6317494eccc4a73154625a6820cb6b50dc1455eb4cf26399299d4f9ce77b2',
+                            u'file': u'Traktandum 2/Beilage/1_Vertraegsentwurf.pdf',
+                            u'modified': u'2016-08-31T16:09:33+02:00',
+                            u'title': u'Vertr\xe4gsentwurf',
+                        }],
+                        u'number': u'2.',
+                        u'number_raw': 2,
+                        u'proposal': {
+                            u'checksum': u'114e7a059dc34c7459dab90904685584e331089d80bb6310183a0de009b66c3b',
+                            u'file': u'Traktandum 2/Vertraege.pdf',
+                            u'modified': u'2016-08-31T16:09:33+02:00',
+                        },
+                        u'sort_order': 3,
+                        u'title': u'Vertr\xe4ge',
+                    },
+                ],
+                u'committee': {u'oguid': u'plone:1010073300', u'title': u'Rechnungspr\xfcfungskommission'},
+                u'end': u'2016-09-12T17:00:00+00:00',
+                u'location': u'B\xfcren an der Aare',
+                u'protocol': {
+                    u'checksum': 'unpredictable',
+                    u'file': u'Protokoll-9. Sitzung der Rechnungspruefungskommission- ordentlich.pdf',
+                    u'modified': u'2017-12-14T00:00:00+01:00',
+                },
+                u'documents': [{
+                    u'checksum': 'unpredictable',
+                    u'file': u'Traktandenliste-9. Sitzung der Rechnungspruefungskommission- ordentlich.pdf',
+                    u'modified': u'2017-12-14T00:00:00+01:00',
+                    u'title': u'Traktandenliste-9. Sitzung der Rechnungspr\xfcfungskommission, ordentlich',
+                }],
+                u'start': u'2016-09-12T15:30:00+00:00',
+                u'title': u'9. Sitzung der Rechnungspr\xfcfungskommission, ordentlich',
+            }],
+            u'version': u'1.0.0',
+        }
+        self.assert_json_structure_equal(expected_meeting_json, meeting_json)
+
+        expected_file_names = [
+            'Protokoll-9. Sitzung der Rechnungspruefungskommission- ordentlich.pdf',
+            'Traktandenliste-9. Sitzung der Rechnungspruefungskommission- ordentlich.pdf',
+            'Traktandum 1/Ad-hoc Traktandthm.pdf',
+            'Traktandum 2/Beilage/1_Vertraegsentwurf.pdf',
+            'Traktandum 2/Vertraege.pdf',
+            'meeting.json',
+            ]
+        file_names = sorted(zip_file.namelist())
+        self.assertEqual(expected_file_names, file_names)

--- a/opengever/meeting/tests/test_meeting_zipexport.py
+++ b/opengever/meeting/tests/test_meeting_zipexport.py
@@ -5,8 +5,6 @@ from ftw.testbrowser.pages import statusmessages
 from ftw.testing import freeze
 from ftw.zipexport.zipfilestream import ZipFile
 from opengever.meeting.browser.meetings.agendaitem_list import GenerateAgendaItemList
-from opengever.meeting.zipexport import MeetingDocumentZipper
-from opengever.meeting.zipexport import MeetingJSONSerializer
 from opengever.testing import IntegrationTestCase
 from opengever.testing import set_preferred_language
 from opengever.testing.helpers import localized_datetime
@@ -177,59 +175,6 @@ class TestMeetingZipExportView(IntegrationTestCase):
         self.assertEquals(
             ['meeting.json'],
             zip_file.namelist())
-
-    def test_meeting_data_for_zip_export_json(self):
-        set_preferred_language(self.portal.REQUEST, 'de-ch')
-        self.login(self.committee_responsible)
-        self.schedule_paragraph(self.meeting, u'A Gesch\xfcfte')
-        with freeze(localized_datetime(2017, 12, 13)):
-            self.schedule_ad_hoc(self.meeting, u'Ad-hoc Traktand\xfem')
-        self.schedule_proposal(self.meeting, self.submitted_proposal)
-
-        serializer = MeetingJSONSerializer(
-            self.meeting.model,
-            MeetingDocumentZipper(self.meeting.model, None))
-        serializer.traverse()
-        expected_agenda_items = {
-            'agenda_items': [
-                {'opengever_id': 2, 'sort_order': 1, 'title': u'A Gesch\xfcfte'},
-                {
-                    'number': '1.', 'number_raw': 1, 'opengever_id': 3, 'proposal': {
-                        'checksum': 'e00d6c8fb32c30d3ca3a3f8e5d873565482567561023016d9ca18243ff1cfa14',
-                        'file': 'Traktandum 1/Ad-hoc Traktandthm.docx',
-                        'modified': u'2017-12-13T00:00:00+01:00',
-                    },
-                    'sort_order': 2,
-                    'title': u'Ad-hoc Traktand\xfem'
-                },
-                {
-                    'attachments': [{
-                        'checksum': '51d6317494eccc4a73154625a6820cb6b50dc1455eb4cf26399299d4f9ce77b2',
-                        'file': 'Traktandum 2/Beilage/1_Vertraegsentwurf.docx',
-                        'modified': u'2016-08-31T16:09:33+02:00',
-                        'title': u'Vertr\xe4gsentwurf',
-                    }],
-                    'number': '2.',
-                    'number_raw': 2,
-                    'opengever_id': 4,
-                    'proposal': {
-                        'checksum': '114e7a059dc34c7459dab90904685584e331089d80bb6310183a0de009b66c3b',
-                        'file': 'Traktandum 2/Vertraege.docx',
-                        'modified': u'2016-08-31T16:09:33+02:00',
-                    },
-                    'sort_order': 3,
-                    'title': u'Vertr\xe4ge',
-                },
-            ],
-            'committee': {'oguid': u'plone:1010073300', 'title': u'Rechnungspr\xfcfungskommission'},
-            'end': u'2016-09-12T17:00:00+00:00',
-            'location': u'B\xfcren an der Aare',
-            'opengever_id': 1,
-            'start': u'2016-09-12T15:30:00+00:00',
-            'title': u'9. Sitzung der Rechnungspr\xfcfungskommission',
-        }
-
-        self.assertEquals(expected_agenda_items, serializer.data)
 
     @browsing
     def test_exported_meeting_json_has_correct_file_names(self, browser):

--- a/opengever/meeting/zipexport.py
+++ b/opengever/meeting/zipexport.py
@@ -44,11 +44,9 @@ class MeetingDocumentZipper(MeetingDocumentWithFileTraverser):
     def __init__(self, meeting, generator):
         super(MeetingDocumentZipper, self).__init__(meeting)
         self.generator = generator
-        self.json_serializer = MeetingJSONSerializer(self.meeting, self)
 
     def get_zip_file(self):
         self.traverse()
-        self.generator.add_file('meeting.json', self.get_meeting_json_file())
         return self.generator.generate()
 
     def get_filename(self, document):
@@ -104,9 +102,6 @@ class MeetingDocumentZipper(MeetingDocumentWithFileTraverser):
             self.get_file(document).open()
         )
 
-    def get_meeting_json_file(self):
-        return StringIO(self.json_serializer.get_json())
-
 
 class MeetingPDFDocumentZipper(MeetingDocumentZipper):
     """Zip a meetings documents, but replace documents with a PDF if available.
@@ -116,6 +111,14 @@ class MeetingPDFDocumentZipper(MeetingDocumentZipper):
     def __init__(self, meeting, pdfs, generator):
         super(MeetingPDFDocumentZipper, self).__init__(meeting, generator)
         self.pdfs = pdfs
+
+    def get_zip_file(self):
+        self.generator.add_file('meeting.json', self.get_meeting_json_file())
+        return super(MeetingPDFDocumentZipper, self).get_zip_file()
+
+    def get_meeting_json_file(self):
+        json_serializer = MeetingJSONSerializer(self.meeting, self)
+        return StringIO(json_serializer.get_json())
 
     def get_filename(self, document):
         document_id = IUUID(document)

--- a/opengever/private/tests/test_dossier.py
+++ b/opengever/private/tests/test_dossier.py
@@ -107,16 +107,6 @@ class TestPrivateDossierTabbedView(IntegrationTestCase):
              'Resolve'],
             editbar.menu_options("Actions"))
 
-    @browsing
-    def test_participation_and_task_box_are_hidden_on_overview(self, browser):
-        self.login(self.regular_user, browser=browser)
-        browser.open(self.private_dossier, view='tabbedview_view-overview')
-
-        self.assertEquals(
-            ['Dossier structure', 'Comments', 'Linked dossiers',
-             'Newest documents', 'Description', 'Keywords'],
-            browser.css('.box h2').text)
-
     def test_columns_are_hidden_in_documents_tab(self):
         """Some columns do not make a lot of sense in a private dossier.
         We hide them in the default configuration.
@@ -130,6 +120,19 @@ class TestPrivateDossierTabbedView(IntegrationTestCase):
         self.assertTrue(columns_by_name['public_trial'].get('hidden', None))
         self.assertTrue(columns_by_name['receipt_date'].get('hidden', None))
         self.assertTrue(columns_by_name['delivery_date'].get('hidden', None))
+
+
+class TestPrivateDossierTabbedViewSolr(SolrIntegrationTestCase):
+
+    @browsing
+    def test_participation_and_task_box_are_hidden_on_overview(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.private_dossier, view='tabbedview_view-overview')
+
+        self.assertEquals(
+            ['Dossier structure', 'Comments', 'Linked dossiers',
+             'Newest documents', 'Description', 'Keywords'],
+            browser.css('.box h2').text)
 
 
 class TestPrivateDossierWorkflow(IntegrationTestCase):

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -618,7 +618,7 @@ class IntegrationTestCase(TestCase):
         command = CreateGeneratedDocumentCommand(
             meeting.get_dossier(), meeting, AgendaItemListOperations(),
             )
-        command.execute()
+        return command.execute()
 
     def as_relation_value(self, obj):
         return RelationValue(getUtility(IIntIds).getId(obj))


### PR DESCRIPTION
Grimlock does no longer support uploading documents which are not a PDF, but Users nevertheless sometimes upload the ZIP with original files to Grimlock.

Instead of adding validation to Grimlock which may be expensive, we no longer add the `meetings.json` metadata file to the zip of originals. This will prevent such ZIPs being processed by Grimlock. This JSON file is only used for Grimlock import, but as the import for originals is no longer possible it does not make sense to include the metadata in the zip.

I had to move the tests around a bit:
- An exhaustive functional test which asserts the whole structure of the `meetings.json` file in the downloaded zip, i moved it to the PDF ZIP oriented tests
- I dropped some of the tests which only test  a subset of aforementioned test
- Also I extracted tests that only assert the json file structure without a browser download

Jira: https://4teamwork.atlassian.net/browse/CA-1732

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

