### PR TITLE
Add primary_repository URL to the @config endpoint.

### DIFF
--- a/changes/CA-1119.feature
+++ b/changes/CA-1119.feature
@@ -1,0 +1,1 @@
+Add primary_repository URL to the @config endpoint.

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -13,6 +13,7 @@ Breaking Changes
 Other Changes
 ^^^^^^^^^^^^^
 
+- Add ``primary_repository`` information to the ``@config`` endpoint.
 - Dossier and document serialization provides now an additional attribute ``back_references_relatedDossiers`` and ``back_references_relatedItems``.
 - ``@globalindex``: Include ``containing_subdossier``, ``review_state_label`` and ``sequence_number`` in task serialization. (see :ref:`docs <globalindex>`)
 - ``@extract-attachments`` endpoint now also works for mails in a workspace.

--- a/opengever/api/config.py
+++ b/opengever/api/config.py
@@ -7,6 +7,7 @@ from opengever.officeconnector.helpers import is_client_ip_in_office_connector_d
 from opengever.ogds.base.utils import get_current_org_unit
 from opengever.ogds.models.service import ogds_service
 from opengever.private import get_private_folder_url
+from opengever.repository.browser.primary_repository_root import PrimaryRepositoryRoot
 from plone.restapi.services import Service
 
 
@@ -44,3 +45,7 @@ class ConfigGet(Service):
         ogds_inbox = get_current_org_unit().inbox()
         current_user = ogds_service().fetch_current_user()
         config['is_inbox_user'] = current_user in ogds_inbox.assigned_users()
+
+        primary_root = PrimaryRepositoryRoot(
+            self.context, self.request).get_primary_repository_root()
+        config['primary_repository'] = primary_root.absolute_url()

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -1,3 +1,5 @@
+from ftw.builder import Builder
+from ftw.builder import create
 from ftw.casauth.plugin import CASAuthenticationPlugin
 from ftw.testbrowser import browsing
 from opengever.base.interfaces import IUserSnapSettings
@@ -308,3 +310,17 @@ class TestConfig(IntegrationTestCase):
         browser.open(self.config_url, headers=self.api_headers)
         self.assertEqual(browser.status_code, 200)
         self.assertEqual(browser.json.get(u'bumblebee_notifications_url'), u'http://bumblebee.local/YnVtYmxlYmVl/api/notifications')
+
+    @browsing
+    def test_config_contains_primary_repository(self, browser):
+        self.login(self.regular_user, browser)
+
+        browser.open(self.config_url, headers=self.api_headers)
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual(browser.json.get(u'primary_repository'), self.repository_root.absolute_url())
+
+        root2 = create(Builder('repository_root').titled(u'Ordnungssystem V2'))
+
+        browser.open(self.config_url, headers=self.api_headers)
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual(browser.json.get(u'primary_repository'), root2.absolute_url())


### PR DESCRIPTION
For GEVER deployments with multiple repositories, the gever-ui needs to know which is the primary one. Therefore I added the `primary_repository` to the `@config` endpoint.  For https://4teamwork.atlassian.net/browse/CA-1119

In the refinement part of the story it was described that the navigation endpoint should be extended. This would be much more difficult for the UI and above all it would mean that a catalog query for repositoryroots would have to be performed for every route change. Therefore I decided to extend the config endpoint instead.


## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
