### PR TITLE
Allow cookie based authentication when using @login endpoint

### DIFF
--- a/changes/CA-2075a.other
+++ b/changes/CA-2075a.other
@@ -1,0 +1,1 @@
+Customize @login endpoint by adding support for cookie based authentication. [buchi]

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -1100,6 +1100,15 @@
 
   <plone:service
       method="POST"
+      name="@login"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      factory=".login.GeverLogin"
+      permission="zope.Public"
+      layer="opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
+  <plone:service
+      method="POST"
       name="@logout"
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"
       factory=".logout.GeverLogout"

--- a/opengever/api/login.py
+++ b/opengever/api/login.py
@@ -1,0 +1,73 @@
+from plone.restapi.deserializer import json_body
+from plone.restapi.services.auth.login import Login
+from Products.PluggableAuthService.interfaces.plugins import IAuthenticationPlugin
+from zope.interface import alsoProvides
+import plone.protect.interfaces
+import six
+
+
+# Copied from plone.restapi.services.auth.login.py
+# Customized to allow cookie-based authentication in addition to JWT
+class GeverLogin(Login):
+    def reply(self):
+        data = json_body(self.request)
+        if "login" not in data or "password" not in data:
+            self.request.response.setStatus(400)
+            return dict(
+                error=dict(
+                    type="Missing credentials",
+                    message="Login and password must be provided in body.",
+                )
+            )
+
+        # Disable CSRF protection
+        if "IDisableCSRFProtection" in dir(plone.protect.interfaces):
+            alsoProvides(self.request, plone.protect.interfaces.IDisableCSRFProtection)
+
+        set_cookie = data.get('set_cookie', False)
+        userid = data["login"]
+        password = data["password"]
+        if six.PY2:
+            userid = userid.encode("utf8")
+            password = password.encode("utf8")
+        uf = self._find_userfolder(userid)
+
+        if uf is not None:
+            if not set_cookie:
+                plugins = uf._getOb("plugins")
+                authenticators = plugins.listPlugins(IAuthenticationPlugin)
+                plugin = None
+                for _id, authenticator in authenticators:
+                    if authenticator.meta_type == "JWT Authentication Plugin":
+                        plugin = authenticator
+                        break
+
+                if plugin is None:
+                    self.request.response.setStatus(501)
+                    return dict(
+                        error=dict(
+                            type="Login failed",
+                            message="JWT authentication plugin not installed.",
+                        )
+                    )
+
+            user = uf.authenticate(userid, password, self.request)
+        else:
+            user = None
+
+        if not user:
+            self.request.response.setStatus(401)
+            return dict(
+                error=dict(
+                    type="Invalid credentials", message="Wrong login and/or password."
+                )
+            )
+
+        if set_cookie:
+            uf.updateCredentials(
+                self.request, self.request.response, user.getUserName(), password)
+            return {'userid': userid, 'fullname': user.getProperty('fullname')}
+        else:
+            payload = {}
+            payload["fullname"] = user.getProperty("fullname")
+            return {"token": plugin.create_token(user.getId(), data=payload)}

--- a/opengever/api/tests/test_login.py
+++ b/opengever/api/tests/test_login.py
@@ -1,0 +1,54 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+from plone.app.testing import TEST_USER_NAME
+from plone.app.testing import TEST_USER_PASSWORD
+import json
+
+
+class TestLogin(IntegrationTestCase):
+
+    @browsing
+    def test_login_returns_jwt_by_default(self, browser):
+        browser.open(
+            self.portal.absolute_url() + '/@login',
+            data=json.dumps({
+                "login": TEST_USER_NAME,
+                "password": TEST_USER_PASSWORD,
+            }),
+            method='POST',
+            headers={'Accept': 'application/json',
+                     'Content-Type': 'application/json'},
+        )
+        self.assertEqual(browser.status_code, 200)
+        self.assertIn(u'token', browser.json)
+
+    @browsing
+    def test_login_returns_ac_cookie_if_requested(self, browser):
+        browser.open(
+            self.portal.absolute_url() + '/@login',
+            data=json.dumps({
+                "login": TEST_USER_NAME,
+                "password": TEST_USER_PASSWORD,
+                "set_cookie": True,
+            }),
+            method='POST',
+            headers={'Accept': 'application/json',
+                     'Content-Type': 'application/json'},
+        )
+        self.assertEqual(browser.status_code, 200)
+        self.assertIn(u'userid', browser.json)
+        self.assertIn(u'__ac', browser.cookies)
+
+    @browsing
+    def test_login_fails_with_wrong_credentials(self, browser):
+        with browser.expect_unauthorized():
+            browser.open(
+                self.portal.absolute_url() + '/@login',
+                data=json.dumps({
+                    "login": TEST_USER_NAME,
+                    "password": 'wrong password',
+                }),
+                method='POST',
+                headers={'Accept': 'application/json',
+                         'Content-Type': 'application/json'},
+            )

--- a/opengever/core/testserver.py
+++ b/opengever/core/testserver.py
@@ -88,6 +88,9 @@ class TestserverLayer(OpengeverFixture):
         portal.portal_languages.use_combined_language_codes = True
         portal.portal_languages.addSupportedLanguage('de-ch')
 
+        # Disable secure session cookie as tests are run without HTTPS
+        portal.acl_users['session'].secure = False
+
         api.portal.set_registry_record('use_solr', True, interface=ISearchSettings)
         activate_bumblebee_feature()
 


### PR DESCRIPTION
Allows us to authenticate with a cookie instead of a JWT.
We use the @login endpoint only for local development and testing. In production we use ftw.casauth for login.

JIRA: https://4teamwork.atlassian.net/browse/CA-2075

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
