### PR TITLE
Add language code parameter to office online edit link.

### DIFF
--- a/changes/CA-2246.bugfix
+++ b/changes/CA-2246.bugfix
@@ -1,0 +1,1 @@
+Add language code parameter to office online edit link. [phgross]

--- a/opengever/wopi/browser/edit.py
+++ b/opengever/wopi/browser/edit.py
@@ -17,6 +17,13 @@ import logging
 
 logger = logging.getLogger('opengever.wopi')
 
+# See https://wopi.readthedocs.io/en/latest/faq/languages.html#languages
+LANGUAGE_CODE_MAPPING = {
+    'de-ch': 'de-DE',
+    'fr-ch': 'fr-FR',
+    'en-us': 'en-US',
+}
+
 
 class EditOnlineView(BrowserView):
 
@@ -54,7 +61,7 @@ class EditOnlineView(BrowserView):
         self.access_token_ttl = int(time() + 43200) * 1000
 
         self.params = {
-            'UI_LLCC': '',
+            'UI_LLCC': self.get_WOPI_language_code(),
             'DC_LLCC': '',
             'DISABLE_CHAT': '1',
             'BUSINESS_USER': '0',
@@ -86,6 +93,11 @@ class EditOnlineView(BrowserView):
         self.urlsrc = '?'.join([url, ''.join(params_with_values)])
 
         return self.index()
+
+    def get_WOPI_language_code(self):
+        lang_tool = api.portal.get_tool('portal_languages')
+        language_code = lang_tool.getPreferredLanguage()
+        return LANGUAGE_CODE_MAPPING.get(language_code, '')
 
     def is_locked_but_not_by_WOPI(self):
         if not self.context.is_locked():

--- a/opengever/wopi/tests/test_edit.py
+++ b/opengever/wopi/tests/test_edit.py
@@ -3,6 +3,7 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser.pages.statusmessages import error_messages
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.testing import IntegrationTestCase
+from opengever.testing import set_preferred_language
 from opengever.wopi.interfaces import IWOPISettings
 from opengever.wopi.token import validate_access_token
 from plone import api
@@ -31,6 +32,23 @@ class TestEditView(IntegrationTestCase):
                 urlsafe_b64decode(access_token),
                 'createtreatydossiers000000000002'),
             'kathi.barfuss')
+
+    @browsing
+    def test_UI_language_is_prefered_language(self, browser):
+        self.login(self.regular_user, browser=browser)
+        self.enable_languages()
+        browser.open()
+        browser.click_on("Deutsch")
+
+        browser.open(self.document, view="office_online_edit")
+
+        action = browser.css("#office_form").first.get("action")
+        self.assertEqual(
+            action,
+            "https://FFC-word-edit.officeapps.live.com/we/wordeditorframe.aspx"
+            "?ui=de-DE&rs=&dchat=1&IsLicensedUser=1&WOPISrc=http://nohost"
+            "/plone/wopi/files/createtreatydossiers000000000002&",
+        )
 
     @browsing
     def test_edit_view_returns_form_action_for_non_business_users(self, browser):


### PR DESCRIPTION
Resolves https://4teamwork.atlassian.net/browse/CA-2246

I tested it briefly in St. Gallen, works as desired - the Office Online UI is translated correctly.

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

