### PR TITLE
Fix UI toggler, remove the adminunit specific cookie.

### DIFF
--- a/opengever/base/browser/resources/base.js
+++ b/opengever/base/browser/resources/base.js
@@ -46,6 +46,9 @@ $(document).delegate('body', 'tabbedview.unknownresponse', function(event, overv
  */
 function switchUI(){
   setTourAsSeen('be_new_frontend_teaser').then(function() {
+    var pathname = new URL($('body').data('portal-url')).pathname;
+    // Remove the old, admin_unit specific geverui cookie
+    Cookies.remove('geverui', {path: pathname});
     Cookies.set('geverui', '1', {expires: 365});
     window.location.reload(true);
   });


### PR DESCRIPTION
otherwise the path specific cookie wins over the `/` cookie and the new ui is still shown.

https://4teamwork.atlassian.net/browse/CA-2063

_Changelog entry already exists._