### PR TITLE
Attachment extraction now also works for mails in a workspace.

### DIFF
--- a/changes/CA-2222.bugfix
+++ b/changes/CA-2222.bugfix
@@ -1,0 +1,1 @@
+Attachment extraction now also works for mails in a workspace. [tinagerber]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -14,6 +14,7 @@ Other Changes
 ^^^^^^^^^^^^^
 
 - ``@globalindex``: Include ``containing_subdossier``, ``review_state_label`` and ``sequence_number`` in task serialization. (see :ref:`docs <globalindex>`)
+- ``@extract-attachments`` endpoint now also works for mails in a workspace.
 
 2021.10.0 (2021-05-12)
 ----------------------

--- a/docs/public/dev-manual/api/extract_attachments.rst
+++ b/docs/public/dev-manual/api/extract_attachments.rst
@@ -2,7 +2,7 @@
 Anhänge speichern
 =================
 
-E-Mail-Anhänge können in OneGov GEVER als separate Dokumente gespeichert werden (nur einmal pro Anhang). Dies wird in der REST API mit einem ``POST`` Request auf den ``@extract-attachments`` Endpoint ermöglicht. Der ``positions`` Parameter erlaubt auszuwählen, welche Anhänge extrahiert werden sollen und entspricht der ``position``, die in der Response eines ``GET`` Request auf eine E-Mail für jeden Anhang enthalten ist. Wenn ``positions`` nicht angegeben wird, dann werden alle Anhänge extrahiert, welche noch nicht gespeichert wurden. Die Dokumente werden im selben Gefäss erstellt, in welchem sich die E-Mail befindet.
+E-Mail-Anhänge können als separate Dokumente gespeichert werden (nur einmal pro Anhang). Dies wird in der REST API mit einem ``POST`` Request auf den ``@extract-attachments`` Endpoint ermöglicht. Der ``positions`` Parameter erlaubt auszuwählen, welche Anhänge extrahiert werden sollen und entspricht der ``position``, die in der Response eines ``GET`` Request auf eine E-Mail für jeden Anhang enthalten ist. Wenn ``positions`` nicht angegeben wird, dann werden alle Anhänge extrahiert, welche noch nicht gespeichert wurden. Die Dokumente werden im selben Gefäss erstellt, in welchem sich die E-Mail befindet.
 
 **Beispiel-Request**:
 

--- a/opengever/api/tests/test_mail.py
+++ b/opengever/api/tests/test_mail.py
@@ -260,6 +260,42 @@ class TestExtractAttachments(IntegrationTestCase):
         self.assertEqual(expected_response, browser.json)
 
     @browsing
+    def test_extracts_attachment_in_workspace(self, browser):
+        self.login(self.workspace_member, browser)
+        mail = create(Builder('mail')
+                      .within(self.workspace)
+                      .with_asset_message(
+                          'mail_with_multiple_attachments.eml'))
+
+        with self.observe_children(self.workspace) as children:
+            browser.open(
+                "/".join([mail.absolute_url(), "@extract-attachments"]),
+                data=json.dumps({'positions': [4]}),
+                method='POST',
+                headers=self.api_headers)
+
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual(1, len(children['added']))
+
+    @browsing
+    def test_extracts_attachment_in_workspace_folder(self, browser):
+        self.login(self.workspace_member, browser)
+        mail = create(Builder('mail')
+                      .within(self.workspace_folder)
+                      .with_asset_message(
+                          'mail_with_multiple_attachments.eml'))
+
+        with self.observe_children(self.workspace_folder) as children:
+            browser.open(
+                "/".join([mail.absolute_url(), "@extract-attachments"]),
+                data=json.dumps({'positions': [4]}),
+                method='POST',
+                headers=self.api_headers)
+
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual(1, len(children['added']))
+
+    @browsing
     def test_returns_error_when_specified_positions_are_not_valid_for_extraction(self, browser):
         self.login(self.regular_user, browser)
         mail = create(Builder('mail')

--- a/opengever/document/base.py
+++ b/opengever/document/base.py
@@ -16,6 +16,8 @@ from opengever.meeting.proposal import IBaseProposal
 from opengever.meeting.proposal import ISubmittedProposal
 from opengever.task.task import ITask
 from opengever.trash.trash import ITrashed
+from opengever.workspace.interfaces import IWorkspace
+from opengever.workspace.interfaces import IWorkspaceFolder
 from plone import api
 from plone.dexterity.content import Item
 from plone.locking.interfaces import ILockable
@@ -72,6 +74,13 @@ class BaseDocumentMixin(object):
         if IInbox.providedBy(parent):
             return parent
 
+        return None
+
+    def get_parent_workspace_container(self):
+        parent = aq_parent(aq_inner(self))
+        if IWorkspaceFolder.providedBy(parent) or \
+           IWorkspace.providedBy(parent):
+            return parent
         return None
 
     def get_submitted_proposal(self, check_security=True):

--- a/opengever/mail/mail.py
+++ b/opengever/mail/mail.py
@@ -153,7 +153,8 @@ class OGMail(Mail, BaseDocumentMixin):
 
     def get_extraction_parent(self):
         """Return the parent that accepts extracted attachments."""
-        return self.get_parent_dossier() or self.get_parent_inbox()
+        return self.get_parent_dossier() or self.get_parent_inbox() or \
+            self.get_parent_workspace_container()
 
     def get_attachments(self, unextracted_only=False):
         """Returns a list of dicts describing the attachements.
@@ -185,8 +186,8 @@ class OGMail(Mail, BaseDocumentMixin):
         return dict(info)
 
     def extract_attachments_into_parent(self, positions):
-        """Extract all specified attachments into the mails parent dossier or
-        inbox.
+        """Extract all specified attachments into the mails parent dossier,
+        inbox, workspace or workspace folder.
 
         Also add a reference from all attached documents (*not* mails) to self.
 
@@ -217,7 +218,7 @@ class OGMail(Mail, BaseDocumentMixin):
         parent = self.get_extraction_parent()
         if parent is None:
             raise RuntimeError(
-                "Could not find a parent dossier or inbox for "
+                "Could not find a parent dossier, inbox, workspace or workspace folder for "
                 "{}".format(self.absolute_url()))
 
         data, content_type, filename = self._get_attachment_data(position)


### PR DESCRIPTION
Until now, extracting attachments from mail in a workspace did not work because no parent was found where the attachment could be saved.

Jira: https://4teamwork.atlassian.net/browse/CA-2222

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guideline