### PR TITLE
Upgradestep optimization for ZG Release

### DIFF
--- a/changes/CA-2090.other
+++ b/changes/CA-2090.other
@@ -1,0 +1,1 @@
+Upgrade steps merged to shorten upgrade runtime. [phgross]

--- a/opengever/core/upgrades/20200429114820_add_is_subdossier_to_catalog_metadata/upgrade.py
+++ b/opengever/core/upgrades/20200429114820_add_is_subdossier_to_catalog_metadata/upgrade.py
@@ -14,12 +14,17 @@ class AddIsSubdossierToCatalogMetadata(UpgradeStep):
 
     def __call__(self):
         self.install_upgrade_profile()
-        query = {
-            'object_provides': [IDossierMarker.__identifier__,
-                                IDossierTemplateMarker.__identifier__]
-            }
-        # To avoid reindexing the whole objects, we pick any index that exists
-        # for all objects and is fast to compute.
-        # is_subdossier is already a solr field, so we don't need to pass it
-        # as an index here.
-        self.catalog_reindex_objects(query, idxs=['UID'])
+
+        # Disable the reindex part, because the reindexObject for all Dossiers
+        # and DossierTemplates is done by a later upgradestep anyways
+        # 20210128083955_index_blocked_local_roles_in_solr_for_repository_folders_and_dossiers
+
+        # query = {
+        #     'object_provides': [IDossierMarker.__identifier__,
+        #                         IDossierTemplateMarker.__identifier__]
+        #     }
+        # # To avoid reindexing the whole objects, we pick any index that exists
+        # # for all objects and is fast to compute.
+        # # is_subdossier is already a solr field, so we don't need to pass it
+        # # as an index here.
+        # self.catalog_reindex_objects(query, idxs=['UID'])

--- a/opengever/core/upgrades/20201008152233_add_and_index_participations_solr_field/upgrade.py
+++ b/opengever/core/upgrades/20201008152233_add_and_index_participations_solr_field/upgrade.py
@@ -8,8 +8,13 @@ class AddAndIndexParticipationsSolrField(UpgradeStep):
     deferrable = True
 
     def __call__(self):
-        query = {'object_provides': IParticipationAwareMarker.__identifier__}
-        for dossier in self.objects(query, 'Index participations field in solr.'):
-            # participations is only in solr, prevent reindexing all catalog
-            # indexes by picking a cheap catalog index `UID`.
-            dossier.reindexObject(idxs=['UID', 'participations'])
+        # Disable this upgradestep because the reindexObject for all
+        # Participatationobjects (dossiers) have been moved to a later upgradestep
+        # 20210128083955_index_blocked_local_roles_in_solr_for_repository_folders_and_dossiers
+
+        return
+        # query = {'object_provides': IParticipationAwareMarker.__identifier__}
+        # for dossier in self.objects(query, 'Index participations field in solr.'):
+        #     # participations is only in solr, prevent reindexing all catalog
+        #     # indexes by picking a cheap catalog index `UID`.
+        #     dossier.reindexObject(idxs=['UID', 'participations'])

--- a/opengever/core/upgrades/20210128083955_index_blocked_local_roles_in_solr_for_repository_folders_and_dossiers/upgrade.py
+++ b/opengever/core/upgrades/20210128083955_index_blocked_local_roles_in_solr_for_repository_folders_and_dossiers/upgrade.py
@@ -2,6 +2,7 @@ from ftw.upgrade import UpgradeStep
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.dossiertemplate.behaviors import IDossierTemplateMarker
 from opengever.repository.interfaces import IRepositoryFolder
+from opengever.dossier.behaviors.participation import IParticipationAwareMarker
 
 
 class IndexBlockedLocalRolesInSolrForRepositoryFoldersAndDossiers(UpgradeStep):
@@ -15,7 +16,8 @@ class IndexBlockedLocalRolesInSolrForRepositoryFoldersAndDossiers(UpgradeStep):
             IDossierMarker.__identifier__,
             IRepositoryFolder.__identifier__,
             IDossierTemplateMarker.__identifier__,
+            IParticipationAwareMarker.__identifier__
         ]}
 
-        for obj in self.objects(query, 'Index blocked_local_roles field in solr.'):
-            obj.reindexObject(idxs=['blocked_local_roles'])
+        for obj in self.objects(query, 'Index blocked_local_roles and participation field in solr.'):
+            obj.reindexObject(idxs=['blocked_local_roles', 'participations'])

--- a/opengever/core/upgrades/20210128083955_index_blocked_local_roles_in_solr_for_repository_folders_and_dossiers/upgrade.py
+++ b/opengever/core/upgrades/20210128083955_index_blocked_local_roles_in_solr_for_repository_folders_and_dossiers/upgrade.py
@@ -1,5 +1,6 @@
 from ftw.upgrade import UpgradeStep
 from opengever.dossier.behaviors.dossier import IDossierMarker
+from opengever.dossier.dossiertemplate.behaviors import IDossierTemplateMarker
 from opengever.repository.interfaces import IRepositoryFolder
 
 
@@ -13,6 +14,7 @@ class IndexBlockedLocalRolesInSolrForRepositoryFoldersAndDossiers(UpgradeStep):
         query = {'object_provides': [
             IDossierMarker.__identifier__,
             IRepositoryFolder.__identifier__,
+            IDossierTemplateMarker.__identifier__,
         ]}
 
         for obj in self.objects(query, 'Index blocked_local_roles field in solr.'):


### PR DESCRIPTION
I analysed the upgradestep from `2019.6.5` to `master` and optimized two upgradesteps by merging them together to avoid multiple reindexObject specially the catalog metadata updating part, during the the GEVER ZG Release (https://4teamwork.atlassian.net/browse/CA-2090).

Auszug der Analyse:
```
20200427154326@opengever.core:default DEFERRABLE  Always use solr for table source.                                       |  Upgrade: alle Kontakt und alle abgeschlossenen Dossiers -> OK
20200429114820@opengever.core:default DEFERRABLE  Add is_subdossier to catalog metadata.                                  |  Upgrade: alle Dossiers -> Wurde kurzgeschlossen
20200508163000@opengever.core:default ORPHAN      Update filename of mails with file extension msg.                       |  Upgrade: alle *.msg Mails, wieso nicht deferrable? -> OK, Begründung steht im PR #6551
20200518084137@opengever.core:default DEFERRABLE  Cleanup catalog indexes and metadata.                                   |  Upgrade: muss ich noch abklären -> Wird lange dauern, kein Potential für ein Merge
20200701082851@opengever.core:default DEFERRABLE  Update Solr field "touched" for all dossiers.                           |  Upgrade: alle Dossiers aber nur via SOLR -> Ok
20200716130341@opengever.core:default DEFERRABLE  Reindex task watchers in solr.                                          |  Upgrade: alle Aufgaben inkl. Weiterleitungen -> Ok, das sind pro Mandant max. nur wenige tausende.
20200730094255@opengever.core:default DEFERRABLE  Fix docs only partially indexed in solr.                                |  Korrigiert nicht korrekt indexierte Dokumente via SOLR -> OK, keine Optimierung möglich.
20200817143709@opengever.core:default DEFERRABLE  Reindex container modified during bundle import.                        |  Upgrade: -> Wohl unproblematisch da nur Dossiers nch Bundle-Import betroffen sind.
20200925090651@opengever.core:default DEFERRABLE  Migrate participations.                                                 |  alle Dossiers aber nur Objekte -> Aufwand und Risiko lohnen sich wohl nicht ihn mit 20201008143927 zusammenzuführen.
20201006142950@opengever.core:default DEFERRABLE  Reindex external_reference for objects in solr.                         |  Upgrade: alle Dossiers mit external_reference -> OK, unproblematisch
20201008143927@opengever.core:default DEFERRABLE  Store plone participations in persistent dict.                          |  alle Dossiers aber nur Objekte -> siehe 20200925090651
20201008152233@opengever.core:default DEFERRABLE  Add and index participations solr field.                                |  alle Dossiers -> wurde kurzgeschlossen
20210128083955@opengever.core:default DEFERRABLE  Index blocked_local_roles in solr for repository folders and dossiers.  |  Upgrade: Alle Ordnungspositionen und Dossiers -> Enthält bereits ander Upgradesteps
20210128112320@opengever.core:default DEFERRABLE  Index is folderish solr index.                                          |  Upgrade: Alle Objekte `is_folderish` -> Nur Solr updae würde keine Optimierung
20210205084521@opengever.core:default DEFERRABLE  Add sortable reference number index.                                    |  alled Objekte ->
20210601180416@opengever.core:default DEFERRABLE  Update/reindex reference and sortable_reference index.                  |  alle Objekte -> Für die meisten Objekte nur Schreibzugriff in den Solr.
```

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
