### PR TITLE
Switch GEVER-UI setting to an overall admin_unit setting.

### DIFF
--- a/changes/CA-2063.other
+++ b/changes/CA-2063.other
@@ -1,0 +1,1 @@
+Switch GEVER-UI setting to a overall admin_unit setting.

--- a/opengever/base/browser/resources/base.js
+++ b/opengever/base/browser/resources/base.js
@@ -46,8 +46,7 @@ $(document).delegate('body', 'tabbedview.unknownresponse', function(event, overv
  */
 function switchUI(){
   setTourAsSeen('be_new_frontend_teaser').then(function() {
-    var pathname = new URL($('body').data('portal-url')).pathname;
-    Cookies.set('geverui', '1', {path: pathname, expires: 365});
+    Cookies.set('geverui', '1', {expires: 365});
     window.location.reload(true);
   });
 }


### PR DESCRIPTION
Remove path limitation in the geverui cookie, because the decision which UI the user wants to use, should be for the all admin units. Accepting multi admin unit tasks with different UI selected, leads to not found errors (see https://4teamwork.atlassian.net/browse/CA-2063).

Not sure if there is a possibility to migrate or update existing settings.

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/


## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
