### PR TITLE
Include backreference list to dossier and documents api serialization.

### DIFF
--- a/changes/CA-1970.feature
+++ b/changes/CA-1970.feature
@@ -1,1 +1,1 @@
-Include backreference list to dossier api serialization. [phgross]
+Include backreference list in dossier and documents api serialization. [phgross]

--- a/changes/CA-1970.feature
+++ b/changes/CA-1970.feature
@@ -1,0 +1,1 @@
+Include backreference list to dossier api serialization. [phgross]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -13,6 +13,7 @@ Breaking Changes
 Other Changes
 ^^^^^^^^^^^^^
 
+- Dossier and document serialization provides now an additional attribute ``back_references_relatedDossiers`` and ``back_references_relatedItems``.
 - ``@globalindex``: Include ``containing_subdossier``, ``review_state_label`` and ``sequence_number`` in task serialization. (see :ref:`docs <globalindex>`)
 - ``@extract-attachments`` endpoint now also works for mails in a workspace.
 - Update ``@upload-structure`` endpoint to also control for possible duplicates. (see :ref:`docs <upload-structure>`)

--- a/opengever/api/document.py
+++ b/opengever/api/document.py
@@ -1,5 +1,6 @@
 from ftw import bumblebee
 from opengever.api.actors import serialize_actor_id_to_json_summary
+from opengever.api.serializer import extend_with_backreferences
 from opengever.api.serializer import GeverSerializeToJson
 from opengever.base.helpers import display_name
 from opengever.base.interfaces import IReferenceNumber
@@ -36,6 +37,9 @@ class SerializeDocumentToJson(GeverSerializeToJson):
         result[u'pdf_url'] = bumblebee_service.get_representation_url(
             obj, 'pdf')
         result[u'file_extension'] = self.context.get_file_extension()
+
+        extend_with_backreferences(
+            result, self.context, self.request, 'relatedItems')
 
         checked_out_by = obj.checked_out_by()
         checked_out_by_fullname = display_name(checked_out_by) if checked_out_by else None

--- a/opengever/api/dossier.py
+++ b/opengever/api/dossier.py
@@ -1,5 +1,6 @@
 from ftw.mail.interfaces import IEmailAddress
 from opengever.api.actors import serialize_actor_id_to_json_summary
+from opengever.api.serializer import extend_with_backreferences
 from opengever.api.serializer import GeverSerializeFolderToJson
 from opengever.base.interfaces import IOpengeverBaseLayer
 from opengever.dossier.behaviors.dossier import IDossier
@@ -10,6 +11,7 @@ from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.interfaces import ISerializeToJsonSummary
 from zope.component import adapter
 from zope.component import getMultiAdapter
+from zope.component import getUtility
 from zope.interface import implementer
 from zope.interface import Interface
 
@@ -32,6 +34,9 @@ class SerializeDossierToJson(GeverSerializeFolderToJson):
             self.context)
         result[u'blocked_local_roles'] = bool(
             getattr(self.context.aq_inner, '__ac_local_roles_block__', False))
+
+        extend_with_backreferences(
+            result, self.context, self.request, 'relatedDossier')
 
         return result
 

--- a/opengever/api/tests/test_document.py
+++ b/opengever/api/tests/test_document.py
@@ -150,6 +150,25 @@ class TestDocumentSerializer(IntegrationTestCase):
         }
         self.assertEqual(expected_links, browser.json['teamraum_connect_links'])
 
+    @browsing
+    def test_contains_dossier_backreferences(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(self.subdocument, method="GET", headers=self.api_headers)
+        self.assertEqual(
+            [{u'@id': self.subsubdocument.absolute_url(),
+              u'@type': u'opengever.document.document',
+              u'checked_out': None,
+              u'description': u'',
+              u'file_extension': u'.xlsx',
+              u'is_leafnode': None,
+              u'review_state': u'document-state-draft',
+              u'title': self.subsubdocument.title}],
+            browser.json['back_references_relatedItems'])
+
+        browser.open(self.mail_eml, method="GET", headers=self.api_headers)
+        self.assertEqual([], browser.json['back_references_relatedItems'])
+
 
 class TestWorkspaceDocument(IntegrationTestCase):
 

--- a/opengever/api/tests/test_dossier.py
+++ b/opengever/api/tests/test_dossier.py
@@ -91,6 +91,24 @@ class TestDossierSerializer(IntegrationTestCase):
         self.assertEqual(u"2016-08-31", browser.json["touched"])
 
 
+    @browsing
+    def test_contains_dossier_backreferences(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(self.dossier, method="GET", headers=self.api_headers)
+        self.assertEqual(
+            [{u'description': u'',
+              u'title': self.closed_meeting_dossier.title,
+              u'is_subdossier': False, u'is_leafnode': None,
+              u'review_state': u'dossier-state-active',
+              u'@id': self.closed_meeting_dossier.absolute_url(),
+              u'@type': u'opengever.meeting.meetingdossier'}],
+            browser.json['back_references_relatedDossier'])
+
+        browser.open(self.subdossier, method="GET", headers=self.api_headers)
+        self.assertEqual([], browser.json['back_references_relatedDossier'])
+
+
 class TestMainDossierExpansion(IntegrationTestCase):
 
     @browsing


### PR DESCRIPTION
This PR adds an additional key to the dossier and documents api serialization which lists summaries of all backreferences. It uses plone.restapis default summary serializer for the backreferences.

This is used for display backreferences in the new UI, see https://4teamwork.atlassian.net/browse/CA-1970


## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
