### PR TITLE
Add duplicate control in @upload-structure endpoint.

### DIFF
--- a/changes/CA-2215.feature
+++ b/changes/CA-2215.feature
@@ -1,0 +1,1 @@
+Check for possible duplicate documents in @upload-structure endpoint. [njohner]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -15,6 +15,8 @@ Other Changes
 
 - ``@globalindex``: Include ``containing_subdossier``, ``review_state_label`` and ``sequence_number`` in task serialization. (see :ref:`docs <globalindex>`)
 - ``@extract-attachments`` endpoint now also works for mails in a workspace.
+- Update ``@upload-structure`` endpoint to also control for possible duplicates. (see :ref:`docs <upload-structure>`)
+
 
 2021.10.0 (2021-05-12)
 ----------------------

--- a/docs/public/dev-manual/api/upload_structure.rst
+++ b/docs/public/dev-manual/api/upload_structure.rst
@@ -4,6 +4,7 @@ Dossier und Dokumente hochladen
 ===============================
 
 Der ``@upload-structure`` Endpoint kann verwendet werden um zu überprüfen ob der Upload von Datein möglich ist. Eine Liste von relativen Pfade muss im ``files`` Parameter mitgegeben werden. Der Endpoint berechnet die Struktur von Dossiers und Dokumente welche erstellt werden müsste um die ``files`` Liste in GEVER zu erstellen.
+Der Endpoint überprüft auch ob es mögliche Dupplikate für die Dokumente in der ``files`` Liste gibt.
 
 
   .. sourcecode:: http
@@ -50,6 +51,16 @@ Der ``@upload-structure`` Endpoint kann verwendet werden um zu überprüfen ob d
         },
         "items_total": 4,
         "max_container_depth": 2
+        "possible_duplicates": {
+            "test.docx": [
+                {
+                    "@id": "/ordnungssystem/dossier-23/dossier-24/document-90",
+                    "@type": "opengever.document.document",
+                    "filename": "file.txt",
+                    "title": "file"
+                }
+            ]
+    }
     }
 
 Wenn die Erstellung dieser Struktur nich möglich wäre, zum Beispiel wegen Berechtigungen, Subdossier Tiefe oder weil im Gewünschtem Kontext keine Dossiers / Dokumente erstellt werden können, dann wird mit ``400 Bad Request`` geantwortet.

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -1280,6 +1280,7 @@
   <adapter factory=".upload_structure.RepositoryFolderUploadStructureAnalyser" />
   <adapter factory=".upload_structure.PrivateFolderUploadStructureAnalyser" />
   <adapter factory=".upload_structure.PrivateDossierUploadStructureAnalyser" />
+  <adapter factory=".upload_structure.TemplateFolderUploadStructureAnalyser" />
   <adapter factory=".upload_structure.WorkspaceUploadStructureAnalyser" />
   <adapter factory=".upload_structure.WorkspaceFolderUploadStructureAnalyser" />
 


### PR DESCRIPTION
With this PR we add possible duplicate identification in the `@upload-structure` endpoint. Note that the implementation has the following shortcomings:

1. For now the control is limited to files and we are not checking for folder names. 
2. Also note that it only partially works for mails, as the during upload the filename is modified to match the Subject of the E-mail, so that subsequently uploading the same E-mail will not identify it as a possible duplicate. This is not easily solved as during the control we do not have the actual files, only the filenames, so that we cannot analyse mails to check their subjects. Note that the current implementation in the gever-ui was not handling this issue either.

For https://4teamwork.atlassian.net/browse/CA-2215

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed