### PR TITLE
Fix `@history` endpoint when no history exists.

### DIFF
--- a/changes/CA-2110.bugfix
+++ b/changes/CA-2110.bugfix
@@ -1,0 +1,1 @@
+Fix `@history` endpoint when no history exists. [deiferni]

--- a/opengever/base/monkey/patches/__init__.py
+++ b/opengever/base/monkey/patches/__init__.py
@@ -1,6 +1,7 @@
 from .action_info import PatchActionInfo
 from .cmf_catalog_aware import PatchCMFCatalogAware
 from .cmf_catalog_aware import PatchCMFCatalogAwareHandlers
+from .content_history_viewlet import PatchFullHistory
 from .default_values import PatchBuilderCreate
 from .default_values import PatchDeserializeFromJson
 from .default_values import PatchDexterityContentGetattr
@@ -74,6 +75,7 @@ PatchZ3CFormChangedField()()
 PatchZ3CFormWidgetUpdate()()
 ScrubBoboExceptions()()
 PatchGetJsonschemaForPortalType()()
+PatchFullHistory()()
 
 # These three patches implement role and permission filtering during RO mode.
 # We only apply these conditionally when RO mode actually is active.

--- a/opengever/base/monkey/patches/content_history_viewlet.py
+++ b/opengever/base/monkey/patches/content_history_viewlet.py
@@ -1,0 +1,18 @@
+from opengever.base.monkey.patching import MonkeyPatch
+
+
+class PatchFullHistory(MonkeyPatch):
+
+    def __call__(self):
+
+        def fullHistory(viewlet):
+            history = original_fullHistory(viewlet)
+            if history is None:
+                history = []
+            return history
+
+        from plone.app.layout.viewlets.content import ContentHistoryViewlet
+
+        locals()['__patch_refs__'] = False
+        original_fullHistory = ContentHistoryViewlet.fullHistory
+        self.patch_refs(ContentHistoryViewlet, 'fullHistory', fullHistory)


### PR DESCRIPTION
With this PR we prevent an exception in the `@history` endpoint for users who only have the `Reader` role on context they access.

We need to workaround the following problem:
- plone.restapi relies on history viewlet https://github.com/plone/plone.restapi/blob/d78a8411d1166ee785ee71292a540f39fc2cf44c/src/plone/restapi/services/history/get.py#L42 and iterates over its result https://github.com/plone/plone.restapi/blob/d78a8411d1166ee785ee71292a540f39fc2cf44c/src/plone/restapi/services/history/get.py#L54 
- however full history returns `None` when the history can't be retrieved or is empty https://github.com/plone/plone.app.layout/blob/0ba390844d7c4f7dc88fe1688e80876eea58be66/plone/app/layout/viewlets/content.py#L481 
- which is the case when there are no versions and user can’t access initial review state, for which user needs `Review … ` permissions https://github.com/plone/plone.app.layout/blob/0ba390844d7c4f7dc88fe1688e80876eea58be66/plone/app/layout/viewlets/content.py#L344-L347 

The easiest to implement workaround was to patch the re-used viewlet and change its behavior to return an empty list instead of `None`.

Other solutions would have involved to either overwrite the full `@history` endpoint in `plone.restapi` or call the potentially expensive method `fullHistory` or its delegates beforehand.

Jira: https://4teamwork.atlassian.net/browse/CA-2110
Source-Story in RIS: https://4teamwork.atlassian.net/browse/HG-1132


## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
