### PR TITLE
Add close-remote-task endpoint 

### DIFF
--- a/changes/CA-1641.feature
+++ b/changes/CA-1641.feature
@@ -1,0 +1,1 @@
+Added close-remote-task endpoint, for closing remote tasks of type `information`. [phgross]

--- a/docs/public/dev-manual/api/close_remote_task.rst
+++ b/docs/public/dev-manual/api/close_remote_task.rst
@@ -1,0 +1,25 @@
+.. _close_remote_task:
+
+Remote-Task "Zur Kentnissnahme" abschliessen
+============================================
+
+Der ``@close-remote-task`` Endpoint ermöglicht den Abschluss einer mandantenübergreifende Aufgabe vom Type "zur Kentnissnahme" abzuschliessen und dabei gewisse an die Aufgabe angehängte Dokumente in den eigenen Mandanten zu kopieren.
+
+Im untenstehenden Beispiel ist ``fd`` der Remote-Mandant, und der Benutzer, hugo.boss, will die Aufgabe abschliessen und dabei zwei Dokumente auf seinem lokalen Mandanten ``rk`` kopieren.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       POST /rk/@accept-remote-task HTTP/1.1
+       Content-Type: application/json
+       Accept: application/json
+
+       {
+         "task_oguid": "fd:12345",
+         "dossier_uid": "9823u409823094",
+         "document_oguids": ["fd:34567", "fd:45678",],
+         "text": "Ist ok!"
+       }
+
+Der Endpoint antwortet mit dem StatusCode 201.

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -64,4 +64,5 @@ Inhalt:
    accept_remote_task.rst
    complete_successor_task.rst
    upload_structure.rst
+   close_remote_task.rst
    examples/index.rst

--- a/opengever/api/close_remote_task.py
+++ b/opengever/api/close_remote_task.py
@@ -1,0 +1,83 @@
+from opengever.api.remote_task_base import RemoteTaskBaseService
+from opengever.base.exceptions import MalformedOguid
+from opengever.base.oguid import Oguid
+from opengever.globalindex.model.task import Task
+from opengever.task.browser.close import CloseTaskHelper
+from plone.app.uuid.utils import uuidToObject
+from plone.protect.interfaces import IDisableCSRFProtection
+from zExceptions import BadRequest
+from zope.interface import alsoProvides
+
+
+class CloseRemoteTaskPost(RemoteTaskBaseService):
+    """Close a task on a remote admin unit, copying documents to the given
+    dossier on the current admin unit if selected.
+
+    this is only possible for `information`-tasks
+
+    POST /dossier-17/@close-remote-task
+
+    {
+      "task_oguid": "fd:12345",
+      "text": "I'm accepting this task into this dossier."
+      "dossier_uid": "9823u409823094"
+      "document_oguids": ["rk:23459", "rk:94598"]
+    }
+
+    This endpoint will close a remote task (a task that is assigned to the
+    current user, but physically is located on a different admin unit) and
+    copy the selected documents to the given dossier.
+
+    The remote task is identified via the "task_oguid" in the JSON body, and
+    *must* be on a different admin unit than the current one.
+    """
+
+    required_params = ('task_oguid', )
+    optional_params = ('text', 'document_oguids', 'dossier_uid')
+
+    def is_remote(self, oguid):
+        return not oguid.is_on_current_admin_unit
+
+    def reply(self):
+        # Disable CSRF protection
+        alsoProvides(self.request, IDisableCSRFProtection)
+
+        # Extract and validate parameters, assign defaults
+        params = self.extract_params()
+
+        raw_task_oguid = params['task_oguid']
+        response_text = params.get('text', u'')
+        dossier_uid = params.get('dossier_uid', u'')
+        document_oguids = params.get('document_oguids', u'')
+
+        # Validate that Oguid is well-formed and refers to a task that is
+        # actually remote. Turn any Python exceptions into proper
+        # 400 Bad Request responses with details in the JSON body.
+        try:
+            task_oguid = Oguid.parse(raw_task_oguid)
+            task = Task.query.by_oguid(task_oguid)
+        except MalformedOguid as exc:
+            raise BadRequest(self.format_exception(exc))
+
+        if document_oguids and not dossier_uid:
+            raise BadRequest('dossier_uid is required when selecting '
+                             'documents for copying.')
+
+        if not self.is_remote(task_oguid):
+            raise BadRequest(
+                'Task must be on remote admin unit. '
+                'Oguid %s refers to a local task, however.' % raw_task_oguid)
+
+        closer = CloseTaskHelper()
+        if dossier_uid:
+            dossier = uuidToObject(dossier_uid)
+            document_intids = [Oguid.parse(oguid).int_id for oguid in document_oguids]
+            closer.copy_documents(task, dossier, document_intids)
+
+        closer.close_task(task, response_text)
+
+        self.request.response.setStatus(201)
+        self.request.response.setHeader("Location", dossier.absolute_url())
+
+        serialized_dossier = self.serialize(dossier)
+        return serialized_dossier

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -51,6 +51,7 @@
   <adapter factory=".proposal.SerializeProposalToJson" />
   <adapter factory=".proposal.SerializeSubmittedProposalToJson" />
   <adapter factory=".serializer.long_converter" />
+  <adapter factory=".serializer.oguid_converter" />
   <adapter factory=".field_deserializers.PersistentDefaultFieldDeserializer" />
   <adapter factory=".field_deserializers.PersistentDatetimeFieldDeserializer" />
   <adapter factory=".field_deserializers.DateFieldDeserializer" />

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -1138,6 +1138,15 @@
       />
 
   <plone:service
+      method="POST"
+      name="@close-remote-task"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      factory=".close_remote_task.CloseRemoteTaskPost"
+      layer="opengever.base.interfaces.IOpengeverBaseLayer"
+      permission="zope2.View"
+      />
+
+  <plone:service
       method="PATCH"
       name="@tus-upload"
       for="opengever.document.document.IDocumentSchema"

--- a/opengever/api/serializer.py
+++ b/opengever/api/serializer.py
@@ -5,6 +5,7 @@ from opengever.api.batch import SQLHypermediaBatch
 from opengever.base.behaviors.translated_title import get_inactive_languages
 from opengever.base.interfaces import IOpengeverBaseLayer
 from opengever.base.oguid import Oguid
+from opengever.base.oguid import Oguid
 from opengever.base.response import IResponseContainer
 from opengever.base.response import IResponseSupported
 from opengever.base.sentry import log_msg_to_sentry
@@ -133,6 +134,14 @@ def long_converter(value):
     in a later release.
     """
     return value
+
+
+@adapter(Oguid)
+@implementer(IJsonCompatible)
+def oguid_converter(value):
+    """Returns the id for the Oguid object.
+    """
+    return value.id
 
 
 class SerializeSQLModelToJsonBase(object):

--- a/opengever/api/serializer.py
+++ b/opengever/api/serializer.py
@@ -307,6 +307,9 @@ class GeverSerializeToJsonSummary(DefaultJSONSummarySerializer):
 
         extend_with_is_subdossier(summary, self.context, self.request)
 
+        if 'oguid' in self.metadata_fields():
+            extend_with_oguid(summary, self.context)
+
         summary['is_leafnode'] = None
         if IRepositoryFolder.providedBy(self.context):
             summary['is_leafnode'] = self.context.is_leaf_node()

--- a/opengever/api/tests/test_close_remote_task.py
+++ b/opengever/api/tests/test_close_remote_task.py
@@ -1,0 +1,93 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from mock import patch
+from opengever.base.oguid import Oguid
+from opengever.base.response import IResponseContainer
+from opengever.testing import IntegrationTestCase
+from plone import api
+import json
+
+
+class TestCloseRemoteTaskPost(IntegrationTestCase):
+
+    def last_response(self, obj):
+        return IResponseContainer(obj).list()[-1]
+
+    @browsing
+    def test_requires_task_oguid_parameter(self, browser):
+        self.login(self.regular_user, browser)
+        url = '{}/@close-remote-task'.format(self.portal.absolute_url())
+
+        with browser.expect_http_error(code=400):
+            browser.open(url, method='POST', headers=self.api_headers)
+
+        self.assertEqual(
+            {u'type': u'BadRequest',
+             u'message': u'Required parameter "task_oguid" is missing in body'},
+            browser.json)
+
+    @browsing
+    def test_requires_dossier_uid_when_documents_are_selected(self, browser):
+        self.login(self.regular_user, browser)
+
+        task = create(Builder('task')
+                      .within(self.dossier)
+                      .having(issuer=self.dossier_responsible.id,
+                              responsible=self.regular_user.id,
+                              responsible_client='fa',
+                              task_type='information')
+                      .relate_to([self.document, self.mail_eml])
+                      .in_state('task-state-open')
+                      .titled(u'Task x'))
+
+        url = '{}/@close-remote-task'.format(self.portal.absolute_url())
+        request_body = json.dumps({
+            'task_oguid': u'plone:%s' % task.get_sql_object().int_id,
+            'text': u'All right!',
+            'document_oguids': [Oguid.for_object(self.document).id],
+        })
+
+        with browser.expect_http_error(code=400):
+            browser.open(url, method='POST', data=request_body, headers=self.api_headers)
+
+        self.assertEqual(
+            {u'type': u'BadRequest',
+             u'message': u'dossier_uid is required when selecting documents for copying.'},
+            browser.json)
+
+    @browsing
+    def test_closes_and_copy_documents_successfull(self, browser):
+        self.login(self.regular_user, browser)
+
+        task = create(Builder('task')
+                      .within(self.dossier)
+                      .having(issuer=self.dossier_responsible.id,
+                              responsible=self.regular_user.id,
+                              responsible_client='fa',
+                              task_type='information')
+                      .relate_to([self.document, self.mail_eml])
+                      .in_state('task-state-open')
+                      .titled(u'Task x'))
+
+        url = '{}/@close-remote-task'.format(self.portal.absolute_url())
+        request_body = json.dumps({
+            'task_oguid': Oguid.for_object(task).id,
+            'dossier_uid': self.empty_dossier.UID(),
+            'text': u'All right!',
+            'document_oguids': [Oguid.for_object(self.document).id],
+        })
+
+        with self.observe_children(self.empty_dossier) as children:
+            with patch('opengever.api.close_remote_task.'
+                       'CloseRemoteTaskPost.is_remote') as mock_is_remote:
+                mock_is_remote.return_value = True
+                browser.open(url, method='POST', data=request_body,
+                             headers=self.api_headers)
+
+        doc, = children['added']
+        self.assertEqual(self.document.title, doc.title)
+        self.assertEqual(self.document.file.data, doc.file.data)
+
+        self.assertEqual('task-state-tested-and-closed',
+                         api.content.get_state(task))

--- a/opengever/api/tests/test_serializer.py
+++ b/opengever/api/tests/test_serializer.py
@@ -1,9 +1,11 @@
 from ftw.bumblebee.interfaces import IBumblebeeDocument
 from ftw.bumblebee.tests.helpers import DOCX_CHECKSUM
 from ftw.testbrowser import browsing
+from opengever.base.oguid import Oguid
 from opengever.repository.behaviors.responsibleorg import IResponsibleOrgUnit
 from opengever.testing import IntegrationTestCase
 from plone import api
+from plone.restapi.serializer.converters import json_compatible
 from plone.restapi.serializer.dxcontent import SerializeFolderToJson
 from plone.restapi.serializer.dxcontent import SerializeToJson
 from zope.component import getUtility
@@ -321,3 +323,13 @@ class TestGroupSerializer(IntegrationTestCase):
                                     u'token': u'service.user'}],
                         u'items_total': 17}},
             response)
+
+
+class TestOguidConverter(IntegrationTestCase):
+
+    @browsing
+    def test_oguid_converter(self, browser):
+        self.login(self.manager, browser)
+
+        oguid = Oguid.for_object(self.task)
+        self.assertEqual(oguid.id, json_compatible(oguid))

--- a/opengever/api/tests/test_summary_serializer.py
+++ b/opengever/api/tests/test_summary_serializer.py
@@ -1,4 +1,5 @@
 from ftw.testbrowser import browsing
+from opengever.base.oguid import Oguid
 from opengever.testing import IntegrationTestCase
 from plone.restapi.interfaces import ISerializeToJsonSummary
 from zope.component import getMultiAdapter
@@ -21,7 +22,7 @@ class TestGeverSummarySerializer(IntegrationTestCase):
         self.assertNotIn('creator', serilized_doc)
 
         self.request.form['metadata_fields'] = [
-            'filename', 'filesize', 'mimetype', 'creator']
+            'filename', 'filesize', 'mimetype', 'creator', 'oguid']
         serializer = getMultiAdapter(
             (self.document, self.request),
             ISerializeToJsonSummary)
@@ -42,6 +43,7 @@ class TestGeverSummarySerializer(IntegrationTestCase):
              'filename': u'Vertraegsentwurf.docx',
              'filesize': 27413,
              'mimetype': u'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+             'oguid': Oguid.for_object(self.document).id,
              'is_leafnode': None,
              'review_state': u'document-state-draft',
              'title': u'Vertr\xe4gsentwurf'},
@@ -62,7 +64,7 @@ class TestGeverSummarySerializer(IntegrationTestCase):
         self.assertNotIn('creator', serilized_doc)
 
         self.request.form['metadata_fields'] = [
-            'filename', 'filesize', 'mimetype', 'creator']
+            'filename', 'filesize', 'mimetype', 'creator', 'oguid']
         serializer = getMultiAdapter(
             (self.mail_eml, self.request),
             ISerializeToJsonSummary)
@@ -83,6 +85,7 @@ class TestGeverSummarySerializer(IntegrationTestCase):
              'filename': u'Die Buergschaft.eml',
              'filesize': 1108,
              'mimetype': u'text/plain',
+             'oguid': Oguid.for_object(self.mail_eml).id,
              'is_leafnode': None,
              'review_state': u'mail-state-active',
              'title': u'Die B\xfcrgschaft'},


### PR DESCRIPTION
Adds an additional API endpoint `close-remote-task` which allows to close a remote task and copy documents (related or contained) to a dossier of the current admin_unit.

https://4teamwork.atlassian.net/browse/CA-1641

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated