### PR TITLE
Fix policy generator for GEVER policies

### DIFF
--- a/changes/CA-1753.other
+++ b/changes/CA-1753.other
@@ -1,0 +1,1 @@
+Fix policygenerator for GEVER policies. [njohner, phgross]

--- a/opengever/policytemplates/hooks.py
+++ b/opengever/policytemplates/hooks.py
@@ -49,7 +49,6 @@ IGNORED_QUESTIONS = {
         'deployment.workspace_creators_group',
         'deployment.workspace_users_group',
         'setup.invitation_group_dn',
-        'base.apps_endpoint_url',
         'base.workspace_secret',
         'setup.enable_workspace_meeting_feature',
         'setup.enable_todo_feature'

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/deployment-+base.server_name+-+base.deployment_number+-+base.domain+.cfg.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/deployment-+base.server_name+-+base.deployment_number+-+base.domain+.cfg.bob
@@ -42,10 +42,9 @@ environment-vars +=
     SABLON_URL http://localhost:8091/
     PDFLATEX_URL http://localhost:8092/
 {{% endif %}}
+{{% if is_teamraum %}}
 {{% if setup.enable_workspace_meeting_feature %}}
     WEASYPRINT_URL http://localhost:8093/
 {{% endif %}}
-
-{{% if is_teamraum %}}
     WORKSPACE_SECRET {{{base.workspace_secret}}}
 {{% endif %}}


### PR DESCRIPTION
* Apps endpoint URL question should not be ignored for GEVER deployments
* check enable_workspace_meeting_feature should only be used for teamraum policies.

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry