### PR TITLE
Fix filtering on values containing spaces in @listing endpoint.

### DIFF
--- a/changes/CA-2176.bugfix
+++ b/changes/CA-2176.bugfix
@@ -1,0 +1,1 @@
+Fix filtering on values containing spaces in @listing endpoint. [tinagerber]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -14,6 +14,7 @@ Other Changes
 ^^^^^^^^^^^^^
 
 - Add ``primary_repository`` information to the ``@config`` endpoint.
+- ``@listing``: Fix filtering on values containing spaces.
 - Dossier and document serialization provides now an additional attribute ``back_references_relatedDossiers`` and ``back_references_relatedItems``.
 - ``@globalindex``: Include ``containing_subdossier``, ``review_state_label`` and ``sequence_number`` in task serialization. (see :ref:`docs <globalindex>`)
 - ``@extract-attachments`` endpoint now also works for mails in a workspace.

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -1,10 +1,9 @@
-from copy import copy
 from copy import deepcopy
 from DateTime import DateTime
 from DateTime.interfaces import DateTimeError
 from ftw.solr.converters import to_iso8601
 from ftw.solr.interfaces import ISolrSearch
-from ftw.solr.query import SPECIAL_CHARS
+from ftw.solr.query import escape
 from opengever.base.behaviors.translated_title import ITranslatedTitleSupport
 from opengever.base.helpers import display_name
 from opengever.base.solr import OGSolrContentListing
@@ -30,19 +29,14 @@ from zope.i18n import translate
 import Missing
 
 
-TO_ESCAPE = copy(SPECIAL_CHARS)
-TO_ESCAPE.append(' ')
-
-
 def filter_escape(term):
-    """Copy of ftw.solr.query.escape, but using the above defined TO_ESCAPE
-    instead of SPECIAL_CHARS, additionally including a white space. For queries,
-    whitespaces should not be escaped, but for filters they should be.
+    """If there is a space in the term, then quotation marks are required around the term
     """
     if isinstance(term, bool):
         return term
-    for char in TO_ESCAPE:
-        term = term.replace(char, '\\' + char)
+    term = escape(term)
+    if ' ' in term:
+        term = '"{}"'.format(term)
     return term
 
 


### PR DESCRIPTION
In order to filter correctly in solr, terms containing spaces must be surrounded by quotation marks.

Jira: https://4teamwork.atlassian.net/browse/CA-2176

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))