### PR TITLE
Bundle import: Skip configuration import if not exists.

### DIFF
--- a/changes/CA-1224.bugfix
+++ b/changes/CA-1224.bugfix
@@ -1,0 +1,1 @@
+Bundle import: Skip configuration import if not exists. [phgross]

--- a/opengever/bundle/console.py
+++ b/opengever/bundle/console.py
@@ -87,8 +87,9 @@ def import_config_from_bundle(app, args):
 
     development_mode = bool(os.environ.get('IS_DEVELOPMENT_MODE'))
     json_data = _load_json(args.bundle_path, 'configuration.json')
-    importer = ConfigImporter(json_data)
-    importer.run(development_mode=development_mode)
+    if json_data:
+        importer = ConfigImporter(json_data)
+        importer.run(development_mode=development_mode)
 
 
 def setup_logging():


### PR DESCRIPTION
Since #6968 its no longer be possible to import a bundle without a configuration file.

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/


## Checklist
- [x] Changelog entry