### PR TITLE
Prevent creation of property sheets with conflicting fields.

### DIFF
--- a/changes/CA-1494.other
+++ b/changes/CA-1494.other
@@ -1,0 +1,1 @@
+Prevent adding property sheets with conflicting field names. [deiferni]

--- a/opengever/propertysheets/assignment.py
+++ b/opengever/propertysheets/assignment.py
@@ -75,3 +75,24 @@ def get_dossier_assignment_slots():
 
 def dossier_type_assignment_slot_name(value):
     return u"{}.{}".format(DOSSIER_TYPE_ASSIGNMENT_SLOT_PREFIX, value)
+
+
+def get_slots_enforcing_unique_field_names(slot_name):
+    """Return other slots that enforce unique fields names.
+
+    Given a slot name return all other slot names which cannot have field
+    names overlap with this slot.
+
+    This function is used by storage to validate if new property sheets can
+    be added.
+    """
+    if slot_name == DOCUMENT_DEFAULT_ASSIGNMENT_SLOT:
+        return set(_get_document_type_slots())
+    elif slot_name == DOSSIER_DEFAULT_ASSIGNMENT_SLOT:
+        return set(_get_dossier_type_slots())
+    elif slot_name.startswith(DOCUMENT_TYPE_ASSIGNMENT_SLOT_PREFIX):
+        return {DOCUMENT_DEFAULT_ASSIGNMENT_SLOT}
+    elif slot_name.startswith(DOSSIER_TYPE_ASSIGNMENT_SLOT_PREFIX):
+        return {DOSSIER_DEFAULT_ASSIGNMENT_SLOT}
+
+    return {}

--- a/opengever/propertysheets/assignment.py
+++ b/opengever/propertysheets/assignment.py
@@ -26,21 +26,24 @@ class PropertySheetAssignmentVocabulary(object):
         return SimpleVocabulary(assignment_terms)
 
 
+def _get_document_type_slots():
+    vocabulary_factory = getUtility(
+        IVocabularyFactory, name="opengever.document.document_types"
+    )
+    return [
+        document_type_assignment_slot_name(term.value)
+        for term in vocabulary_factory(None)
+    ]
+
+
 def get_document_assignment_slots():
     """"Return a list of all valid assignment slots for documents.
 
     This is limited to one slot per possible value of the
     `document_type` field and the default document slot.
     """
-    vocabulary_factory = getUtility(
-        IVocabularyFactory, name="opengever.document.document_types"
-    )
-    terms = [
-        document_type_assignment_slot_name(term.value)
-        for term in vocabulary_factory(None)
-    ]
 
-    return [DOCUMENT_DEFAULT_ASSIGNMENT_SLOT] + terms
+    return [DOCUMENT_DEFAULT_ASSIGNMENT_SLOT] + _get_document_type_slots()
 
 
 def document_type_assignment_slot_name(value):
@@ -50,21 +53,24 @@ def document_type_assignment_slot_name(value):
     )
 
 
+def _get_dossier_type_slots():
+    vocabulary_factory = getUtility(
+        IVocabularyFactory, name="opengever.dossier.dossier_types"
+    )
+    return [
+        dossier_type_assignment_slot_name(term.value)
+        for term in vocabulary_factory(None)
+    ]
+
+
 def get_dossier_assignment_slots():
     """"Return a list of all valid assignment slots for dossiers.
 
     This is limited to one slot per possible value of the
     `dossier_type` field and the default dossier slot.
     """
-    vocabulary_factory = getUtility(
-        IVocabularyFactory, name="opengever.dossier.dossier_types"
-    )
-    terms = [
-        dossier_type_assignment_slot_name(term.value)
-        for term in vocabulary_factory(None)
-    ]
 
-    return [DOSSIER_DEFAULT_ASSIGNMENT_SLOT] + terms
+    return [DOSSIER_DEFAULT_ASSIGNMENT_SLOT] + _get_dossier_type_slots()
 
 
 def dossier_type_assignment_slot_name(value):

--- a/opengever/propertysheets/storage.py
+++ b/opengever/propertysheets/storage.py
@@ -1,3 +1,4 @@
+from opengever.propertysheets.assignment import get_slots_enforcing_unique_field_names
 from opengever.propertysheets.definition import PropertySheetSchemaDefinition
 from opengever.propertysheets.exceptions import InvalidSchemaAssignment
 from persistent.mapping import PersistentMapping
@@ -36,25 +37,70 @@ class PropertySheetSchemaStorage(object):
             result.append(self.get(name))
         return result
 
-    def save(self, schema_definition):
-        annotations = IAnnotations(self.context)
+    def _validate_schema_definition(self, storage, new_definition):
+        """Validate a new schema definition.
 
-        if self.ANNOTATIONS_KEY not in annotations:
-            annotations[self.ANNOTATIONS_KEY] = PersistentMapping()
+        Performs the following validations:
+        - Ensure that there is at most one definition per slot.
+        - Ensure that a definition is not assigned to conflicting slots.
+        - Ensure that fields within the schema definitions do not overlap.
+          Currently an external method defines the relationship between
+          different slots and which slots could overlap other slots.
 
-        storage = annotations[self.ANNOTATIONS_KEY]
-
+        """
         used_assignments = set()
         for definition_data in storage.values():
             used_assignments.update(definition_data['assignments'])
 
-        for new_assignment in schema_definition.assignments:
+        for new_assignment in new_definition.assignments:
             if new_assignment in used_assignments:
                 raise InvalidSchemaAssignment(
                     u"The assignment '{}' is already in use.".format(
                         new_assignment)
                 )
             used_assignments.add(new_assignment)
+
+        maybe_conflicting = set()
+        for slot_name in new_definition.assignments:
+            maybe_conflicting.update(
+                get_slots_enforcing_unique_field_names(slot_name)
+            )
+
+        conflicting_within_new_definition = [
+            assignment for assignment in new_definition.assignments
+            if assignment in maybe_conflicting
+        ]
+        if conflicting_within_new_definition:
+            raise InvalidSchemaAssignment(
+                u"The assignments '{}' cannot be used for the same "
+                u"sheet.".format(
+                    u"', '".join(conflicting_within_new_definition))
+            )
+
+        # sort for stable validation order/output
+        for assignment in sorted(maybe_conflicting):
+            existing_definition = self.query(assignment)
+            if not existing_definition:
+                continue
+
+            intersecting_fields = (
+                set(existing_definition.get_fieldnames())
+                & set(new_definition.get_fieldnames())
+            )
+            if intersecting_fields:
+                raise InvalidSchemaAssignment(
+                    u"Overlapping field names '{}' in assignment '{}'".format(
+                        u"', '".join(intersecting_fields), assignment
+                    )
+                )
+
+    def save(self, schema_definition):
+        annotations = IAnnotations(self.context)
+        if self.ANNOTATIONS_KEY not in annotations:
+            annotations[self.ANNOTATIONS_KEY] = PersistentMapping()
+        storage = annotations[self.ANNOTATIONS_KEY]
+
+        self._validate_schema_definition(storage, schema_definition)
 
         schema_definition._save(storage)
 

--- a/opengever/propertysheets/tests/test_field.py
+++ b/opengever/propertysheets/tests/test_field.py
@@ -306,14 +306,14 @@ class TestPropertySheetField(FunctionalTestCase):
             Builder("property_sheet_schema")
             .named("schema")
             .assigned_to_slots(u"IDocumentMetadata.document_type.question")
-            .with_simple_boolean_field()
+            .with_simple_textline_field()
         )
 
         self.request["some_request_key"] = [u"question"]
 
         self.field.validate(
             {"IDocument.default": {"yesorno": True},
-             "IDocumentMetadata.document_type.question": {"yesorno": True}}
+             "IDocumentMetadata.document_type.question": {"shorttext": u"bla"}}
         )
 
     def test_default_slot_gets_validated(self):

--- a/opengever/propertysheets/tests/test_storage.py
+++ b/opengever/propertysheets/tests/test_storage.py
@@ -125,6 +125,127 @@ class TestPropertySheetSchemaStorage(FunctionalTestCase):
             exc.message
         )
 
+    def test_prevents_self_conflicting_assignment(self):
+        storage = PropertySheetSchemaStorage()
+        conflict = PropertySheetSchemaDefinition.create(
+            "fixture",
+            assignments=[
+                u"IDocument.default",
+                u"IDocumentMetadata.document_type.report"
+            ]
+        )
+        with self.assertRaises(InvalidSchemaAssignment) as cm:
+            storage.save(conflict)
+
+        self.assertEqual(
+            u"The assignments 'IDocument.default', "
+            u"'IDocumentMetadata.document_type.report' cannot be used for "
+            u"the same sheet.",
+            cm.exception.message
+        )
+
+    def test_prevents_document_field_name_default_conflicts_with_type(self):
+        storage = PropertySheetSchemaStorage()
+        fixture = PropertySheetSchemaDefinition.create(
+            "fixture",
+            assignments=[u"IDocument.default"],
+        )
+        fixture.add_field("bool", u"yesorno", u"y/n", u"", False)
+        storage.save(fixture)
+
+        conflict = PropertySheetSchemaDefinition.create(
+            "conflict",
+            assignments=[u"IDocumentMetadata.document_type.report"]
+        )
+        conflict.add_field("bool", u"yesorno", u"y/n", u"", False)
+        with self.assertRaises(InvalidSchemaAssignment) as cm:
+            storage.save(conflict)
+
+        exc = cm.exception
+        self.assertEqual(
+            u"Overlapping field names 'yesorno' in assignment "
+            u"'IDocument.default'",
+            exc.message
+        )
+
+    def test_prevents_document_field_name_type_conflicts_with_default(self):
+        storage = PropertySheetSchemaStorage()
+        fixture1 = PropertySheetSchemaDefinition.create(
+            "fixture1",
+            assignments=[u"IDocumentMetadata.document_type.report"]
+        )
+        fixture1.add_field("bool", u"yesorno", u"y/n", u"", False)
+        storage.save(fixture1)
+        fixture2 = PropertySheetSchemaDefinition.create(
+            "fixture2",
+            assignments=[u"IDocumentMetadata.document_type.question"]
+        )
+        fixture2.add_field("bool", u"yesorno", u"y/n", u"", False)
+        storage.save(fixture2)
+
+        conflict = PropertySheetSchemaDefinition.create(
+            "conflict",
+            assignments=[u"IDocument.default"],
+        )
+        conflict.add_field("bool", u"yesorno", u"y/n", u"", False)
+        with self.assertRaises(InvalidSchemaAssignment) as cm:
+            storage.save(conflict)
+
+        exc = cm.exception
+        self.assertEqual(
+            u"Overlapping field names 'yesorno' in assignment "
+            "'IDocumentMetadata.document_type.question'",
+            exc.message
+        )
+
+    def test_prevents_dossier_field_name_default_conflicts_with_type(self):
+        storage = PropertySheetSchemaStorage()
+        fixture = PropertySheetSchemaDefinition.create(
+            "fixture",
+            assignments=[u"IDossier.default"],
+        )
+        fixture.add_field("textline", u"yesorno", u"blabla", u"", False)
+        storage.save(fixture)
+
+        conflict = PropertySheetSchemaDefinition.create(
+            "conflict",
+            assignments=[u"IDossier.dossier_type.businesscase"]
+        )
+        conflict.add_field("bool", u"yesorno", u"y/n", u"", False)
+        with self.assertRaises(InvalidSchemaAssignment) as cm:
+            storage.save(conflict)
+
+        exc = cm.exception
+        self.assertEqual(
+            u"Overlapping field names 'yesorno' in assignment "
+            u"'IDossier.default'",
+            exc.message
+        )
+
+    def test_prevents_dossier_field_name_type_conflicts_with_default(self):
+        storage = PropertySheetSchemaStorage()
+        fixture = PropertySheetSchemaDefinition.create(
+            "fixture",
+            assignments=[u"IDossier.dossier_type.businesscase"]
+        )
+        fixture.add_field("bool", u"yesorno", u"y/n", u"", False)
+        storage.save(fixture)
+
+        conflict = PropertySheetSchemaDefinition.create(
+            "conflict",
+            assignments=[u"IDossier.default"],
+        )
+        conflict.add_field("int", u"yesorno", u"a number", u"", False)
+        with self.assertRaises(InvalidSchemaAssignment) as cm:
+            storage.save(conflict)
+
+        exc = cm.exception
+        self.assertEqual(
+            u"Overlapping field names 'yesorno' in assignment "
+            "'IDossier.dossier_type.businesscase'",
+            exc.message
+        )
+
     def test_query_for_schema_by_assignment(self):
         storage = PropertySheetSchemaStorage()
         fixture = PropertySheetSchemaDefinition.create(

--- a/opengever/testing/builders/propertysheets.py
+++ b/opengever/testing/builders/propertysheets.py
@@ -29,6 +29,11 @@ class PropertySheetSchemaBuilder(object):
     def with_simple_boolean_field(self):
         return self.with_field("bool", u"yesorno", u"y/n", u"", True)
 
+    def with_simple_textline_field(self):
+        return self.with_field(
+            "textline", u"shorttext", u"Text", u"Say something.", True
+        )
+
     def with_field(self, field_type, name, title, description, required, values=None):
         self.field_defs.append(
             (field_type, name, title, description, required, values)


### PR DESCRIPTION
We now enforce unique fields names within certain subsets of slots.

This has become necessary as our Solr dynamic field implementation of https://github.com/4teamwork/opengever.core/pull/6959 potentially shares field names between different property sheets. To prevent undefined behavior when a sheet for the default slot and a sheet for a type specific slot define the same field, we don't allow this to happen in the first place.

We also don't allow the same property sheet to be assigned to the default slot and a type specific slot at the same time.

The implementation here is a bit more strict that would be necessary as same name but different type would currently result in different Solr dynamic field names. I think it is a reasonable and future proof restrictions, and users can just choose a new name like `title_1` to avoid conflicts.

Jira: https://4teamwork.atlassian.net/browse/CA-1494

_I have not written an api changelog as the API is currently only available for `Manager` and not customer facing._

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
