### PR TITLE
Move workspace links, when moving a dossier with linked workspace in to a dossier.

### DIFF
--- a/changes/CA-1276.bugfix
+++ b/changes/CA-1276.bugfix
@@ -1,0 +1,1 @@
+Transfer workspace link to parent dossier when moving dossier into another dossier. [phgross]

--- a/opengever/dossier/configure.zcml
+++ b/opengever/dossier/configure.zcml
@@ -251,6 +251,12 @@
 
   <subscriber
       for="opengever.dossier.behaviors.dossier.IDossierMarker
+           zope.lifecycleevent.interfaces.IObjectMovedEvent"
+      handler=".handlers.move_connected_teamraum_to_main_dossier"
+      />
+
+  <subscriber
+      for="opengever.dossier.behaviors.dossier.IDossierMarker
            zope.lifecycleevent.interfaces.IObjectModifiedEvent"
       handler=".handlers.reindex_contained_objects"
       />

--- a/opengever/dossier/handlers.py
+++ b/opengever/dossier/handlers.py
@@ -11,6 +11,8 @@ from opengever.globalindex.handlers.task import sync_task
 from opengever.globalindex.handlers.task import TaskSqlSyncer
 from opengever.meeting.handlers import ProposalSqlSyncer
 from opengever.task.task import ITask
+from opengever.workspaceclient.interfaces import ILinkedToWorkspace
+from opengever.workspaceclient.interfaces import ILinkedWorkspaces
 from plone import api
 from plone.app.workflow.interfaces import ILocalrolesModifiedEvent
 from Products.CMFPlone.interfaces import IPloneSiteRoot
@@ -169,3 +171,18 @@ def update_dossier_touched_date_for_move_event(obj, event):
     """
     if obj == event.object:
         update_dossier_touched_date(obj, event)
+
+
+def move_connected_teamraum_to_main_dossier(obj, event):
+    """If a dossier with linked workspaces gets moved into a dossier,
+    the workspace link needs to be updated and moved to the new main dossier.
+    """
+    # make sure obj wasn't just created or deleted
+    if not event.oldParent or not event.newParent:
+        return
+
+    if not ILinkedToWorkspace.providedBy(obj):
+        return
+
+    linked_workspaces = ILinkedWorkspaces(obj)
+    linked_workspaces.move_workspace_links_to_main_dossier()

--- a/opengever/workspaceclient/client.py
+++ b/opengever/workspaceclient/client.py
@@ -90,6 +90,14 @@ class WorkspaceClient(object):
                                   json={'external_reference': dossier_oguid},
                                   headers={'Prefer': 'return=representation'}).json()
 
+    def update_dossier_uid(self, workspace_uid, new_dossier_oguid):
+        """Updates external_reference on the remote workspace."""
+
+        workspace = self.get_by_uid(uid=workspace_uid)
+        return self.request.patch(
+            workspace.get('@id'),
+            json={'external_reference': new_dossier_oguid})
+
     def get_by_uid(self, uid, **kwargs):
         """Searches on the remote system for an object having the given UID
         and returns it (serialized).

--- a/opengever/workspaceclient/storage.py
+++ b/opengever/workspaceclient/storage.py
@@ -20,6 +20,11 @@ class LinkedWorkspacesStorage(object):
         """
         self._storage.append(uid)
 
+    def remove(self, uid):
+        """Remove a workspace by its UID.
+        """
+        self._storage.remove(uid)
+
     def list(self):
         """Returns the stored linked workspace UID's
         """


### PR DESCRIPTION
Workspace links are only allowed on main dossiers, but with moving a dossier into a subdossier it was possible to make a main dossier with linked workspaces to a subdossier. This PR fixes this issue, by automatically move the workspace link to the main_dossier. For https://4teamwork.atlassian.net/browse/CA-1276

There is a small possibility, where a move ist not possible, because the user is not allowed to update the linked workspaces. In that case it raises an Exception. Which is currently not handled with a specific error message in the frontend (I added a not to https://4teamwork.atlassian.net/browse/CA-396, because we need to define the right format for such messages first).

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
- Further improvements needed:
  - [x] Create follow-up stories and link them in the PR and Jira issue