### PR TITLE
Properly resolves path_parent field queries for the @solrsearch endpoint if they are relative to the virtual root

### DIFF
--- a/changes/CA-1588.other
+++ b/changes/CA-1588.other
@@ -1,0 +1,1 @@
+The `path_parent` field query of the `@solrsearch` endpoint properly resolves paths relative to the virtual host url and joins multiple `path_parent` field queries with an OR operator. [elioschmutz]


### PR DESCRIPTION
The `path_parent` field query of the `@solrsearch` endpoint properly resolves paths relative to the virtual host url and joins multiple `path_parent` field queries with an OR operator.

Jira: https://4teamwork.atlassian.net/browse/CA-1588

This change is required because a frontend does not know anything about the physical path of an object which is required to do solr-path queries.

the path indexes of an object is always the physical path:

<img width="911" alt="Bildschirmfoto 2021-05-27 um 13 16 22" src="https://user-images.githubusercontent.com/557005/119817126-e1d08d80-beed-11eb-8a43-d7422d473f45.png">

But a frontend does not know anything about it. I.e.

the url http://www.example.com/examplecontent can point to the same physical path like the url http://localhost:8080/fd/examplecontent =>

http://www.example.com/examplecontent => `/plone/examplecontent`
http://localhost:8080/plone/examplecontent => `/plone/examplecontent`

But we can only extract the path relative to the current site domain:

http://www.example.com/examplecontent => `/examplecontent`
http://localhost:8080/plone/examplecontent => `/plone/examplecontent`

In the backend, we need to replace this path relative to the virtual host with the physical path of the content itself to be able to do a solr query.

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
