### PR TITLE
Improve archival file conversion job management when resolving dossiers.

### DIFF
--- a/changes/CA-1871.other
+++ b/changes/CA-1871.other
@@ -1,0 +1,1 @@
+Improve archival file conversion job management when resolving dossiers. [njohner]

--- a/opengever/document/archival_file.py
+++ b/opengever/document/archival_file.py
@@ -30,12 +30,13 @@ class ArchivalFileConverter(object):
     def trigger_conversion(self):
         if self.document.is_archival_file_conversion_skipped():
             self.set_state(STATE_FAILED_PERMANENTLY)
-            return
+            return False
 
         if self.get_state() == STATE_MANUALLY_PROVIDED:
-            return
+            return False
 
         self.queue_conversion()
+        return True
 
     def queue_conversion(self):
         self.set_state(STATE_CONVERTING)

--- a/opengever/document/archival_file.py
+++ b/opengever/document/archival_file.py
@@ -3,9 +3,6 @@ from ftw.bumblebee.config import PROCESSING_QUEUE
 from ftw.bumblebee.interfaces import IBumblebeeServiceV3
 from opengever.document.behaviors.metadata import IDocumentMetadata
 from plone.namedfile.file import NamedBlobFile
-from zope.annotation.interfaces import IAnnotations
-from zope.app.intid.interfaces import IIntIds
-from zope.component import getUtility
 from zope.globalrequest import getRequest
 import os
 
@@ -24,15 +21,11 @@ ARCHIVAL_FILE_STATE_MAPPING = {
     5: "STATE_FAILED_PERMANENTLY",
 }
 
-ARCHIVAL_FILE_CONVERSION_QUEUE_KEY = 'opengever.document.\
-                                      archival_file_conversion_queue_annotations_key'
-
 
 class ArchivalFileConverter(object):
 
     def __init__(self, document):
         self.document = document
-        self.document_intid = getUtility(IIntIds).getId(self.document)
 
     def trigger_conversion(self):
         if self.document.is_archival_file_conversion_skipped():
@@ -42,9 +35,6 @@ class ArchivalFileConverter(object):
         if self.get_state() == STATE_MANUALLY_PROVIDED:
             return
 
-        if self.is_already_queued():
-            return
-
         self.queue_conversion()
 
     def queue_conversion(self):
@@ -52,19 +42,6 @@ class ArchivalFileConverter(object):
         IBumblebeeServiceV3(getRequest()).queue_conversion(
             self.document, PROCESSING_QUEUE,
             self.get_callback_url(), target_format='pdf/a')
-
-        annotations = IAnnotations(getRequest())
-        if ARCHIVAL_FILE_CONVERSION_QUEUE_KEY not in annotations:
-            annotations[ARCHIVAL_FILE_CONVERSION_QUEUE_KEY] = []
-        annotations[ARCHIVAL_FILE_CONVERSION_QUEUE_KEY].append(self.document_intid)
-
-    def is_already_queued(self):
-        """ Check whether the conversion has already been queued during this
-        request
-        """
-        annotations = IAnnotations(getRequest())
-        queued = annotations.get(ARCHIVAL_FILE_CONVERSION_QUEUE_KEY, [])
-        return self.document_intid in queued
 
     def get_state(self):
         return IDocumentMetadata(self.document).archival_file_state

--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -233,19 +233,25 @@ class DossierContainer(Container):
 
         return subdossiers
 
-    def get_contained_documents(self):
+    def get_contained_documents(self, unrestricted=False):
         """Returns all documents that are not contained in any subdossier,
         i.e. documents whose parent dossier is this object, this includes
         documents in tasks directly contained in this dossier, etc.
         """
-        path = '/'.join(self.getPhysicalPath())
-        documents = self.portal_catalog.unrestrictedSearchResults(
-            path=path,
-            object_provides=IBaseDocument.__identifier__)
+        query = {
+            'path': '/'.join(self.getPhysicalPath()),
+            'object_provides': IBaseDocument.__identifier__}
+
+        if unrestricted:
+            search_function = self.portal_catalog.unrestrictedSearchResults
+        else:
+            search_function = self.portal_catalog
+
+        documents = search_function(query)
 
         docs_in_subdossiers = set()
         for subdossier in self.get_subdossiers(depth=1, unrestricted=True):
-            results = self.portal_catalog.unrestrictedSearchResults(
+            results = search_function(
                     path=subdossier.getPath(),
                     object_provides=IBaseDocument.__identifier__)
             docs_in_subdossiers.update(brain.UID for brain in results)

--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -233,6 +233,24 @@ class DossierContainer(Container):
 
         return subdossiers
 
+    def get_contained_documents(self):
+        """Returns all documents that are not contained in any subdossier,
+        i.e. documents whose parent dossier is this object, this includes
+        documents in tasks directly contained in this dossier, etc.
+        """
+        path = '/'.join(self.getPhysicalPath())
+        documents = self.portal_catalog.unrestrictedSearchResults(
+            path=path,
+            object_provides=IBaseDocument.__identifier__)
+
+        docs_in_subdossiers = set()
+        for subdossier in self.get_subdossiers(depth=1, unrestricted=True):
+            results = self.portal_catalog.unrestrictedSearchResults(
+                    path=subdossier.getPath(),
+                    object_provides=IBaseDocument.__identifier__)
+            docs_in_subdossiers.update(brain.UID for brain in results)
+        return [doc for doc in documents if doc.UID not in docs_in_subdossiers]
+
     def is_subdossier(self):
         return bool(self.get_parent_dossier())
 

--- a/opengever/dossier/nightly_after_resolve_job.py
+++ b/opengever/dossier/nightly_after_resolve_job.py
@@ -9,6 +9,12 @@ from zope.publisher.interfaces.browser import IBrowserRequest
 import logging
 
 
+MAX_CONVERSION_REQUESTS_PER_NIGHT = 10000
+
+# Track total number of conversion requests sent per nightly run
+sent_conversion_requests = 0
+
+
 @implementer(INightlyJobProvider)
 @adapter(IPloneSiteRoot, IBrowserRequest, logging.Logger)
 class ExecuteNightlyAfterResolveJobs(object):
@@ -30,14 +36,26 @@ class ExecuteNightlyAfterResolveJobs(object):
 
     def __iter__(self):
         pending = self.catalog.unrestrictedSearchResults(self.query)
-        return iter([{'path': brain.getPath()} for brain in pending])
+        for brain in pending:
+            self.logger.info('sent_conversion_requests: {}'.format(
+                sent_conversion_requests))
+            if sent_conversion_requests >= MAX_CONVERSION_REQUESTS_PER_NIGHT:
+                self.logger.warn(
+                    "Reached MAX_CONVERSION_REQUESTS_PER_NIGHT "
+                    "(%r) limit, stopping after resolve jobs for tonight." %
+                    MAX_CONVERSION_REQUESTS_PER_NIGHT)
+                raise StopIteration
+            yield {'path': brain.getPath()}
 
     def __len__(self):
         resultset = self.catalog.unrestrictedSearchResults(self.query)
         return resultset.actual_result_count
 
     def run_job(self, job, interrupt_if_necessary):
+        global sent_conversion_requests
         path = job['path']
         dossier = self.context.unrestrictedTraverse(path)
         self.logger.info("Running AfterResolve jobs for %r" % dossier)
-        AfterResolveJobs(dossier).execute(nightly_run=True)
+        after_resolve_jobs = AfterResolveJobs(dossier)
+        after_resolve_jobs.execute(nightly_run=True)
+        sent_conversion_requests += after_resolve_jobs.num_pdf_conversions

--- a/opengever/dossier/resolve.py
+++ b/opengever/dossier/resolve.py
@@ -574,11 +574,7 @@ class AfterResolveJobs(object):
         if not self.get_property('archival_file_conversion_enabled'):
             return
 
-        path = '/'.join(self.context.getPhysicalPath())
-        docs = self.catalog.unrestrictedSearchResults(
-            path=path,
-            object_provides=IBaseDocument.__identifier__)
-        for doc in docs:
+        for doc in self.context.get_contained_documents():
             ArchivalFileConverter(doc.getObject()).trigger_conversion()
 
 

--- a/opengever/dossier/resolve.py
+++ b/opengever/dossier/resolve.py
@@ -387,6 +387,7 @@ class AfterResolveJobs(object):
     def __init__(self, context):
         self.context = context
         self.catalog = api.portal.get_tool('portal_catalog')
+        self.num_pdf_conversions = 0
 
     def get_property(self, name):
         return api.portal.get_registry_record(
@@ -575,7 +576,8 @@ class AfterResolveJobs(object):
             return
 
         for doc in self.context.get_contained_documents():
-            ArchivalFileConverter(doc.getObject()).trigger_conversion()
+            self.num_pdf_conversions += ArchivalFileConverter(
+                doc.getObject()).trigger_conversion()
 
 
 class LenientDossierResolver(StrictDossierResolver):

--- a/opengever/dossier/resolve.py
+++ b/opengever/dossier/resolve.py
@@ -575,7 +575,7 @@ class AfterResolveJobs(object):
         if not self.get_property('archival_file_conversion_enabled'):
             return
 
-        for doc in self.context.get_contained_documents():
+        for doc in self.context.get_contained_documents(unrestricted=True):
             self.num_pdf_conversions += ArchivalFileConverter(
                 doc.getObject()).trigger_conversion()
 


### PR DESCRIPTION
To avoid swamping bumblebee with PDF conversion jobs when executing the `NightlyAfterResolveJobs`, we add a limit to the number of conversion jobs triggered by a deployment in one night.
Note that the `AfterResolveJobs.trigger_pdf_conversion` method was not very smart as it submitted conversion jobs for all documents in the dossier being resolved, but as dossier resolution is recursive, this happens for every subdossier too. We had already introduced a mechanism to at least [avoid sending several jobs for the same document in a single request](https://github.com/4teamwork/opengever.core/pull/5600), but this is not sufficient. Indeed it would still queue conversion jobs for documents from a previously resolved subdossier (which was not resolved in the same request). Also this will not work properly if the `AfterResolveJobs` for a large dossier and its subdossiers are handled over several nights by the nightly jobs. We therefore change `AfterResolveJobs.trigger_pdf_conversion` to only submit documents of the current dossier which are not contained in any of its subdossiers (so directly contained documents or contained in tasks or proposal that are in that dossier). This is much cleaner IMHO and allows us to set a limit to the number of conversion jobs queued to bumblebee in one night (not that we always send all documents for a given dossier / subdossier together, so that the limit is not a hard limit in the sense that it is only checked between jobs)

For https://4teamwork.atlassian.net/browse/CA-1871

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
