### PR TITLE
Fixed moving dossier with a tasktemplate process.

### DIFF
--- a/changes/CA-2343.bugfix
+++ b/changes/CA-2343.bugfix
@@ -1,0 +1,1 @@
+Fixed moving dossier with a tasktemplate process. [phgross]

--- a/opengever/base/handlers.py
+++ b/opengever/base/handlers.py
@@ -108,7 +108,7 @@ def object_moved_or_added(context, event):
 
     # synchronize with model if necessary
     if ITask.providedBy(context):
-        sync_task(context, event)
+        sync_task(context, event, graceful=True)
 
 
 def remove_favorites(context, event):


### PR DESCRIPTION
When moving a dossier with a task_process it is not guaranteed that the objects are moved in the tasktemplate order, so it can happen, that the predecessor does not yet exists. Because the intid stays the same after move, its safe to just don't update the predecessor.

Fixes https://4teamwork.atlassian.net/browse/CA-2343

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

