### PR TITLE
Include containing_subdossier, review_state_label and sequence_number in task model serialization

### DIFF
--- a/changes/CA-2117.other
+++ b/changes/CA-2117.other
@@ -1,0 +1,1 @@
+Include `containing_subdossier`, `review_state_label` and `sequence_number` in task model serialization. [tinagerber]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -13,6 +13,7 @@ Breaking Changes
 Other Changes
 ^^^^^^^^^^^^^
 
+- ``@globalindex``: Include ``containing_subdossier``, ``review_state_label`` and ``sequence_number`` in task serialization. (see :ref:`docs <globalindex>`)
 
 2021.10.0 (2021-05-12)
 ----------------------

--- a/docs/public/dev-manual/api/globalindex.rst
+++ b/docs/public/dev-manual/api/globalindex.rst
@@ -1,4 +1,4 @@
-.. globalindex:
+.. _globalindex:
 
 Globalindex
 ===========
@@ -21,10 +21,11 @@ Die Felder ``issuer_fullname`` und ``responsible_fullname`` sind überholt und d
       "batching": null,
       "facets": {},
       "items": [
-        { "@id": "http://localhost:8080/ordnungssystem/dossier-23/document-123/task-1",
+        { "@id": "http://localhost:8080/ordnungssystem/dossier-23/task-1",
           "@type": "opengever.task.task",
           "assigned_org_unit": "fa",
           "containing_dossier": "Anfragen 2019",
+          "containing_subdossier": "",
           "created": "2016-08-31T18:27:33",
           "deadline": "2020-01-01",
           "is_private": true,
@@ -34,7 +35,7 @@ Die Felder ``issuer_fullname`` und ``responsible_fullname`` sind überholt und d
           "issuer_actor": {
             "@id": "http://localhost:8080/@actors/robert.ziegler"
             "identifier": "robert.ziegler"
-          }
+          },
           "issuing_org_unit": "fa",
           "modified": "2016-08-31T18:27:33",
           "oguid": "plone:1016273300",
@@ -44,8 +45,10 @@ Die Felder ``issuer_fullname`` und ``responsible_fullname`` sind überholt und d
           "responsible_actor": {
             "@id": "http://localhost:8080/@actors/inbox:fa"
             "identifier": "inbox:fa"
-          }
+          },
           "review_state": "task-state-in-progress",
+          "review_state_label": "In Arbeit",
+          "sequence_number": 1,
           "task_id": 14,
           "task_type": "For direct execution",
           "title": "re: Direkte Anfrage"

--- a/opengever/api/task.py
+++ b/opengever/api/task.py
@@ -1,5 +1,6 @@
 from opengever.api.actors import serialize_actor_id_to_json_summary
 from opengever.api.add import FolderPost
+from opengever.api.globalindex import translate_review_state
 from opengever.api.response import ResponsePost
 from opengever.api.response import SerializeResponseToJson
 from opengever.api.serializer import GeverSerializeFolderToJson
@@ -142,13 +143,11 @@ class SerializeTaskModelToJson(SerializeSQLModelToJsonBase):
         'admin_unit_id',
         'breadcrumb_title',
         'completed',
-        'containing_subdossier',
         'dossier_sequence_number',
         'icon',
         'int_id',
         'physical_path',
         'reference_number',
-        'sequence_number',
         'tasktemplate_predecessor_id',
         'text',
     ]
@@ -170,6 +169,7 @@ class SerializeTaskModelToJson(SerializeSQLModelToJsonBase):
             # XXX deprecated
             'responsible_fullname': display_name(self.context.responsible),
             'responsible_actor': serialize_actor_id_to_json_summary(self.context.responsible),
+            'review_state_label': translate_review_state(self.context.review_state),
             'task_type': task_type_helper(self.context.task_type),
         })
 

--- a/opengever/api/tests/test_globalindex.py
+++ b/opengever/api/tests/test_globalindex.py
@@ -22,6 +22,7 @@ class TestGlobalIndexGet(IntegrationTestCase):
              u'@type': u'opengever.task.task',
              u'assigned_org_unit': u'fa',
              u'containing_dossier': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
+             u'containing_subdossier': u'',
              u'created': u'2016-08-31T18:27:33',
              u'deadline': u'2020-01-01',
              u'is_private': True,
@@ -41,6 +42,8 @@ class TestGlobalIndexGet(IntegrationTestCase):
                  u'@id': u'http://nohost/plone/@actors/inbox:fa',
                  u'identifier': u'inbox:fa'},
              u'review_state': u'task-state-in-progress',
+             u'review_state_label': u'In progress',
+             u'sequence_number': 13,
              u'task_id': 14,
              u'task_type': u'For direct execution',
              u'title': u're: Diskr\xe4te Dinge',
@@ -49,6 +52,19 @@ class TestGlobalIndexGet(IntegrationTestCase):
 
         # default row size is 25
         self.assertIsNone(browser.json.get('batching'))
+
+    @browsing
+    def test_globalindex_has_containing_subdossier(self, browser):
+        self.login(self.regular_user, browser=browser)
+        task_in_subdossier = create(Builder('task')
+                                    .within(self.subdossier)
+                                    .having(
+                                        responsible_client='fa',
+                                        responsible=self.regular_user.getId(),
+                                        issuer=self.dossier_responsible.getId(),
+                                    ))
+        browser.open(self.portal, view='@globalindex?sort_on=created', headers=self.api_headers)
+        self.assertEqual(self.subdossier.Title(), browser.json['items'][0]['containing_subdossier'])
 
     @browsing
     def test_respect_batching_parameters(self, browser):


### PR DESCRIPTION
On the dashboard in the new frontend, the @globalindex endpoint is used for listing tasks. Since the table listing can also display the values "Subdossier", "Status" and "Laufzeitnummer", these values must also be available via the @globalindex endpoint.

Jira: https://4teamwork.atlassian.net/browse/CA-2117 and https://4teamwork.atlassian.net/browse/CA-2230

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))