### PR TITLE
Change sorting of search results of AllUsersInboxesAndTeamsSource

### DIFF
--- a/opengever/ogds/base/locales/fr/LC_MESSAGES/opengever.ogds.base.po
+++ b/opengever/ogds/base/locales/fr/LC_MESSAGES/opengever.ogds.base.po
@@ -34,7 +34,7 @@ msgstr "Oui"
 #: ./opengever/ogds/base/actor.py
 #: ./opengever/ogds/base/sources.py
 msgid "inbox_label"
-msgstr "Boîte de réception"
+msgstr "Boîte de réception: ${client}"
 
 #. Default: "Current user"
 #: ./opengever/ogds/base/actor.py

--- a/opengever/ogds/base/sources.py
+++ b/opengever/ogds/base/sources.py
@@ -22,6 +22,7 @@ from sqlalchemy import func
 from sqlalchemy import orm
 from sqlalchemy import sql
 from sqlalchemy.sql.expression import asc
+from sqlalchemy.sql.expression import desc
 from z3c.formwidget.query.interfaces import IQuerySource
 from zope.component import getUtility
 from zope.globalrequest import getRequest
@@ -257,7 +258,8 @@ class AllUsersInboxesAndTeamsSource(BaseQuerySoure):
 
         query = query.filter_by(active=True)
         query = query.order_by(asc(func.lower(User.lastname)),
-                               asc(func.lower(User.firstname)))
+                               asc(func.lower(User.firstname)),
+                               asc(func.lower(OrgUnit.title)))
 
         for user, orgunit in query:
             self.terms.append(
@@ -281,6 +283,8 @@ class AllUsersInboxesAndTeamsSource(BaseQuerySoure):
         query = OrgUnit.query
         query = query.filter(OrgUnit.enabled == True)  # noqa
         query = query.filter(OrgUnit.hidden == False)  # noqa
+        # Sort search results in descending order, as the terms are added in reverse order
+        query = query.order_by(desc(func.lower(OrgUnit.title)))
 
         if self.only_current_inbox:
             query = query.filter(OrgUnit.unit_id == self.client_id)
@@ -295,6 +299,8 @@ class AllUsersInboxesAndTeamsSource(BaseQuerySoure):
 
     def _extend_terms_with_teams(self, text_filters):
         query = Team.query.filter(Team.active == True)  # noqa
+        # Sort search results in descending order, as the terms are added in reverse order
+        query = query.order_by(desc(func.lower(Team.title)))
         query = extend_query_with_textfilter(query, [Team.title], text_filters)
 
         for team in query:


### PR DESCRIPTION
Changes in AllUsersInboxesAndTeamsSource
- Users are now additionally sorted by OrgUnit title
- Teams are sorted by team title
- Inboxes are sorted by OrgUnit title

Jira: https://4teamwork.atlassian.net/browse/CA-1989

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)