### PR TITLE
Allow querying by custom properties in `@listing` endpoint.

### DIFF
--- a/changes/CA-1494.feature
+++ b/changes/CA-1494.feature
@@ -1,0 +1,1 @@
+Add `@listing-custom-fields` endpoint and allow retrieving custom properties in `@listing`. [deiferni]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -10,6 +10,7 @@ Other Changes
 ^^^^^^^^^^^^^
 
 - The ``@participations`` endpoint now prevents removing the last ``WorkspaceAdmin`` from a workspace.
+- Added ``@listing-custom-fields`` endpoint and allow retrieving custom properties in ``@listing``. (see :ref:`docs <listing-property_sheets>`)
 
 
 2021.9.0 (2021-04-29)

--- a/docs/public/dev-manual/api/listings.rst
+++ b/docs/public/dev-manual/api/listings.rst
@@ -126,6 +126,8 @@ werden. Folgende Felder stehen zur Verfügung:
 - ``UID``: UID des Objektes
 - ``watchers``: Liste von Beobachtern des Objekts (Benutzernamen)
 
+Weitere dynamische Felder sind gemäss :ref:`benutzerdefinierte Felder <listing-property_sheets>` verfügbar.
+
 Je nach Auflistungstyp und Inhalt sind bestimmte Felder nicht verfügbar. In diesem
 Fall wird der Wert ``none`` zurückgegeben. So haben Dossiers bspw. keinen Dateinamen,
 siehe Tabelle:
@@ -243,6 +245,54 @@ siehe Tabelle:
     |``watchers``              |   nein   |   nein  |     nein     |        nein        |   ja    |  nein   |  nein   |   nein   |       nein      |       nein       |       nein      |   nein   |       nein       |      nein      |
     +--------------------------+----------+---------+--------------+--------------------+---------+---------+---------+----------+-----------------+------------------+-----------------+----------+------------------+----------------+
 
+.. _listing-property_sheets:
+
+Benutzerdefinierte Felder:
+--------------------------
+
+Falls :ref:`benutzerdefinierte Felder <propertysheets>` definiert sind, stehen
+mit dem Endpoint ``@listing-custom-fields`` weitere, dynamische Felder zur
+Verfügung. Der Endpoint kann z.B. dafür benutzt werden um in einem Filtermenü
+sichtbare Spalten darzustellen. Er leifert ``title``, ``type`` und ``name``
+zurück. Der ``name`` kann für den Parameter ``columns`` des ``@listing``
+Endpoints verwendet werden.
+
+  .. sourcecode:: http
+
+    GET /@listing-custom-fields HTTP/1.1
+    Accept: application/json
+
+  .. sourcecode:: http
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    {
+        "documents": {
+            "properties": {
+                "buul_custom_field_boolean": {
+                    "name": "buul_custom_field_boolean",
+                    "title": "J/N",
+                    "type": "boolean"
+                },
+                "choice_custom_field_string": {
+                    "name": "choice_custom_field_string",
+                    "title": "Auswahl",
+                    "type": "string"
+                },
+                "num_custom_field_int": {
+                    "name": "num_custom_field_int",
+                    "title": "Zahl",
+                    "type": "integer"
+                },
+                "textline_custom_field_string": {
+                    "name": "textline_custom_field_string",
+                    "title": "Zeile Text",
+                    "type": "string"
+                }
+            }
+        }
+    }
 
 
 Optionale Parameter:

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -458,6 +458,14 @@
       permission="zope2.View"
       />
 
+  <plone:service
+      method="GET"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      factory=".listing_custom_fields.ListingCustomFieldsGet"
+      name="@listing-custom-fields"
+      permission="zope2.View"
+      />
+
   <adapter
       factory=".listing_stats.ListingStats"
       name="listing-stats"

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -4,13 +4,13 @@ from opengever.api.solr_query_service import REQUIRED_RESPONSE_FIELDS as DEFAULT
 from opengever.api.solr_query_service import SolrQueryBaseService
 from opengever.base.interfaces import ISearchSettings
 from opengever.dossier.indexers import ParticipationIndexHelper
+from opengever.propertysheets.definition import SolrDynamicField
 from plone.registry.interfaces import IRegistry
 from plone.uuid.interfaces import IUUID
 from Products.CMFPlone.utils import safe_unicode
 from zExceptions import BadRequest
 from zope.component import getUtility
 from ZPublisher.HTTPRequest import record
-
 
 # Fields with no mapping but allowed in the listing endpoint.
 OTHER_ALLOWED_FIELDS = set([
@@ -343,4 +343,7 @@ class ListingGet(SolrQueryBaseService):
         return res
 
     def is_field_allowed(self, field):
-        return field in self.allowed_fields
+        return (
+            field in self.allowed_fields
+            or SolrDynamicField.is_dynamic_field(field)
+        )

--- a/opengever/api/listing_custom_fields.py
+++ b/opengever/api/listing_custom_fields.py
@@ -1,0 +1,50 @@
+from plone.restapi.services import Service
+from opengever.propertysheets.assignment import get_dossier_assignment_slots
+from opengever.propertysheets.assignment import get_document_assignment_slots
+from opengever.propertysheets.storage import PropertySheetSchemaStorage
+
+
+LISTING_TO_SLOTS = {
+    u'dossiers': get_dossier_assignment_slots,
+    u'documents': get_document_assignment_slots,
+}
+
+
+class ListingCustomFieldsGet(Service):
+    """API Endpoint which returns custom fields available for listings.
+
+    It returns a nested data structure with custom fields for each supported
+    listing, if available.
+    Custom fields are provided as follows:
+    - Custom field source are property sheets registerd for a type associated
+      with a listing
+    - Custom fields must be indexed in solr (i.e. everything but `Text`)
+    - If different sheets for the same type index to the same field, only the
+      last field is returned.
+
+    GET /@listing-custom-fields HTTP/1.1
+    """
+
+    def reply(self):
+        solr_fields = {}
+
+        storage = PropertySheetSchemaStorage()
+        if not storage:
+            return solr_fields
+
+        for listing_name, slot_provider in LISTING_TO_SLOTS.items():
+            fields_by_listing = {}
+
+            for slot_name in slot_provider():
+                definition = storage.query(slot_name)
+                if definition is not None:
+                    fields_by_listing.update(
+                        definition.get_solr_dynamic_field_schema()
+                    )
+
+            if fields_by_listing:
+                solr_fields[listing_name] = {
+                    'properties': fields_by_listing
+                }
+
+        return solr_fields

--- a/opengever/propertysheets/definition.py
+++ b/opengever/propertysheets/definition.py
@@ -46,6 +46,10 @@ class SolrDynamicField(object):
     DYNAMIC_FIELD_IDENT = '_custom_field_'
 
     @classmethod
+    def is_dynamic_field(cls, name):
+        return cls.DYNAMIC_FIELD_IDENT in name
+
+    @classmethod
     def supports(cls, field):
         return type(field) in cls.SUPPORTED_TYPES
 

--- a/opengever/propertysheets/definition.py
+++ b/opengever/propertysheets/definition.py
@@ -5,16 +5,23 @@ from opengever.propertysheets.exceptions import InvalidSchemaAssignment
 from opengever.propertysheets.schema import get_property_sheet_schema
 from persistent.list import PersistentList
 from persistent.mapping import PersistentMapping
+from plone import api
 from plone.restapi.serializer.converters import IJsonCompatible
+from plone.restapi.types.interfaces import IJsonSchemaProvider
 from plone.schemaeditor import fields
 from plone.schemaeditor.utils import IEditableSchema
 from plone.supermodel import loadString
 from plone.supermodel import model
 from plone.supermodel import serializeSchema
 from zope.component import getUtility
+from zope.component import queryMultiAdapter
+from zope.globalrequest import getRequest
+from zope.schema import Bool
 from zope.schema import Choice
 from zope.schema import getFieldNamesInOrder
 from zope.schema import getFieldsInOrder
+from zope.schema import Int
+from zope.schema import TextLine
 from zope.schema import ValidationError
 from zope.schema.interfaces import IVocabularyFactory
 from zope.schema.interfaces import WrongType
@@ -26,6 +33,44 @@ import tokenize
 
 def isidentifier(val):
     return re.match(tokenize.Name + r'\Z', val) and not keyword.iskeyword(val)
+
+
+class SolrDynamicField(object):
+
+    SUPPORTED_TYPES = {
+        Bool: 'boolean',
+        Choice: 'string',
+        Int: 'int',
+        TextLine: 'string',
+    }
+    DYNAMIC_FIELD_IDENT = '_custom_field_'
+
+    @classmethod
+    def supports(cls, field):
+        return type(field) in cls.SUPPORTED_TYPES
+
+    def __init__(self, name, field):
+        assert self.supports(field)
+
+        solr_type = self.SUPPORTED_TYPES[type(field)]
+        self.solr_field_name = '{}{}{}'.format(
+            name, self.DYNAMIC_FIELD_IDENT, solr_type
+        )
+        self.field = field
+        self.name = name
+
+    def get_schema(self):
+        provider = queryMultiAdapter(
+            (self.field, api.portal.get(), getRequest()),
+            interface=IJsonSchemaProvider
+        )
+        schema = provider.get_schema()
+
+        return {
+            'title': schema['title'],
+            'name': self.solr_field_name,
+            'type': schema['type'],
+        }
 
 
 class PropertySheetSchemaDefinition(object):
@@ -168,6 +213,13 @@ class PropertySheetSchemaDefinition(object):
         """Return a list of (name, field) tuples in native schema order."""
         return getFieldsInOrder(self.schema_class)
 
+    def get_solr_dynamic_fields(self):
+        """Return all solr dynamic fields for this definition's schema."""
+        return [
+            SolrDynamicField(name, field) for name, field in self.get_fields()
+            if SolrDynamicField.supports(field)
+        ]
+
     def get_fieldnames(self):
         """Return a list of fieldnames in native schema order."""
         return getFieldNamesInOrder(self.schema_class)
@@ -176,6 +228,12 @@ class PropertySheetSchemaDefinition(object):
         schema_info = get_property_sheet_schema(self.schema_class)
         schema_info["assignments"] = IJsonCompatible(self.assignments)
         return schema_info
+
+    def get_solr_dynamic_field_schema(self):
+        solr_schema = {}
+        for solr_field in self.get_solr_dynamic_fields():
+            solr_schema[solr_field.solr_field_name] = solr_field.get_schema()
+        return solr_schema
 
     def validate(self, data):
         """Validate data against the definition's schema.

--- a/opengever/propertysheets/solr.py
+++ b/opengever/propertysheets/solr.py
@@ -4,15 +4,6 @@ from opengever.document.behaviors.customproperties import IDocumentCustomPropert
 from opengever.dossier.behaviors.customproperties import IDossierCustomProperties
 from opengever.propertysheets.storage import PropertySheetSchemaStorage
 from zope.schema import getFields
-from zope.schema import Text
-
-
-SOLR_TYPES = {
-    'unicode': 'string',
-    'str': 'string',
-    'bool': 'boolean',
-    'int': 'int',
-}
 
 
 class CustomPropertiesIndexHandler(DefaultIndexHandler):
@@ -47,15 +38,11 @@ class CustomPropertiesIndexHandler(DefaultIndexHandler):
             if not definition:
                 continue
 
-            for name, custom_field in definition.get_fields():
-                # Custom properties are indexed for filtering and sorting.
-                # This doesn't make sense for multiline text.
-                if type(custom_field) == Text:
-                    continue
+            for solr_field in definition.get_solr_dynamic_fields():
+                name = solr_field.name
                 if name in custom_properties[slot]:
                     value = custom_properties[slot][name]
-                    solr_type = SOLR_TYPES.get(type(value).__name__, 'string')
-                    data['{}_custom_field_{}'.format(name, solr_type)] = value
+                    data[solr_field.solr_field_name] = value
 
         return data
 

--- a/opengever/propertysheets/tests/test_definition.py
+++ b/opengever/propertysheets/tests/test_definition.py
@@ -97,6 +97,86 @@ class TestSchemaDefinitionRichComparison(FunctionalTestCase):
         )
 
 
+class TestSchemaDefinitionSolrFields(FunctionalTestCase):
+
+    maxDiff = None
+
+    def test_bool_field_solr_dynamic_field_info(self):
+        definition = PropertySheetSchemaDefinition.create("foo")
+        definition.add_field("bool", u"yesorno", u"y/n", u"", False)
+
+        self.assertEqual(
+            {
+                'yesorno_custom_field_boolean': {
+                    'name': 'yesorno_custom_field_boolean',
+                    'title': u'y/n',
+                    'type': u'boolean',
+                }
+            },
+            definition.get_solr_dynamic_field_schema()
+        )
+
+    def test_choice_field_solr_dynamic_field_info(self):
+        definition = PropertySheetSchemaDefinition.create("foo")
+        choices = ['one', 'two', 'three']
+        definition.add_field(
+            "choice", u"chooseone", u"choose", u"", False, values=choices
+        )
+
+        self.assertEqual(
+            {
+                'chooseone_custom_field_string': {
+                    'name': 'chooseone_custom_field_string',
+                    'title': u'choose',
+                    'type': u'string',
+                }
+            },
+            definition.get_solr_dynamic_field_schema()
+        )
+
+    def test_int_field_solr_dynamic_field_info(self):
+        definition = PropertySheetSchemaDefinition.create("foo")
+        definition.add_field(
+            "int", u"num", u"A number", u"Put a number.", True
+        )
+
+        self.assertEqual(
+            {
+                'num_custom_field_int': {
+                    'name': 'num_custom_field_int',
+                    'title': u'A number',
+                    'type': u'integer',
+                }
+            },
+            definition.get_solr_dynamic_field_schema()
+        )
+
+    def test_text_field_solr_dynamic_field_info(self):
+        definition = PropertySheetSchemaDefinition.create("foo")
+        definition.add_field(
+            "text", u"blabla", u"Text", u"Say something long.", True
+        )
+
+        self.assertEqual({}, definition.get_solr_dynamic_field_schema())
+
+    def test_textline_field_solr_dynamic_field_info(self):
+        definition = PropertySheetSchemaDefinition.create("foo")
+        definition.add_field(
+            "textline", u"bla", u"Textline", u"Say something short.", True
+        )
+
+        self.assertEqual(
+            {
+                'bla_custom_field_string': {
+                    'name': 'bla_custom_field_string',
+                    'title': u'Textline',
+                    'type': u'string',
+                }
+            },
+            definition.get_solr_dynamic_field_schema()
+        )
+
+
 class TestSchemaDefinition(FunctionalTestCase):
 
     def test_create_empty_schema_definition(self):


### PR DESCRIPTION
We add support to query the `@listing` endpoint with custom properties/dynamic fields. Available custom columns by listing are provided globally in a `@listing-custom-fields` endpoint.

The custom fields are provided in a global endpoint on the plone site, so that the UI can request these mostly static information once, and then retrieve it from from global application state rather than querying the available fields every time before a listing is requested from the backend.

The `@listing-custom-fields` endpoint returns all available fields based on currently registered property sheets. It takes care of associating property sheets to available listing names and merges fields from different property sheets with the same name and type while building the list.

The `@listing` endpoint now allows all those additional fields to be retrieved via the `columns` argument.

I have moved the responsibility/knowledge about what fields can be indexed in solr to the property sheet schema definition class and provided a distinct field class for solr fields with `SolrDynamicField`.

I have discovered some assumptions built into https://github.com/4teamwork/opengever.core/pull/6959 which are not yet completely validated upon input. The changes here also silently rely on certain states not being introduced into the system. If you do (which you currenlty can) behavior is undefined
- make sure default slot and type-based slot property names don't overlap
- only allow string type values in choices

_I will amend validation in a separate PR._

Jira: https://4teamwork.atlassian.net/browse/CA-1494

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))