### PR TITLE
Fix SQLHypermediaBatch for undefined sort orders.

### DIFF
--- a/changes/CA-2060.bugfix
+++ b/changes/CA-2060.bugfix
@@ -1,0 +1,1 @@
+Fix SQLHypermediaBatch for undefined sort orders.

--- a/opengever/api/batch.py
+++ b/opengever/api/batch.py
@@ -2,6 +2,7 @@ from plone.batching.batch import BaseBatch
 from plone.restapi.batching import DEFAULT_BATCH_SIZE
 from plone.restapi.batching import HypermediaBatch
 from plone.restapi.deserializer import json_body
+from sqlalchemy.sql.expression import asc
 from zExceptions import BadRequest
 
 
@@ -50,8 +51,16 @@ class SQLHypermediaBatch(HypermediaBatch):
     """Plone.restapi HypermediaBatch for SQLAlchmey queries.
     """
 
-    def __init__(self, request, results):
+    def __init__(self, request, query, unique_sort_key, unique_sort_order=asc):
         self.request = request
+
+        # unique_sort_key is needed to make sure that results are always
+        # sorted, otherwise sorting can be undefined. As a separate query is
+        # made for every batch and for every item, undefined sort order can
+        # lead to problems when iterating over the items and batching
+        # (some items returned more than once and others missing).
+        query = self.extend_query_with_unique_sorting(
+            query, unique_sort_key, unique_sort_order)
 
         self.b_start = int(json_body(self.request).get('b_start', False)) \
             or int(self.request.form.get("b_start", 0))
@@ -63,10 +72,13 @@ class SQLHypermediaBatch(HypermediaBatch):
         if self.b_size < 0:
             raise BadRequest("The parameter 'b_size' can't be negative.")
 
-        self.batch = SQLBatch(results, self.b_size, self.b_start)
+        self.batch = SQLBatch(query, self.b_size, self.b_start)
 
     def _batch_for_page(self, pagenumber):
         new_batch = SQLBatch.fromPagenumber(
             self.batch._sequence, pagesize=self.b_size, pagenumber=pagenumber
         )
         return new_batch
+
+    def extend_query_with_unique_sorting(self, query, unique_key, unique_sort_order):
+        return query.order_by(unique_sort_order(unique_key))

--- a/opengever/api/dossier_participations.py
+++ b/opengever/api/dossier_participations.py
@@ -50,7 +50,7 @@ class Participations(object):
         participations = handler.get_participations()
 
         if is_contact_feature_enabled():
-            batch = SQLHypermediaBatch(self.request, participations)
+            batch = SQLHypermediaBatch(self.request, participations, 'id')
         else:
             batch = HypermediaBatch(self.request, participations)
 

--- a/opengever/api/ogdslistingbase.py
+++ b/opengever/api/ogdslistingbase.py
@@ -41,15 +41,15 @@ class OGDSListingBaseService(Service):
         sort_on, sort_order, search, filters = self.extract_params()
         query = self.get_base_query()
         query = self.extend_query_with_sorting(query, sort_on, sort_order)
-
-        if self.unique_sort_on != sort_on:
-            query = self.extend_query_with_sorting(
-                query, self.unique_sort_on, sort_order)
-
         query = self.extend_query_with_search(query, search)
         query = self.extend_query_with_filters(query, filters)
 
-        batch = SQLHypermediaBatch(self.request, query)
+        if sort_order in ['descending', 'reverse']:
+            order_f = desc
+        else:
+            order_f = asc
+
+        batch = SQLHypermediaBatch(self.request, query, self.unique_sort_on, order_f)
         items = []
         for item in batch:
             serializer = queryMultiAdapter(

--- a/opengever/api/serializer.py
+++ b/opengever/api/serializer.py
@@ -200,7 +200,7 @@ class SerializeSQLModelToJsonBase(object):
         query = self.get_item_query()
         if not query:
             return
-        batch = SQLHypermediaBatch(self.request, query)
+        batch = SQLHypermediaBatch(self.request, query, 'userid')
         items = [queryMultiAdapter((item, self.request), ISerializeToJsonSummary)()
                  for item in batch]
 


### PR DESCRIPTION
When sorting according to a non-unique column, response of SQLHypermediaBatches could contain duplicate items and other items could be missing. This is because the sort order of successive queries is not guaranteed to be identical (except when specifically sorting on a key with a unique value for each item).

This issue has been fixed with #6624 for ogds listings but not for all cases we use the SQLHypermediaBatches, therefore i moved the additional sorting on unique key to the SQLHyperMediaBatch itself.


Closes https://4teamwork.atlassian.net/browse/CA-2060


## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)