### PR TITLE
Add virusscanner for file upload and download.

### DIFF
--- a/changes/CA-1504.feature
+++ b/changes/CA-1504.feature
@@ -1,0 +1,1 @@
+Add virusscan validation upon file download and upload. [njohner]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,3 +17,9 @@ services:
     image: 4teamwork/weasyprint:latest
     ports:
       - 8093:8080
+  clamav:
+    image: mkodockx/docker-clamav:alpine
+    ports:
+      - 3310:3310
+    profiles:
+      - clamav

--- a/opengever/api/utils.py
+++ b/opengever/api/utils.py
@@ -1,0 +1,11 @@
+
+
+def is_api_request(request):
+    if request.getHeader("Accept") == 'application/json':
+        return True
+    return False
+
+
+def raise_for_api_request(request, exc):
+    if is_api_request(request):
+        raise exc

--- a/opengever/api/utils.py
+++ b/opengever/api/utils.py
@@ -1,11 +1,4 @@
 
-
-def is_api_request(request):
-    if request.getHeader("Accept") == 'application/json':
-        return True
-    return False
-
-
 def raise_for_api_request(request, exc):
-    if is_api_request(request):
+    if not request.get("error_as_message"):
         raise exc

--- a/opengever/base/quickupload.py
+++ b/opengever/base/quickupload.py
@@ -122,7 +122,7 @@ class OGQuickUploadCapableFileFactory(object):
 
     def validate(self, filename, data):
         # if scanning is disabled for upload, we skip
-        if not api.portal.get_registry_record(name='scan_before_upload',
+        if not api.portal.get_registry_record(name='scan_on_upload',
                                               interface=IAVScannerSettings):
             return
 

--- a/opengever/base/quickupload.py
+++ b/opengever/base/quickupload.py
@@ -10,12 +10,17 @@ from opengever.base.command import CreateEmailCommand
 from opengever.mail.mail import MESSAGE_SOURCE_DRAG_DROP_UPLOAD
 from opengever.mail.utils import is_rfc822_ish_mimetype
 from opengever.quota.exceptions import ForbiddenByQuota
+from opengever.virusscan.interfaces import IAVScannerSettings
+from opengever.virusscan.validator import validateStream
+from plone import api
 from plone.protect import createToken
 from plone.protect.interfaces import IDisableCSRFProtection
+from six import BytesIO
 from zope.component import adapter
 from zope.i18n import translate
 from zope.interface import alsoProvides
 from zope.interface import implementer
+from zope.interface import Invalid
 import mimetypes
 import os
 import transaction
@@ -79,6 +84,14 @@ class OGQuickUploadCapableFileFactory(object):
         """Quickupload description inputs are hidden in gever
         therefore we skip the description.
         """
+        try:
+            self.validate(filename, data)
+        except Invalid as exc:
+            # this is an error, we must not commit
+            transaction.abort()
+            return {'error': translate(exc.message,
+                                       context=self.context.REQUEST),
+                    'success': None}
         if self.is_email_upload(filename):
             command = CreateEmailCommand(
                 self.context, filename, data,
@@ -106,3 +119,12 @@ class OGQuickUploadCapableFileFactory(object):
 
     def _get_mimetype(self, extension):
         return mimetypes.types_map.get(extension)
+
+    def validate(self, filename, data):
+        # if scanning is disabled for upload, we skip
+        if not api.portal.get_registry_record(name='scan_before_upload',
+                                              interface=IAVScannerSettings):
+            return
+
+        validateStream(filename, BytesIO(data), self.context.REQUEST)
+        return

--- a/opengever/core/profiles/default/registry.xml
+++ b/opengever/core/profiles/default/registry.xml
@@ -208,4 +208,7 @@
   <!-- WorkspaceClient-->
   <records interface="opengever.workspaceclient.interfaces.IWorkspaceClientSettings" />
 
+  <!-- Virus scanning -->
+  <records interface="opengever.virusscan.interfaces.IAVScannerSettings" />
+
 </registry>

--- a/opengever/core/upgrades/20210517152346_add_virus_scan_settings/registry.xml
+++ b/opengever/core/upgrades/20210517152346_add_virus_scan_settings/registry.xml
@@ -1,0 +1,7 @@
+<registry>
+
+  <!-- Virus scanning -->
+  <records interface="opengever.virusscan.interfaces.IAVScannerSettings" />
+
+
+</registry>

--- a/opengever/core/upgrades/20210517152346_add_virus_scan_settings/upgrade.py
+++ b/opengever/core/upgrades/20210517152346_add_virus_scan_settings/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddVirusScanSettings(UpgradeStep):
+    """Add virus scan settings.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/document/behaviors/metadata.py
+++ b/opengever/document/behaviors/metadata.py
@@ -1,13 +1,14 @@
 from collective import dexteritytextindexer
-from opengever.base.vocabulary import wrap_vocabulary
 from datetime import date
 from ftw.datepicker.widget import DatePickerFieldWidget
 from ftw.keywordwidget.field import ChoicePlus
 from ftw.keywordwidget.vocabularies import KeywordSearchableAndAddableSourceBinder
 from ftw.keywordwidget.widget import KeywordFieldWidget
 from ftw.mail.mail import IMail
+from opengever.base.vocabulary import wrap_vocabulary
 from opengever.document import _
 from opengever.document.interfaces import IDocumentSettings
+from opengever.virusscan.validator import validateUploadForFieldIfNecessary
 from plone import api
 from plone.autoform import directives as form
 from plone.autoform.interfaces import IFormFieldProvider
@@ -16,8 +17,10 @@ from plone.supermodel import model
 from z3c.form import validator
 from z3c.form.browser import checkbox
 from zope import schema
+from zope.globalrequest import getRequest
 from zope.interface import alsoProvides
 from zope.interface import Invalid
+from zope.interface import invariant
 
 
 def document_date_default():
@@ -171,6 +174,13 @@ class IDocumentMetadata(model.Schema):
         description=_(u'help_preview', default=''),
         required=False,
         )
+
+    @invariant
+    def scan_for_virus(data):
+        if data.archival_file:
+            validateUploadForFieldIfNecessary(
+                "archival_file", data.archival_file.filename,
+                data.archival_file.open(), getRequest())
 
 
 alsoProvides(IDocumentMetadata, IFormFieldProvider)

--- a/opengever/document/browser/download.py
+++ b/opengever/document/browser/download.py
@@ -104,11 +104,11 @@ class DownloadConfirmation(BrowserView):
 
     def download_url(self):
         if self.request.get('version_id'):
-            return '%s/download_file_version?version_id=%s' % (
+            return '%s/download_file_version?version_id=%s&error_as_message=1' % (
                 self.context.absolute_url(),
                 self.request.get('version_id'))
         else:
-            return '%s/download' % (self.context.absolute_url())
+            return '%s/download?error_as_message=1' % (self.context.absolute_url())
 
     def download_available(self):
         """ check whether download is available.
@@ -174,6 +174,10 @@ class DownloadConfirmationHelper(object):
         else:
             clazz = ' '.join(additional_classes)
 
+        if url_extension:
+            url_extension += "&error_as_message=1"
+        else:
+            url_extension += "?error_as_message=1"
         url = '{0}/{1}{2}'.format(file_url, viewname, url_extension)
         if include_token:
             url = addTokenToUrl(url)

--- a/opengever/document/browser/download.py
+++ b/opengever/document/browser/download.py
@@ -1,3 +1,4 @@
+from opengever.api.utils import raise_for_api_request
 from opengever.base.behaviors.utils import set_attachment_content_disposition
 from opengever.base.viewlets.download import DownloadFileVersion
 from opengever.core import dictstorage
@@ -66,6 +67,7 @@ class DocumentishDownload(Download):
         try:
             validateDownloadIfNecessary(self.filename, named_file, self.request)
         except Invalid as exc:
+            raise_for_api_request(self.request, BadRequest(exc.message))
             api.portal.show_message(exc.message, self.request, type='error')
             return self.request.RESPONSE.redirect(
                 get_redirect_url(self.context))

--- a/opengever/document/browser/download.py
+++ b/opengever/document/browser/download.py
@@ -201,6 +201,17 @@ class DocumentDownloadFileVersion(DownloadFileVersion):
 
         self._init_version_file()
         if self.version_file:
+            try:
+                validateDownloadIfNecessary(
+                    self.version_file.filename.encode('utf-8'),
+                    self.version_file,
+                    self.request)
+            except Invalid as exc:
+                raise_for_api_request(self.request, BadRequest(exc.message))
+                api.portal.show_message(exc.message, self.request, type='error')
+                return self.request.RESPONSE.redirect(
+                    get_redirect_url(self.context))
+
             notify(FileCopyDownloadedEvent(
                 self.context,
                 getattr(self.request, 'version_id', None)))

--- a/opengever/document/browser/edit.py
+++ b/opengever/document/browser/edit.py
@@ -17,7 +17,7 @@ def get_redirect_url(context):
     referer = context.REQUEST.environ.get('HTTP_REFERER')
     portal_url = '/'.join(context.portal_url().split('/')[:-1])
     if referer:
-        obj_path = referer[len(portal_url):]
+        obj_path = referer[len(portal_url):].split("?")[0]
         try:
             obj = context.restrictedTraverse(obj_path)
         except KeyError:
@@ -30,6 +30,8 @@ def get_redirect_url(context):
             return '%s#mydocuments' % (obj.absolute_url())
         elif IDossierMarker.providedBy(obj):
             return '%s#documents' % (obj.absolute_url())
+        elif isinstance(obj, BrowserView):
+            return obj.context.absolute_url()
         else:
             return obj.absolute_url()
 

--- a/opengever/document/browser/edit.py
+++ b/opengever/document/browser/edit.py
@@ -12,30 +12,29 @@ from zope.component import getMultiAdapter
 
 
 def get_redirect_url(context):
-        """return the url where the editing_document view was called from
-        It should be a document listing."""
-
-        referer = context.REQUEST.environ.get('HTTP_REFERER')
-        portal_url = '/'.join(context.portal_url().split('/')[:-1])
-        if referer:
-            obj_path = referer[len(portal_url):]
-            try:
-                obj = context.restrictedTraverse(obj_path)
-            except KeyError:
-                return '%s#overview' % context.absolute_url()
-
-            # redirect to right tabbedview-tab
-            if ITask.providedBy(obj):
-                return '%s#relateddocuments' % (obj.absolute_url())
-            elif IPloneSiteRoot.providedBy(obj):
-                return '%s#mydocuments' % (obj.absolute_url())
-            elif IDossierMarker.providedBy(obj):
-                return '%s#documents' % (obj.absolute_url())
-            else:
-                return obj.absolute_url()
-
-        else:
+    """return the url where the editing_document view was called from
+    It should be a document listing."""
+    referer = context.REQUEST.environ.get('HTTP_REFERER')
+    portal_url = '/'.join(context.portal_url().split('/')[:-1])
+    if referer:
+        obj_path = referer[len(portal_url):]
+        try:
+            obj = context.restrictedTraverse(obj_path)
+        except KeyError:
             return '%s#overview' % context.absolute_url()
+
+        # redirect to right tabbedview-tab
+        if ITask.providedBy(obj):
+            return '%s#relateddocuments' % (obj.absolute_url())
+        elif IPloneSiteRoot.providedBy(obj):
+            return '%s#mydocuments' % (obj.absolute_url())
+        elif IDossierMarker.providedBy(obj):
+            return '%s#documents' % (obj.absolute_url())
+        else:
+            return obj.absolute_url()
+
+    else:
+        return '%s#overview' % context.absolute_url()
 
 
 class EditCheckerView(BrowserView):
@@ -45,8 +44,7 @@ class EditCheckerView(BrowserView):
 
     def __call__(self):
         mtool = getToolByName(self.context, 'portal_membership')
-        if mtool.checkPermission(
-            'Modify portal content', self.context):
+        if mtool.checkPermission('Modify portal content', self.context):
             return self.request.RESPONSE.redirect(
                 '%s/edit' % (self.context.absolute_url()))
         else:
@@ -87,8 +85,8 @@ class EditingDocument(BrowserView):
         if manager.get_checked_out_by() == userid:
             # check if the document is locked
             # otherwies only open with the ext. editor
-            info = getMultiAdapter((self.context, self.request),
-                        name="plone_lock_info")
+            info = getMultiAdapter(
+                (self.context, self.request), name="plone_lock_info")
 
             if info.is_locked():
                 msg = _(u"Can't edit the document at moment, "

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -24,7 +24,7 @@ from opengever.officeconnector.helpers import is_officeconnector_checkout_featur
 from opengever.officeconnector.mimetypes import get_editable_types
 from opengever.oneoffixx import is_oneoffixx_feature_enabled
 from opengever.virusscan.validator import validateUploadForFieldIfNecessary
-from opengever.virusscan.validator import Z3CFormclamavValidator
+from opengever.virusscan.validator import Z3CFormClamavValidator
 from opengever.wopi.discovery import editable_extensions
 from plone import api
 from plone.app.versioningbehavior.behaviors import IVersionable
@@ -127,7 +127,7 @@ class IDocumentSchema(model.Schema):
                 "file", data.file.filename, data.file.open(), getRequest())
 
 
-class UploadValidator(Z3CFormclamavValidator):
+class UploadValidator(Z3CFormClamavValidator):
     """Validate document uploads."""
 
     def validate(self, value):

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -7,6 +7,7 @@ from ftw.mail.interfaces import IEmailAddress
 from ftw.tabbedview.interfaces import ITabbedviewUploadable
 from opengever.base.interfaces import IRedirector
 from opengever.base.model.favorite import Favorite
+from opengever.virusscan.validator import Z3CFormclamavValidator
 from opengever.docugate import is_docugate_feature_enabled
 from opengever.docugate.interfaces import IDocumentFromDocugate
 from opengever.document import _
@@ -119,7 +120,7 @@ class IDocumentSchema(model.Schema):
                 "portal_type ftw.mail.mail instead.")
 
 
-class UploadValidator(validator.SimpleFieldValidator):
+class UploadValidator(Z3CFormclamavValidator):
     """Validate document uploads."""
 
     def validate(self, value):
@@ -153,6 +154,7 @@ class UploadValidator(validator.SimpleFieldValidator):
                     u'error_proposal_document_type',
                     default=(u"It's not possible to have non-.docx documents as proposal documents.")
                     ))
+        super(UploadValidator, self).validate(value)
 
     def is_proposal_upload(self):
         """The upload form context can be, for example, a Dossier."""
@@ -179,8 +181,8 @@ class UploadValidator(validator.SimpleFieldValidator):
         raise Invalid(_(
             u'error_mail_upload',
             default=(u"It's not possible to add E-mails here, please "
-            "send it to ${mailaddress} or drag it to the dossier "
-            "(Dragn'n'Drop)."),
+                     u"send it to ${mailaddress} or drag it to the dossier "
+                     u"(Dragn'n'Drop)."),
             mapping={'mailaddress': mail_address}
             ))
 

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -23,8 +23,7 @@ from opengever.officeconnector.helpers import is_client_ip_in_office_connector_d
 from opengever.officeconnector.helpers import is_officeconnector_checkout_feature_enabled
 from opengever.officeconnector.mimetypes import get_editable_types
 from opengever.oneoffixx import is_oneoffixx_feature_enabled
-from opengever.virusscan.interfaces import IAVScannerSettings
-from opengever.virusscan.validator import validateStream
+from opengever.virusscan.validator import validateUploadForFieldIfNecessary
 from opengever.virusscan.validator import Z3CFormclamavValidator
 from opengever.wopi.discovery import editable_extensions
 from plone import api
@@ -123,11 +122,9 @@ class IDocumentSchema(model.Schema):
 
     @invariant
     def scan_for_virus(data):
-        if not api.portal.get_registry_record(name='scan_before_upload',
-                                              interface=IAVScannerSettings):
-            return True
         if data.file:
-            validateStream(data.file.filename, data.file.open(), getRequest())
+            validateUploadForFieldIfNecessary(
+                "file", data.file.filename, data.file.open(), getRequest())
 
 
 class UploadValidator(Z3CFormclamavValidator):

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -7,7 +7,6 @@ from ftw.mail.interfaces import IEmailAddress
 from ftw.tabbedview.interfaces import ITabbedviewUploadable
 from opengever.base.interfaces import IRedirector
 from opengever.base.model.favorite import Favorite
-from opengever.virusscan.validator import Z3CFormclamavValidator
 from opengever.docugate import is_docugate_feature_enabled
 from opengever.docugate.interfaces import IDocumentFromDocugate
 from opengever.document import _
@@ -24,6 +23,9 @@ from opengever.officeconnector.helpers import is_client_ip_in_office_connector_d
 from opengever.officeconnector.helpers import is_officeconnector_checkout_feature_enabled
 from opengever.officeconnector.mimetypes import get_editable_types
 from opengever.oneoffixx import is_oneoffixx_feature_enabled
+from opengever.virusscan.interfaces import IAVScannerSettings
+from opengever.virusscan.validator import validateStream
+from opengever.virusscan.validator import Z3CFormclamavValidator
 from opengever.wopi.discovery import editable_extensions
 from plone import api
 from plone.app.versioningbehavior.behaviors import IVersionable
@@ -118,6 +120,14 @@ class IDocumentSchema(model.Schema):
             raise Invalid(
                 u"It is not possible to add E-mails as document, use "
                 "portal_type ftw.mail.mail instead.")
+
+    @invariant
+    def scan_for_virus(data):
+        if not api.portal.get_registry_record(name='scan_before_upload',
+                                              interface=IAVScannerSettings):
+            return True
+        if data.file:
+            validateStream(data.file.filename, data.file.open(), getRequest())
 
 
 class UploadValidator(Z3CFormclamavValidator):

--- a/opengever/document/tests/test_document.py
+++ b/opengever/document/tests/test_document.py
@@ -461,7 +461,7 @@ class TestUploadValidator(FunctionalTestCase):
             self.assertFalse(validator.validate(file))
 
         self.assertEquals(
-            'Validation failed, file is virus-infected. (Eicar-Test-Signature FOUND)',
+            'file_infected',
             str(cm.exception))
 
     def validator_arguments(self):

--- a/opengever/document/tests/test_document.py
+++ b/opengever/document/tests/test_document.py
@@ -452,7 +452,7 @@ class TestUploadValidator(FunctionalTestCase):
     def test_rejects_file_containing_virus(self):
         register_mock_av_scanner()
         api.portal.set_registry_record(
-            'scan_before_upload', True,interface=IAVScannerSettings)
+            'scan_on_upload', True,interface=IAVScannerSettings)
 
         file = NamedBlobFile(EICAR, filename=u'test.txt')
         validator = UploadValidator(*self.validator_arguments())

--- a/opengever/document/tests/test_document_tooltip.py
+++ b/opengever/document/tests/test_document_tooltip.py
@@ -57,7 +57,7 @@ class TestDocumentTooltip(IntegrationTestCase):
         self.assertTrue(download.get('href').startswith(
             'http://nohost/plone/ordnungssystem/fuhrung'
             '/vertrage-und-vereinbarungen/dossier-1/document-14'
-            '/file_download_confirmation?_authenticator='))
+            '/file_download_confirmation?error_as_message=1&_authenticator='))
 
         # link to details
         self.assertEquals('Open detail view', details.text)

--- a/opengever/document/tests/test_download.py
+++ b/opengever/document/tests/test_download.py
@@ -74,7 +74,9 @@ class TestDocumentDownloadConfirmation(IntegrationTestCase):
             browser.css(".details > p").first.text,
         )
         browser.find('Download').click()
-        self.assertEqual("{}/download".format(self.document.absolute_url()), browser.url)
+        self.assertEqual(
+            "{}/download?error_as_message=1".format(self.document.absolute_url()),
+            browser.url)
         self.assertEqual(self.document.file.data, browser.contents)
 
     @browsing
@@ -89,7 +91,7 @@ class TestDocumentDownloadConfirmation(IntegrationTestCase):
             browser.css(".details > p").first.text,
         )
         browser.find('Download').click()
-        expected_url = "{}/download_file_version?version_id=1".format(self.document.absolute_url())
+        expected_url = "{}/download_file_version?version_id=1&error_as_message=1".format(self.document.absolute_url())
         self.assertEqual(expected_url, browser.url)
         self.assertEqual(self.document.file.data, browser.contents)
 

--- a/opengever/document/widgets/configure.zcml
+++ b/opengever/document/widgets/configure.zcml
@@ -25,4 +25,12 @@
       template="tooltip.pt"
       />
 
+  <browser:page
+      name="download"
+      for="plone.formwidget.namedfile.interfaces.INamedFileWidget"
+      class=".namedfile.GeverNamedFileDownload"
+      permission="zope2.View"
+      layer="opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
 </configure>

--- a/opengever/document/widgets/namedfile.py
+++ b/opengever/document/widgets/namedfile.py
@@ -1,0 +1,21 @@
+from opengever.document.browser.edit import get_redirect_url
+from opengever.virusscan.validator import validateDownloadStreamIfNecessary
+from plone import api
+from plone.formwidget.namedfile.widget import Download
+from zope.interface import Invalid
+
+
+class GeverNamedFileDownload(Download):
+    """Download a file, via ../context/form/++widget++/@@download/filename
+    but first check for viruses if necessary
+    """
+
+    def __call__(self):
+        stream = super(GeverNamedFileDownload, self).__call__()
+        try:
+            validateDownloadStreamIfNecessary(self.filename, stream, self.request)
+        except Invalid as exc:
+            api.portal.show_message(exc.message, self.request, type='error')
+            return self.request.RESPONSE.redirect(
+                get_redirect_url(self.context.context))
+        return stream

--- a/opengever/mail/browser/configure.zcml
+++ b/opengever/mail/browser/configure.zcml
@@ -92,4 +92,12 @@
         />
   </configure>
 
+  <browser:page
+      for="Products.CMFCore.interfaces.ISiteRoot"
+      name="mail-inbound"
+      class=".inbound.GeverMailInbound"
+      permission="zope2.View"
+      layer="opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
 </configure>

--- a/opengever/mail/browser/inbound.py
+++ b/opengever/mail/browser/inbound.py
@@ -1,0 +1,22 @@
+from ftw.mail.inbound import MailInbound
+from opengever.mail.exceptions import MessageContainsVirus
+from opengever.virusscan.validator import validateUploadForFieldIfNecessary
+from six import BytesIO
+from zope.interface import Invalid
+
+
+class GeverMailInbound(MailInbound):
+
+    def msg(self):
+        """We add scanning for viruses and raise an exception inheriting from
+        MailInboundException, setting an appropriate exit code.
+        """
+        msg = super(GeverMailInbound, self).msg()
+        filelike = BytesIO(msg)
+        filename = '<stream>'
+
+        try:
+            validateUploadForFieldIfNecessary(
+                'message', filename, filelike, self.request)
+        except Invalid as e:
+            raise MessageContainsVirus(e.message)

--- a/opengever/mail/exceptions.py
+++ b/opengever/mail/exceptions.py
@@ -1,3 +1,6 @@
+from ftw.mail.exceptions import MailInboundException
+from ftw.mail.config import EXIT_CODES
+
 
 class AlreadyExtractedError(Exception):
     """Attachment already extracted from Mail.
@@ -24,3 +27,10 @@ class SourceMailNotFound(Exception):
     """Raised when a document extracted from a Mail is modified and its
     info cannot be updated in the Mail from which it was extracted because
     it could not be found"""
+
+
+class MessageContainsVirus(MailInboundException):
+
+    def __init__(self, message):
+        MailInboundException.__init__(
+            self, EXIT_CODES['DATAERR'], message)

--- a/opengever/mail/mail.py
+++ b/opengever/mail/mail.py
@@ -22,6 +22,7 @@ from opengever.mail.exceptions import InvalidAttachmentPosition
 from opengever.mail.interfaces import IExtractedFromMail
 from opengever.mail.utils import is_rfc822_ish_mimetype
 from opengever.ogds.models.user import User
+from opengever.virusscan.validator import validateUploadForFieldIfNecessary
 from plone import api
 from plone.app.dexterity.behaviors import metadata
 from plone.autoform import directives as form
@@ -38,6 +39,7 @@ from z3c.relationfield.relation import RelationValue
 from zope import schema
 from zope.component import getUtility
 from zope.component.hooks import getSite
+from zope.globalrequest import getRequest
 from zope.i18n import translate
 from zope.interface import alsoProvides
 from zope.interface import Interface
@@ -60,6 +62,15 @@ IMail.setTaggedValue(FIELDSETS_KEY, [
              label=base_mf(u'fieldset_common', u'Common'),
              fields=[u'message'])
 ])
+
+
+def scan_for_virus(data):
+    if data.message:
+        validateUploadForFieldIfNecessary(
+            "message", data.message.filename, data.message.open(), getRequest())
+
+
+IMail.setTaggedValue('invariants', [scan_for_virus])
 
 
 class IOGMailMarker(Interface):

--- a/opengever/virusscan/__init__.py
+++ b/opengever/virusscan/__init__.py
@@ -1,0 +1,3 @@
+from zope.i18nmessageid import MessageFactory
+
+_ = MessageFactory("opengever.virusscan")

--- a/opengever/virusscan/configure.zcml
+++ b/opengever/virusscan/configure.zcml
@@ -1,0 +1,47 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    xmlns:i18n="http://namespaces.zope.org/i18n"
+    i18n_domain="collective.clamav">
+
+  <i18n:registerTranslations directory="locales" />
+
+  <includeDependencies package="." />
+
+  <include package=".browser" />
+
+
+  <genericsetup:registerProfile
+      name="default"
+      title="collective.clamav"
+      directory="profiles/default"
+      description="Installs the collective.clamav add-on."
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      />
+
+  <genericsetup:registerProfile
+      name="uninstall"
+      title="collective.clamav (uninstall)"
+      directory="profiles/uninstall"
+      description="Uninstalls the collective.clamav add-on."
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      />
+
+  <utility
+      factory=".setuphandlers.HiddenProfiles"
+      name="collective.clamav-hiddenprofiles" />
+
+  <utility factory=".scanner.ClamavScanner" />
+
+
+  <adapter
+      name="collective.clamav.file"
+      factory=".schema.VirusFreeFileModifier" />
+
+  <adapter
+     name="collective.clamav.image"
+     factory=".schema.VirusFreeImageModifier" />
+
+  <adapter factory=".validator.Z3CFormclamavValidator" />
+
+</configure>

--- a/opengever/virusscan/configure.zcml
+++ b/opengever/virusscan/configure.zcml
@@ -2,45 +2,11 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     xmlns:i18n="http://namespaces.zope.org/i18n"
-    i18n_domain="collective.clamav">
+    i18n_domain="opengever.virusscan">
 
   <i18n:registerTranslations directory="locales" />
 
-  <includeDependencies package="." />
-
-  <include package=".browser" />
-
-
-  <genericsetup:registerProfile
-      name="default"
-      title="collective.clamav"
-      directory="profiles/default"
-      description="Installs the collective.clamav add-on."
-      provides="Products.GenericSetup.interfaces.EXTENSION"
-      />
-
-  <genericsetup:registerProfile
-      name="uninstall"
-      title="collective.clamav (uninstall)"
-      directory="profiles/uninstall"
-      description="Uninstalls the collective.clamav add-on."
-      provides="Products.GenericSetup.interfaces.EXTENSION"
-      />
-
-  <utility
-      factory=".setuphandlers.HiddenProfiles"
-      name="collective.clamav-hiddenprofiles" />
-
   <utility factory=".scanner.ClamavScanner" />
-
-
-  <adapter
-      name="collective.clamav.file"
-      factory=".schema.VirusFreeFileModifier" />
-
-  <adapter
-     name="collective.clamav.image"
-     factory=".schema.VirusFreeImageModifier" />
 
   <adapter factory=".validator.Z3CFormclamavValidator" />
 

--- a/opengever/virusscan/configure.zcml
+++ b/opengever/virusscan/configure.zcml
@@ -8,6 +8,6 @@
 
   <utility factory=".scanner.ClamavScanner" />
 
-  <adapter factory=".validator.Z3CFormclamavValidator" />
+  <adapter factory=".validator.Z3CFormClamavValidator" />
 
 </configure>

--- a/opengever/virusscan/interfaces.py
+++ b/opengever/virusscan/interfaces.py
@@ -1,15 +1,7 @@
-# -*- coding: utf-8 -*-
-"""Module where all interfaces, events and exceptions live."""
-
 from opengever.virusscan import _
-from zope.publisher.interfaces.browser import IDefaultBrowserLayer
-from zope.interface import Interface
 from zope import schema
+from zope.interface import Interface
 from zope.schema.vocabulary import SimpleVocabulary, SimpleTerm
-
-
-class ICollectiveClamavLayer(IDefaultBrowserLayer):
-    """Marker interface that defines a browser layer."""
 
 
 clamdConnectionType = SimpleVocabulary(
@@ -28,35 +20,35 @@ class IAVScannerSettings(Interface):
     )
 
     clamav_connection = schema.Choice(
-        title=_(u"Connection type to clamd"),
-        description=_(u"Choose whether clamd is accessible through local "
-                      u"UNIX sockets or network."),
+        title=u"Connection type to clamd",
+        description=u"Choose whether clamd is accessible through local "
+                    u"UNIX sockets or network.",
         vocabulary=clamdConnectionType)
 
     clamav_socket = schema.ASCIILine(
-        title=_(u"Clamd local socket file"),
-        description=_(u"If connected to clamd through local UNIX sockets, "
-                      u"the path to the local socket file."),
+        title=u"Clamd local socket file",
+        description=u"If connected to clamd through local UNIX sockets, "
+                    u"the path to the local socket file.",
         default='/var/run/clamd',
         required=True)
 
-    clamav_host = schema.ASCIILine(title=_(u"Scanner host"),
-                                   description=_(u"If connected to clamd "
-                                                 u"through the network, "
-                                                 u"the host running clamd."),
+    clamav_host = schema.ASCIILine(title=u"Scanner host",
+                                   description=u"If connected to clamd "
+                                               u"through the network, "
+                                               u"the host running clamd.",
                                    default='localhost',
                                    required=True)
 
-    clamav_port = schema.Int(title=_(u"Scanner port"),
-                             description=_(u"If connected to clamd "
-                                           u"through the network, the "
-                                           u"port on which clamd listens."),
+    clamav_port = schema.Int(title=u"Scanner port",
+                             description=u"If connected to clamd "
+                                         u"through the network, the "
+                                         u"port on which clamd listens.",
                              default=3310,
                              required=True)
 
-    clamav_timeout = schema.Int(title=_(u"Timeout"),
-                                description=_(u"The timeout in seconds for "
-                                              u"communication with clamd."),
+    clamav_timeout = schema.Int(title=u"Timeout",
+                                description=u"The timeout in seconds for "
+                                            u"communication with clamd.",
                                 default=120,
                                 required=True)
 

--- a/opengever/virusscan/interfaces.py
+++ b/opengever/virusscan/interfaces.py
@@ -11,7 +11,7 @@ clamdConnectionType = SimpleVocabulary(
 
 
 class IAVScannerSettings(Interface):
-    """ Schema for the clamav settings
+    """ Schema for the ClamAV settings
     """
 
     scan_before_download = schema.Bool(

--- a/opengever/virusscan/interfaces.py
+++ b/opengever/virusscan/interfaces.py
@@ -22,7 +22,7 @@ class IAVScannerSettings(Interface):
                     u'virus scanner (see IAVScannerSettings)',
         default=False)
 
-    scan_before_upload = schema.Bool(
+    scan_on_upload = schema.Bool(
         title=u'Scan for viruses before file upload',
         description=u'Whether a virus check should be performed when '
                     u'uploading a file to Gever.'

--- a/opengever/virusscan/interfaces.py
+++ b/opengever/virusscan/interfaces.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+"""Module where all interfaces, events and exceptions live."""
+
+from opengever.virusscan import _
+from zope.publisher.interfaces.browser import IDefaultBrowserLayer
+from zope.interface import Interface
+from zope import schema
+from zope.schema.vocabulary import SimpleVocabulary, SimpleTerm
+
+
+class ICollectiveClamavLayer(IDefaultBrowserLayer):
+    """Marker interface that defines a browser layer."""
+
+
+clamdConnectionType = SimpleVocabulary(
+    [SimpleTerm(title=u"Unix Socket", value="socket"),
+     SimpleTerm(title=u"Network", value="net")]
+)
+
+
+class IAVScannerSettings(Interface):
+    """ Schema for the clamav settings
+    """
+    clamav_enabled = schema.Bool(
+        title=_(u"Scanning enabled"),
+        description=_(u"If not set, no virus scanning will be done"),
+        default=True,
+    )
+
+    clamav_connection = schema.Choice(
+        title=_(u"Connection type to clamd"),
+        description=_(u"Choose whether clamd is accessible through local "
+                      u"UNIX sockets or network."),
+        vocabulary=clamdConnectionType)
+
+    clamav_socket = schema.ASCIILine(
+        title=_(u"Clamd local socket file"),
+        description=_(u"If connected to clamd through local UNIX sockets, "
+                      u"the path to the local socket file."),
+        default='/var/run/clamd',
+        required=True)
+
+    clamav_host = schema.ASCIILine(title=_(u"Scanner host"),
+                                   description=_(u"If connected to clamd "
+                                                 u"through the network, "
+                                                 u"the host running clamd."),
+                                   default='localhost',
+                                   required=True)
+
+    clamav_port = schema.Int(title=_(u"Scanner port"),
+                             description=_(u"If connected to clamd "
+                                           u"through the network, the "
+                                           u"port on which clamd listens."),
+                             default=3310,
+                             required=True)
+
+    clamav_timeout = schema.Int(title=_(u"Timeout"),
+                                description=_(u"The timeout in seconds for "
+                                              u"communication with clamd."),
+                                default=120,
+                                required=True)
+
+
+class IAVScanner(Interface):
+    def ping():
+        pass
+
+    def scanBuffer(buffer):
+        pass
+
+    def scanStream(buffer):
+        pass

--- a/opengever/virusscan/interfaces.py
+++ b/opengever/virusscan/interfaces.py
@@ -13,11 +13,22 @@ clamdConnectionType = SimpleVocabulary(
 class IAVScannerSettings(Interface):
     """ Schema for the clamav settings
     """
-    clamav_enabled = schema.Bool(
-        title=_(u"Scanning enabled"),
-        description=_(u"If not set, no virus scanning will be done"),
-        default=True,
-    )
+
+    scan_before_download = schema.Bool(
+        title=u'Scan for viruses before file download',
+        description=u'Whether a virus check should be performed when '
+                    u'downloading a file from Gever'
+                    u'Note that this requires a correct configuration of the '
+                    u'virus scanner (see IAVScannerSettings)',
+        default=False)
+
+    scan_before_upload = schema.Bool(
+        title=u'Scan for viruses before file upload',
+        description=u'Whether a virus check should be performed when '
+                    u'uploading a file to Gever.'
+                    u'Note that this requires a correct configuration of the '
+                    u'virus scanner (see IAVScannerSettings)',
+        default=False)
 
     clamav_connection = schema.Choice(
         title=u"Connection type to clamd",

--- a/opengever/virusscan/interfaces.py
+++ b/opengever/virusscan/interfaces.py
@@ -17,7 +17,7 @@ class IAVScannerSettings(Interface):
     scan_before_download = schema.Bool(
         title=u'Scan for viruses before file download',
         description=u'Whether a virus check should be performed when '
-                    u'downloading a file from Gever'
+                    u'downloading a file.'
                     u'Note that this requires a correct configuration of the '
                     u'virus scanner (see IAVScannerSettings)',
         default=False)
@@ -25,7 +25,7 @@ class IAVScannerSettings(Interface):
     scan_on_upload = schema.Bool(
         title=u'Scan for viruses before file upload',
         description=u'Whether a virus check should be performed when '
-                    u'uploading a file to Gever.'
+                    u'uploading a file.'
                     u'Note that this requires a correct configuration of the '
                     u'virus scanner (see IAVScannerSettings)',
         default=False)

--- a/opengever/virusscan/locales/de/LC_MESSAGES/opengever.virusscan.po
+++ b/opengever/virusscan/locales/de/LC_MESSAGES/opengever.virusscan.po
@@ -22,4 +22,4 @@ msgstr "Beim Scannen der Datei auf Viren ist ein Fehler aufgetreten. Bitte melde
 #. Default: "Validation failed, file is virus-infected."
 #: ./opengever/virusscan/validator.py
 msgid "file_infected"
-msgstr "Achtung, diese Datei enthält einen Virus."
+msgstr "Fehler - Virus gefunden!"

--- a/opengever/virusscan/locales/de/LC_MESSAGES/opengever.virusscan.po
+++ b/opengever/virusscan/locales/de/LC_MESSAGES/opengever.virusscan.po
@@ -1,6 +1,3 @@
-# --- PLEASE EDIT THE LINES BELOW CORRECTLY ---
-# SOME DESCRIPTIVE TITLE.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
@@ -15,14 +12,14 @@ msgstr ""
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
-"Domain: opengever.virusscan\n"
+"Domain: DOMAIN\n"
 
 #. Default: "There was an error while checking the file for viruses."
 #: ./opengever/virusscan/validator.py
 msgid "error_while_scanning"
-msgstr ""
+msgstr "Beim Scannen der Datei auf Viren ist ein Fehler aufgetreten. Bitte melden Sie dies dem Fachapplikationsverantwortlichen."
 
 #. Default: "Validation failed, file is virus-infected."
 #: ./opengever/virusscan/validator.py
 msgid "file_infected"
-msgstr ""
+msgstr "Achtung, diese Datei enthält einen Virus."

--- a/opengever/virusscan/locales/en/LC_MESSAGES/opengever.virusscan.po
+++ b/opengever/virusscan/locales/en/LC_MESSAGES/opengever.virusscan.po
@@ -1,6 +1,3 @@
-# --- PLEASE EDIT THE LINES BELOW CORRECTLY ---
-# SOME DESCRIPTIVE TITLE.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
@@ -15,14 +12,14 @@ msgstr ""
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
-"Domain: opengever.virusscan\n"
+"Domain: DOMAIN\n"
 
 #. Default: "There was an error while checking the file for viruses."
 #: ./opengever/virusscan/validator.py
 msgid "error_while_scanning"
-msgstr ""
+msgstr "There was an error while checking the file for viruses. Please contact the application administrator."
 
 #. Default: "Validation failed, file is virus-infected."
 #: ./opengever/virusscan/validator.py
 msgid "file_infected"
-msgstr ""
+msgstr "Careful, this file contains a virus."

--- a/opengever/virusscan/locales/en/LC_MESSAGES/opengever.virusscan.po
+++ b/opengever/virusscan/locales/en/LC_MESSAGES/opengever.virusscan.po
@@ -22,4 +22,4 @@ msgstr "There was an error while checking the file for viruses. Please contact t
 #. Default: "Validation failed, file is virus-infected."
 #: ./opengever/virusscan/validator.py
 msgid "file_infected"
-msgstr "Careful, this file contains a virus."
+msgstr "Error - Virus detected!"

--- a/opengever/virusscan/locales/fr/LC_MESSAGES/opengever.virusscan.po
+++ b/opengever/virusscan/locales/fr/LC_MESSAGES/opengever.virusscan.po
@@ -22,4 +22,4 @@ msgstr "Un erreur s'est produite durant la détection de virus. Veuillez contact
 #. Default: "Validation failed, file is virus-infected."
 #: ./opengever/virusscan/validator.py
 msgid "file_infected"
-msgstr "Attention, ce fichier contient un virus."
+msgstr "Erreur - Virus détecté!"

--- a/opengever/virusscan/locales/fr/LC_MESSAGES/opengever.virusscan.po
+++ b/opengever/virusscan/locales/fr/LC_MESSAGES/opengever.virusscan.po
@@ -1,6 +1,3 @@
-# --- PLEASE EDIT THE LINES BELOW CORRECTLY ---
-# SOME DESCRIPTIVE TITLE.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
@@ -15,14 +12,14 @@ msgstr ""
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
-"Domain: opengever.virusscan\n"
+"Domain: DOMAIN\n"
 
 #. Default: "There was an error while checking the file for viruses."
 #: ./opengever/virusscan/validator.py
 msgid "error_while_scanning"
-msgstr ""
+msgstr "Un erreur s'est produite durant la détection de virus. Veuillez contacter le responsable de l'application."
 
 #. Default: "Validation failed, file is virus-infected."
 #: ./opengever/virusscan/validator.py
 msgid "file_infected"
-msgstr ""
+msgstr "Attention, ce fichier contient un virus."

--- a/opengever/virusscan/scanner.py
+++ b/opengever/virusscan/scanner.py
@@ -1,4 +1,4 @@
-from collective.clamav.interfaces import IAVScanner
+from opengever.virusscan.interfaces import IAVScanner
 from six import BytesIO
 from zope.interface import implements
 import clamd

--- a/opengever/virusscan/scanner.py
+++ b/opengever/virusscan/scanner.py
@@ -1,0 +1,56 @@
+from collective.clamav.interfaces import IAVScanner
+from six import BytesIO
+from zope.interface import implements
+import clamd
+
+
+class ScanError(Exception):
+    """Generic exception for AV checks.
+    """
+
+    def __init__(self, message):
+        super(ScanError, self).__init__(message)
+
+
+def _make_clamd(type, **kwargs):
+    timeout = kwargs.get('timeout', 10.0)
+    if type == 'socket':
+        socketpath = kwargs.get('socketpath', '/var/run/clamd')
+        return clamd.ClamdUnixSocket(path=socketpath, timeout=timeout)
+    elif type == 'net':
+        host = kwargs.get('host', 'localhost')
+        port = kwargs.get('port', 3310)
+        return clamd.ClamdNetworkSocket(host=host, port=port, timeout=timeout)
+    else:
+        raise ScanError('Invalid call')
+
+
+class ClamavScanner(object):
+    """
+    """
+    implements(IAVScanner)
+
+    def ping(self, type, **kwargs):
+        if not _make_clamd(type, **kwargs).ping() == "PONG":
+            raise ScanError('Could not ping clamd server')
+        return True
+
+    def scanBuffer(self, buffer, type, **kwargs):
+        """Scans a buffer for viruses
+        """
+        return self.scanStream(BytesIO(buffer), type, **kwargs)
+
+    def scanStream(self, stream, type, **kwargs):
+        """Scans a stream for viruses
+        """
+
+        timeout = kwargs.get('timeout', 120.0)
+        kwargs_copy = dict(kwargs)
+        kwargs_copy.update(timeout=timeout)
+        cd = _make_clamd(type, **kwargs_copy)
+        status = cd.instream(stream)
+
+        if status["stream"][0] == "FOUND":
+            return status["stream"][1]
+        if status["stream"][0] == "ERROR":
+            raise ScanError(status["stream"][1])

--- a/opengever/virusscan/testing.py
+++ b/opengever/virusscan/testing.py
@@ -1,0 +1,41 @@
+from opengever.virusscan.interfaces import IAVScanner
+from six import BytesIO
+from zope.component import getSiteManager
+from zope.interface import implements
+
+
+EICAR = """
+    WDVPIVAlQEFQWzRcUFpYNTQoUF4pN0NDKTd9JEVJQ0FSLVNUQU5E
+    QVJELUFOVElWSVJVUy1URVNU\nLUZJTEUhJEgrSCo=\n""".decode('base64')
+
+
+class MockAVScanner(object):
+    """Mock objects to run tests without clamav present.
+    """
+
+    implements(IAVScanner)
+
+    uses = 0
+
+    def ping(self, type, **kwargs):
+        """
+        """
+        return True
+
+    def scanStream(self, stream, type, **kwargs):
+        """
+        """
+        self.uses += 1
+        if EICAR in stream.read():
+            return 'Eicar-Test-Signature FOUND'
+        return None
+
+    def scanBuffer(self, buffer, type, **kwargs):
+        """
+        """
+        return self.scanStream(BytesIO(buffer), type, **kwargs)
+
+
+def register_mock_av_scanner():
+    sm = getSiteManager()
+    sm.registerUtility(MockAVScanner())

--- a/opengever/virusscan/testing.py
+++ b/opengever/virusscan/testing.py
@@ -10,7 +10,7 @@ EICAR = """
 
 
 class MockAVScanner(object):
-    """Mock objects to run tests without clamav present.
+    """Mock objects to run tests without ClamAV present.
     """
 
     implements(IAVScanner)

--- a/opengever/virusscan/tests/test_virusscan_validator.py
+++ b/opengever/virusscan/tests/test_virusscan_validator.py
@@ -23,7 +23,7 @@ class TestVirusScanValidator(IntegrationTestCase):
         super(TestVirusScanValidator, self).setUp()
         register_mock_av_scanner()
         api.portal.set_registry_record(
-            'scan_before_upload', True, interface=IAVScannerSettings)
+            'scan_on_upload', True, interface=IAVScannerSettings)
         api.portal.set_registry_record(
             'scan_before_download', True, interface=IAVScannerSettings)
 
@@ -48,7 +48,7 @@ class TestVirusScanValidator(IntegrationTestCase):
     @browsing
     def test_document_add_form_does_not_scan_file_field_for_viruses_when_disabled(self, browser):
         api.portal.set_registry_record(
-            'scan_before_upload', False, interface=IAVScannerSettings)
+            'scan_on_upload', False, interface=IAVScannerSettings)
 
         self.login(self.regular_user, browser)
         browser.open(self.empty_dossier)
@@ -99,7 +99,7 @@ class TestVirusScanValidator(IntegrationTestCase):
     @browsing
     def test_document_edit_form_does_not_scan_file_field_for_viruses_when_disabled(self, browser):
         api.portal.set_registry_record(
-            'scan_before_upload', False, interface=IAVScannerSettings)
+            'scan_on_upload', False, interface=IAVScannerSettings)
 
         self.login(self.regular_user, browser)
         self.get_checkout_manager(self.document).checkout()
@@ -203,7 +203,7 @@ class TestVirusScanValidator(IntegrationTestCase):
     @browsing
     def test_document_post_does_not_scan_file_for_viruses_when_disabled(self, browser):
         api.portal.set_registry_record(
-            'scan_before_upload', False, interface=IAVScannerSettings)
+            'scan_on_upload', False, interface=IAVScannerSettings)
         self.login(self.regular_user, browser)
 
         with self.observe_children(self.empty_dossier) as children:
@@ -265,7 +265,7 @@ class TestVirusScanValidator(IntegrationTestCase):
     def test_document_post_does_not_scan_archival_file_for_viruses_when_disabled(self, browser):
         self.login(self.manager, browser)
         api.portal.set_registry_record(
-            'scan_before_upload', False, interface=IAVScannerSettings)
+            'scan_on_upload', False, interface=IAVScannerSettings)
 
         with self.observe_children(self.empty_dossier) as children:
             data = {'@type': 'opengever.document.document',

--- a/opengever/virusscan/tests/test_virusscan_validator.py
+++ b/opengever/virusscan/tests/test_virusscan_validator.py
@@ -32,7 +32,7 @@ class TestVirusScanValidator(IntegrationTestCase):
 
         self.assertEqual(["There were some errors."], error_messages())
         self.assertEqual(
-            {'File': ['Validation failed, file is virus-infected. (Eicar-Test-Signature FOUND)']},
+            {'File': ['Validation failed, file is virus-infected.']},
             erroneous_fields())
         self.assertEqual(0, len(self.empty_dossier.contentItems()))
 
@@ -65,7 +65,7 @@ class TestVirusScanValidator(IntegrationTestCase):
 
         self.assertEqual(["There were some errors."], error_messages())
         self.assertEqual(
-            {'Archival file': ['Validation failed, file is virus-infected. (Eicar-Test-Signature FOUND)']},
+            {'Archival file': ['Validation failed, file is virus-infected.']},
             erroneous_fields())
         self.assertEqual(0, len(self.empty_dossier.contentItems()))
 
@@ -82,7 +82,7 @@ class TestVirusScanValidator(IntegrationTestCase):
         browser.fill({'File': (EICAR, 'file.txt', 'text/plain')}).save()
         self.assertEqual(["There were some errors."], error_messages())
         self.assertEqual(
-            {'File': ['Validation failed, file is virus-infected. (Eicar-Test-Signature FOUND)']},
+            {'File': ['Validation failed, file is virus-infected.']},
             erroneous_fields())
         self.assertIsNone(self.empty_document.get_file())
 
@@ -112,7 +112,7 @@ class TestVirusScanValidator(IntegrationTestCase):
         browser.fill({'Archival file': (EICAR, 'file.txt', 'text/plain')}).save()
         self.assertEqual(["There were some errors."], error_messages())
         self.assertEqual(
-            {'Archival file': ['Validation failed, file is virus-infected. (Eicar-Test-Signature FOUND)']},
+            {'Archival file': ['Validation failed, file is virus-infected.']},
             erroneous_fields())
         self.assertIsNone(self.document.archival_file)
 
@@ -133,7 +133,7 @@ class TestVirusScanValidator(IntegrationTestCase):
 
         self.assertIsNone(result['success'])
         self.assertEqual(
-             u'Validation failed, file is virus-infected. (Eicar-Test-Signature FOUND)',
+             u'Validation failed, file is virus-infected.',
              result['error'])
 
         result = factory(filename='file.txt',
@@ -160,8 +160,8 @@ class TestVirusScanValidator(IntegrationTestCase):
         self.assertEqual(400, browser.status_code)
         self.assertEqual(0, len(children['added']))
         self.assertEqual(
-            u"[{'message': 'Validation failed, file is virus-infected. "
-            u"(Eicar-Test-Signature FOUND)', 'error': 'ValidationError'}]",
+            u"[{'message': 'file_infected', "
+            u"'error': 'ValidationError'}]",
             browser.json['message'])
 
         data['file']['data'] = "No virus"
@@ -198,8 +198,8 @@ class TestVirusScanValidator(IntegrationTestCase):
 
         self.assertEqual(400, browser.status_code)
         self.assertEqual(
-            u"[{'message': 'Validation failed, file is virus-infected. "
-            u"(Eicar-Test-Signature FOUND)', 'error': 'ValidationError'}]",
+            u"[{'message': 'file_infected', "
+            u"'error': 'ValidationError'}]",
             browser.json['message'])
 
         data['file']['data'] = "No virus"
@@ -221,8 +221,8 @@ class TestVirusScanValidator(IntegrationTestCase):
 
         self.assertEqual(0, len(children['added']))
         self.assertEqual(
-            u"[{'message': 'Validation failed, file is virus-infected. "
-            u"(Eicar-Test-Signature FOUND)', 'error': 'ValidationError'}]",
+            u"[{'message': 'file_infected', "
+            u"'error': 'ValidationError'}]",
             browser.json['message'])
 
         data['archival_file']['data'] = "No virus"
@@ -266,7 +266,7 @@ class TestVirusScanDownloadValidator(IntegrationTestCase):
 
         browser.open(self.document, view='download')
         self.assertEqual(
-            ['Validation failed, file is virus-infected. (Eicar-Test-Signature FOUND)'],
+            ['Validation failed, file is virus-infected.'],
             error_messages())
         self.assertEqual('text/html;charset=utf-8',
                          browser.headers['content-type'])
@@ -305,7 +305,7 @@ class TestVirusScanDownloadValidator(IntegrationTestCase):
         browser.click_on("Download")
 
         self.assertEqual(
-            ['Validation failed, file is virus-infected. (Eicar-Test-Signature FOUND)'],
+            ['Validation failed, file is virus-infected.'],
             error_messages())
         self.assertEqual('text/html;charset=utf-8',
                          browser.headers['content-type'])
@@ -332,7 +332,7 @@ class TestVirusScanDownloadValidator(IntegrationTestCase):
             browser.open(self.document, view='download', headers=self.api_headers)
 
         self.assertEqual(
-            u'Validation failed, file is virus-infected. (Eicar-Test-Signature FOUND)',
+            u'file_infected',
             browser.json['message'])
 
         browser.open(self.subdocument, view='download')
@@ -352,7 +352,7 @@ class TestVirusScanDownloadValidator(IntegrationTestCase):
         browser.css('a.function-download-copy').first.click()
         browser.find('Download').click()
         self.assertEqual(
-            ['Validation failed, file is virus-infected. (Eicar-Test-Signature FOUND)'],
+            ['Validation failed, file is virus-infected.'],
             error_messages())
         self.assertEqual('text/html;charset=utf-8',
                          browser.headers['content-type'])
@@ -373,7 +373,7 @@ class TestVirusScanDownloadValidator(IntegrationTestCase):
                 headers=self.api_headers)
 
         self.assertEqual(
-            u'Validation failed, file is virus-infected. (Eicar-Test-Signature FOUND)',
+            u'file_infected',
             browser.json['message'])
 
     @browsing

--- a/opengever/virusscan/tests/test_virusscan_validator.py
+++ b/opengever/virusscan/tests/test_virusscan_validator.py
@@ -294,3 +294,31 @@ class TestVirusScanDownloadValidator(IntegrationTestCase):
             'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
             browser.headers['content-type'])
         self.assertEqual(EICAR, browser.contents)
+
+    @browsing
+    def test_download_view_scans_file_from_edit_view(self, browser):
+        self.login(self.regular_user, browser)
+        self.checkout_document(self.document)
+        browser.open(self.document, view='edit')
+        browser.click_on("Vertraegsentwurf.docx")
+        browser.click_on("Download")
+
+        self.assertEqual(
+            ['Validation failed, file is virus-infected. (Eicar-Test-Signature FOUND)'],
+            error_messages())
+        self.assertEqual('text/html;charset=utf-8',
+                         browser.headers['content-type'])
+        self.assertIsNone(browser.headers.get('content-disposition'))
+        self.assertEqual(self.document.absolute_url(), browser.url)
+
+        self.checkout_document(self.subdocument)
+        browser.open(self.subdocument, view='edit')
+        browser.click_on("Uebersicht der Vertraege von 2016.xlsx")
+        browser.click_on("Download")
+        self.assertEqual(
+            'attachment; filename="Uebersicht der Vertraege von 2016.xlsx"',
+            browser.headers.get('content-disposition'))
+        self.assertEqual(
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            browser.headers['content-type'])
+        self.assertEqual("No virus", browser.contents)

--- a/opengever/virusscan/tests/test_virusscan_validator.py
+++ b/opengever/virusscan/tests/test_virusscan_validator.py
@@ -37,7 +37,7 @@ class TestVirusScanValidator(IntegrationTestCase):
 
         self.assertEqual(["There were some errors."], error_messages())
         self.assertEqual(
-            {'File': ['Careful, this file contains a virus.']},
+            {'File': ['Error - Virus detected!']},
             erroneous_fields())
         self.assertEqual(0, len(self.empty_dossier.contentItems()))
 
@@ -70,7 +70,7 @@ class TestVirusScanValidator(IntegrationTestCase):
 
         self.assertEqual(["There were some errors."], error_messages())
         self.assertEqual(
-            {'Archival file': ['Careful, this file contains a virus.']},
+            {'Archival file': ['Error - Virus detected!']},
             erroneous_fields())
         self.assertEqual(0, len(self.empty_dossier.contentItems()))
 
@@ -87,7 +87,7 @@ class TestVirusScanValidator(IntegrationTestCase):
         browser.fill({'File': (EICAR, 'file.txt', 'text/plain')}).save()
         self.assertEqual(["There were some errors."], error_messages())
         self.assertEqual(
-            {'File': ['Careful, this file contains a virus.']},
+            {'File': ['Error - Virus detected!']},
             erroneous_fields())
         self.assertIsNone(self.empty_document.get_file())
 
@@ -116,7 +116,7 @@ class TestVirusScanValidator(IntegrationTestCase):
         browser.fill({'Archival file': (EICAR, 'file.txt', 'text/plain')}).save()
         self.assertEqual(["There were some errors."], error_messages())
         self.assertEqual(
-            {'Archival file': ['Careful, this file contains a virus.']},
+            {'Archival file': ['Error - Virus detected!']},
             erroneous_fields())
         self.assertIsNone(self.document.archival_file)
 
@@ -137,7 +137,7 @@ class TestVirusScanValidator(IntegrationTestCase):
 
         self.assertIsNone(result['success'])
         self.assertEqual(
-             u'Careful, this file contains a virus.',
+             u'Error - Virus detected!',
              result['error'])
 
         result = factory(filename=u'f\xefle.txt',
@@ -162,7 +162,7 @@ class TestVirusScanValidator(IntegrationTestCase):
 
         self.assertIsNone(result['success'])
         self.assertEqual(
-             u'Careful, this file contains a virus.',
+             u'Error - Virus detected!',
              result['error'])
 
         result = factory(filename=u'f\xefle.eml',
@@ -353,7 +353,7 @@ class TestVirusScanDownloadValidator(IntegrationTestCase):
 
         browser.open(self.document, view='download?error_as_message=1')
         self.assertEqual(
-            ['Careful, this file contains a virus.'],
+            ['Error - Virus detected!'],
             error_messages())
         self.assertEqual('text/html;charset=utf-8',
                          browser.headers['content-type'])
@@ -382,7 +382,7 @@ class TestVirusScanDownloadValidator(IntegrationTestCase):
         self.mail_eml.message.data = EICAR
         browser.open(self.mail_eml, view='download?error_as_message=1')
         self.assertEqual(
-            ['Careful, this file contains a virus.'],
+            ['Error - Virus detected!'],
             error_messages())
         self.assertEqual('text/html;charset=utf-8',
                          browser.headers['content-type'])
@@ -412,7 +412,7 @@ class TestVirusScanDownloadValidator(IntegrationTestCase):
         browser.click_on("Download")
 
         self.assertEqual(
-            ['Careful, this file contains a virus.'],
+            ['Error - Virus detected!'],
             error_messages())
         self.assertEqual('text/html;charset=utf-8',
                          browser.headers['content-type'])
@@ -440,7 +440,7 @@ class TestVirusScanDownloadValidator(IntegrationTestCase):
         browser.click_on("Vertraegsentwurf.pdf")
 
         self.assertEqual(
-            ['Careful, this file contains a virus.'],
+            ['Error - Virus detected!'],
             error_messages())
         self.assertEqual('text/html;charset=utf-8',
                          browser.headers['content-type'])
@@ -507,7 +507,7 @@ class TestVirusScanDownloadValidator(IntegrationTestCase):
         browser.css('a.function-download-copy').first.click()
         browser.find('Download').click()
         self.assertEqual(
-            ['Careful, this file contains a virus.'],
+            ['Error - Virus detected!'],
             error_messages())
         self.assertEqual('text/html;charset=utf-8',
                          browser.headers['content-type'])

--- a/opengever/virusscan/tests/test_virusscan_validator.py
+++ b/opengever/virusscan/tests/test_virusscan_validator.py
@@ -1,0 +1,85 @@
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import factoriesmenu
+from ftw.testbrowser.pages.statusmessages import error_messages
+from opengever.virusscan.interfaces import IAVScannerSettings
+from opengever.virusscan.testing import EICAR
+from opengever.virusscan.testing import register_mock_av_scanner
+from plone import api
+from opengever.testing import IntegrationTestCase
+from ftw.testbrowser.pages.dexterity import erroneous_fields
+
+
+class TestVirusScanValidator(IntegrationTestCase):
+
+    def setUp(self):
+        super(TestVirusScanValidator, self).setUp()
+        register_mock_av_scanner()
+        api.portal.set_registry_record(
+            'scan_before_upload', True, interface=IAVScannerSettings)
+        api.portal.set_registry_record(
+            'scan_before_download', True, interface=IAVScannerSettings)
+
+    @browsing
+    def test_document_add_form_scans_file_field_for_viruses_when_enabled(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.empty_dossier)
+        factoriesmenu.add('Document')
+        browser.fill({'Title': u'My Document',
+                      'File': (EICAR, 'file.txt', 'text/plain'),
+                      "Document type": "Inquiry"}).save()
+
+        self.assertEqual(["There were some errors."], error_messages())
+        self.assertEqual(
+            {'File': ['Validation failed, file is virus-infected. (Eicar-Test-Signature FOUND)']},
+            erroneous_fields())
+        self.assertEqual(0, len(self.empty_dossier.contentItems()))
+
+        browser.fill({'File': ("No virus", 'file.txt', 'text/plain')}).save()
+        self.assertEqual([], error_messages())
+        self.assertEqual(1, len(self.empty_dossier.contentItems()))
+
+    @browsing
+    def test_document_add_form_does_not_scan_file_field_for_viruses_when_disabled(self, browser):
+        api.portal.set_registry_record(
+            'scan_before_upload', False, interface=IAVScannerSettings)
+
+        self.login(self.regular_user, browser)
+        browser.open(self.empty_dossier)
+        factoriesmenu.add('Document')
+        browser.fill({'Title': u'My Document',
+                      'File': (EICAR, 'file.txt', 'text/plain'),
+                      "Document type": "Inquiry"}).save()
+
+        self.assertEqual([], error_messages())
+        self.assertEqual(1, len(self.empty_dossier.contentItems()))
+
+    @browsing
+    def test_document_edit_form_scans_file_field_for_viruses_when_enabled(self, browser):
+        self.login(self.regular_user, browser)
+        self.get_checkout_manager(self.empty_document).checkout()
+
+        browser.open(self.empty_document, view='edit')
+        browser.fill({'File': (EICAR, 'file.txt', 'text/plain')}).save()
+        self.assertEqual(["There were some errors."], error_messages())
+        self.assertEqual(
+            {'File': ['Validation failed, file is virus-infected. (Eicar-Test-Signature FOUND)']},
+            erroneous_fields())
+        self.assertIsNone(self.empty_document.get_file())
+
+        browser.open(self.empty_document, view='edit')
+        browser.fill({'File': ("No virus", 'file.txt', 'text/plain')}).save()
+        self.assertEqual([], error_messages())
+        self.assertIsNotNone(self.empty_document.get_file())
+
+    @browsing
+    def test_document_edit_form_does_not_scan_file_field_for_viruses_when_disabled(self, browser):
+        api.portal.set_registry_record(
+            'scan_before_upload', False, interface=IAVScannerSettings)
+
+        self.login(self.regular_user, browser)
+        self.get_checkout_manager(self.document).checkout()
+        browser.open(self.empty_document, view='edit')
+        browser.fill({'File': (EICAR, 'file.txt', 'text/plain')}).save()
+
+        self.assertEqual([], error_messages())
+        self.assertIsNotNone(self.empty_document.get_file())

--- a/opengever/virusscan/tests/test_virusscan_validator.py
+++ b/opengever/virusscan/tests/test_virusscan_validator.py
@@ -1,12 +1,13 @@
+from collective.quickupload.interfaces import IQuickUploadFileFactory
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
+from ftw.testbrowser.pages.dexterity import erroneous_fields
 from ftw.testbrowser.pages.statusmessages import error_messages
+from opengever.testing import IntegrationTestCase
 from opengever.virusscan.interfaces import IAVScannerSettings
 from opengever.virusscan.testing import EICAR
 from opengever.virusscan.testing import register_mock_av_scanner
 from plone import api
-from opengever.testing import IntegrationTestCase
-from ftw.testbrowser.pages.dexterity import erroneous_fields
 
 
 class TestVirusScanValidator(IntegrationTestCase):
@@ -117,3 +118,28 @@ class TestVirusScanValidator(IntegrationTestCase):
         browser.fill({'Archival file': ("No virus", 'file.txt', 'text/plain')}).save()
         self.assertEqual([], error_messages())
         self.assertIsNotNone(self.document.archival_file)
+
+    def test_quickupload_scans_file_for_viruses_when_enabled(self):
+        self.login(self.regular_user)
+        factory = IQuickUploadFileFactory(self.dossier)
+        result = factory(filename='file.txt',
+                         title=None,  # ignored by adapter
+                         description=None,  # ignored by adapter
+                         content_type='text/plain',
+                         data=EICAR,
+                         portal_type='opengever.document.document')
+
+        self.assertIsNone(result['success'])
+        self.assertEqual(
+             u'Validation failed, file is virus-infected. (Eicar-Test-Signature FOUND)',
+             result['error'])
+
+        result = factory(filename='file.txt',
+                         title=None,  # ignored by adapter
+                         description=None,  # ignored by adapter
+                         content_type='text/plain',
+                         data='No virus',
+                         portal_type='opengever.document.document')
+
+        self.assertIsNotNone(result['success'])
+        self.assertEqual('No virus', result['success'].file.data)

--- a/opengever/virusscan/tests/test_virusscan_validator.py
+++ b/opengever/virusscan/tests/test_virusscan_validator.py
@@ -351,7 +351,7 @@ class TestVirusScanDownloadValidator(IntegrationTestCase):
     def test_download_view_scans_file_if_enabled(self, browser):
         self.login(self.regular_user, browser)
 
-        browser.open(self.document, view='download')
+        browser.open(self.document, view='download?error_as_message=1')
         self.assertEqual(
             ['Careful, this file contains a virus.'],
             error_messages())
@@ -371,7 +371,7 @@ class TestVirusScanDownloadValidator(IntegrationTestCase):
     @browsing
     def test_download_view_scans_mail_if_enabled(self, browser):
         self.login(self.regular_user, browser)
-        browser.open(self.mail_eml, view='download')
+        browser.open(self.mail_eml, view='download?error_as_message=1')
         self.assertEqual(
             'attachment; filename="Die Buergschaft.eml"',
             browser.headers.get('content-disposition'))
@@ -380,7 +380,7 @@ class TestVirusScanDownloadValidator(IntegrationTestCase):
             browser.headers['content-type'])
 
         self.mail_eml.message.data = EICAR
-        browser.open(self.mail_eml, view='download')
+        browser.open(self.mail_eml, view='download?error_as_message=1')
         self.assertEqual(
             ['Careful, this file contains a virus.'],
             error_messages())
@@ -394,7 +394,7 @@ class TestVirusScanDownloadValidator(IntegrationTestCase):
             'scan_before_download', False, interface=IAVScannerSettings)
 
         self.login(self.regular_user, browser)
-        browser.open(self.document, view='download')
+        browser.open(self.document, view='download?error_as_message=1')
         self.assertEqual(
             'attachment; filename="Vertraegsentwurf.docx"',
             browser.headers.get('content-disposition'))

--- a/opengever/virusscan/tests/test_virusscan_validator.py
+++ b/opengever/virusscan/tests/test_virusscan_validator.py
@@ -140,7 +140,7 @@ class TestVirusScanValidator(IntegrationTestCase):
              u'Careful, this file contains a virus.',
              result['error'])
 
-        result = factory(filename='file.txt',
+        result = factory(filename=u'f\xefle.txt',
                          title=None,  # ignored by adapter
                          description=None,  # ignored by adapter
                          content_type='text/plain',
@@ -153,7 +153,7 @@ class TestVirusScanValidator(IntegrationTestCase):
     def test_quickupload_scans_mail_for_viruses_when_enabled(self):
         self.login(self.regular_user)
         factory = IQuickUploadFileFactory(self.dossier)
-        result = factory(filename='file.eml',
+        result = factory(filename=u'f\xefle.eml',
                          title=None,  # ignored by adapter
                          description=None,  # ignored by adapter
                          content_type='message/rfc822',
@@ -165,7 +165,7 @@ class TestVirusScanValidator(IntegrationTestCase):
              u'Careful, this file contains a virus.',
              result['error'])
 
-        result = factory(filename='file.eml',
+        result = factory(filename=u'f\xefle.eml',
                          title=None,  # ignored by adapter
                          description=None,  # ignored by adapter
                          content_type='message/rfc822',
@@ -182,7 +182,7 @@ class TestVirusScanValidator(IntegrationTestCase):
         with self.observe_children(self.empty_dossier) as children,\
                 browser.expect_http_error(code=400, reason='Bad Request'):
             data = {'@type': 'opengever.document.document',
-                    'file': {'data': EICAR, 'filename': 'file.txt'}}
+                    'file': {'data': EICAR, 'filename': u'f\xefle.txt'}}
             browser.open(self.empty_dossier, data=json.dumps(data),
                          method='POST', headers=self.api_headers)
 
@@ -208,7 +208,7 @@ class TestVirusScanValidator(IntegrationTestCase):
 
         with self.observe_children(self.empty_dossier) as children:
             data = {'@type': 'opengever.document.document',
-                    'file': {'data': EICAR, 'filename': 'file.txt'}}
+                    'file': {'data': EICAR, 'filename': u'f\xefle.txt'}}
             browser.open(self.empty_dossier, data=json.dumps(data),
                          method='POST', headers=self.api_headers)
 
@@ -221,7 +221,7 @@ class TestVirusScanValidator(IntegrationTestCase):
         self.get_checkout_manager(self.document).checkout()
 
         with browser.expect_http_error(code=400, reason='Bad Request'):
-            data = {'file': {'data': EICAR, 'filename': 'file.txt'}}
+            data = {'file': {'data': EICAR, 'filename': u'f\xefle.txt'}}
             browser.open(self.document, data=json.dumps(data),
                          method='PATCH', headers=self.api_headers)
 
@@ -243,8 +243,8 @@ class TestVirusScanValidator(IntegrationTestCase):
         with self.observe_children(self.empty_dossier) as children,\
                 browser.expect_http_error(code=400):
             data = {'@type': 'opengever.document.document',
-                    'file': {'data': "No virus", 'filename': 'file.txt'},
-                    'archival_file': {'data': EICAR, 'filename': 'file.txt'}}
+                    'file': {'data': "No virus", 'filename': u'f\xefle.txt'},
+                    'archival_file': {'data': EICAR, 'filename': u'f\xefle.txt'}}
             browser.open(self.empty_dossier, data=json.dumps(data),
                          method='POST', headers=self.api_headers)
 
@@ -269,8 +269,8 @@ class TestVirusScanValidator(IntegrationTestCase):
 
         with self.observe_children(self.empty_dossier) as children:
             data = {'@type': 'opengever.document.document',
-                    'file': {'data': "No virus", 'filename': 'file.txt'},
-                    'archival_file': {'data': EICAR, 'filename': 'file.txt'}}
+                    'file': {'data': "No virus", 'filename': u'f\xefle.txt'},
+                    'archival_file': {'data': EICAR, 'filename': u'f\xefle.txt'}}
             browser.open(self.empty_dossier, data=json.dumps(data),
                          method='POST', headers=self.api_headers)
 
@@ -284,7 +284,7 @@ class TestVirusScanValidator(IntegrationTestCase):
         with self.observe_children(self.empty_dossier) as children,\
                 browser.expect_http_error(code=400, reason='Bad Request'):
             data = {'@type': 'ftw.mail.mail',
-                    'message': {'data': EICAR, 'filename': 'mail.eml'}}
+                    'message': {'data': EICAR, 'filename': u'ma\xefl.eml'}}
             browser.open(self.empty_dossier, data=json.dumps(data),
                          method='POST', headers=self.api_headers)
 
@@ -309,7 +309,7 @@ class TestVirusScanValidator(IntegrationTestCase):
         with self.observe_children(self.empty_dossier) as children,\
                 browser.expect_http_error(code=400, reason='Bad Request'):
             data = {'@type': 'ftw.mail.mail',
-                    'message': {'data': EICAR, 'filename': 'mail.msg'}}
+                    'message': {'data': EICAR, 'filename': u'ma\xefl.msg'}}
             browser.open(self.empty_dossier, data=json.dumps(data),
                          method='POST', headers=self.api_headers)
 

--- a/opengever/virusscan/tests/test_virusscan_validator.py
+++ b/opengever/virusscan/tests/test_virusscan_validator.py
@@ -32,7 +32,7 @@ class TestVirusScanValidator(IntegrationTestCase):
 
         self.assertEqual(["There were some errors."], error_messages())
         self.assertEqual(
-            {'File': ['Validation failed, file is virus-infected.']},
+            {'File': ['Careful, this file contains a virus.']},
             erroneous_fields())
         self.assertEqual(0, len(self.empty_dossier.contentItems()))
 
@@ -65,7 +65,7 @@ class TestVirusScanValidator(IntegrationTestCase):
 
         self.assertEqual(["There were some errors."], error_messages())
         self.assertEqual(
-            {'Archival file': ['Validation failed, file is virus-infected.']},
+            {'Archival file': ['Careful, this file contains a virus.']},
             erroneous_fields())
         self.assertEqual(0, len(self.empty_dossier.contentItems()))
 
@@ -82,7 +82,7 @@ class TestVirusScanValidator(IntegrationTestCase):
         browser.fill({'File': (EICAR, 'file.txt', 'text/plain')}).save()
         self.assertEqual(["There were some errors."], error_messages())
         self.assertEqual(
-            {'File': ['Validation failed, file is virus-infected.']},
+            {'File': ['Careful, this file contains a virus.']},
             erroneous_fields())
         self.assertIsNone(self.empty_document.get_file())
 
@@ -112,7 +112,7 @@ class TestVirusScanValidator(IntegrationTestCase):
         browser.fill({'Archival file': (EICAR, 'file.txt', 'text/plain')}).save()
         self.assertEqual(["There were some errors."], error_messages())
         self.assertEqual(
-            {'Archival file': ['Validation failed, file is virus-infected.']},
+            {'Archival file': ['Careful, this file contains a virus.']},
             erroneous_fields())
         self.assertIsNone(self.document.archival_file)
 
@@ -133,7 +133,7 @@ class TestVirusScanValidator(IntegrationTestCase):
 
         self.assertIsNone(result['success'])
         self.assertEqual(
-             u'Validation failed, file is virus-infected.',
+             u'Careful, this file contains a virus.',
              result['error'])
 
         result = factory(filename='file.txt',
@@ -266,7 +266,7 @@ class TestVirusScanDownloadValidator(IntegrationTestCase):
 
         browser.open(self.document, view='download')
         self.assertEqual(
-            ['Validation failed, file is virus-infected.'],
+            ['Careful, this file contains a virus.'],
             error_messages())
         self.assertEqual('text/html;charset=utf-8',
                          browser.headers['content-type'])
@@ -305,7 +305,7 @@ class TestVirusScanDownloadValidator(IntegrationTestCase):
         browser.click_on("Download")
 
         self.assertEqual(
-            ['Validation failed, file is virus-infected.'],
+            ['Careful, this file contains a virus.'],
             error_messages())
         self.assertEqual('text/html;charset=utf-8',
                          browser.headers['content-type'])
@@ -352,7 +352,7 @@ class TestVirusScanDownloadValidator(IntegrationTestCase):
         browser.css('a.function-download-copy').first.click()
         browser.find('Download').click()
         self.assertEqual(
-            ['Validation failed, file is virus-infected.'],
+            ['Careful, this file contains a virus.'],
             error_messages())
         self.assertEqual('text/html;charset=utf-8',
                          browser.headers['content-type'])

--- a/opengever/virusscan/tests/test_virusscan_validator.py
+++ b/opengever/virusscan/tests/test_virusscan_validator.py
@@ -322,3 +322,23 @@ class TestVirusScanDownloadValidator(IntegrationTestCase):
             'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
             browser.headers['content-type'])
         self.assertEqual("No virus", browser.contents)
+
+    @browsing
+    def test_download_over_api_scans_file_if_enabled(self, browser):
+        self.login(self.regular_user, browser)
+
+        with browser.expect_http_error(code=400):
+            browser.open(self.document, view='download', headers=self.api_headers)
+
+        self.assertEqual(
+            u'Validation failed, file is virus-infected. (Eicar-Test-Signature FOUND)',
+            browser.json['message'])
+
+        browser.open(self.subdocument, view='download')
+        self.assertEqual(
+            'attachment; filename="Uebersicht der Vertraege von 2016.xlsx"',
+            browser.headers.get('content-disposition'))
+        self.assertEqual(
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            browser.headers['content-type'])
+        self.assertEqual("No virus", browser.contents)

--- a/opengever/virusscan/validator.py
+++ b/opengever/virusscan/validator.py
@@ -1,20 +1,22 @@
-from collective.clamav import _
-from collective.clamav.interfaces import IAVScanner
-from collective.clamav.interfaces import IAVScannerSettings
-from collective.clamav.scanner import ScanError
+from opengever.virusscan import _
+from opengever.virusscan.interfaces import IAVScanner
+from opengever.virusscan.interfaces import IAVScannerSettings
+from opengever.virusscan.scanner import ScanError
 from plone.registry.interfaces import IRegistry
-from Products.validation.interfaces.IValidator import IValidator
 from six import BytesIO
 from zope.annotation.interfaces import IAnnotations
 from zope.component import getUtility
-from zope.globalrequest import getRequest
 from zope.i18n import translate
-from zope.interface import implements, Invalid
+from zope.interface import Invalid
 import logging
+from z3c.form import validator
+from plone.namedfile.interfaces import INamedField
+from plone.formwidget.namedfile.interfaces import INamedFileWidget
+from plone.formwidget.namedfile.validator import NamedFileWidgetValidator
 
-logger = logging.getLogger('collective.clamav.uploads')
+logger = logging.getLogger('opengever.virusscan.uploads')
 
-SCAN_RESULT_KEY = 'collective.clamav.scan_result'
+SCAN_RESULT_KEY = 'opengever.virusscan.scan_result'
 
 
 def scanStream(stream):
@@ -38,27 +40,15 @@ def scanStream(stream):
     return result
 
 
-def _scanBuffer(buffer):
-    return scanStream(BytesIO(buffer))
+class Z3CFormclamavValidator(NamedFileWidgetValidator):
+    """z3c.form validator to confirm a file upload is virus-free."""
 
+    def validate(self, value):
+        super(Z3CFormclamavValidator, self).validate(value)
 
-class ClamavValidator:
-    """Archetypes validator to confirm a file upload is virus-free."""
-
-    implements(IValidator)
-
-    def __init__(self, name):
-        self.name = name
-
-    def __call__(self, value, *args, **kwargs):
         # Get a previous scan result on this REQUEST if there is one - to
         # avoid scanning the same upload twice.
-        request = kwargs['REQUEST']
-        if not request:
-            # Not very modern, but plone.restapi's DeserializeFromJson doesn't
-            # pass the request object to archetype validators
-            request = getRequest()
-        annotations = IAnnotations(request)
+        annotations = IAnnotations(self.request)
         scan_result = annotations.get(SCAN_RESULT_KEY, None)
         if scan_result is not None:
             logger.debug("File already scanned in this request")
@@ -69,11 +59,11 @@ class ClamavValidator:
             # 'ZPublisher.HTTPRequest.FileUpload'
             filelike = value
             filename = filelike.filename if hasattr(filelike, 'filename') else '<not known>'
-        elif hasattr(value, 'getBlob'):
-            # the value can be a plone.app.blob.field.BlobWrapper
+        elif hasattr(value, 'open'):
+            # the value can be a NamedBlobFile / NamedBlobImage
             # in which case we open the blob file to provide a file interface
             # as used for FileUpload
-            filelike = value.getBlob().open()
+            filelike = value.open()
             filename = filelike.filename if hasattr(filelike, 'filename') else '<not known>'
         elif value:
             filelike = BytesIO(value)
@@ -90,9 +80,11 @@ class ClamavValidator:
             result = scanStream(filelike)
         except ScanError as e:
             logger.error('ScanError %s on %s.' % (e, filename))
-            return _(u'error_while_scanning',
-                     default=u"There was an error while checking the file for "
-                     u"viruses: Please contact your system administrator.")
+            raise Invalid(
+                _(u'error_while_scanning',
+                  default="There was an error while checking the file for "
+                          "viruses: Please contact your system administrator.")
+            )
 
         if result:
             annotations[SCAN_RESULT_KEY] = translate(_(
@@ -100,92 +92,19 @@ class ClamavValidator:
                     default=u"Validation failed, file is virus-infected. (${result})",
                     mapping={u"result": result}
                 ),
-                context=request
+                context=self.request
             )
             logger.warning("{} filename: {}".format(
                 annotations[SCAN_RESULT_KEY],
                 filename
             ))
+            raise Invalid(annotations[SCAN_RESULT_KEY])
         else:
             annotations[SCAN_RESULT_KEY] = True
             logger.info("No virus detected in {}".format(filename))
+            return True
 
-        return annotations[SCAN_RESULT_KEY]
 
-
-try:
-    from z3c.form import validator
-    from plone.namedfile.interfaces import INamedField
-    from plone.formwidget.namedfile.interfaces import INamedFileWidget
-    from plone.formwidget.namedfile.validator import NamedFileWidgetValidator
-except ImportError:
-    pass
-else:
-
-    class Z3CFormclamavValidator(NamedFileWidgetValidator):
-        """z3c.form validator to confirm a file upload is virus-free."""
-
-        def validate(self, value):
-            super(Z3CFormclamavValidator, self).validate(value)
-
-            # Get a previous scan result on this REQUEST if there is one - to
-            # avoid scanning the same upload twice.
-            annotations = IAnnotations(self.request)
-            scan_result = annotations.get(SCAN_RESULT_KEY, None)
-            if scan_result is not None:
-                logger.debug("File already scanned in this request")
-                return scan_result
-
-            if hasattr(value, 'seek'):
-                # when submitted a new 'value' is a
-                # 'ZPublisher.HTTPRequest.FileUpload'
-                filelike = value
-                filename = filelike.filename if hasattr(filelike, 'filename') else '<not known>'
-            elif hasattr(value, 'open'):
-                # the value can be a NamedBlobFile / NamedBlobImage
-                # in which case we open the blob file to provide a file interface
-                # as used for FileUpload
-                filelike = value.open()
-                filename = filelike.filename if hasattr(filelike, 'filename') else '<not known>'
-            elif value:
-                filelike = BytesIO(value)
-                filename = '<stream>'
-            else:
-                # value is falsy - assume we kept existing file
-                return True
-
-            if isinstance(filename, unicode):
-                filename = filename.encode('utf-8')
-            filelike.seek(0)
-            result = ''
-            try:
-                result = scanStream(filelike)
-            except ScanError as e:
-                logger.error('ScanError %s on %s.' % (e, filename))
-                raise Invalid(
-                    _(u'error_while_scanning',
-                      default="There was an error while checking the file for "
-                              "viruses: Please contact your system administrator.")
-                )
-
-            if result:
-                annotations[SCAN_RESULT_KEY] = translate(_(
-                        u'validation_failed',
-                        default=u"Validation failed, file is virus-infected. (${result})",
-                        mapping={u"result": result}
-                    ),
-                    context=self.request
-                )
-                logger.warning("{} filename: {}".format(
-                    annotations[SCAN_RESULT_KEY],
-                    filename
-                ))
-                raise Invalid(annotations[SCAN_RESULT_KEY])
-            else:
-                annotations[SCAN_RESULT_KEY] = True
-                logger.info("No virus detected in {}".format(filename))
-                return True
-
-    validator.WidgetValidatorDiscriminators(Z3CFormclamavValidator,
-                                            field=INamedField,
-                                            widget=INamedFileWidget)
+validator.WidgetValidatorDiscriminators(Z3CFormclamavValidator,
+                                        field=INamedField,
+                                        widget=INamedFileWidget)

--- a/opengever/virusscan/validator.py
+++ b/opengever/virusscan/validator.py
@@ -74,7 +74,7 @@ def validateDownloadIfNecessary(filename, file, request):
 
 def validateUploadForFieldIfNecessary(fieldname, filename, filelike, request):
     # if scanning is disabled for upload, we skip
-    if not api.portal.get_registry_record(name='scan_before_upload',
+    if not api.portal.get_registry_record(name='scan_on_upload',
                                           interface=IAVScannerSettings):
         return True
 

--- a/opengever/virusscan/validator.py
+++ b/opengever/virusscan/validator.py
@@ -7,6 +7,7 @@ from plone.formwidget.namedfile.interfaces import INamedFileWidget
 from plone.formwidget.namedfile.validator import NamedFileWidgetValidator
 from plone.namedfile.interfaces import INamedField
 from plone.registry.interfaces import IRegistry
+from Products.validation.i18n import safe_unicode
 from six import BytesIO
 from z3c.form import validator
 from zope.annotation.interfaces import IAnnotations
@@ -42,10 +43,10 @@ def validateStream(filename, filelike, request):
     try:
         result = scanStream(filelike)
     except ScanError as e:
-        logger.error('ScanError %s on %s.' % (e, filename))
+        logger.error(u'ScanError %s on %s.' % (e, safe_unicode(filename)))
         raise Invalid(
             _(u'error_while_scanning',
-              default="There was an error while checking the file for viruses.")
+              default=u"There was an error while checking the file for viruses.")
         )
 
     if result:
@@ -53,7 +54,7 @@ def validateStream(filename, filelike, request):
                 u'file_infected',
                 default=u"Validation failed, file is virus-infected."
             )
-        logger.warning(u"{} filename: {}".format(message, filename))
+        logger.warning(u"{} filename: {}".format(message, safe_unicode(filename)))
         raise Invalid(message)
 
 
@@ -85,7 +86,7 @@ def validateUploadForFieldIfNecessary(fieldname, filename, filelike, request):
         annotations[SCAN_RESULT_KEY] = e.message
         raise e
     annotations[SCAN_RESULT_KEY] = True
-    logger.info("No virus detected in {}".format(filename))
+    logger.info(u"No virus detected in {}".format(safe_unicode(filename)))
     return annotations[SCAN_RESULT_KEY]
 
 

--- a/opengever/virusscan/validator.py
+++ b/opengever/virusscan/validator.py
@@ -11,7 +11,6 @@ from six import BytesIO
 from z3c.form import validator
 from zope.annotation.interfaces import IAnnotations
 from zope.component import getUtility
-from zope.i18n import translate
 from zope.interface import Invalid
 import logging
 
@@ -46,19 +45,15 @@ def validateStream(filename, filelike, request):
         logger.error('ScanError %s on %s.' % (e, filename))
         raise Invalid(
             _(u'error_while_scanning',
-              default="There was an error while checking the file for "
-                      "viruses: Please contact your system administrator.")
+              default="There was an error while checking the file for viruses.")
         )
 
     if result:
-        message = translate(_(
-                u'validation_failed',
-                default=u"Validation failed, file is virus-infected. (${result})",
-                mapping={u"result": result}
-            ),
-            context=request
-        )
-        logger.warning("{} filename: {}".format(message, filename))
+        message = _(
+                u'file_infected',
+                default=u"Validation failed, file is virus-infected."
+            )
+        logger.warning(u"{} filename: {}".format(message, filename))
         raise Invalid(message)
 
 

--- a/opengever/virusscan/validator.py
+++ b/opengever/virusscan/validator.py
@@ -17,7 +17,7 @@ import logging
 
 logger = logging.getLogger('opengever.virusscan.uploads')
 
-SCAN_RESULT_KEY = 'opengever.virusscan.scan_result'
+SCAN_RESULT_BASE_KEY = 'opengever.virusscan.scan_result'
 
 
 def scanStream(stream):
@@ -51,6 +51,7 @@ class Z3CFormclamavValidator(NamedFileWidgetValidator):
 
         # Get a previous scan result on this REQUEST if there is one - to
         # avoid scanning the same upload twice.
+        SCAN_RESULT_KEY = "{}.{}".format(SCAN_RESULT_BASE_KEY, self.field.getName())
         annotations = IAnnotations(self.request)
         scan_result = annotations.get(SCAN_RESULT_KEY, None)
         if scan_result is not None:

--- a/opengever/virusscan/validator.py
+++ b/opengever/virusscan/validator.py
@@ -62,6 +62,14 @@ def validateStream(filename, filelike, request):
         raise Invalid(message)
 
 
+def validateDownloadIfNecessary(filename, file, request):
+    # if scanning is disabled for download, we skip
+    if not api.portal.get_registry_record(name='scan_before_download',
+                                          interface=IAVScannerSettings):
+        return True
+    validateStream(filename, file.open(), request)
+
+
 def validateUploadForFieldIfNecessary(fieldname, filename, filelike, request):
     # if scanning is disabled for upload, we skip
     if not api.portal.get_registry_record(name='scan_before_upload',

--- a/opengever/virusscan/validator.py
+++ b/opengever/virusscan/validator.py
@@ -58,12 +58,18 @@ def validateStream(filename, filelike, request):
         raise Invalid(message)
 
 
-def validateDownloadIfNecessary(filename, file, request):
+def validateDownloadStreamIfNecessary(filename, stream, request):
     # if scanning is disabled for download, we skip
     if not api.portal.get_registry_record(name='scan_before_download',
                                           interface=IAVScannerSettings):
         return True
-    validateStream(filename, file.open(), request)
+    if not hasattr(stream, "read"):
+        stream = BytesIO(stream)
+    validateStream(filename, stream, request)
+
+
+def validateDownloadIfNecessary(filename, file, request):
+    validateDownloadStreamIfNecessary(filename, file.open(), request)
 
 
 def validateUploadForFieldIfNecessary(fieldname, filename, filelike, request):

--- a/opengever/virusscan/validator.py
+++ b/opengever/virusscan/validator.py
@@ -1,0 +1,191 @@
+from collective.clamav import _
+from collective.clamav.interfaces import IAVScanner
+from collective.clamav.interfaces import IAVScannerSettings
+from collective.clamav.scanner import ScanError
+from plone.registry.interfaces import IRegistry
+from Products.validation.interfaces.IValidator import IValidator
+from six import BytesIO
+from zope.annotation.interfaces import IAnnotations
+from zope.component import getUtility
+from zope.globalrequest import getRequest
+from zope.i18n import translate
+from zope.interface import implements, Invalid
+import logging
+
+logger = logging.getLogger('collective.clamav.uploads')
+
+SCAN_RESULT_KEY = 'collective.clamav.scan_result'
+
+
+def scanStream(stream):
+
+    registry = getUtility(IRegistry)
+    settings = registry.forInterface(IAVScannerSettings, check=False)
+    if settings is None or not settings.clamav_enabled:
+        return ''
+    scanner = getUtility(IAVScanner)
+
+    if settings.clamav_connection == 'net':
+        result = scanner.scanStream(
+            stream, 'net',
+            host=settings.clamav_host,
+            port=int(settings.clamav_port),
+            timeout=float(settings.clamav_timeout))
+    else:
+        result = scanner.scanStream(stream, 'socket',
+                                    socketpath=settings.clamav_socket,
+                                    timeout=float(settings.clamav_timeout))
+    return result
+
+
+def _scanBuffer(buffer):
+    return scanStream(BytesIO(buffer))
+
+
+class ClamavValidator:
+    """Archetypes validator to confirm a file upload is virus-free."""
+
+    implements(IValidator)
+
+    def __init__(self, name):
+        self.name = name
+
+    def __call__(self, value, *args, **kwargs):
+        # Get a previous scan result on this REQUEST if there is one - to
+        # avoid scanning the same upload twice.
+        request = kwargs['REQUEST']
+        if not request:
+            # Not very modern, but plone.restapi's DeserializeFromJson doesn't
+            # pass the request object to archetype validators
+            request = getRequest()
+        annotations = IAnnotations(request)
+        scan_result = annotations.get(SCAN_RESULT_KEY, None)
+        if scan_result is not None:
+            logger.debug("File already scanned in this request")
+            return scan_result
+
+        if hasattr(value, 'seek'):
+            # when submitted a new 'value' is a
+            # 'ZPublisher.HTTPRequest.FileUpload'
+            filelike = value
+            filename = filelike.filename if hasattr(filelike, 'filename') else '<not known>'
+        elif hasattr(value, 'getBlob'):
+            # the value can be a plone.app.blob.field.BlobWrapper
+            # in which case we open the blob file to provide a file interface
+            # as used for FileUpload
+            filelike = value.getBlob().open()
+            filename = filelike.filename if hasattr(filelike, 'filename') else '<not known>'
+        elif value:
+            filelike = BytesIO(value)
+            filename = '<stream>'
+        else:
+            # value is falsy - assume we kept existing file
+            return True
+
+        if isinstance(filename, unicode):
+            filename = filename.encode('utf-8')
+        filelike.seek(0)
+        result = ''
+        try:
+            result = scanStream(filelike)
+        except ScanError as e:
+            logger.error('ScanError %s on %s.' % (e, filename))
+            return _(u'error_while_scanning',
+                     default=u"There was an error while checking the file for "
+                     u"viruses: Please contact your system administrator.")
+
+        if result:
+            annotations[SCAN_RESULT_KEY] = translate(_(
+                    u'validation_failed',
+                    default=u"Validation failed, file is virus-infected. (${result})",
+                    mapping={u"result": result}
+                ),
+                context=request
+            )
+            logger.warning("{} filename: {}".format(
+                annotations[SCAN_RESULT_KEY],
+                filename
+            ))
+        else:
+            annotations[SCAN_RESULT_KEY] = True
+            logger.info("No virus detected in {}".format(filename))
+
+        return annotations[SCAN_RESULT_KEY]
+
+
+try:
+    from z3c.form import validator
+    from plone.namedfile.interfaces import INamedField
+    from plone.formwidget.namedfile.interfaces import INamedFileWidget
+    from plone.formwidget.namedfile.validator import NamedFileWidgetValidator
+except ImportError:
+    pass
+else:
+
+    class Z3CFormclamavValidator(NamedFileWidgetValidator):
+        """z3c.form validator to confirm a file upload is virus-free."""
+
+        def validate(self, value):
+            super(Z3CFormclamavValidator, self).validate(value)
+
+            # Get a previous scan result on this REQUEST if there is one - to
+            # avoid scanning the same upload twice.
+            annotations = IAnnotations(self.request)
+            scan_result = annotations.get(SCAN_RESULT_KEY, None)
+            if scan_result is not None:
+                logger.debug("File already scanned in this request")
+                return scan_result
+
+            if hasattr(value, 'seek'):
+                # when submitted a new 'value' is a
+                # 'ZPublisher.HTTPRequest.FileUpload'
+                filelike = value
+                filename = filelike.filename if hasattr(filelike, 'filename') else '<not known>'
+            elif hasattr(value, 'open'):
+                # the value can be a NamedBlobFile / NamedBlobImage
+                # in which case we open the blob file to provide a file interface
+                # as used for FileUpload
+                filelike = value.open()
+                filename = filelike.filename if hasattr(filelike, 'filename') else '<not known>'
+            elif value:
+                filelike = BytesIO(value)
+                filename = '<stream>'
+            else:
+                # value is falsy - assume we kept existing file
+                return True
+
+            if isinstance(filename, unicode):
+                filename = filename.encode('utf-8')
+            filelike.seek(0)
+            result = ''
+            try:
+                result = scanStream(filelike)
+            except ScanError as e:
+                logger.error('ScanError %s on %s.' % (e, filename))
+                raise Invalid(
+                    _(u'error_while_scanning',
+                      default="There was an error while checking the file for "
+                              "viruses: Please contact your system administrator.")
+                )
+
+            if result:
+                annotations[SCAN_RESULT_KEY] = translate(_(
+                        u'validation_failed',
+                        default=u"Validation failed, file is virus-infected. (${result})",
+                        mapping={u"result": result}
+                    ),
+                    context=self.request
+                )
+                logger.warning("{} filename: {}".format(
+                    annotations[SCAN_RESULT_KEY],
+                    filename
+                ))
+                raise Invalid(annotations[SCAN_RESULT_KEY])
+            else:
+                annotations[SCAN_RESULT_KEY] = True
+                logger.info("No virus detected in {}".format(filename))
+                return True
+
+    validator.WidgetValidatorDiscriminators(Z3CFormclamavValidator,
+                                            field=INamedField,
+                                            widget=INamedFileWidget)

--- a/opengever/virusscan/validator.py
+++ b/opengever/virusscan/validator.py
@@ -96,11 +96,11 @@ def validateUploadForFieldIfNecessary(fieldname, filename, filelike, request):
     return annotations[SCAN_RESULT_KEY]
 
 
-class Z3CFormclamavValidator(NamedFileWidgetValidator):
+class Z3CFormClamavValidator(NamedFileWidgetValidator):
     """z3c.form validator to confirm a file upload is virus-free."""
 
     def validate(self, value):
-        super(Z3CFormclamavValidator, self).validate(value)
+        super(Z3CFormClamavValidator, self).validate(value)
 
         if hasattr(value, 'seek'):
             # when submitted a new 'value' is a
@@ -128,6 +128,6 @@ class Z3CFormclamavValidator(NamedFileWidgetValidator):
             self.field.getName(), filename, filelike, self.request)
 
 
-validator.WidgetValidatorDiscriminators(Z3CFormclamavValidator,
+validator.WidgetValidatorDiscriminators(Z3CFormClamavValidator,
                                         field=INamedField,
                                         widget=INamedFileWidget)

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ setup(name='opengever.core',
       zip_safe=False,
       install_requires=[
           'alembic >= 0.7.0',
+          'clamd',
           'collective.autopermission',
           'collective.blueprint.jsonmigrator',
           'collective.blueprint.usersandgroups',


### PR DESCRIPTION
With this PR we integrate CLAMD for scanning files for viruses both during upload and download. 
- We start from the existing collective.clamd integration, copying over and modifying it for our purposes. 
- We add settings to activate the scan upon upload and download separately
- We make sure that scanning happens over all our entry points (API, forms, download, document version download...)
- We make sure scanning works for the `file` field, but also for the `archival_file` and mails

I hope I've caught all relevant entry points...

For https://4teamwork.atlassian.net/browse/CA-1504

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- New functionality:
  - [x] for `document` also works for `mail`
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- New translations
  - [x] All msg-strings are unicode