### PR TITLE
Fix copy workspace document into a higher classified gever dossier.

### DIFF
--- a/changes/CA-2330.bugfix
+++ b/changes/CA-2330.bugfix
@@ -1,0 +1,1 @@
+Fix copy workspace document into a higher classified gever dossier. [elioschmutz]

--- a/opengever/api/tests/test_linked_workspaces.py
+++ b/opengever/api/tests/test_linked_workspaces.py
@@ -2,6 +2,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.exceptions import HTTPServerError
+from opengever.base.behaviors.classification import IClassification
 from opengever.base.command import CreateEmailCommand
 from opengever.base.oguid import Oguid
 from opengever.document.interfaces import ICheckinCheckoutManager
@@ -1268,3 +1269,80 @@ class TestCopyDocumentFromWorkspacePost(FunctionalWorkspaceClientTestCase):
                  u'message': u"Document can't be copied from workspace "
                              u"because it's currently checked out"},
                 browser.json)
+
+    @browsing
+    def test_copying_document_from_workspace_into_a_classified_dossier_will_update_the_document_classification_if_it_does_not_meet_min_requirements(self, browser):
+        document = create(Builder('document')
+                          .within(self.workspace)
+                          .with_dummy_content())
+
+        payload = {
+            'workspace_uid': self.workspace.UID(),
+            'document_uid': document.UID(),
+        }
+
+        IClassification(self.dossier).classification = 'confidential'
+
+        self.assertEqual('unprotected', document.classification)
+        self.assertEqual('confidential', self.dossier.classification)
+
+        with self.workspace_client_env():
+            manager = ILinkedWorkspaces(self.dossier)
+            manager.storage.add(self.workspace.UID())
+            transaction.commit()
+
+            browser.login()
+            fix_publisher_test_bug(browser, document)
+
+            with self.observe_children(self.dossier) as children:
+                browser.open(
+                    self.dossier.absolute_url() + '/@copy-document-from-workspace',
+                    data=json.dumps(payload),
+                    method='POST',
+                    headers={'Accept': 'application/json',
+                             'Content-Type': 'application/json'},
+                )
+
+        self.assertEqual(len(children['added']), 1)
+        document_copy = children['added'].pop()
+
+        self.assertEqual('confidential', document_copy.classification)
+
+    @browsing
+    def test_copying_a_higher_classified_document_from_workspace_into_a_classified_dossier_will_not_update_the_document_classification(self, browser):
+        document = create(Builder('document')
+                          .within(self.workspace)
+                          .with_dummy_content())
+
+        payload = {
+            'workspace_uid': self.workspace.UID(),
+            'document_uid': document.UID(),
+        }
+
+        IClassification(document).classification = 'classified'
+        IClassification(self.dossier).classification = 'confidential'
+
+        self.assertEqual('classified', document.classification)
+        self.assertEqual('confidential', self.dossier.classification)
+
+        with self.workspace_client_env():
+            manager = ILinkedWorkspaces(self.dossier)
+            manager.storage.add(self.workspace.UID())
+            transaction.commit()
+
+            browser.login()
+            fix_publisher_test_bug(browser, document)
+
+            with self.observe_children(self.dossier) as children:
+                browser.open(
+                    self.dossier.absolute_url() + '/@copy-document-from-workspace',
+                    data=json.dumps(payload),
+                    method='POST',
+                    headers={'Accept': 'application/json',
+                             'Content-Type': 'application/json'},
+                )
+
+        self.assertEqual(len(children['added']), 1)
+        document_copy = children['added'].pop()
+
+        self.assertEqual('classified', document_copy.classification)

--- a/opengever/workspaceclient/linked_workspaces.py
+++ b/opengever/workspaceclient/linked_workspaces.py
@@ -1,4 +1,5 @@
 from opengever.api.add import GeverFolderPost
+from opengever.base.interfaces import IDuringContentCreation
 from opengever.base.oguid import Oguid
 from opengever.document.versioner import Versioner
 from opengever.dossier.behaviors.dossier import IDossierMarker
@@ -23,12 +24,14 @@ from plone.restapi.interfaces import ISerializeToJson
 from time import time
 from zope.component import adapter
 from zope.component import getMultiAdapter
+from zope.component import getUtility
 from zope.component.interfaces import ComponentLookupError
 from zope.globalrequest import getRequest
 from zope.i18n import translate
 from zope.interface import alsoProvides
 from zope.interface import implementer
 from zope.interface import noLongerProvides
+from zope.schema.interfaces import IVocabularyFactory
 
 CACHE_TIMEOUT = 24 * 60 * 60
 
@@ -263,6 +266,22 @@ class LinkedWorkspaces(object):
         elif document_repr.get('message'):
             data = self.client.request.get(document_repr['message']['download'])
             document_repr['message']['data'] = data.content
+
+        # GEVER can restrict the available vocabulary items for the classifcation
+        # fields. We can't copy a document into gever if its classification is
+        # not at least the classifictaion of the dossier itself.
+        # So if the classification of the teamraum document
+        # is not provided by the gever dossiers classification vocabulary,
+        # we have to reset the classification to the next possible value which
+        # is the value of the dossier itself.
+        alsoProvides(self.context.REQUEST, IDuringContentCreation)
+        classification_vocabulary = getUtility(
+            IVocabularyFactory,
+            'classification_classification_vocabulary')(self.context)
+        noLongerProvides(self.context.REQUEST, IDuringContentCreation)
+
+        if document_repr.get('classification', {}).get('token') not in classification_vocabulary:
+            document_repr['classification'] = {'token': self.context.classification}
 
         # We should avoid setting the id ourselves, can lead to conflicts
         document_repr = self._blacklisted_dict(document_repr, ['id'])


### PR DESCRIPTION
Jira: https://4teamwork.atlassian.net/browse/CA-2330

This PR fixes an issue where it was not possible to copy a teamraum document back to gever if the target-dossier was classified with a higher classification than the teamraum document.

The fix will increase the classification level of the teamraum document to dossier classification if it does not meet the requirements.

SIde-info: The classification has nothing to do with permissions on the object itself. It's just an informative attribute.

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
