### PR TITLE
Add @upload-structure endpoint

### DIFF
--- a/changes/CA-2212.feature
+++ b/changes/CA-2212.feature
@@ -1,0 +1,1 @@
+Add @upload-structure endpoint. [njohner]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,7 +11,7 @@ Other Changes
 
 - The ``@participations`` endpoint now prevents removing the last ``WorkspaceAdmin`` from a workspace.
 - Added ``@listing-custom-fields`` endpoint and allow retrieving custom properties in ``@listing``. (see :ref:`docs <listing-property_sheets>`)
-
+- Added ``@upload-structure`` endpoint. (see :ref:`docs <upload-structure>`)
 
 2021.9.0 (2021-04-29)
 ---------------------

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -63,4 +63,5 @@ Inhalt:
    remote_workflow.rst
    accept_remote_task.rst
    complete_successor_task.rst
+   upload_structure.rst
    examples/index.rst

--- a/docs/public/dev-manual/api/upload_structure.rst
+++ b/docs/public/dev-manual/api/upload_structure.rst
@@ -1,0 +1,76 @@
+.. _upload-structure:
+
+Dossier und Dokumente hochladen
+===============================
+
+Der ``@upload-structure`` Endpoint kann verwendet werden um zu überprüfen ob der Upload von Datein möglich ist. Eine Liste von relativen Pfade muss im ``files`` Parameter mitgegeben werden. Der Endpoint berechnet die Struktur von Dossiers und Dokumente welche erstellt werden müsste um die ``files`` Liste in GEVER zu erstellen.
+
+
+  .. sourcecode:: http
+
+    POST /ordnungssystem/dossier-23/@upload-structure HTTP/1.1
+    Accept: application/json
+
+    {
+        "files": ["folder/file.txt", "folder/subfolder/mail.msg"]
+    }
+
+
+  .. sourcecode:: http
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    {
+        "items": {
+            "folder": {
+                "@type": "opengever.dossier.businesscasedossier",
+                "is_container": true,
+                "items": {
+                    "file.txt": {
+                        "@type": "opengever.document.document",
+                        "is_container": false,
+                        "relative_path": "folder/file.txt"
+                    },
+                    "subfolder": {
+                        "@type": "opengever.dossier.businesscasedossier",
+                        "is_container": true,
+                        "items": {
+                            "mail.msg": {
+                                "@type": "ftw.mail.mail",
+                                "is_container": false,
+                                "relative_path": "folder/subfolder/mail.msg"
+                            }
+                        },
+                        "relative_path": "folder/subfolder"
+                    }
+                },
+                "relative_path": "folder"
+            }
+        },
+        "items_total": 4,
+        "max_container_depth": 2
+    }
+
+Wenn die Erstellung dieser Struktur nich möglich wäre, zum Beispiel wegen Berechtigungen, Subdossier Tiefe oder weil im Gewünschtem Kontext keine Dossiers / Dokumente erstellt werden können, dann wird mit ``400 Bad Request`` geantwortet.
+
+  .. sourcecode:: http
+
+    POST /ordnungssystem/@upload-structure HTTP/1.1
+    Accept: application/json
+
+    {
+        "files": ["file.txt"]
+    }
+
+
+  .. sourcecode:: http
+
+    HTTP/1.1 400 Bad Request
+    Content-Type: application/json
+
+    {
+        "message": "Some of the objects cannot be added here",
+        "type": "BadRequest"
+    }
+

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -1264,6 +1264,15 @@
       layer="opengever.base.interfaces.IOpengeverBaseLayer"
       />
 
+
+  <adapter factory=".upload_structure.DefaultUploadStructureAnalyser" />
+  <adapter factory=".upload_structure.DossierUploadStructureAnalyser" />
+  <adapter factory=".upload_structure.RepositoryFolderUploadStructureAnalyser" />
+  <adapter factory=".upload_structure.PrivateFolderUploadStructureAnalyser" />
+  <adapter factory=".upload_structure.PrivateDossierUploadStructureAnalyser" />
+  <adapter factory=".upload_structure.WorkspaceUploadStructureAnalyser" />
+  <adapter factory=".upload_structure.WorkspaceFolderUploadStructureAnalyser" />
+
   <plone:service
       method="POST"
       for="zope.interface.Interface"

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -1264,4 +1264,13 @@
       layer="opengever.base.interfaces.IOpengeverBaseLayer"
       />
 
+  <plone:service
+      method="POST"
+      for="zope.interface.Interface"
+      factory=".upload_structure.UploadStructurePost"
+      name="@upload-structure"
+      layer="opengever.base.interfaces.IOpengeverBaseLayer"
+      permission="zope2.View"
+      />
+
 </configure>

--- a/opengever/api/tests/test_upload_structure.py
+++ b/opengever/api/tests/test_upload_structure.py
@@ -85,3 +85,20 @@ class TestUploadStructure(IntegrationTestCase):
         self.assertEqual(
             {u'message': u"Property 'files' is required", u'type': u'BadRequest'},
             browser.json)
+
+    @browsing
+    def test_upload_structure_raises_if_user_cannot_add_content_in_context(self, browser):
+        self.login(self.regular_user, browser)
+
+        payload = {
+            u'files': ['/folder/file.txt']
+        }
+        with browser.expect_http_error(code=400):
+            browser.open("{}/@upload-structure".format(self.inactive_dossier.absolute_url()),
+                         data=json.dumps(payload),
+                         method='POST',
+                         headers=self.api_headers)
+        self.assertEqual(
+            {u'message': u'User is not allowed to add objects here',
+             u'type': u'BadRequest'},
+            browser.json)

--- a/opengever/api/tests/test_upload_structure.py
+++ b/opengever/api/tests/test_upload_structure.py
@@ -410,3 +410,22 @@ class TestUploadStructure(IntegrationTestCase):
         self.assert_upload_structure_raises_bad_request(
             browser, self.private_root, ['file.txt'],
             u'Some of the objects cannot be added here')
+
+    @browsing
+    def test_upload_structure_in_private_folder(self, browser):
+        self.login(self.regular_user, browser)
+
+        # document cannot be added in private folder
+        self.assert_upload_structure_raises_bad_request(
+            browser, self.private_folder, ['file.txt'],
+            u'Some of the objects cannot be added here')
+
+        # dossier can be added in private folder
+        self.assert_upload_structure_returns_ok(
+            browser, self.private_folder, ['folder/file.txt'])
+
+        folder = browser.json['items']['folder']
+        self.assertEqual(folder['@type'],
+                         u'opengever.private.dossier')
+        self.assertEqual(folder['items']['file.txt']['@type'],
+                         u'opengever.document.document')

--- a/opengever/api/tests/test_upload_structure.py
+++ b/opengever/api/tests/test_upload_structure.py
@@ -1,0 +1,87 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+import json
+
+
+class TestUploadStructure(IntegrationTestCase):
+
+    @browsing
+    def test_upload_structure(self, browser):
+        self.login(self.regular_user, browser)
+        payload = {
+            u'files': ['folder/file.txt', 'folder/subfolder/file2.txt']
+        }
+        response = browser.open(
+            "{}/@upload-structure".format(self.leaf_repofolder.absolute_url()),
+            data=json.dumps(payload),
+            method='POST',
+            headers=self.api_headers)
+
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(
+            {u'items': {
+                u'folder': {
+                    u'@type': u'opengever.dossier.businesscasedossier',
+                    u'relative_path': u'folder',
+                    u'items': {
+                        u'file.txt': {
+                            u'@type': u'opengever.document.document',
+                            u'relative_path': u'folder/file.txt'},
+                        u'subfolder': {
+                            u'@type': u'opengever.dossier.businesscasedossier',
+                            u'relative_path': u'folder/subfolder',
+                            u'items': {
+                                u'file2.txt': {
+                                    u'@type': u'opengever.document.document',
+                                    u'relative_path': u'folder/subfolder/file2.txt'}
+                                }
+                            }
+                        }
+                    }
+                },
+             u'max_container_depth': 2,
+             u'items_total': 4},
+            browser.json)
+
+    @browsing
+    def test_upload_structure_respects_leading_slash(self, browser):
+        self.login(self.regular_user, browser)
+        payload = {
+            u'files': ['/folder/file.txt']
+        }
+        response = browser.open(
+            "{}/@upload-structure".format(self.leaf_repofolder.absolute_url()),
+            data=json.dumps(payload),
+            method='POST',
+            headers=self.api_headers)
+
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(
+            {u'items': {
+                u'folder': {
+                    u'@type': u'opengever.dossier.businesscasedossier',
+                    u'relative_path': u'/folder',
+                    u'items': {
+                        u'file.txt': {
+                            u'@type': u'opengever.document.document',
+                            u'relative_path': u'/folder/file.txt'},
+                        }
+                    }
+                },
+             u'max_container_depth': 1,
+             u'items_total': 2},
+            browser.json)
+
+    @browsing
+    def test_upload_structure_requires_files_list(self, browser):
+        self.login(self.regular_user, browser)
+
+        payload = {}
+        with browser.expect_http_error(code=400):
+            browser.open("{}/@upload-structure".format(self.leaf_repofolder.absolute_url()),
+                         data=json.dumps(payload),
+                         method='POST',
+                         headers=self.api_headers)
+        self.assertEqual(
+            {u'message': u"Property 'files' is required", u'type': u'BadRequest'},
+            browser.json)

--- a/opengever/api/tests/test_upload_structure.py
+++ b/opengever/api/tests/test_upload_structure.py
@@ -123,9 +123,17 @@ class TestUploadStructure(IntegrationTestCase):
     def test_upload_structure_raises_if_user_cannot_add_content_in_context(self, browser):
         self.login(self.regular_user, browser)
 
-        self.assert_upload_structure_raises_bad_request(
-            browser, self.inactive_dossier, ['/folder/file.txt'],
-            u'User is not allowed to add objects here')
+        payload = {u'files': ['/folder/file.txt']}
+        with browser.expect_http_error(code=403):
+            browser.open(self.inactive_dossier,
+                         view="@upload-structure",
+                         data=json.dumps(payload),
+                         method='POST',
+                         headers=self.api_headers)
+
+        self.assertEqual(u'User is not allowed to add objects here',
+                         browser.json['message'])
+        self.assertEqual(u'Forbidden', browser.json['type'])
 
     @browsing
     def test_upload_structure_raises_if_max_dossier_depth_would_be_exceeded(self, browser):

--- a/opengever/api/tests/test_upload_structure.py
+++ b/opengever/api/tests/test_upload_structure.py
@@ -102,6 +102,18 @@ class TestUploadStructure(IntegrationTestCase):
             browser.json)
 
     @browsing
+    def test_upload_structure_requires_non_empty_filenames(self, browser):
+        self.login(self.regular_user, browser)
+
+        self.assert_upload_structure_raises_bad_request(
+            browser, self.dossier, [''],
+            u'Empty filename not supported')
+
+        self.assert_upload_structure_raises_bad_request(
+            browser, self.dossier, [None],
+            u'Empty filename not supported')
+
+    @browsing
     def test_upload_structure_raises_if_user_cannot_add_content_in_context(self, browser):
         self.login(self.regular_user, browser)
 

--- a/opengever/api/tests/test_upload_structure.py
+++ b/opengever/api/tests/test_upload_structure.py
@@ -137,6 +137,15 @@ class TestUploadStructure(IntegrationTestCase):
             u'Maximum dossier depth exceeded')
 
     @browsing
+    def test_upload_structure_ignores_maximal_depth_in_workspace_area(self, browser):
+        self.login(self.workspace_member, browser)
+
+        self.assert_upload_structure_returns_ok(
+            browser,
+            self.workspace,
+            ['/folder/folder/folder/file.txt'])
+
+    @browsing
     def test_upload_structure_in_inbox_container(self, browser):
         self.login(self.manager, browser)
 

--- a/opengever/api/tests/test_upload_structure.py
+++ b/opengever/api/tests/test_upload_structure.py
@@ -5,19 +5,37 @@ import json
 
 class TestUploadStructure(IntegrationTestCase):
 
+    def assert_upload_structure_returns_ok(self, browser, context, files):
+        payload = {u'files': files}
+        browser.open(context,
+                     view="@upload-structure",
+                     data=json.dumps(payload),
+                     method='POST',
+                     headers=self.api_headers)
+
+        self.assertEqual(200, browser.status_code)
+
+    def assert_upload_structure_raises_bad_request(self, browser, context, files, message):
+        payload = {u'files': files}
+        with browser.expect_http_error(code=400):
+            browser.open(context,
+                         view="@upload-structure",
+                         data=json.dumps(payload),
+                         method='POST',
+                         headers=self.api_headers)
+
+        self.assertEqual(message, browser.json['message'])
+        self.assertEqual(u'BadRequest', browser.json['type'])
+
     @browsing
     def test_upload_structure(self, browser):
         self.login(self.regular_user, browser)
-        payload = {
-            u'files': ['folder/file.txt', 'folder/subfolder/file2.txt']
-        }
-        response = browser.open(
-            "{}/@upload-structure".format(self.leaf_repofolder.absolute_url()),
-            data=json.dumps(payload),
-            method='POST',
-            headers=self.api_headers)
 
-        self.assertEqual(200, response.status_code)
+        self.assert_upload_structure_returns_ok(
+            browser,
+            self.leaf_repofolder,
+            ['folder/file.txt', 'folder/subfolder/file2.txt'])
+
         self.assertEqual(
             {u'items': {
                 u'folder': {
@@ -46,16 +64,12 @@ class TestUploadStructure(IntegrationTestCase):
     @browsing
     def test_upload_structure_respects_leading_slash(self, browser):
         self.login(self.regular_user, browser)
-        payload = {
-            u'files': ['/folder/file.txt']
-        }
-        response = browser.open(
-            "{}/@upload-structure".format(self.leaf_repofolder.absolute_url()),
-            data=json.dumps(payload),
-            method='POST',
-            headers=self.api_headers)
 
-        self.assertEqual(200, response.status_code)
+        self.assert_upload_structure_returns_ok(
+            browser,
+            self.leaf_repofolder,
+            ['/folder/file.txt'])
+
         self.assertEqual(
             {u'items': {
                 u'folder': {
@@ -78,7 +92,8 @@ class TestUploadStructure(IntegrationTestCase):
 
         payload = {}
         with browser.expect_http_error(code=400):
-            browser.open("{}/@upload-structure".format(self.leaf_repofolder.absolute_url()),
+            browser.open(self.leaf_repofolder,
+                         view="@upload-structure",
                          data=json.dumps(payload),
                          method='POST',
                          headers=self.api_headers)
@@ -90,138 +105,308 @@ class TestUploadStructure(IntegrationTestCase):
     def test_upload_structure_raises_if_user_cannot_add_content_in_context(self, browser):
         self.login(self.regular_user, browser)
 
-        payload = {
-            u'files': ['/folder/file.txt']
-        }
-        with browser.expect_http_error(code=400):
-            browser.open("{}/@upload-structure".format(self.inactive_dossier.absolute_url()),
-                         data=json.dumps(payload),
-                         method='POST',
-                         headers=self.api_headers)
-        self.assertEqual(
-            {u'message': u'User is not allowed to add objects here',
-             u'type': u'BadRequest'},
-            browser.json)
+        self.assert_upload_structure_raises_bad_request(
+            browser, self.inactive_dossier, ['/folder/file.txt'],
+            u'User is not allowed to add objects here')
 
     @browsing
     def test_upload_structure_raises_if_max_dossier_depth_would_be_exceeded(self, browser):
         self.login(self.regular_user, browser)
 
-        payload = {
-            u'files': ['folder/file.txt']
-        }
-        browser.open("{}/@upload-structure".format(self.dossier.absolute_url()),
-                     data=json.dumps(payload),
-                     method='POST',
-                     headers=self.api_headers)
-        self.assertEqual(200, browser.status_code)
+        self.assert_upload_structure_returns_ok(
+            browser,
+            self.dossier,
+            ['/folder/file.txt'])
 
-        with browser.expect_http_error(code=400):
-            browser.open("{}/@upload-structure".format(self.subdossier.absolute_url()),
-                         data=json.dumps(payload),
-                         method='POST',
-                         headers=self.api_headers)
-        self.assertEqual(
-            {u'message': u'Maximum dossier depth exceeded',
-             u'type': u'BadRequest'},
-            browser.json)
+        self.assert_upload_structure_raises_bad_request(
+            browser,
+            self.subdossier,
+            ['/folder/file.txt'],
+            u'Maximum dossier depth exceeded')
 
     @browsing
-    def test_upload_structure_raises_if_portal_type_not_addable_in_context(self, browser):
-        self.login(self.regular_user, browser)
+    def test_upload_structure_in_inbox_container(self, browser):
+        self.login(self.manager, browser)
+
+        # dossier cannot be added in inbox container
+        self.assert_upload_structure_raises_bad_request(
+            browser, self.inbox_container, ['folder/file.txt'],
+            u'Some of the objects cannot be added here')
+
+        # document cannot be added in inbox container
+        self.assert_upload_structure_raises_bad_request(
+            browser, self.inbox_container, ['file.txt'],
+            u'Some of the objects cannot be added here')
+
+    @browsing
+    def test_upload_structure_in_inbox(self, browser):
+        self.login(self.manager, browser)
+
+        # dossier cannot be added in inbox
+        self.assert_upload_structure_raises_bad_request(
+            browser, self.inbox, ['folder/file.txt'],
+            u'Some of the objects cannot be added here')
+
+        # document can be added in inbox
+        self.assert_upload_structure_returns_ok(
+            browser, self.inbox, ['file.txt'])
+
+        self.assertEqual(browser.json['items']['file.txt']['@type'],
+                         u'opengever.document.document')
+
+    @browsing
+    def test_upload_structure_in_repository_root(self, browser):
+        self.login(self.manager, browser)
+
+        # dossier cannot be added in repository root
+        self.assert_upload_structure_raises_bad_request(
+            browser, self.repository_root, ['folder/file.txt'],
+            u'Some of the objects cannot be added here')
+
+        # document cannot be added in repository root
+        self.assert_upload_structure_raises_bad_request(
+            browser, self.repository_root, ['file.txt'],
+            u'Some of the objects cannot be added here')
+
+    @browsing
+    def test_upload_structure_in_branch_repofolder(self, browser):
+        self.login(self.manager, browser)
+
+        # dossier cannot be added in branch repofolder
+        self.assert_upload_structure_raises_bad_request(
+            browser, self.branch_repofolder, ['folder/file.txt'],
+            u'Some of the objects cannot be added here')
+
+        # document cannot be added in branch repofolder
+        self.assert_upload_structure_raises_bad_request(
+            browser, self.branch_repofolder, ['file.txt'],
+            u'Some of the objects cannot be added here')
+
+    @browsing
+    def test_upload_structure_in_leaf_repofolder(self, browser):
+        self.login(self.manager, browser)
 
         # document cannot be added in repository folder
-        payload = {
-            u'files': ['file.txt']
-        }
-        with browser.expect_http_error(code=400):
-            browser.open("{}/@upload-structure".format(self.leaf_repofolder.absolute_url()),
-                         data=json.dumps(payload),
-                         method='POST',
-                         headers=self.api_headers)
-        self.assertEqual(
-            {u'message': u'Some of the objects cannot be added here',
-             u'type': u'BadRequest'},
-            browser.json)
+        self.assert_upload_structure_raises_bad_request(
+            browser, self.leaf_repofolder, ['file.txt'],
+            u'Some of the objects cannot be added here')
 
-        # dossier cannot be added in branch repository folder
-        payload = {
-            u'files': ['folder/file.txt']
-        }
-        with browser.expect_http_error(code=400):
-            browser.open("{}/@upload-structure".format(self.branch_repofolder.absolute_url()),
-                         data=json.dumps(payload),
-                         method='POST',
-                         headers=self.api_headers)
-        self.assertEqual(
-            {u'message': u'Some of the objects cannot be added here',
-             u'type': u'BadRequest'},
-            browser.json)
+        # dossier can be added in repository folder
+        self.assert_upload_structure_returns_ok(
+            browser,
+            self.leaf_repofolder,
+            ['folder/file.txt', 'folder/file.msg'])
+
+        folder = browser.json['items']['folder']
+        self.assertEqual(folder['@type'],
+                         u'opengever.dossier.businesscasedossier')
+        self.assertEqual(folder['items']['file.txt']['@type'],
+                         u'opengever.document.document')
+        self.assertEqual(folder['items']['file.msg']['@type'],
+                         u'ftw.mail.mail')
+    @browsing
+    def test_upload_structure_in_dossier(self, browser):
+        self.login(self.regular_user, browser)
+        self.assert_upload_structure_returns_ok(
+            browser,
+            self.dossier,
+            ['folder/file.txt', 'file.msg'])
+
+        folder = browser.json['items']['folder']
+        self.assertEqual(folder['@type'],
+                         u'opengever.dossier.businesscasedossier')
+        self.assertEqual(folder['items']['file.txt']['@type'],
+                         u'opengever.document.document')
+        self.assertEqual(browser.json['items']['file.msg']['@type'],
+                         u'ftw.mail.mail')
 
     @browsing
-    def test_upload_chooses_correct_portal_types(self, browser):
-        self.login(self.regular_user, browser)
+    def test_upload_structure_in_workspace_root(self, browser):
+        self.login(self.manager, browser)
 
-        payload = {
-            u'files': ['folder/file.txt', 'folder/file.msg']
-        }
-        response = browser.open(
-            "{}/@upload-structure".format(self.leaf_repofolder.absolute_url()),
-            data=json.dumps(payload),
-            method='POST',
-            headers=self.api_headers)
+        # dossier cannot be added in workspace root
+        self.assert_upload_structure_raises_bad_request(
+            browser, self.workspace_root, ['folder/file.txt'],
+            u'Some of the objects cannot be added here')
 
-        self.assertEqual(200, response.status_code)
-        folder = response.json['items']['folder']
-        self.assertEqual(folder['@type'],
-                         u'opengever.dossier.businesscasedossier')
-        self.assertEqual(folder['items']['file.txt']['@type'],
-                         u'opengever.document.document')
-        self.assertEqual(folder['items']['file.msg']['@type'],
-                         u'ftw.mail.mail')
+        # document cannot be added in workspace root
+        self.assert_upload_structure_raises_bad_request(
+            browser, self.workspace_root, ['file.txt'],
+            u'Some of the objects cannot be added here')
 
-        response = browser.open(
-            "{}/@upload-structure".format(self.dossier.absolute_url()),
-            data=json.dumps(payload),
-            method='POST',
-            headers=self.api_headers)
-
-        self.assertEqual(200, response.status_code)
-        folder = response.json['items']['folder']
-        self.assertEqual(folder['@type'],
-                         u'opengever.dossier.businesscasedossier')
-        self.assertEqual(folder['items']['file.txt']['@type'],
-                         u'opengever.document.document')
-        self.assertEqual(folder['items']['file.msg']['@type'],
-                         u'ftw.mail.mail')
-
+    @browsing
+    def test_upload_structure_in_workspace(self, browser):
         self.login(self.workspace_member, browser)
-        response = browser.open(
-            "{}/@upload-structure".format(self.workspace.absolute_url()),
-            data=json.dumps(payload),
-            method='POST',
-            headers=self.api_headers)
+        self.assert_upload_structure_returns_ok(
+            browser,
+            self.workspace,
+            ['folder/file.txt', 'file.msg'])
 
-        self.assertEqual(200, response.status_code)
-        folder = response.json['items']['folder']
+        folder = browser.json['items']['folder']
         self.assertEqual(folder['@type'],
                          u'opengever.workspace.folder')
         self.assertEqual(folder['items']['file.txt']['@type'],
                          u'opengever.document.document')
-        self.assertEqual(folder['items']['file.msg']['@type'],
+        self.assertEqual(browser.json['items']['file.msg']['@type'],
                          u'ftw.mail.mail')
 
-        response = browser.open(
-            "{}/@upload-structure".format(self.workspace_folder.absolute_url()),
-            data=json.dumps(payload),
-            method='POST',
-            headers=self.api_headers)
+    @browsing
+    def test_upload_structure_in_workspace_folder(self, browser):
+        self.login(self.workspace_member, browser)
+        self.assert_upload_structure_returns_ok(
+            browser,
+            self.workspace_folder,
+            ['folder/file.txt', 'file.msg'])
 
-        self.assertEqual(200, response.status_code)
-        folder = response.json['items']['folder']
+        folder = browser.json['items']['folder']
         self.assertEqual(folder['@type'],
                          u'opengever.workspace.folder')
         self.assertEqual(folder['items']['file.txt']['@type'],
                          u'opengever.document.document')
-        self.assertEqual(folder['items']['file.msg']['@type'],
+        self.assertEqual(browser.json['items']['file.msg']['@type'],
                          u'ftw.mail.mail')
+
+    @browsing
+    def test_upload_structure_in_task(self, browser):
+        self.login(self.manager, browser)
+
+        # dossier cannot be added in task
+        self.assert_upload_structure_raises_bad_request(
+            browser, self.task, ['folder/file.txt'],
+            u'Some of the objects cannot be added here')
+
+        self.assert_upload_structure_returns_ok(
+            browser, self.task, ['file.txt', 'file.msg'])
+        self.assertEqual(browser.json['items']['file.txt']['@type'],
+                         u'opengever.document.document')
+        self.assertEqual(browser.json['items']['file.msg']['@type'],
+                         u'ftw.mail.mail')
+
+    @browsing
+    def test_upload_structure_in_proposal(self, browser):
+        self.login(self.manager, browser)
+
+        # dossier cannot be added in proposal
+        self.assert_upload_structure_raises_bad_request(
+            browser, self.proposal, ['folder/file.txt'],
+            u'Some of the objects cannot be added here')
+
+        # document cannot be added in proposal
+        self.assert_upload_structure_raises_bad_request(
+            browser, self.proposal, ['file.txt'],
+            u'Some of the objects cannot be added here')
+
+    @browsing
+    def test_upload_structure_in_contact_folder(self, browser):
+        self.login(self.manager, browser)
+
+        # dossier cannot be added in contact folder
+        self.assert_upload_structure_raises_bad_request(
+            browser, self.contactfolder, ['folder/file.txt'],
+            u'Some of the objects cannot be added here')
+
+        # document cannot be added in contact folder
+        self.assert_upload_structure_raises_bad_request(
+            browser, self.contactfolder, ['file.txt'],
+            u'Some of the objects cannot be added here')
+
+    @browsing
+    def test_upload_structure_in_committee_container(self, browser):
+        self.login(self.manager, browser)
+
+        # dossier cannot be added in committee container
+        self.assert_upload_structure_raises_bad_request(
+            browser, self.committee_container, ['folder/file.txt'],
+            u'Some of the objects cannot be added here')
+
+        # document cannot be added in committee container
+        self.assert_upload_structure_raises_bad_request(
+            browser, self.committee_container, ['file.txt'],
+            u'Some of the objects cannot be added here')
+
+    @browsing
+    def test_upload_structure_in_committee(self, browser):
+        self.login(self.manager, browser)
+
+        # dossier cannot be added in committee
+        self.assert_upload_structure_raises_bad_request(
+            browser, self.committee, ['folder/file.txt'],
+            u'Some of the objects cannot be added here')
+
+        # document cannot be added in committee
+        self.assert_upload_structure_raises_bad_request(
+            browser, self.committee_container, ['file.txt'],
+            u'Some of the objects cannot be added here')
+
+    @browsing
+    def test_upload_structure_in_templatefolder(self, browser):
+        self.login(self.manager, browser)
+
+        # dossier cannot be added in templatefolder
+        self.assert_upload_structure_raises_bad_request(
+            browser, self.templates, ['folder/file.txt'],
+            u'Some of the objects cannot be added here')
+
+        # document can be added in templatefolder
+        self.assert_upload_structure_returns_ok(
+            browser, self.templates, ['file.txt'])
+        self.assertEqual(browser.json['items']['file.txt']['@type'],
+                         u'opengever.document.document')
+
+    @browsing
+    def test_upload_structure_in_dossiertemplate(self, browser):
+        self.login(self.manager, browser)
+
+        # dossier cannot be added in dossiertemplate
+        self.assert_upload_structure_raises_bad_request(
+            browser, self.dossiertemplate, ['folder/file.txt'],
+            u'Some of the objects cannot be added here')
+
+        # document can be added in dossiertemplate
+        self.assert_upload_structure_returns_ok(
+            browser, self.dossiertemplate, ['file.txt'])
+        self.assertEqual(browser.json['items']['file.txt']['@type'],
+                         u'opengever.document.document')
+
+    @browsing
+    def test_upload_structure_in_proposal_template(self, browser):
+        self.login(self.manager, browser)
+
+        # dossier cannot be added in proposal_template
+        self.assert_upload_structure_raises_bad_request(
+            browser, self.proposal_template, ['folder/file.txt'],
+            u'Some of the objects cannot be added here')
+
+        # document can be added in proposal_template
+        self.assert_upload_structure_returns_ok(
+            browser, self.proposal_template, ['file.txt'])
+        self.assertEqual(browser.json['items']['file.txt']['@type'],
+                         u'opengever.document.document')
+
+    @browsing
+    def test_upload_structure_in_tasktemplate(self, browser):
+        self.login(self.manager, browser)
+
+        # dossier cannot be added in tasktemplate
+        self.assert_upload_structure_raises_bad_request(
+            browser, self.tasktemplate, ['folder/file.txt'],
+            u'Some of the objects cannot be added here')
+
+        # document cannot be added in tasktemplate
+        self.assert_upload_structure_raises_bad_request(
+            browser, self.tasktemplate, ['file.txt'],
+            u'Some of the objects cannot be added here')
+
+    @browsing
+    def test_upload_structure_in_private_root(self, browser):
+        self.login(self.manager, browser)
+
+        # dossier cannot be added in private root
+        self.assert_upload_structure_raises_bad_request(
+            browser, self.private_root, ['folder/file.txt'],
+            u'Some of the objects cannot be added here')
+
+        # document cannot be added in private root
+        self.assert_upload_structure_raises_bad_request(
+            browser, self.private_root, ['file.txt'],
+            u'Some of the objects cannot be added here')

--- a/opengever/api/tests/test_upload_structure.py
+++ b/opengever/api/tests/test_upload_structure.py
@@ -102,3 +102,26 @@ class TestUploadStructure(IntegrationTestCase):
             {u'message': u'User is not allowed to add objects here',
              u'type': u'BadRequest'},
             browser.json)
+
+    @browsing
+    def test_upload_structure_raises_if_max_dossier_depth_would_be_exceeded(self, browser):
+        self.login(self.regular_user, browser)
+
+        payload = {
+            u'files': ['folder/file.txt']
+        }
+        browser.open("{}/@upload-structure".format(self.dossier.absolute_url()),
+                     data=json.dumps(payload),
+                     method='POST',
+                     headers=self.api_headers)
+        self.assertEqual(200, browser.status_code)
+
+        with browser.expect_http_error(code=400):
+            browser.open("{}/@upload-structure".format(self.subdossier.absolute_url()),
+                         data=json.dumps(payload),
+                         method='POST',
+                         headers=self.api_headers)
+        self.assertEqual(
+            {u'message': u'Maximum dossier depth exceeded',
+             u'type': u'BadRequest'},
+            browser.json)

--- a/opengever/api/tests/test_upload_structure.py
+++ b/opengever/api/tests/test_upload_structure.py
@@ -158,3 +158,70 @@ class TestUploadStructure(IntegrationTestCase):
              u'type': u'BadRequest'},
             browser.json)
 
+    @browsing
+    def test_upload_chooses_correct_portal_types(self, browser):
+        self.login(self.regular_user, browser)
+
+        payload = {
+            u'files': ['folder/file.txt', 'folder/file.msg']
+        }
+        response = browser.open(
+            "{}/@upload-structure".format(self.leaf_repofolder.absolute_url()),
+            data=json.dumps(payload),
+            method='POST',
+            headers=self.api_headers)
+
+        self.assertEqual(200, response.status_code)
+        folder = response.json['items']['folder']
+        self.assertEqual(folder['@type'],
+                         u'opengever.dossier.businesscasedossier')
+        self.assertEqual(folder['items']['file.txt']['@type'],
+                         u'opengever.document.document')
+        self.assertEqual(folder['items']['file.msg']['@type'],
+                         u'ftw.mail.mail')
+
+        response = browser.open(
+            "{}/@upload-structure".format(self.dossier.absolute_url()),
+            data=json.dumps(payload),
+            method='POST',
+            headers=self.api_headers)
+
+        self.assertEqual(200, response.status_code)
+        folder = response.json['items']['folder']
+        self.assertEqual(folder['@type'],
+                         u'opengever.dossier.businesscasedossier')
+        self.assertEqual(folder['items']['file.txt']['@type'],
+                         u'opengever.document.document')
+        self.assertEqual(folder['items']['file.msg']['@type'],
+                         u'ftw.mail.mail')
+
+        self.login(self.workspace_member, browser)
+        response = browser.open(
+            "{}/@upload-structure".format(self.workspace.absolute_url()),
+            data=json.dumps(payload),
+            method='POST',
+            headers=self.api_headers)
+
+        self.assertEqual(200, response.status_code)
+        folder = response.json['items']['folder']
+        self.assertEqual(folder['@type'],
+                         u'opengever.workspace.folder')
+        self.assertEqual(folder['items']['file.txt']['@type'],
+                         u'opengever.document.document')
+        self.assertEqual(folder['items']['file.msg']['@type'],
+                         u'ftw.mail.mail')
+
+        response = browser.open(
+            "{}/@upload-structure".format(self.workspace_folder.absolute_url()),
+            data=json.dumps(payload),
+            method='POST',
+            headers=self.api_headers)
+
+        self.assertEqual(200, response.status_code)
+        folder = response.json['items']['folder']
+        self.assertEqual(folder['@type'],
+                         u'opengever.workspace.folder')
+        self.assertEqual(folder['items']['file.txt']['@type'],
+                         u'opengever.document.document')
+        self.assertEqual(folder['items']['file.msg']['@type'],
+                         u'ftw.mail.mail')

--- a/opengever/api/tests/test_upload_structure.py
+++ b/opengever/api/tests/test_upload_structure.py
@@ -41,17 +41,21 @@ class TestUploadStructure(IntegrationTestCase):
                 u'folder': {
                     u'@type': u'opengever.dossier.businesscasedossier',
                     u'relative_path': u'folder',
+                    u'is_container': True,
                     u'items': {
                         u'file.txt': {
                             u'@type': u'opengever.document.document',
-                            u'relative_path': u'folder/file.txt'},
+                            u'relative_path': u'folder/file.txt',
+                            u'is_container': False},
                         u'subfolder': {
                             u'@type': u'opengever.dossier.businesscasedossier',
                             u'relative_path': u'folder/subfolder',
+                            u'is_container': True,
                             u'items': {
                                 u'file2.txt': {
                                     u'@type': u'opengever.document.document',
-                                    u'relative_path': u'folder/subfolder/file2.txt'}
+                                    u'relative_path': u'folder/subfolder/file2.txt',
+                                    u'is_container': False}
                                 }
                             }
                         }
@@ -75,10 +79,12 @@ class TestUploadStructure(IntegrationTestCase):
                 u'folder': {
                     u'@type': u'opengever.dossier.businesscasedossier',
                     u'relative_path': u'/folder',
+                    u'is_container': True,
                     u'items': {
                         u'file.txt': {
                             u'@type': u'opengever.document.document',
-                            u'relative_path': u'/folder/file.txt'},
+                            u'relative_path': u'/folder/file.txt',
+                            u'is_container': False},
                         }
                     }
                 },

--- a/opengever/api/tests/test_upload_structure.py
+++ b/opengever/api/tests/test_upload_structure.py
@@ -125,3 +125,36 @@ class TestUploadStructure(IntegrationTestCase):
             {u'message': u'Maximum dossier depth exceeded',
              u'type': u'BadRequest'},
             browser.json)
+
+    @browsing
+    def test_upload_structure_raises_if_portal_type_not_addable_in_context(self, browser):
+        self.login(self.regular_user, browser)
+
+        # document cannot be added in repository folder
+        payload = {
+            u'files': ['file.txt']
+        }
+        with browser.expect_http_error(code=400):
+            browser.open("{}/@upload-structure".format(self.leaf_repofolder.absolute_url()),
+                         data=json.dumps(payload),
+                         method='POST',
+                         headers=self.api_headers)
+        self.assertEqual(
+            {u'message': u'Some of the objects cannot be added here',
+             u'type': u'BadRequest'},
+            browser.json)
+
+        # dossier cannot be added in branch repository folder
+        payload = {
+            u'files': ['folder/file.txt']
+        }
+        with browser.expect_http_error(code=400):
+            browser.open("{}/@upload-structure".format(self.branch_repofolder.absolute_url()),
+                         data=json.dumps(payload),
+                         method='POST',
+                         headers=self.api_headers)
+        self.assertEqual(
+            {u'message': u'Some of the objects cannot be added here',
+             u'type': u'BadRequest'},
+            browser.json)
+

--- a/opengever/api/upload_structure.py
+++ b/opengever/api/upload_structure.py
@@ -1,4 +1,5 @@
 from opengever.document.document import is_email_upload
+from plone import api
 from plone.restapi.deserializer import json_body
 from plone.restapi.serializer.converters import json_compatible
 from plone.restapi.services import Service
@@ -39,6 +40,10 @@ class UploadStructurePost(Service):
             raise BadRequest("Property 'files' is required")
         return files
 
+    def check_permission(self):
+        if not api.user.has_permission('Add portal content', obj=self.context):
+            raise BadRequest("User is not allowed to add objects here")
+
     def extract_structure(self, files):
         root = {'items': {}}
         max_depth = 0
@@ -70,5 +75,6 @@ class UploadStructurePost(Service):
 
     def reply(self):
         files = self.extract_data()
+        self.check_permission()
         structure = self.extract_structure(files)
         return json_compatible(structure)

--- a/opengever/api/upload_structure.py
+++ b/opengever/api/upload_structure.py
@@ -1,0 +1,74 @@
+from opengever.document.document import is_email_upload
+from plone.restapi.deserializer import json_body
+from plone.restapi.serializer.converters import json_compatible
+from plone.restapi.services import Service
+from zExceptions import BadRequest
+
+
+class UploadStructurePost(Service):
+    """API Endpoint to check the structure of an upload. It takes a mandatory
+    list of 'files' as input, deduces and returns the list of containers
+    and documents / mails that will need to be created to reproduce the
+    file hierarchy being uploaded.
+
+    POST /@upload-structure HTTP/1.1
+    {
+        "files": ["folder1/file1.txt", "folder1/folder2/file2.eml"]
+    }
+    """
+    container_type = 'opengever.dossier.businesscasedossier'
+    mail_type = 'ftw.mail.mail'
+    document_type = 'opengever.document.document'
+
+    def container(self, relative_path):
+        return {'@type': self.container_type,
+                'relative_path': relative_path,
+                'items': {}}
+
+    def file(self, relative_path, filename):
+        if is_email_upload(filename):
+            return {'@type': self.mail_type,
+                    'relative_path': relative_path}
+        return {'@type': self.document_type,
+                'relative_path': relative_path}
+
+    def extract_data(self):
+        data = json_body(self.request)
+        files = data.get("files", None)
+        if not files:
+            raise BadRequest("Property 'files' is required")
+        return files
+
+    def extract_structure(self, files):
+        root = {'items': {}}
+        max_depth = 0
+        items_total = 0
+        for path in sorted(files):
+            curr_depth = 0
+            segments = path.split("/")
+            parent = root
+            for i, segment in enumerate(segments[:-1]):
+                relative_path = "/".join(segments[:i+1])
+                if not segment:
+                    continue
+                curr_depth += 1
+                if segment not in parent['items']:
+                    parent['items'][segment] = self.container(
+                        relative_path)
+                    items_total += 1
+                child = parent['items'][segment]
+                if 'items' not in child:
+                    raise BadRequest("Name conflict")
+                parent = child
+            parent['items'][segments[-1]] = self.file(
+                path, segments[-1])
+            items_total += 1
+            max_depth = max(max_depth, curr_depth)
+        root['max_container_depth'] = max_depth
+        root['items_total'] = items_total
+        return root
+
+    def reply(self):
+        files = self.extract_data()
+        structure = self.extract_structure(files)
+        return json_compatible(structure)

--- a/opengever/api/upload_structure.py
+++ b/opengever/api/upload_structure.py
@@ -37,13 +37,16 @@ class UploadStructurePost(Service):
     def container(self, relative_path):
         return {'@type': self.container_type,
                 'relative_path': relative_path,
+                'is_container': True,
                 'items': {}}
 
     def file(self, relative_path, filename):
         if is_email_upload(filename):
             return {'@type': self.mail_type,
+                    'is_container': False,
                     'relative_path': relative_path}
         return {'@type': self.document_type,
+                'is_container': False,
                 'relative_path': relative_path}
 
     def extract_data(self):

--- a/opengever/api/upload_structure.py
+++ b/opengever/api/upload_structure.py
@@ -1,38 +1,59 @@
 from opengever.document.document import is_email_upload
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.interfaces import IDossierContainerTypes
-from opengever.private.interfaces import IPrivateContainer
-from opengever.workspace.utils import is_within_workspace
+from opengever.private.dossier import IPrivateDossier
+from opengever.private.folder import IPrivateFolder
+from opengever.repository.interfaces import IRepositoryFolder
+from opengever.workspace.interfaces import IWorkspace
+from opengever.workspace.interfaces import IWorkspaceFolder
 from plone import api
 from plone.restapi.deserializer import json_body
 from plone.restapi.serializer.converters import json_compatible
 from plone.restapi.services import Service
 from zExceptions import BadRequest
+from zExceptions import Forbidden
+from zope.component import adapter
+from zope.interface import implementer
+from zope.interface import Interface
 
 
-class UploadStructurePost(Service):
-    """API Endpoint to check the structure of an upload. It takes a mandatory
-    list of 'files' as input, deduces and returns the list of containers
-    and documents / mails that will need to be created to reproduce the
-    file hierarchy being uploaded.
-
-    POST /@upload-structure HTTP/1.1
-    {
-        "files": ["folder1/file1.txt", "folder1/folder2/file2.eml"]
-    }
+class MaximalDepthExceeded(Exception):
+    """Raised when maximal depth would be exceeded by upload.
     """
+
+
+class TypeNotAddable(Exception):
+    """Raised when upload would add an object from a type not
+    addable on the context.
+    """
+
+
+class IUploadStructureAnalyser(Interface):
+    """Adapter interface for upload structure checking
+    """
+
+
+@implementer(IUploadStructureAnalyser)
+@adapter(Interface)
+class DefaultUploadStructureAnalyser(object):
 
     mail_type = 'ftw.mail.mail'
     document_type = 'opengever.document.document'
+    container_type = None
 
-    def __init__(self, context, request):
-        super(UploadStructurePost, self).__init__(context, request)
-        if is_within_workspace(self.context):
-            self.container_type = 'opengever.workspace.folder'
-        elif IPrivateContainer.providedBy(context):
-            self.container_type = 'opengever.private.dossier'
-        else:
-            self.container_type = 'opengever.dossier.businesscasedossier'
+    def __init__(self, context):
+        self.context = context
+
+    def __call__(self, files):
+        self.check_preconditions()
+        self.structure = self.extract_structure(files)
+        self.check_structure()
+
+    def check_preconditions(self):
+        self.check_permission()
+
+    def check_structure(self):
+        self.check_addable()
 
     def container(self, relative_path):
         return {'@type': self.container_type,
@@ -49,19 +70,9 @@ class UploadStructurePost(Service):
                 'is_container': False,
                 'relative_path': relative_path}
 
-    def extract_data(self):
-        data = json_body(self.request)
-        files = data.get("files", None)
-        if not files:
-            raise BadRequest("Property 'files' is required")
-        for file in files:
-            if not file:
-                raise BadRequest("Empty filename not supported")
-        return files
-
     def check_permission(self):
         if not api.user.has_permission('Add portal content', obj=self.context):
-            raise BadRequest("User is not allowed to add objects here")
+            raise Forbidden("User is not allowed to add objects here")
 
     def extract_structure(self, files):
         root = {'items': {}}
@@ -92,39 +103,102 @@ class UploadStructurePost(Service):
         root['items_total'] = items_total
         return root
 
-    def _is_dossier(self):
-        return IDossierMarker.providedBy(self.context)
+    def check_addable(self):
+        """We check whether the items that would be created directly in
+        the current context are allowed
+        """
+        portal_types = set(item["@type"] for item in self.structure["items"].values())
+        allowed = [fti.getId() for fti in self.context.allowedContentTypes()]
+        for portal_type in portal_types:
+            if portal_type not in allowed:
+                raise TypeNotAddable("Some of the objects cannot be added here")
 
-    def check_dossier_depth(self, structure):
-        if is_within_workspace(self.context):
-            return
 
-        if self._is_dossier():
-            current_depth = self.context._get_dossier_depth()
-        else:
-            current_depth = 0
+@adapter(IDossierMarker)
+class DossierUploadStructureAnalyser(DefaultUploadStructureAnalyser):
+    """Additionally checks that upload would not exceed the maximal allowed
+    dossier depth.
+    """
+    container_type = 'opengever.dossier.businesscasedossier'
 
+    def check_structure(self):
+        self.check_dossier_depth()
+        super(DossierUploadStructureAnalyser, self).check_structure()
+
+    @property
+    def current_depth(self):
+        return self.context._get_dossier_depth()
+
+    def check_dossier_depth(self):
         max_depth = api.portal.get_registry_record(
             name='maximum_dossier_depth',
             interface=IDossierContainerTypes
             )
-        if current_depth + structure["max_container_depth"] > max_depth + 1:
-            raise BadRequest("Maximum dossier depth exceeded")
+        if self.current_depth + self.structure["max_container_depth"] > max_depth + 1:
+            raise MaximalDepthExceeded("Maximum dossier depth exceeded")
 
-    def check_addable(self, structure):
-        """We check whether the items that would be created directly in
-        the current context are allowed
-        """
-        portal_types = set(item["@type"] for item in structure["items"].values())
-        allowed = [fti.getId() for fti in self.context.allowedContentTypes()]
-        for portal_type in portal_types:
-            if portal_type not in allowed:
-                raise BadRequest("Some of the objects cannot be added here")
+
+@adapter(IRepositoryFolder)
+class RepositoryFolderUploadStructureAnalyser(DossierUploadStructureAnalyser):
+
+    @property
+    def current_depth(self):
+        return 0
+
+
+@adapter(IPrivateFolder)
+class PrivateFolderUploadStructureAnalyser(RepositoryFolderUploadStructureAnalyser):
+
+    container_type = 'opengever.private.dossier'
+
+
+@adapter(IPrivateDossier)
+class PrivateDossierUploadStructureAnalyser(DossierUploadStructureAnalyser):
+
+    container_type = 'opengever.private.dossier'
+
+
+@adapter(IWorkspace)
+class WorkspaceUploadStructureAnalyser(DefaultUploadStructureAnalyser):
+
+    container_type = 'opengever.workspace.folder'
+
+
+@adapter(IWorkspaceFolder)
+class WorkspaceFolderUploadStructureAnalyser(DefaultUploadStructureAnalyser):
+
+    container_type = 'opengever.workspace.folder'
+
+
+class UploadStructurePost(Service):
+    """API Endpoint to check the structure of an upload. It takes a mandatory
+    list of 'files' as input, deduces and returns the list of containers
+    and documents / mails that will need to be created to reproduce the
+    file hierarchy being uploaded.
+
+    POST /@upload-structure HTTP/1.1
+    {
+        "files": ["folder1/file1.txt", "folder1/folder2/file2.eml"]
+    }
+    """
+
+    def extract_data(self):
+        data = json_body(self.request)
+        files = data.get("files", None)
+        if not files:
+            raise BadRequest("Property 'files' is required")
+        for file in files:
+            if not file:
+                raise BadRequest("Empty filename not supported")
+        return files
 
     def reply(self):
         files = self.extract_data()
         self.check_permission()
-        structure = self.extract_structure(files)
-        self.check_dossier_depth(structure)
-        self.check_addable(structure)
-        return json_compatible(structure)
+
+        upload_checker = IUploadStructureAnalyser(self.context)
+        try:
+            upload_checker(files)
+        except (MaximalDepthExceeded, TypeNotAddable) as exc:
+            raise BadRequest(exc.message)
+        return json_compatible(upload_checker.structure)

--- a/opengever/api/upload_structure.py
+++ b/opengever/api/upload_structure.py
@@ -51,6 +51,9 @@ class UploadStructurePost(Service):
         files = data.get("files", None)
         if not files:
             raise BadRequest("Property 'files' is required")
+        for file in files:
+            if not file:
+                raise BadRequest("Empty filename not supported")
         return files
 
     def check_permission(self):

--- a/opengever/api/upload_structure.py
+++ b/opengever/api/upload_structure.py
@@ -1,6 +1,7 @@
 from opengever.document.document import is_email_upload
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.interfaces import IDossierContainerTypes
+from opengever.workspace.utils import is_within_workspace
 from plone import api
 from plone.restapi.deserializer import json_body
 from plone.restapi.serializer.converters import json_compatible
@@ -19,9 +20,16 @@ class UploadStructurePost(Service):
         "files": ["folder1/file1.txt", "folder1/folder2/file2.eml"]
     }
     """
-    container_type = 'opengever.dossier.businesscasedossier'
+
     mail_type = 'ftw.mail.mail'
     document_type = 'opengever.document.document'
+
+    def __init__(self, context, request):
+        super(UploadStructurePost, self).__init__(context, request)
+        if is_within_workspace(self.context):
+            self.container_type = 'opengever.workspace.folder'
+        else:
+            self.container_type = 'opengever.dossier.businesscasedossier'
 
     def container(self, relative_path):
         return {'@type': self.container_type,

--- a/opengever/api/upload_structure.py
+++ b/opengever/api/upload_structure.py
@@ -93,6 +93,9 @@ class UploadStructurePost(Service):
         return IDossierMarker.providedBy(self.context)
 
     def check_dossier_depth(self, structure):
+        if is_within_workspace(self.context):
+            return
+
         if self._is_dossier():
             current_depth = self.context._get_dossier_depth()
         else:

--- a/opengever/api/upload_structure.py
+++ b/opengever/api/upload_structure.py
@@ -1,6 +1,7 @@
 from opengever.document.document import is_email_upload
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.interfaces import IDossierContainerTypes
+from opengever.private.interfaces import IPrivateContainer
 from opengever.workspace.utils import is_within_workspace
 from plone import api
 from plone.restapi.deserializer import json_body
@@ -28,6 +29,8 @@ class UploadStructurePost(Service):
         super(UploadStructurePost, self).__init__(context, request)
         if is_within_workspace(self.context):
             self.container_type = 'opengever.workspace.folder'
+        elif IPrivateContainer.providedBy(context):
+            self.container_type = 'opengever.private.dossier'
         else:
             self.container_type = 'opengever.dossier.businesscasedossier'
 


### PR DESCRIPTION
We add an endpoint @upload-structure to help prepare a dossier upload into Gever. The endpoint will check whether the proposed upload is possible and reply with information about the structure that would need to be created in Gever, including 
which containers should be created and the `portal_type`s that should be used.

The endpoint checks whether the user is allowed to create content in the given context and whether the objects (container, documents and mails) that would need to be created for that upload are allowed in the current context, including whether the maximal subdossier depth would be exceeded.

For https://4teamwork.atlassian.net/browse/CA-2212

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed