### PR TITLE
Properly handle non string choices in property sheet definition.

### DIFF
--- a/opengever/propertysheets/definition.py
+++ b/opengever/propertysheets/definition.py
@@ -188,6 +188,12 @@ class PropertySheetSchemaDefinition(object):
                 raise InvalidFieldTypeDefinition(
                     "For 'choice' fields types values are required."
                 )
+
+            if not all(isinstance(choice, basestring) for choice in values):
+                raise InvalidFieldTypeDefinition(
+                    "For 'choice' field types values must be string."
+                )
+
             # Using `unicode_escape` encoding for tokens is a requirement of
             # `ChoiceHandler` which otherwise refuses to write the vocabulary
             # to XML.

--- a/opengever/propertysheets/tests/test_definition.py
+++ b/opengever/propertysheets/tests/test_definition.py
@@ -298,6 +298,30 @@ class TestSchemaDefinition(FunctionalTestCase):
                 "choice", u"chooseone", u"choose", u"", False, values=choices
             )
 
+    def test_add_choice_field_rejects_integer_values(self):
+        definition = PropertySheetSchemaDefinition.create("foo")
+        choices = [1, 2]
+        with self.assertRaises(InvalidFieldTypeDefinition):
+            definition.add_field(
+                "choice", u"chooseone", u"choose", u"", False, values=choices
+            )
+
+    def test_add_choice_field_rejects_boolean_values(self):
+        definition = PropertySheetSchemaDefinition.create("foo")
+        choices = [True, False]
+        with self.assertRaises(InvalidFieldTypeDefinition):
+            definition.add_field(
+                "choice", u"chooseone", u"choose", u"", False, values=choices
+            )
+
+    def test_add_choice_field_rejects_mixed_values(self):
+        definition = PropertySheetSchemaDefinition.create("foo")
+        choices = ["blah", u'blub', 1, True]
+        with self.assertRaises(InvalidFieldTypeDefinition):
+            definition.add_field(
+                "choice", u"chooseone", u"choose", u"", False, values=choices
+            )
+
     def test_add_non_choice_field_prevents_adding_values(self):
         definition = PropertySheetSchemaDefinition.create("foo")
         with self.assertRaises(InvalidFieldTypeDefinition):

--- a/opengever/propertysheets/tests/test_schema_definition_post.py
+++ b/opengever/propertysheets/tests/test_schema_definition_post.py
@@ -160,6 +160,40 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
         )
 
     @browsing
+    def test_property_sheet_schema_definition_post_reject_invalid_choices(self, browser):
+        self.login(self.manager, browser)
+
+        data = {
+            "fields": [
+                {
+                    "name": "wahl",
+                    "field_type": u"choice",
+                    "title": u"w\xe4hl was",
+                    "values": [1, True]
+                }
+            ],
+            "assignments": ["IDocumentMetadata.document_type.question"],
+        }
+
+        with browser.expect_http_error(400):
+            browser.open(
+                view="@propertysheets/foo",
+                method="POST",
+                data=json.dumps(data),
+                headers=self.api_headers,
+            )
+
+        self.assertDictContainsSubset(
+            {
+                "type": "BadRequest",
+            },
+            browser.json,
+        )
+
+        storage = PropertySheetSchemaStorage()
+        self.assertEqual(3, len(storage))
+
+    @browsing
     def test_property_sheet_schema_definition_post_replaces_existing_schema(self, browser):
         self.login(self.manager, browser)
         create(Builder("property_sheet_schema").named("question"))


### PR DESCRIPTION
With this PR we explicitly prevent that users add non string choice values to a choice field in a property sheet definition.

This would not have been prevented before indirectly due to a call to `encode` on all values. Nevertheless we add explicit handling to disallow non string values in choice fields and raise an exception with a more explicit message.

Amends https://github.com/4teamwork/opengever.core/pull/7000, i have not added a separate CL entry.

Jira: https://4teamwork.atlassian.net/browse/CA-1494

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- ~~[ ] Changelog entry~~
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
