### PR TITLE
Add skip state to the list of finished task states.

### DIFF
--- a/changes/CA-2253.bugfix
+++ b/changes/CA-2253.bugfix
@@ -1,0 +1,1 @@
+Add skip state to the list of finished task states. [phgross]

--- a/opengever/task/__init__.py
+++ b/opengever/task/__init__.py
@@ -22,7 +22,8 @@ CLOSED_TASK_STATES = [
 FINISHED_TASK_STATES = [
     'task-state-tested-and-closed',
     'task-state-rejected',
-    'task-state-cancelled'
+    'task-state-cancelled',
+    'task-state-skipped'
 ]
 
 TASK_STATE_PLANNED = 'task-state-planned'

--- a/opengever/task/tests/test_task_checker.py
+++ b/opengever/task/tests/test_task_checker.py
@@ -88,6 +88,7 @@ class TestTaskControllerChecker(IntegrationTestCase):
         self.login(self.dossier_responsible)
         for state in ('task-state-rejected',
                       'task-state-cancelled',
+                      'task-state-skipped',
                       'task-state-tested-and-closed'):
             self.set_workflow_state(state, self.subtask)
             self.assertTrue(get_checker(self.task).task.all_subtasks_finished)


### PR DESCRIPTION
Otherwise it's not possible to close a sequential_task process, where some task have been skipped.

Close https://4teamwork.atlassian.net/browse/CA-2253


## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

