### PR TITLE
Fix closing remote task without copying any documents to a dossier

### DIFF
--- a/changes/CA-2306.bugfix
+++ b/changes/CA-2306.bugfix
@@ -1,0 +1,1 @@
+Fix closing remote task without copying any documents to a dossier. [elioschmutz]

--- a/opengever/api/close_remote_task.py
+++ b/opengever/api/close_remote_task.py
@@ -69,6 +69,7 @@ class CloseRemoteTaskPost(RemoteTaskBaseService):
                 'Oguid %s refers to a local task, however.' % raw_task_oguid)
 
         closer = CloseTaskHelper()
+        dossier = None
         if dossier_uid:
             dossier = uuidToObject(dossier_uid)
             document_intids = [Oguid.parse(oguid).int_id for oguid in document_oguids]
@@ -76,8 +77,11 @@ class CloseRemoteTaskPost(RemoteTaskBaseService):
 
         closer.close_task(task, response_text)
 
-        self.request.response.setStatus(201)
-        self.request.response.setHeader("Location", dossier.absolute_url())
+        if dossier:
+            self.request.response.setStatus(201)
+            self.request.response.setHeader("Location", dossier.absolute_url())
 
-        serialized_dossier = self.serialize(dossier)
-        return serialized_dossier
+            serialized_dossier = self.serialize(dossier)
+            return serialized_dossier
+
+        self.request.response.setStatus(204)


### PR DESCRIPTION
This PR fixes an issue where it was not possible to close a remote task without copying documents to a local dossier.

Jira: https://4teamwork.atlassian.net/browse/CA-2306

Follow-Up of: https://github.com/4teamwork/opengever.core/pull/7003

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
