### PR TITLE
Allow to move dossiers from an old repository root to a new one.

### DIFF
--- a/changes/CA-2089.feature
+++ b/changes/CA-2089.feature
@@ -1,0 +1,1 @@
+Allow to move contents from an old repository root to a new one. [elioschmutz]


### PR DESCRIPTION
Jira: https://4teamwork.atlassian.net/browse/CA-2089

This PR extends the `RepositorySourcePathBinder` to allow moving contents between an old and a new repository-root if the user is within an old repository root.

The implementation differs to the main refinement in the following case:
I have not implemented the registry entry. It behaves like in the frontend: if the user tries to move an object within an old repository root, he is allowed to move it to the new one but not vice versa.

## Moving within an old repository root:
<img width="1106" alt="Bildschirmfoto 2021-06-08 um 15 42 37" src="https://user-images.githubusercontent.com/557005/121197768-ded08800-c871-11eb-9ff9-8bb550660a2a.png">

# Moving within a new repository root:
<img width="1140" alt="Bildschirmfoto 2021-06-08 um 15 40 46" src="https://user-images.githubusercontent.com/557005/121195786-3110a980-c870-11eb-88a5-699cfd8858d2.png">


## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
