### PR TITLE
Fix a problem in relation deserializer when not all path elements are accessible.

### DIFF
--- a/changes/CA-2220.bugfix
+++ b/changes/CA-2220.bugfix
@@ -1,0 +1,1 @@
+Fix a problem in relation deserializer when not all path elements are accessible. [phgross]

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -56,6 +56,11 @@
   <adapter factory=".field_deserializers.PersistentDatetimeFieldDeserializer" />
   <adapter factory=".field_deserializers.DateFieldDeserializer" />
   <adapter factory=".field_deserializers.DatetimeFieldDeserializer" />
+
+  <configure zcml:condition="installed z3c.relationfield">
+    <adapter factory=".relationfield.GeverRelationChoiceFieldDeserializer" />
+  </configure>
+
   <adapter
       factory=".local_roles.GeverSerializeLocalRolesToJson"
       name="local_roles"

--- a/opengever/api/relationfield.py
+++ b/opengever/api/relationfield.py
@@ -1,0 +1,79 @@
+from opengever.base.interfaces import IOpengeverBaseLayer
+from plone.dexterity.interfaces import IDexterityContent
+from plone.restapi.deserializer.relationfield import RelationChoiceFieldDeserializer
+from plone.restapi.interfaces import IFieldDeserializer
+from Products.CMFCore.utils import getToolByName
+from z3c.relationfield.interfaces import IRelationChoice
+from zope.component import adapter
+from zope.component import getMultiAdapter
+from zope.component import queryUtility
+from zope.interface import implementer
+from zope.intid.interfaces import IIntIds
+import six
+
+
+@implementer(IFieldDeserializer)
+@adapter(IRelationChoice, IDexterityContent, IOpengeverBaseLayer)
+class GeverRelationChoiceFieldDeserializer(RelationChoiceFieldDeserializer):
+    """Customize the RelationFieldDeserializer to fix a problem when
+    referencing objects by the path or URL and not the complete path is
+    accessible for the current user.
+    """
+
+    def __call__(self, value):
+        """Copied from the baseclass"""
+
+        obj = None
+
+        if isinstance(value, dict):
+            # We are trying to deserialize the output of a serialization
+            # which is enhanced, extract it and put it on the loop again
+            value = value["@id"]
+
+        if isinstance(value, int):
+            # Resolve by intid
+            intids = queryUtility(IIntIds)
+            obj = intids.queryObject(value)
+            resolved_by = "intid"
+        elif isinstance(value, six.string_types):
+            if six.PY2 and isinstance(value, six.text_type):
+                value = value.encode("utf8")
+            portal = getMultiAdapter(
+                (self.context, self.request), name="plone_portal_state"
+            ).portal()
+            portal_url = portal.absolute_url()
+            if value.startswith(portal_url):
+                # Resolve by URL
+                obj = self.get_obj_by_path(portal, value[len(portal_url) + 1:])
+                resolved_by = "URL"
+            elif value.startswith("/"):
+                # Resolve by path
+                obj = self.get_obj_by_path(portal, value.lstrip("/"))
+                resolved_by = "path"
+            else:
+                # Resolve by UID
+                catalog = getToolByName(self.context, "portal_catalog")
+                brain = catalog(UID=value)
+                if brain:
+                    obj = brain[0].getObject()
+                resolved_by = "UID"
+
+        if obj is None:
+            self.request.response.setStatus(400)
+            raise ValueError(
+                u"Could not resolve object for {}={}".format(resolved_by, value)
+            )
+
+        self.field.validate(obj)
+        return obj
+
+    def get_obj_by_path(self, portal, path):
+        """restrictedTraverse checks all of the objects along the path are
+        validated with the security machinery. But we only need to know if the
+        user is able to access the given object."""
+        path = path.rstrip('/').split('/')
+        parent = portal.unrestrictedTraverse(path[:-1], None)
+        if not parent:
+            return None
+
+        return parent.restrictedTraverse(path[-1], None)

--- a/opengever/api/tests/test_relationfield.py
+++ b/opengever/api/tests/test_relationfield.py
@@ -1,0 +1,67 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.base.role_assignments import RoleAssignmentManager
+from opengever.base.role_assignments import SharingRoleAssignment
+from opengever.dossier.behaviors.dossier import IDossier
+from opengever.testing import IntegrationTestCase
+import json
+
+
+class GeverRelationChoiceFieldDeserializer(IntegrationTestCase):
+
+    @browsing
+    def test_relation_by_url_is_possible(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(
+            self.dossier.absolute_url(),
+            method='PATCH',
+            data=json.dumps(
+                {'relatedDossier': [self.empty_dossier.absolute_url()]}
+            ),
+            headers=self.api_headers)
+
+        self.assertEquals(
+            [self.empty_dossier],
+            [rel.to_object for rel in IDossier(self.dossier).relatedDossier])
+
+    @browsing
+    def test_relation_by_path_is_possible(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        relative_path = self.empty_dossier.absolute_url_path().replace('/plone', '')
+        browser.open(
+            self.dossier.absolute_url(),
+            method='PATCH',
+            data=json.dumps(
+                {'relatedDossier': [relative_path]}
+            ),
+            headers=self.api_headers)
+
+        self.assertEquals(
+            [self.empty_dossier],
+            [rel.to_object for rel in IDossier(self.dossier).relatedDossier])
+
+    @browsing
+    def test_relation_to_object_inside_protected_dossier_is_possible(self, browser):
+        self.login(self.administrator, browser=browser)
+        subdossier = create(Builder('dossier')
+                            .titled(u'Sub')
+                            .within(self.protected_dossier))
+        RoleAssignmentManager(subdossier).add_or_update_assignments(
+            [SharingRoleAssignment(self.regular_user.id, ['Editor'])])
+        doc = create(Builder('document')
+                     .titled(u'doc')
+                     .within(subdossier))
+
+        self.login(self.regular_user, browser=browser)
+        browser.open(
+            self.document.absolute_url(),
+            method='PATCH',
+            data=json.dumps(
+                {'relatedItems': [doc.absolute_url()]}
+            ),
+            headers=self.api_headers)
+
+        self.assertEquals([doc], self.document.related_items())


### PR DESCRIPTION
plone.restapi's RelationChoiceFieldDeserializer uses restrictedTraverse to fetch relations given by URL or path. But this only works if every single path element is accesssible by the current user. Therefore I customized the Relation deseralizer and fetch the element in the same manner the ZCatalog does - fetch the parent unrestricted and the object itself restricted.

See https://4teamwork.atlassian.net/browse/CA-2220


## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
