### PR TITLE
Handle no template for paragraphs in DebugDocxCompose view.

### DIFF
--- a/changes/CA-2173.bugfix
+++ b/changes/CA-2173.bugfix
@@ -1,0 +1,1 @@
+Handle no template for paragraphs in DebugDocxCompose view. [njohner]

--- a/opengever/meeting/browser/meetings/debug.py
+++ b/opengever/meeting/browser/meetings/debug.py
@@ -71,7 +71,8 @@ class DebugDocxCompose(BrowserView):
     def add_sablon_for_paragraph(self, index, agenda_item, generator):
         committee = self.meeting.committee.resolve_committee()
         template = committee.get_paragraph_template()
-
+        if template is None:
+            return
         sablon = Sablon(template).process(
             ProtocolData(self.meeting, [agenda_item]).as_json())
 


### PR DESCRIPTION
It is not mandatory to define a template for paragraphs, therefore we need to handle the situation where the template is not defined, as is already done in the view generating the protocol (https://github.com/4teamwork/opengever.core/blob/master/opengever/meeting/command.py#L333-L336).

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)