### PR TITLE
Add reference_number_addendum field to repository root and use it in reference number

### DIFF
--- a/changes/CA-2088.feature
+++ b/changes/CA-2088.feature
@@ -1,0 +1,1 @@
+Add reference_number_addendum field to repository root and use it in reference number. [tinagerber]

--- a/docs/schema-dumps/opengever.repository.repositoryroot.schema.json
+++ b/docs/schema-dumps/opengever.repository.repositoryroot.schema.json
@@ -24,6 +24,12 @@
             "description": "",
             "_zope_schema_type": "TextLine"
         },
+        "reference_number_addendum": {
+            "type": "string",
+            "title": "Aktenzeichen Zusatz",
+            "description": "Achtung: \u00c4nderung erfordert Neuindexierung von \"reference\" und \"sortable_reference\".",
+            "_zope_schema_type": "TextLine"
+        },
         "title_de": {
             "type": "string",
             "title": "Titel (deutsch)",
@@ -68,6 +74,7 @@
         "valid_from",
         "valid_until",
         "version",
+        "reference_number_addendum",
         "title_de",
         "title_fr",
         "title_en"

--- a/opengever/api/tests/test_repository.py
+++ b/opengever/api/tests/test_repository.py
@@ -3,6 +3,7 @@ from opengever.testing import IntegrationTestCase
 from plone import api
 from zope.component import getUtility
 from zope.intid.interfaces import IIntIds
+import json
 
 
 class TestRepositoryAPI(IntegrationTestCase):
@@ -83,6 +84,7 @@ class TestRepositoryAPI(IntegrationTestCase):
                 u"description": u"",
                 u"title": u"Contacts"
             },
+            u'reference_number_addendum': None,
             u'relative_path': u'ordnungssystem',
             u'review_state': u'repositoryroot-state-active',
             u'title_de': u'Ordnungssystem',
@@ -94,3 +96,24 @@ class TestRepositoryAPI(IntegrationTestCase):
 
         }
         self.assert_json_structure_equal(expected_repository_root, browser.json)
+
+    @browsing
+    def test_admin_cannot_set_reference_number_addendum_field(self, browser):
+        self.login(self.administrator, browser)
+
+        browser.open(self.repository_root, method="PATCH", headers=self.api_headers,
+                     data=json.dumps({'reference_number_addendum': 'NO'}))
+
+        self.assertIsNone(self.repository_root.reference_number_addendum)
+
+    @browsing
+    def test_manager_can_set_reference_number_addendum_field(self, browser):
+        self.login(self.manager, browser)
+
+        browser.open(self.repository_root, method="PATCH", headers=self.api_headers,
+                     data=json.dumps({'reference_number_addendum': 'NO'}))
+
+        self.assertEqual(u'NO', self.repository_root.reference_number_addendum)
+
+        browser.open(self.repository_root, method="GET", headers={"Accept": "application/json"})
+        self.assertEqual(u'NO', browser.json['reference_number_addendum'])

--- a/opengever/base/reference_formatter.py
+++ b/opengever/base/reference_formatter.py
@@ -74,6 +74,9 @@ class DottedReferenceFormatter(object):
                 reference_number,
                 )
 
+        if self.repositoryroot_addendum(numbers):
+            reference_number = u'%s %s' % (reference_number, self.repositoryroot_addendum(numbers))
+
         if self.repository_number(numbers):
             if reference_number:
                 reference_number = u'%s %s' % (
@@ -105,6 +108,9 @@ class DottedReferenceFormatter(object):
         if location_prefix:
             return ''.join(location_prefix)
         return None
+
+    def repositoryroot_addendum(self, numbers):
+        return u''.join(numbers.get('repositoryroot', []))
 
     def repository_number(self, numbers):
         """Generate the reposiotry reference number part.
@@ -276,6 +282,9 @@ class NoClientIdDottedReferenceFormatter(DottedReferenceFormatter):
         if self.location_prefix(numbers):
             reference_number = self.location_prefix(numbers)
 
+        if self.repositoryroot_addendum(numbers):
+            reference_number = u'%s %s' % (reference_number, self.repositoryroot_addendum(numbers))
+
         if self.repository_number(numbers):
             if reference_number:
                 reference_number = u'%s %s' % (
@@ -314,6 +323,9 @@ class NoClientIdGroupedByThreeFormatter(GroupedByThreeReferenceFormatter):
 
         if self.location_prefix(numbers):
             reference_number = self.location_prefix(numbers)
+
+        if self.repositoryroot_addendum(numbers):
+            reference_number = u'%s %s' % (reference_number, self.repositoryroot_addendum(numbers))
 
         if self.repository_number(numbers):
             if reference_number:

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -53,6 +53,7 @@ REPOROOT_MISSING_VALUES = {
     'valid_from': None,
     'valid_until': None,
     'version': None,
+    'reference_number_addendum': None,
 }
 
 

--- a/opengever/base/tests/test_reference.py
+++ b/opengever/base/tests/test_reference.py
@@ -20,6 +20,13 @@ class TestLocalReferenceNumber(IntegrationTestCase):
         self.assertEquals(
             u'', IReferenceNumber(self.repository_root).get_local_number())
 
+    def test_repository_root_returns_reference_number_addendum(self):
+        self.login(self.regular_user)
+        self.repository_root.reference_number_addendum = u'NO'
+
+        self.assertEquals(
+            u'NO', IReferenceNumber(self.repository_root).get_local_number())
+
     def test_repositoryfolder_returns_reference_prefix_of_the_context(self):
         self.login(self.regular_user)
 
@@ -331,6 +338,13 @@ class TestReferenceNumberAdapter(IntegrationTestCase):
 
         self.assertEquals(u'vorlagen Client1',
                           IReferenceNumber(self.subdossiertemplate).get_number())
+
+    def test_reference_number_contains_addendum(self):
+        self.login(self.regular_user)
+        self.repository_root.reference_number_addendum = u'NO'
+
+        self.assertEquals(u'Client1 NO 1.1 / 1.1',
+                          IReferenceNumber(self.subdossier).get_number())
 
 
 class TestDottedFormatterBase(IntegrationTestCase):

--- a/opengever/bundle/schemas/reporoots.schema.json
+++ b/opengever/bundle/schemas/reporoots.schema.json
@@ -39,6 +39,15 @@
                     "description": "",
                     "_zope_schema_type": "TextLine"
                 },
+                "reference_number_addendum": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "title": "Aktenzeichen Zusatz",
+                    "description": "Achtung: \u00c4nderung erfordert Neuindexierung von \"reference\" und \"sortable_reference\".",
+                    "_zope_schema_type": "TextLine"
+                },
                 "title_de": {
                     "type": [
                         "null",
@@ -108,6 +117,7 @@
                 "valid_from",
                 "valid_until",
                 "version",
+                "reference_number_addendum",
                 "title_de",
                 "title_fr",
                 "title_en"

--- a/opengever/repository/locales/de/LC_MESSAGES/opengever.repository.po
+++ b/opengever/repository/locales/de/LC_MESSAGES/opengever.repository.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-01-25 09:56+0000\n"
+"POT-Creation-Date: 2021-05-28 13:17+0000\n"
 "PO-Revision-Date: 2014-11-25 11:31+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -42,6 +42,11 @@ msgstr "Hinzufügen von Geschäftsdossiers erlauben"
 #: ./opengever/repository/repositoryfolder.py
 msgid "description_allow_add_businesscase_dossier"
 msgstr "Wählen Sie, ob es in dieser Ordnungsposition erlaubt ist, Geschäftsdossiers hinzuzufügen. Ist diese Option deaktiviert, kann der Benutzer nur Dossiers aus einer Vorlage oder Spezialdossiers erstellen."
+
+#. Default: "Attention: Change requires reindexing of \"reference\" and \"sortable_reference\"."
+#: ./opengever/repository/repositoryroot.py
+msgid "description_reference_number_addendum"
+msgstr "Achtung: Änderung erfordert Neuindexierung von \"reference\" und \"sortable_reference\"."
 
 #. Default: "No nested repositorys available."
 #: ./opengever/repository/browser/templates/referenceprefixmanager.pt
@@ -179,6 +184,11 @@ msgstr "Übersicht"
 #: ./opengever/repository/browser/tabbed.py
 msgid "label_proposals"
 msgstr "Anträge"
+
+#. Default: "Reference number addendum"
+#: ./opengever/repository/repositoryroot.py
+msgid "label_reference_number_addendum"
+msgstr "Aktenzeichen Zusatz"
 
 #. Default: "Reference Prefix"
 #: ./opengever/repository/behaviors/referenceprefix.py

--- a/opengever/repository/locales/en/LC_MESSAGES/opengever.repository.po
+++ b/opengever/repository/locales/en/LC_MESSAGES/opengever.repository.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-01-25 09:56+0000\n"
+"POT-Creation-Date: 2021-05-28 13:17+0000\n"
 "PO-Revision-Date: 2014-11-25 11:31+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -48,6 +48,11 @@ msgstr "Allow creation of regular business case dossiers"
 #: ./opengever/repository/repositoryfolder.py
 msgid "description_allow_add_businesscase_dossier"
 msgstr "Choose whether the user is allowed to add regular business case dossiers or only dossiers created from a dossier template."
+
+#. Default: "Attention: Change requires reindexing of \"reference\" and \"sortable_reference\"."
+#: ./opengever/repository/repositoryroot.py
+msgid "description_reference_number_addendum"
+msgstr "Attention: Change requires reindexing of \"reference\" and \"sortable_reference\"."
 
 #. German translation: Keine untergeordnete Ordnungspositionen verfügbar.
 #. Default: "No nested repositorys available."
@@ -213,6 +218,11 @@ msgstr "Overview"
 #: ./opengever/repository/browser/tabbed.py
 msgid "label_proposals"
 msgstr "Proposals"
+
+#. Default: "Reference number addendum"
+#: ./opengever/repository/repositoryroot.py
+msgid "label_reference_number_addendum"
+msgstr "Reference number addendum"
 
 #. German translation: Präfix des Aktenzeichens
 #. Default: "Reference Prefix"

--- a/opengever/repository/locales/fr/LC_MESSAGES/opengever.repository.po
+++ b/opengever/repository/locales/fr/LC_MESSAGES/opengever.repository.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-25 09:56+0000\n"
+"POT-Creation-Date: 2021-05-28 13:17+0000\n"
 "PO-Revision-Date: 2017-12-03 11:31+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-repository/fr/>\n"
@@ -41,6 +41,11 @@ msgstr "Permettre l'ajout de dossiers commerciaux"
 #: ./opengever/repository/repositoryfolder.py
 msgid "description_allow_add_businesscase_dossier"
 msgstr "Déterminez s'il est permis d'ajouter des dossiers commerciaux à ce niveau. Si cette option est désactivée, l'utilisateur ne peut créer que des dossiers spéciaux ou bien des dossiers à partir d'un modèle."
+
+#. Default: "Attention: Change requires reindexing of \"reference\" and \"sortable_reference\"."
+#: ./opengever/repository/repositoryroot.py
+msgid "description_reference_number_addendum"
+msgstr ""
 
 #. Default: "No nested repositorys available."
 #: ./opengever/repository/browser/templates/referenceprefixmanager.pt
@@ -178,6 +183,11 @@ msgstr "Sommaire"
 #: ./opengever/repository/browser/tabbed.py
 msgid "label_proposals"
 msgstr "Requêtes"
+
+#. Default: "Reference number addendum"
+#: ./opengever/repository/repositoryroot.py
+msgid "label_reference_number_addendum"
+msgstr "Numéro de référence addendum"
 
 #. Default: "Reference Prefix"
 #: ./opengever/repository/behaviors/referenceprefix.py

--- a/opengever/repository/locales/opengever.repository.pot
+++ b/opengever/repository/locales/opengever.repository.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-25 09:56+0000\n"
+"POT-Creation-Date: 2021-05-28 13:17+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -41,6 +41,11 @@ msgstr ""
 #. Default: "Choose if the user is allowed to add businesscase dossiers or only dossiers from a  dossiertemplate."
 #: ./opengever/repository/repositoryfolder.py
 msgid "description_allow_add_businesscase_dossier"
+msgstr ""
+
+#. Default: "Attention: Change requires reindexing of \"reference\" and \"sortable_reference\"."
+#: ./opengever/repository/repositoryroot.py
+msgid "description_reference_number_addendum"
 msgstr ""
 
 #. Default: "No nested repositorys available."
@@ -178,6 +183,11 @@ msgstr ""
 #. Default: "Proposals"
 #: ./opengever/repository/browser/tabbed.py
 msgid "label_proposals"
+msgstr ""
+
+#. Default: "Reference number addendum"
+#: ./opengever/repository/repositoryroot.py
+msgid "label_reference_number_addendum"
 msgstr ""
 
 #. Default: "Reference Prefix"

--- a/opengever/repository/reference.py
+++ b/opengever/repository/reference.py
@@ -11,6 +11,9 @@ class RepositoryRootNumber(BasicReferenceNumber):
     """
     ref_type = 'repositoryroot'
 
+    def get_local_number(self):
+        return self.context.reference_number_addendum or ''
+
 
 @adapter(IRepositoryFolderSchema)
 class RepositoryFolderReferenceNumber(BasicReferenceNumber):

--- a/opengever/repository/repositoryroot.py
+++ b/opengever/repository/repositoryroot.py
@@ -4,6 +4,7 @@ from opengever.base.behaviors.translated_title import TranslatedTitleMixin
 from opengever.repository import _
 from opengever.repository.mixin import RepositoryMixin
 from plone.app.content.interfaces import INameFromTitle
+from plone.autoform import directives as form
 from plone.dexterity.content import Container
 from plone.supermodel import model
 from zope import schema
@@ -22,6 +23,7 @@ class IRepositoryRoot(model.Schema):
             'valid_from',
             'valid_until',
             'version',
+            'reference_number_addendum',
         ],
     )
 
@@ -39,6 +41,15 @@ class IRepositoryRoot(model.Schema):
         title=_(u'label_version', default=u'Version'),
         required=False,
         )
+
+    form.write_permission(reference_number_addendum='cmf.ManagePortal')
+    reference_number_addendum = schema.TextLine(
+        title=_(u'label_reference_number_addendum', default=u'Reference number addendum'),
+        description=_(u'description_reference_number_addendum',
+                      default=u'Attention: Change requires reindexing of "reference" '
+                              u'and "sortable_reference".'),
+        required=False,
+    )
 
 
 class RepositoryRoot(Container, RepositoryMixin, TranslatedTitleMixin):


### PR DESCRIPTION
This change is necessary in order to have the possibility of having unique reference numbers even when using two repository roots. 
If the field `reference_number_addendum` is changed, `reference` and `sortable_reference` must be reindexed in Solr.

Jira: https://4teamwork.atlassian.net/browse/CA-2088

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- New translations
  - [x] All msg-strings are unicode