### PR TITLE
Add workspaces_without_view_permission attribute to @linked-workspaces endpoint

### DIFF
--- a/changes/CA-1180.other
+++ b/changes/CA-1180.other
@@ -1,0 +1,1 @@
+Add `workspaces_without_view_permission` attribute to @linked-workspaces endpoint. [tinagerber]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -16,6 +16,7 @@ Other Changes
 - ``@globalindex``: Include ``containing_subdossier``, ``review_state_label`` and ``sequence_number`` in task serialization. (see :ref:`docs <globalindex>`)
 - ``@extract-attachments`` endpoint now also works for mails in a workspace.
 - Update ``@upload-structure`` endpoint to also control for possible duplicates. (see :ref:`docs <upload-structure>`)
+- ``linked-workspaces``: Add field ``workspaces_without_view_permission`` (see :ref:`docs <get-linked-workspaces>`)
 
 
 2021.10.0 (2021-05-12)

--- a/docs/public/dev-manual/api/linked_workspaces.rst
+++ b/docs/public/dev-manual/api/linked_workspaces.rst
@@ -3,6 +3,8 @@ Verknüpfte Arbeitsräume
 
 Arbeitsräume können direkt aus GEVER heraus erstellt und mit einem Dossier verknüpft werden.
 
+.. _get-linked-workspaces:
+
 Verknüpfte Teamräume abrufen
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -33,8 +35,11 @@ Ein GET-Request auf den Endpoint `@linked-workspaces` auf einem Dossier gibt die
           "...": "..."
         }
       ],
-      "items_total": 2
+      "items_total": 2,
+      "workspaces_without_view_permission": false
     }
+
+Das Feld `workspaces_without_view_permission` gibt an, ob noch weitere Teamräume existieren, für die der Benutzer keine Leserechte hat.
 
 
 Dossier mit Teamraum verknüpfen

--- a/opengever/api/linked_workspaces.py
+++ b/opengever/api/linked_workspaces.py
@@ -139,6 +139,8 @@ class LinkedWorkspacesGet(ProxyHypermediaBatch):
     """
     def get_remote_client_reply(self):
         response = ILinkedWorkspaces(self.context).list(**self.request.form)
+        response['workspaces_without_view_permission'] = bool(ILinkedWorkspaces(
+            self.context).number_of_linked_workspaces() - response['items_total'])
         return response
 
 

--- a/opengever/api/tests/test_linked_workspaces.py
+++ b/opengever/api/tests/test_linked_workspaces.py
@@ -261,6 +261,22 @@ class TestLinkedWorkspacesGet(FunctionalWorkspaceClientTestCase):
                 [self.workspace.absolute_url()],
                 [workspace.get('@id') for workspace in response.get('items')])
 
+            self.assertFalse(response['workspaces_without_view_permission'])
+
+    @browsing
+    def test_workspaces_without_view_permission(self, browser):
+        with self.workspace_client_env():
+            manager = ILinkedWorkspaces(self.dossier)
+            manager.storage.add('a_workspace_uid')
+            transaction.commit()
+
+            browser.login()
+            response = browser.open(
+                self.dossier.absolute_url() + '/@linked-workspaces',
+                method='GET', headers={'Accept': 'application/json'}).json
+
+            self.assertTrue(response['workspaces_without_view_permission'])
+
     @browsing
     def test_get_linked_workspaces_replaces_service_url_with_actual_request_url(self, browser):
         url = self.dossier.absolute_url() + '/@linked-workspaces'

--- a/opengever/workspaceclient/linked_workspaces.py
+++ b/opengever/workspaceclient/linked_workspaces.py
@@ -120,6 +120,9 @@ class LinkedWorkspaces(object):
             metadata_fields="UID",
             **kwargs)
 
+    def number_of_linked_workspaces(self):
+        return len(self.storage.list())
+
     def create(self, **data):
         """Creates a new workspace an links it with the current dossier.
 


### PR DESCRIPTION
In the new frontend, a warning should be displayed on the dossier overview if the dossier is linked to workspaces to which the user does not have access. Therefore, it must be known whether such workspaces exist.

Jira: https://4teamwork.atlassian.net/browse/CA-1180

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide]