### PR TITLE
Translate the error message if trying to remove the last remaining workspace admin.

### DIFF
--- a/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-26 10:33+0000\n"
+"POT-Creation-Date: 2021-05-10 20:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -92,6 +92,11 @@ msgstr "Gast"
 #: ./opengever/workspace/participation/__init__.py
 msgid "WorkspaceMember"
 msgstr "Teammitglied"
+
+#. Default: "At least one principal must remain admin."
+#: ./opengever/workspace/participation/browser/manage_participants.py
+msgid "exception_at_least_one_admin"
+msgstr "Mindestens einem Beteiligten muss die Admin-Rolle zugewiesen sein."
 
 #. Default: "Common"
 #: ./opengever/workspace/workspace_meeting.py

--- a/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-26 10:33+0000\n"
+"POT-Creation-Date: 2021-05-10 20:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -111,6 +111,11 @@ msgstr "Guest"
 #: ./opengever/workspace/participation/__init__.py
 msgid "WorkspaceMember"
 msgstr "Member"
+
+#. Default: "At least one principal must remain admin."
+#: ./opengever/workspace/participation/browser/manage_participants.py
+msgid "exception_at_least_one_admin"
+msgstr "At least one principal must remain admin."
 
 #. German translation: Allgemein
 #. Default: "Common"

--- a/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-26 10:33+0000\n"
+"POT-Creation-Date: 2021-05-10 20:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -92,6 +92,11 @@ msgstr "Invité"
 #: ./opengever/workspace/participation/__init__.py
 msgid "WorkspaceMember"
 msgstr "Membre du team"
+
+#. Default: "At least one principal must remain admin."
+#: ./opengever/workspace/participation/browser/manage_participants.py
+msgid "exception_at_least_one_admin"
+msgstr ""
 
 #. Default: "Common"
 #: ./opengever/workspace/workspace_meeting.py

--- a/opengever/workspace/locales/opengever.workspace.pot
+++ b/opengever/workspace/locales/opengever.workspace.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-26 10:33+0000\n"
+"POT-Creation-Date: 2021-05-10 20:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -94,6 +94,11 @@ msgstr ""
 #. Default: "Member"
 #: ./opengever/workspace/participation/__init__.py
 msgid "WorkspaceMember"
+msgstr ""
+
+#. Default: "At least one principal must remain admin."
+#: ./opengever/workspace/participation/browser/manage_participants.py
+msgid "exception_at_least_one_admin"
 msgstr ""
 
 #. Default: "Common"

--- a/opengever/workspace/participation/browser/manage_participants.py
+++ b/opengever/workspace/participation/browser/manage_participants.py
@@ -3,6 +3,7 @@ from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.base.role_assignments import SharingRoleAssignment
 from opengever.ogds.base.actor import Actor
 from opengever.ogds.base.sources import PotentialWorkspaceMembersSource
+from opengever.workspace import _
 from opengever.workspace.participation import can_manage_member
 from opengever.workspace.participation import invitation_to_item
 from opengever.workspace.participation.storage import IInvitationStorage
@@ -14,6 +15,7 @@ from Products.Five.browser import BrowserView
 from zExceptions import BadRequest
 from zExceptions import Unauthorized
 from zope.component import getUtility
+from zope.i18n import translate
 import json
 
 
@@ -176,7 +178,11 @@ class ManageParticipants(BrowserView):
             if ADMIN_ROLE in assignment.get('roles', []):
                 return
 
-        raise BadRequest('At least one principal must remain admin.')
+        raise BadRequest(translate(
+            _(
+                'exception_at_least_one_admin',
+                default="At least one principal must remain admin."),
+            context=self.request))
 
     def search(self):
         """ A traversable method to search for users"""


### PR DESCRIPTION
Jira: https://4teamwork.atlassian.net/browse/CA-1840

This PR translates the error message if trying to remove the last remaining workspace admin.

This allows us to directly use it in the gever-ui.

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
