### PR TITLE
Allow meetings to be reopened by a Manager.

### DIFF
--- a/changes/CA-1724.other
+++ b/changes/CA-1724.other
@@ -1,0 +1,1 @@
+Allow meetings to be reopened by a Manager. [deiferni]

--- a/opengever/core/locales/de/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/de/LC_MESSAGES/opengever.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-03-25 20:40+0000\n"
+"POT-Creation-Date: 2021-04-27 08:43+0000\n"
 "PO-Revision-Date: 2017-09-18 15:21+0200\n"
 "Last-Translator: Philippe Gross <p.gross@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -261,6 +261,11 @@ msgstr "Antrag"
 #: ./opengever/core/profiles/default/types/opengever.meeting.proposaltemplate.xml
 msgid "Proposal Template"
 msgstr "Antragsvorlage"
+
+#: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20210426170717_add_reopen_meeting_action/actions.xml
+msgid "Reopen meeting"
+msgstr "Sitzung wieder öffnen"
 
 #. Default: "RepositoryFolder"
 #: ./opengever/core/profiles/default/types/opengever.repository.repositoryfolder.xml

--- a/opengever/core/locales/en/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/en/LC_MESSAGES/opengever.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-03-25 20:40+0000\n"
+"POT-Creation-Date: 2021-04-27 08:43+0000\n"
 "PO-Revision-Date: 2017-09-18 15:21+0200\n"
 "Last-Translator: Philippe Gross <p.gross@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -316,6 +316,11 @@ msgstr "Proposal"
 #: ./opengever/core/profiles/default/types/opengever.meeting.proposaltemplate.xml
 msgid "Proposal Template"
 msgstr "Proposal Template"
+
+#: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20210426170717_add_reopen_meeting_action/actions.xml
+msgid "Reopen meeting"
+msgstr "Reopen meeting"
 
 #. German translation: Ordnungsposition
 #. Default: "RepositoryFolder"

--- a/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-03-25 20:40+0000\n"
+"POT-Creation-Date: 2021-04-27 08:43+0000\n"
 "PO-Revision-Date: 2013-03-27 10:44+0100\n"
 "Last-Translator: Philippe Gross <p.gross@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -258,6 +258,11 @@ msgstr "Requête"
 #: ./opengever/core/profiles/default/types/opengever.meeting.proposaltemplate.xml
 msgid "Proposal Template"
 msgstr "Modèle de requête"
+
+#: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20210426170717_add_reopen_meeting_action/actions.xml
+msgid "Reopen meeting"
+msgstr "Rouvrir la séance"
 
 #: ./opengever/core/profiles/default/types/opengever.repository.repositoryfolder.xml
 msgid "RepositoryFolder"

--- a/opengever/core/locales/opengever.core.pot
+++ b/opengever/core/locales/opengever.core.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-25 20:40+0000\n"
+"POT-Creation-Date: 2021-04-27 08:43+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -260,6 +260,11 @@ msgstr ""
 
 #: ./opengever/core/profiles/default/types/opengever.meeting.proposaltemplate.xml
 msgid "Proposal Template"
+msgstr ""
+
+#: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20210426170717_add_reopen_meeting_action/actions.xml
+msgid "Reopen meeting"
 msgstr ""
 
 #: ./opengever/core/profiles/default/types/opengever.repository.repositoryfolder.xml

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -918,6 +918,18 @@
       <property name="visible">True</property>
     </object>
 
+    <object name="reopen_meeting" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Reopen meeting</property>
+      <property name="description" i18n:translate="" />
+      <property name="url_expr">string:${object_url}/reopen_meeting</property>
+      <property name="icon_expr" />
+      <property name="available_expr">python:here.restrictedTraverse('@@plone_interface_info').provides('opengever.meeting.interfaces.IMeetingWrapper')</property>
+      <property name="permissions">
+        <element value="Manage portal" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
     <object name="revoke_permissions" meta_type="CMF Action" i18n:domain="opengever.core">
       <property name="title" i18n:translate="">Revoke permissions</property>
       <property name="description" i18n:translate="" />

--- a/opengever/core/upgrades/20210426170717_add_reopen_meeting_action/actions.xml
+++ b/opengever/core/upgrades/20210426170717_add_reopen_meeting_action/actions.xml
@@ -1,0 +1,20 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="portal_actions" meta_type="Plone Actions Tool">
+
+  <!-- OBJECT BUTTONS -->
+  <object name="object_buttons" meta_type="CMF Action Category">
+
+    <object name="reopen_meeting" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Reopen meeting</property>
+      <property name="description" i18n:translate="" />
+      <property name="url_expr">string:${object_url}/reopen_meeting</property>
+      <property name="icon_expr" />
+      <property name="available_expr">python:here.restrictedTraverse('@@plone_interface_info').provides('opengever.meeting.interfaces.IMeetingWrapper')</property>
+      <property name="permissions">
+        <element value="Manage portal" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
+  </object>
+
+</object>

--- a/opengever/core/upgrades/20210426170717_add_reopen_meeting_action/upgrade.py
+++ b/opengever/core/upgrades/20210426170717_add_reopen_meeting_action/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddReopenMeetingAction(UpgradeStep):
+    """Add reopen meeting action.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/meeting/browser/meetings/configure.zcml
+++ b/opengever/meeting/browser/meetings/configure.zcml
@@ -142,4 +142,12 @@
       permission="zope2.View"
       />
 
+  <browser:page
+      for="opengever.meeting.interfaces.IMeetingWrapper"
+      name="reopen_meeting"
+      class=".reopen.ReopenMeetingForm"
+      permission="cmf.ManagePortal"
+      template="templates/reopen_meeting.pt"
+      />
+
 </configure>

--- a/opengever/meeting/browser/meetings/reopen.py
+++ b/opengever/meeting/browser/meetings/reopen.py
@@ -1,0 +1,42 @@
+from opengever.meeting.reopen import ReopenMeeting
+from Products.statusmessages.interfaces import IStatusMessage
+from z3c.form import button
+from z3c.form.form import Form
+
+
+class ReopenMeetingForm(Form):
+    ignoreContext = True
+
+    def prepare_reopener(self):
+        self.reopener = ReopenMeeting(self.context.model)
+        self.errors = self.reopener.get_errors()
+
+    def render(self):
+        self.request.set('disable_border', True)
+        self.prepare_reopener()
+        return self.index()
+
+    @button.buttonAndHandler(u'Confirm')
+    def handle_confirm(self, action):
+        self.prepare_reopener()
+        data, errors = self.extractData()
+        if not errors:
+            reopen_errors = self.reopener.get_errors()
+            status = IStatusMessage(self.request)
+            if reopen_errors:
+                for msg in reopen_errors:
+                    status.addStatusMessage(msg, type='error')
+            else:
+                self.reopener.reopen_meeting()
+                msg = u'The meeting has been reopened.'
+                status.addStatusMessage(msg, type='info')
+
+            return self._redirect_to_meeting()
+
+    @button.buttonAndHandler(u'Cancel')
+    def handle_cancel(self, action):
+        return self._redirect_to_meeting()
+
+    def _redirect_to_meeting(self):
+        url = self.context.model.get_url()
+        return self.request.RESPONSE.redirect(url)

--- a/opengever/meeting/browser/meetings/templates/reopen_meeting.pt
+++ b/opengever/meeting/browser/meetings/templates/reopen_meeting.pt
@@ -1,0 +1,53 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      lang="en"
+      metal:use-macro="context/main_template/macros/master"
+      i18n:domain="opengever.meeting">
+<body>
+
+<metal:main fill-slot="main" tal:define="reopener view/reopener">
+
+    <h1 class="documentFirstHeading">Reopen meeting</h1>
+
+    <h2>Current state</h2>
+
+    <p>Meeting state: <span tal:replace="reopener/meeting/workflow_state" />
+    </p>
+    <p>Meeting number: <span tal:replace="reopener/meeting/meeting_number" />
+    </p>
+    Decision numbers:
+    <ul>
+        <li tal:repeat="num reopener/decision_numbers" tal:content="num" />
+    </ul>
+    <p>Period decision sequence number: <span tal:replace="reopener/period/decision_sequence_number" /></p>
+    <p>Period meeting sequence number: <span tal:replace="reopener/period/meeting_sequence_number" /></p>
+
+    <tal:block tal:condition="not: view/errors">
+        <h2>Proposed actions</h2>
+        <p tal:condition="python: reopener.reset_decision_number is not None">
+            Set period decision sequence number to: <span tal:replace="reopener/reset_decision_number" />
+        </p>
+        <p>Set period meeting sequence number to: <span tal:replace="reopener/reset_meeting_number" /></p>
+        <p>Set meeting state to: pending</p>
+        <p tal:condition="python: reopener.reset_decision_number is not None">Set agenda item states to: pending</p>
+    </tal:block>
+
+    <tal:block tal:condition="view/errors">
+        <h2>Errors</h2>
+        <ul>
+        <tal:repeat tal:repeat="error view/errors">
+            <li tal:content="error"></li>
+        </tal:repeat>
+        </ul>
+    </tal:block>
+
+    <div id="content-core">
+        <metal:block use-macro="context/@@ploneform-macros/titlelessform" />
+    </div>
+
+</metal:main>
+
+</body>
+</html>

--- a/opengever/meeting/model/query.py
+++ b/opengever/meeting/model/query.py
@@ -198,11 +198,11 @@ SubmittedDocument.query_cls = SubmittedDocumentQuery
 
 class MeetingQuery(BaseQuery):
 
-    def _committee_meetings(self, committee):
+    def by_committee(self, committee):
         return self.filter(Meeting.committee == committee)
 
     def _upcoming_meetings(self, committee):
-        query = self._committee_meetings(committee)
+        query = self.by_committee(committee)
         query = query.filter(
             Meeting.workflow_state != Meeting.STATE_CANCELLED.name)
         query = query.filter(Meeting.start >= utcnow_tz_aware())
@@ -210,7 +210,7 @@ class MeetingQuery(BaseQuery):
         return query
 
     def _past_meetings(self, committee):
-        query = self._committee_meetings(committee)
+        query = self.by_committee(committee)
         query = query.filter(
             Meeting.workflow_state != Meeting.STATE_CANCELLED.name)
         query = query.filter(Meeting.start < utcnow_tz_aware())
@@ -230,7 +230,7 @@ class MeetingQuery(BaseQuery):
         return self._past_meetings(committee).first()
 
     def pending_meetings(self, committee):
-        query = self._committee_meetings(committee)
+        query = self.by_committee(committee)
         query = query.filter(
             Meeting.workflow_state != Meeting.STATE_CLOSED.name,
             Meeting.workflow_state != Meeting.STATE_CANCELLED.name

--- a/opengever/meeting/reopen.py
+++ b/opengever/meeting/reopen.py
@@ -1,0 +1,69 @@
+from opengever.meeting.model import Meeting
+from opengever.meeting.period import Period
+
+
+class ReopenMeeting(object):
+
+    def __init__(self, meeting):
+        self.meeting = meeting
+        self.period = Period.get_current(
+            self.meeting.committee.resolve_committee(),
+            self.meeting.start.date()
+        )
+        self.agenda_items = [
+            item for item in self.meeting.agenda_items if not item.is_paragraph
+        ]
+        self.decision_numbers = [
+            each.decision_number for each
+            in self.agenda_items
+            if each.decision_number is not None
+        ]
+        if self.decision_numbers:
+            self.reset_decision_number = min(self.decision_numbers) - 1
+        else:
+            self.reset_decision_number = None
+
+        self.meeting_number = self.meeting.meeting_number
+        if self.meeting_number:
+            self.reset_meeting_number = self.meeting_number - 1
+        else:
+            self.reset_meeting_number = None
+
+    def get_errors(self):
+        errors = []
+        if self.meeting.workflow_state not in ('held', 'closed'):
+            errors.append(u"Can't reopen meeting in state '{}'.".format(
+                self.meeting.workflow_state)
+            )
+        if self.agenda_items and self.reset_decision_number is None:
+            errors.append(
+                u"Unexpected state, have agenda items but "
+                u"can't reset decision number."
+            )
+        if self.reset_meeting_number is None:
+            errors.append(u"Unexpected state, can't reset meeting number.")
+        if errors:
+            # return here to prevent invalid query
+            return errors
+
+        newer_held_meetings = Meeting.query.by_committee(
+            self.meeting.committee).filter(
+            Meeting.meeting_number > self.meeting_number).all()
+        if newer_held_meetings:
+            errors.append(u"The meetings '{}' need to be reopened first.".format(
+                u"', '".join(each.get_title() for each in newer_held_meetings))
+            )
+
+        return errors
+
+    def reopen_meeting(self):
+        assert not self.get_errors()
+
+        self.meeting.workflow_state = u'pending'
+        self.meeting.meeting_number = None
+        for agenda_item in self.meeting.agenda_items:
+            agenda_item.workflow_state = u'pending'
+            agenda_item.decision_number = None
+        if self.reset_decision_number is not None:
+            self.period.decision_sequence_number = self.reset_decision_number
+        self.period.meeting_sequence_number = self.reset_meeting_number

--- a/opengever/meeting/tests/test_meeting_reopen.py
+++ b/opengever/meeting/tests/test_meeting_reopen.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import editbar
 from ftw.testbrowser.pages.statusmessages import info_messages
 from opengever.meeting.period import Period
 from opengever.meeting.reopen import ReopenMeeting
@@ -12,6 +13,7 @@ import pytz
 class TestReopenMeeting(IntegrationTestCase):
 
     features = ('meeting',)
+    REOPEN_MEETING_ACTION = 'Reopen meeting'
 
     def test_reopen_held_meeting(self):
         self.login(self.committee_responsible)
@@ -172,7 +174,8 @@ class TestReopenMeeting(IntegrationTestCase):
         self.assertEqual(2, model.meeting_number)
 
         self.login(self.manager, browser)
-        browser.open(model.get_url(view='reopen_meeting'))
+        browser.open(model.get_url())
+        editbar.menu_option('Actions', self.REOPEN_MEETING_ACTION).click()
         browser.find('Confirm').click()
 
         self.assertEqual([u"The meeting has been reopened."], info_messages())
@@ -188,5 +191,9 @@ class TestReopenMeeting(IntegrationTestCase):
     @browsing
     def test_non_manager_cannot_reopen(self, browser):
         self.login(self.administrator, browser)
+        browser.open(self.meeting.model.get_url())
+        self.assertNotIn(
+            self.REOPEN_MEETING_ACTION, editbar.menu_options('Actions')
+        )
         with browser.expect_unauthorized():
             browser.open(self.meeting.model.get_url(view='reopen_meeting'))

--- a/opengever/meeting/tests/test_meeting_reopen.py
+++ b/opengever/meeting/tests/test_meeting_reopen.py
@@ -1,0 +1,142 @@
+from datetime import datetime
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.meeting.period import Period
+from opengever.meeting.reopen import ReopenMeeting
+from opengever.testing import IntegrationTestCase
+import pytz
+
+
+class TestReopenMeeting(IntegrationTestCase):
+
+    features = ('meeting',)
+
+    def test_reopen_held_meeting(self):
+        self.login(self.committee_responsible)
+
+        self.schedule_ad_hoc(self.meeting, 'Foo')
+        self.schedule_paragraph(self.meeting, u'Para')
+        agenda_item = self.schedule_proposal(
+            self.meeting, self.submitted_proposal
+        )
+        agenda_item.decide()
+        model = self.meeting.model
+        period = Period.get_current(
+            model.committee.resolve_committee(),
+            model.start.date()
+        )
+
+        self.assertEqual(3, period.decision_sequence_number)
+        self.assertEqual(2, period.meeting_sequence_number)
+        self.assertEqual('held', model.workflow_state)
+        self.assertEqual(
+            ['pending', 'pending', 'decided'],
+            [each.workflow_state for each in model.agenda_items]
+        )
+        self.assertEqual(
+            [2, None, 3],
+            [each.decision_number for each in model.agenda_items]
+        )
+        self.assertEqual(2, model.meeting_number)
+
+        ReopenMeeting(model).reopen_meeting()
+
+        self.assertEqual('pending', model.workflow_state)
+        self.assertEqual(
+            ['pending', 'pending', 'pending'],
+            [each.workflow_state for each in model.agenda_items]
+        )
+        self.assertEqual(1, period.decision_sequence_number)
+        self.assertEqual(1, period.meeting_sequence_number)
+
+    def test_reopen_closed_meeting(self):
+        self.login(self.committee_responsible)
+
+        agenda_item = self.schedule_ad_hoc(self.meeting, 'Foo')
+        self.schedule_paragraph(self.meeting, u'Para')
+        agenda_item.decide()
+        model = self.meeting.model
+        model.close()
+        period = Period.get_current(
+            model.committee.resolve_committee(),
+            model.start.date()
+        )
+
+        self.assertEqual(2, period.decision_sequence_number)
+        self.assertEqual(2, period.meeting_sequence_number)
+        self.assertEqual('closed', model.workflow_state)
+        self.assertEqual(
+            ['decided', 'pending'],  # the paragraph is always pending
+            [each.workflow_state for each in model.agenda_items]
+        )
+        self.assertEqual(
+            [2, None],
+            [each.decision_number for each in model.agenda_items]
+        )
+        self.assertEqual(2, model.meeting_number)
+
+        ReopenMeeting(model).reopen_meeting()
+
+        self.assertEqual('pending', model.workflow_state)
+        self.assertEqual(
+            ['pending', 'pending'],
+            [each.workflow_state for each in model.agenda_items]
+        )
+        self.assertEqual(1, period.decision_sequence_number)
+        self.assertEqual(1, period.meeting_sequence_number)
+
+    def test_error_invalid_meeting_state(self):
+        self.login(self.committee_responsible)
+
+        reopener = ReopenMeeting(self.meeting.model)
+        self.assertEqual(
+            [u"Can't reopen meeting in state 'pending'.",
+             u"Unexpected state, can't reset meeting number."],
+            reopener.get_errors()
+        )
+
+    def test_error_invalid_agenda_item_state(self):
+        self.login(self.committee_responsible)
+
+        agenda_item = self.schedule_ad_hoc(self.meeting, 'Foo')
+        agenda_item.decide()
+        agenda_item.decision_number = None
+
+        reopener = ReopenMeeting(self.meeting.model)
+        self.assertEqual(
+            [u"Unexpected state, have agenda items but "
+             u"can't reset decision number."],
+            reopener.get_errors()
+        )
+
+    def test_error_newer_meetings_with_meeting_number_exist(self):
+        self.login(self.committee_responsible)
+
+        agenda_item = self.schedule_ad_hoc(self.meeting, 'Foo')
+        self.schedule_paragraph(self.meeting, u'Para')
+        agenda_item.decide()
+        model = self.meeting.model
+        model.close()
+
+        meeting_dossier = create(
+            Builder('meeting_dossier')
+            .within(self.leaf_repofolder)
+        )
+        newer_meeting = create(
+            Builder('meeting')
+            .having(
+                title=u'8. Sitzung der Rechnungspr\xfcfungskommission',
+                committee=self.committee.load_model(),
+                start=datetime(2016, 9, 12, 19, 30, tzinfo=pytz.UTC),
+            )
+            .link_with(meeting_dossier)
+        )
+        agenda_item = self.schedule_ad_hoc(newer_meeting, 'Foo')
+        agenda_item.decide()
+
+        reopener = ReopenMeeting(self.meeting.model)
+        self.assertEqual(
+            [u"The meetings '8. Sitzung der Rechnungspr\xfcfungskommission' "
+             u"need to be reopened first."],
+            reopener.get_errors()
+        )

--- a/opengever/meeting/tests/test_meeting_view.py
+++ b/opengever/meeting/tests/test_meeting_view.py
@@ -27,7 +27,8 @@ class TestMeetingView(IntegrationTestCase):
     def test_displays_correct_edit_bar_actions_for_manager(self, browser):
         expected_menu = ['Download docxcompose debug files', 'Download meeting protocol JSON',
                          'Export as ZIP file', 'Properties', 'Sharing',
-                         'Policy...', 'Close meeting', 'Cancel']
+                         'Policy...', 'Close meeting', 'Cancel',
+                         'Reopen meeting']
         self.login(self.manager, browser)
         browser.open(self.meeting)
 


### PR DESCRIPTION
With this PR we add functionality to automatically reopen meetings. So far this was unsupported and had to be done manually via debug shell.

At the moment the action is only visible for a `Manager` as we want to test it out ourself before enabling it for customers.

A simple view will open which shows a summary of actions to be performed or reasons why they can't be performed at the moment.

I have translated only the action but not the view, as the view will only be used by us at the moment.
 
![Screenshot 2021-04-27 at 10 45 46](https://user-images.githubusercontent.com/736583/116218139-84102080-a74a-11eb-9321-2797519e1ff7.png)
![Screenshot 2021-04-27 at 11 06 08](https://user-images.githubusercontent.com/736583/116218143-85414d80-a74a-11eb-9596-97e6112f9fde.png)

Jira: https://4teamwork.atlassian.net/browse/CA-1724

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Further improvements needed:
  - [x] Create follow-up stories and link them in the PR and Jira issue
- New translations
  - [x] All msg-strings are unicode
