### PR TITLE
Implement additional usermigrations.

### DIFF
--- a/changes/CA-2016.feature
+++ b/changes/CA-2016.feature
@@ -1,0 +1,1 @@
+Add userid migration for UserSettings, NotificationSetting, Favorite, recently touched objects, task reminders, task templates, meetings and proposals. [deiferni]

--- a/opengever/usermigration/base.py
+++ b/opengever/usermigration/base.py
@@ -9,7 +9,7 @@ logger = logging.getLogger('opengever.usermigration')
 
 class BaseUserMigration(object):
 
-    def __init__(self, portal, principal_mapping, mode='move', strict=True):
+    def __init__(self, portal, principal_mapping, mode='move'):
         if mode != 'move':
             raise NotImplementedError(
                 u"Migration only supports 'move' mode"
@@ -18,7 +18,6 @@ class BaseUserMigration(object):
         self.portal = portal
         self.principal_mapping = principal_mapping
         self.mode = mode
-        self.strict = strict
 
     def _verify_user(self, userid):
         ogds_user = ogds_service().fetch_user(userid)
@@ -33,9 +32,9 @@ class BasePloneObjectAttributesMigrator(BaseUserMigration):
     interface_to_query = None
     interface_to_adapt = None
 
-    def __init__(self, portal, principal_mapping, mode='move', strict=True):
+    def __init__(self, portal, principal_mapping, mode='move'):
         super(BasePloneObjectAttributesMigrator, self).__init__(
-            portal, principal_mapping, mode=mode, strict=strict
+            portal, principal_mapping, mode=mode
         )
 
         self.to_reindex = set()

--- a/opengever/usermigration/base.py
+++ b/opengever/usermigration/base.py
@@ -1,0 +1,88 @@
+from opengever.ogds.models.service import ogds_service
+from opengever.usermigration.exceptions import UserMigrationException
+from plone import api
+import logging
+
+
+logger = logging.getLogger('opengever.usermigration')
+
+
+class BasePloneObjectAttributesMigrator(object):
+
+    fields_to_migrate = tuple()
+    interface_to_query = None
+    interface_to_adapt = None
+
+    def __init__(self, portal, principal_mapping, mode='move', strict=True):
+        if mode != 'move':
+            raise NotImplementedError(
+                "Plone object migrator only supports 'move' mode")
+
+        self.portal = portal
+        self.principal_mapping = principal_mapping
+        self.mode = mode
+        self.strict = strict
+
+        self.to_reindex = set()
+        self.moves = {
+            field_name: []
+            for field_name in self.fields_to_migrate
+        }
+
+    def _verify_users(self):
+        # Verify all new users exist before doing anything
+        for new_userid in self.principal_mapping.values():
+            ogds_user = ogds_service().fetch_user(new_userid)
+            if ogds_user is None:
+                msg = "User '{}' not found in OGDS!".format(new_userid)
+                raise UserMigrationException(msg)
+
+    @property
+    def catalog_query(self):
+        return {
+            'object_provides': self.interface_to_query.__identifier__
+        }
+
+    def _iter_objects(self):
+        catalog = api.portal.get_tool('portal_catalog')
+        for brain in catalog.unrestrictedSearchResults(self.catalog_query):
+            yield brain.getObject()
+
+    def _migrate_object(self, obj):
+        for field_name in self.fields_to_migrate:
+            old_userid = getattr(obj, field_name, None)
+            if old_userid in self.principal_mapping:
+                path = '/'.join(obj.getPhysicalPath())
+                logger.info('Fixing %r for %s' % (field_name, path))
+                new_userid = self.principal_mapping[old_userid]
+                setattr(obj, field_name, new_userid)
+                self.to_reindex.add(obj)
+                self.moves[field_name].append(
+                    (path, old_userid, new_userid)
+                )
+
+    def _reindex_objects(self):
+        for obj in self.to_reindex:
+            logger.info('Reindexing %s' % '/'.join(obj.getPhysicalPath()))
+            obj.reindexObject(idxs=self.fields_to_migrate)
+
+    def _report_results(self):
+        results = dict()
+        for field_name, moves in self.moves.items():
+            key = '.'.join([self.interface_to_adapt.__name__, field_name])
+            results[key] = {
+                'moved': moves,
+                'copied': [],
+                'deleted': [],
+            }
+        return results
+
+    def migrate(self):
+        self._verify_users()
+
+        for obj in self._iter_objects():
+            obj = self.interface_to_adapt(obj)
+            self._migrate_object(obj)
+
+        self._reindex_objects()
+        return self._report_results()

--- a/opengever/usermigration/checked_out_docs.py
+++ b/opengever/usermigration/checked_out_docs.py
@@ -4,34 +4,17 @@ Migrate user IDs in checked out state for documents as well as WebDAV locks.
 
 from opengever.document.checkout.manager import CHECKIN_CHECKOUT_ANNOTATIONS_KEY  # noqa
 from opengever.document.interfaces import ICheckinCheckoutManager
-from opengever.ogds.models.service import ogds_service
-from opengever.usermigration.exceptions import UserMigrationException
+from opengever.usermigration.base import BaseUserMigration
 from plone import api
+from plone.locking.interfaces import IRefreshableLockable
 from zope.component import getMultiAdapter
 import logging
-from plone.locking.interfaces import IRefreshableLockable
 
 
 logger = logging.getLogger('opengever.usermigration')
 
 
-class CheckedOutDocsMigrator(object):
-
-    def __init__(self, portal, principal_mapping, mode='move', strict=True):
-        self.portal = portal
-        self.principal_mapping = principal_mapping
-
-        if mode != 'move':
-            raise NotImplementedError(
-                "CheckedOutDocsMigrator only supports 'move' mode")
-        self.mode = mode
-        self.strict = strict
-
-    def _verify_user(self, userid):
-        ogds_user = ogds_service().fetch_user(userid)
-        if ogds_user is None:
-            msg = "User '{}' not found in OGDS!".format(userid)
-            raise UserMigrationException(msg)
+class CheckedOutDocsMigrator(BaseUserMigration):
 
     def _migrate_checked_out_doc(self, doc, old_userid, new_userid):
         # Migrate "checked out by" information and reindex

--- a/opengever/usermigration/configure.zcml
+++ b/opengever/usermigration/configure.zcml
@@ -67,4 +67,12 @@
       name="GEVER: Checked out documents (checked_out_by and WebDAV locks)"
       />
 
+  <adapter
+      factory=".migrations.RecentlyTouchedMigration"
+      provides="ftw.usermigration.interfaces.IPreMigrationHook"
+      for="Products.CMFPlone.interfaces.siteroot.IPloneSiteRoot
+           zope.publisher.interfaces.browser.IBrowserRequest"
+      name="GEVER: Recently touched objects"
+      />
+
 </configure>

--- a/opengever/usermigration/configure.zcml
+++ b/opengever/usermigration/configure.zcml
@@ -83,4 +83,12 @@
       name="GEVER: Recently touched objects"
       />
 
+  <adapter
+      factory=".migrations.ProposalsMigration"
+      provides="ftw.usermigration.interfaces.IPreMigrationHook"
+      for="Products.CMFPlone.interfaces.siteroot.IPloneSiteRoot
+           zope.publisher.interfaces.browser.IBrowserRequest"
+      name="GEVER: Proposals and submitted proposals"
+      />
+
 </configure>

--- a/opengever/usermigration/configure.zcml
+++ b/opengever/usermigration/configure.zcml
@@ -52,6 +52,14 @@
       />
 
   <adapter
+      factory=".migrations.TaskTemplateMigration"
+      provides="ftw.usermigration.interfaces.IPreMigrationHook"
+      for="Products.CMFPlone.interfaces.siteroot.IPloneSiteRoot
+           zope.publisher.interfaces.browser.IBrowserRequest"
+      name="GEVER: Tasks templates (issuers, responsibles)"
+      />
+
+  <adapter
       factory=".migrations.PrivateFoldersMigration"
       provides="ftw.usermigration.interfaces.IPreMigrationHook"
       for="Products.CMFPlone.interfaces.siteroot.IPloneSiteRoot

--- a/opengever/usermigration/creator.py
+++ b/opengever/usermigration/creator.py
@@ -14,9 +14,9 @@ logger = logging.getLogger('opengever.usermigration')
 
 class CreatorMigrator(BaseUserMigration):
 
-    def __init__(self, portal, principal_mapping, mode='move', strict=True):
+    def __init__(self, portal, principal_mapping, mode='move'):
         super(CreatorMigrator, self).__init__(
-            portal, principal_mapping, mode=mode, strict=strict
+            portal, principal_mapping, mode=mode
         )
 
         self.catalog = api.portal.get_tool('portal_catalog')
@@ -33,10 +33,7 @@ class CreatorMigrator(BaseUserMigration):
         users = pas_search.searchUsers(id=userid)
         if len(users) < 1:
             msg = "User '{}' not found in acl_users!".format(userid)
-            if self.strict:
-                raise UserMigrationException(msg)
-            else:
-                logger.warn(msg)
+            raise UserMigrationException(msg)
 
     def _migrate_creators(self, obj):
         if not hasattr(obj, 'creators'):

--- a/opengever/usermigration/creator.py
+++ b/opengever/usermigration/creator.py
@@ -2,6 +2,7 @@
 Helper for migrating creators on Dexterity objects.
 """
 
+from opengever.usermigration.base import BaseUserMigration
 from opengever.usermigration.exceptions import UserMigrationException
 from plone import api
 from zope.component import getMultiAdapter
@@ -11,18 +12,13 @@ import logging
 logger = logging.getLogger('opengever.usermigration')
 
 
-class CreatorMigrator(object):
+class CreatorMigrator(BaseUserMigration):
 
     def __init__(self, portal, principal_mapping, mode='move', strict=True):
-        self.portal = portal
-        self.principal_mapping = principal_mapping
+        super(CreatorMigrator, self).__init__(
+            portal, principal_mapping, mode=mode, strict=strict
+        )
 
-        if mode != 'move':
-            raise NotImplementedError(
-                "CreatorMigrator only supports 'move' mode as of yet")
-        self.mode = mode
-
-        self.strict = strict
         self.catalog = api.portal.get_tool('portal_catalog')
         self.acl_users = api.portal.get_tool('acl_users')
 

--- a/opengever/usermigration/dictstorage.py
+++ b/opengever/usermigration/dictstorage.py
@@ -4,8 +4,7 @@ Helpers for migrating user and group related data in dictstorage SQL tables.
 
 from ftw.dictstorage.sql import DictStorageModel
 from opengever.base.model import create_session
-from opengever.ogds.models.service import ogds_service
-from opengever.usermigration.exceptions import UserMigrationException
+from opengever.usermigration.base import BaseUserMigration
 import logging
 
 
@@ -19,7 +18,7 @@ def rreplace(s, old, new, maxreplace=-1):
     return new.join(s.rsplit(old, maxreplace))
 
 
-class DictstorageMigrator(object):
+class DictstorageMigrator(BaseUserMigration):
     """Migrates occurences of a username in dictstorage keys in SQL.
 
     Will replace the first occurence of the old user ID *from the right*
@@ -31,25 +30,10 @@ class DictstorageMigrator(object):
     """
 
     def __init__(self, portal, principal_mapping, mode='move', strict=True):
-        self.portal = portal
-        self.principal_mapping = principal_mapping
-
-        if mode != 'move':
-            raise NotImplementedError(
-                "OGDSMigrator only supports 'move' mode as of yet")
-        self.mode = mode
-
-        self.strict = strict
+        super(DictstorageMigrator, self).__init__(
+            portal, principal_mapping, mode=mode, strict=strict
+        )
         self.session = create_session()
-
-    def _verify_user(self, userid):
-        ogds_user = ogds_service().fetch_user(userid)
-        if ogds_user is None:
-            msg = "User '{}' not found in OGDS!".format(userid)
-            if self.strict:
-                raise UserMigrationException(msg)
-            else:
-                logger.warn(msg)
 
     def _migrate_dictstorage_keys(self):
         moved = []

--- a/opengever/usermigration/dictstorage.py
+++ b/opengever/usermigration/dictstorage.py
@@ -29,9 +29,9 @@ class DictstorageMigrator(BaseUserMigration):
     'user42' and 'other-user42'. That should be highly unlikely though.
     """
 
-    def __init__(self, portal, principal_mapping, mode='move', strict=True):
+    def __init__(self, portal, principal_mapping, mode='move'):
         super(DictstorageMigrator, self).__init__(
-            portal, principal_mapping, mode=mode, strict=strict
+            portal, principal_mapping, mode=mode
         )
         self.session = create_session()
 

--- a/opengever/usermigration/dossier.py
+++ b/opengever/usermigration/dossier.py
@@ -16,9 +16,9 @@ logger = logging.getLogger('opengever.usermigration')
 
 class DossierMigrator(BaseUserMigration):
 
-    def __init__(self, portal, principal_mapping, mode='move', strict=True):
+    def __init__(self, portal, principal_mapping, mode='move'):
         super(DossierMigrator, self).__init__(
-            portal, principal_mapping, mode=mode, strict=strict
+            portal, principal_mapping, mode=mode
         )
         self.catalog = api.portal.get_tool('portal_catalog')
         self.dossiers_to_reindex = set()

--- a/opengever/usermigration/dossier.py
+++ b/opengever/usermigration/dossier.py
@@ -6,8 +6,7 @@ from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.behaviors.participation import IParticipationAware
 from opengever.dossier.behaviors.participation import IParticipationAwareMarker
-from opengever.ogds.models.service import ogds_service
-from opengever.usermigration.exceptions import UserMigrationException
+from opengever.usermigration.base import BaseUserMigration
 from plone import api
 import logging
 
@@ -15,18 +14,12 @@ import logging
 logger = logging.getLogger('opengever.usermigration')
 
 
-class DossierMigrator(object):
+class DossierMigrator(BaseUserMigration):
 
     def __init__(self, portal, principal_mapping, mode='move', strict=True):
-        self.portal = portal
-        self.principal_mapping = principal_mapping
-
-        if mode != 'move':
-            raise NotImplementedError(
-                "DossierMigrator only supports 'move' mode as of yet")
-        self.mode = mode
-
-        self.strict = strict
+        super(DossierMigrator, self).__init__(
+            portal, principal_mapping, mode=mode, strict=strict
+        )
         self.catalog = api.portal.get_tool('portal_catalog')
         self.dossiers_to_reindex = set()
 
@@ -36,15 +29,6 @@ class DossierMigrator(object):
 
         for brain in dossier_brains:
             yield brain.getObject()
-
-    def _verify_user(self, userid):
-        ogds_user = ogds_service().fetch_user(userid)
-        if ogds_user is None:
-            msg = "User '{}' not found in OGDS!".format(userid)
-            if self.strict:
-                raise UserMigrationException(msg)
-            else:
-                logger.warn(msg)
 
     def _migrate_responsible(self, dossier):
         moved = []

--- a/opengever/usermigration/migrations.py
+++ b/opengever/usermigration/migrations.py
@@ -26,8 +26,7 @@ class OGDSMigration(object):
         self.request = request
 
     def execute(self, principal_mapping, mode):
-        migrator = OGDSMigrator(self.portal, principal_mapping,
-                                mode=mode, strict=True)
+        migrator = OGDSMigrator(self.portal, principal_mapping, mode=mode)
         results = migrator.migrate()
         return results
 
@@ -39,8 +38,7 @@ class DossierMigration(object):
         self.request = request
 
     def execute(self, principal_mapping, mode):
-        migrator = DossierMigrator(self.portal, principal_mapping,
-                                   mode=mode, strict=True)
+        migrator = DossierMigrator(self.portal, principal_mapping, mode=mode)
         results = migrator.migrate()
         return results
 
@@ -52,8 +50,7 @@ class CreatorMigration(object):
         self.request = request
 
     def execute(self, principal_mapping, mode):
-        migrator = CreatorMigrator(self.portal, principal_mapping,
-                                   mode=mode, strict=True)
+        migrator = CreatorMigrator(self.portal, principal_mapping, mode=mode)
         results = migrator.migrate()
         return results
 
@@ -65,8 +62,9 @@ class DictstorageMigration(object):
         self.request = request
 
     def execute(self, principal_mapping, mode):
-        migrator = DictstorageMigrator(self.portal, principal_mapping,
-                                       mode=mode, strict=True)
+        migrator = DictstorageMigrator(
+            self.portal, principal_mapping, mode=mode
+        )
         results = migrator.migrate()
         return results
 
@@ -78,8 +76,9 @@ class OGDSUserReferencesMigration(object):
         self.request = request
 
     def execute(self, principal_mapping, mode):
-        migrator = OGDSUserReferencesMigrator(self.portal, principal_mapping,
-                                              mode=mode, strict=True)
+        migrator = OGDSUserReferencesMigrator(
+            self.portal, principal_mapping, mode=mode
+        )
         results = migrator.migrate()
         return results
 
@@ -91,8 +90,9 @@ class PloneTasksMigration(object):
         self.request = request
 
     def execute(self, principal_mapping, mode):
-        migrator = PloneTasksMigrator(self.portal, principal_mapping,
-                                      mode=mode, strict=True)
+        migrator = PloneTasksMigrator(
+            self.portal, principal_mapping, mode=mode
+        )
         results = migrator.migrate()
         return results
 
@@ -104,8 +104,9 @@ class TaskTemplateMigration(object):
         self.request = request
 
     def execute(self, principal_mapping, mode):
-        migrator = TaskTemplateMigrator(self.portal, principal_mapping,
-                                        mode=mode, strict=True)
+        migrator = TaskTemplateMigrator(
+            self.portal, principal_mapping, mode=mode
+        )
         results = migrator.migrate()
         return results
 
@@ -117,8 +118,9 @@ class PrivateFoldersMigration(object):
         self.request = request
 
     def execute(self, principal_mapping, mode):
-        migrator = PrivateFoldersMigrator(self.portal, principal_mapping,
-                                          mode=mode, strict=True)
+        migrator = PrivateFoldersMigrator(
+            self.portal, principal_mapping, mode=mode
+        )
         results = migrator.migrate()
         return results
 
@@ -130,8 +132,9 @@ class CheckedOutDocsMigration(object):
         self.request = request
 
     def execute(self, principal_mapping, mode):
-        migrator = CheckedOutDocsMigrator(self.portal, principal_mapping,
-                                          mode=mode, strict=True)
+        migrator = CheckedOutDocsMigrator(
+            self.portal, principal_mapping, mode=mode
+        )
         results = migrator.migrate()
         return results
 
@@ -143,8 +146,9 @@ class RecentlyTouchedMigration(object):
         self.request = request
 
     def execute(self, principal_mapping, mode):
-        migrator = RecentlyTouchedMigrator(self.portal, principal_mapping,
-                                           mode=mode, strict=True)
+        migrator = RecentlyTouchedMigrator(
+            self.portal, principal_mapping, mode=mode
+        )
         results = migrator.migrate()
         return results
 
@@ -156,7 +160,6 @@ class ProposalsMigration(object):
         self.request = request
 
     def execute(self, principal_mapping, mode):
-        migrator = ProposalsMigrator(self.portal, principal_mapping,
-                                     mode=mode, strict=True)
+        migrator = ProposalsMigrator(self.portal, principal_mapping, mode=mode)
         results = migrator.migrate()
         return results

--- a/opengever/usermigration/migrations.py
+++ b/opengever/usermigration/migrations.py
@@ -15,6 +15,7 @@ from opengever.usermigration.ogds_references import OGDSUserReferencesMigrator
 from opengever.usermigration.plone_tasks import PloneTasksMigrator
 from opengever.usermigration.private_folders import PrivateFoldersMigrator
 from opengever.usermigration.recently_touched import RecentlyTouchedMigrator
+from opengever.usermigration.task_templates import TaskTemplateMigrator
 
 
 class OGDSMigration(object):
@@ -91,6 +92,19 @@ class PloneTasksMigration(object):
     def execute(self, principal_mapping, mode):
         migrator = PloneTasksMigrator(self.portal, principal_mapping,
                                       mode=mode, strict=True)
+        results = migrator.migrate()
+        return results
+
+
+class TaskTemplateMigration(object):
+
+    def __init__(self, portal, request):
+        self.portal = portal
+        self.request = request
+
+    def execute(self, principal_mapping, mode):
+        migrator = TaskTemplateMigrator(self.portal, principal_mapping,
+                                        mode=mode, strict=True)
         results = migrator.migrate()
         return results
 

--- a/opengever/usermigration/migrations.py
+++ b/opengever/usermigration/migrations.py
@@ -14,6 +14,7 @@ from opengever.usermigration.ogds import OGDSMigrator
 from opengever.usermigration.ogds_references import OGDSUserReferencesMigrator
 from opengever.usermigration.plone_tasks import PloneTasksMigrator
 from opengever.usermigration.private_folders import PrivateFoldersMigrator
+from opengever.usermigration.recently_touched import RecentlyTouchedMigrator
 
 
 class OGDSMigration(object):
@@ -116,5 +117,18 @@ class CheckedOutDocsMigration(object):
     def execute(self, principal_mapping, mode):
         migrator = CheckedOutDocsMigrator(self.portal, principal_mapping,
                                           mode=mode, strict=True)
+        results = migrator.migrate()
+        return results
+
+
+class RecentlyTouchedMigration(object):
+
+    def __init__(self, portal, request):
+        self.portal = portal
+        self.request = request
+
+    def execute(self, principal_mapping, mode):
+        migrator = RecentlyTouchedMigrator(self.portal, principal_mapping,
+                                           mode=mode, strict=True)
         results = migrator.migrate()
         return results

--- a/opengever/usermigration/migrations.py
+++ b/opengever/usermigration/migrations.py
@@ -14,6 +14,7 @@ from opengever.usermigration.ogds import OGDSMigrator
 from opengever.usermigration.ogds_references import OGDSUserReferencesMigrator
 from opengever.usermigration.plone_tasks import PloneTasksMigrator
 from opengever.usermigration.private_folders import PrivateFoldersMigrator
+from opengever.usermigration.proposals import ProposalsMigrator
 from opengever.usermigration.recently_touched import RecentlyTouchedMigrator
 from opengever.usermigration.task_templates import TaskTemplateMigrator
 
@@ -144,5 +145,18 @@ class RecentlyTouchedMigration(object):
     def execute(self, principal_mapping, mode):
         migrator = RecentlyTouchedMigrator(self.portal, principal_mapping,
                                            mode=mode, strict=True)
+        results = migrator.migrate()
+        return results
+
+
+class ProposalsMigration(object):
+
+    def __init__(self, portal, request):
+        self.portal = portal
+        self.request = request
+
+    def execute(self, principal_mapping, mode):
+        migrator = ProposalsMigrator(self.portal, principal_mapping,
+                                     mode=mode, strict=True)
         results = migrator.migrate()
         return results

--- a/opengever/usermigration/ogds.py
+++ b/opengever/usermigration/ogds.py
@@ -3,6 +3,7 @@ Helpers for migrating user and group related data in OGDS SQL tables.
 """
 
 from opengever.ogds.models.service import ogds_service
+from opengever.usermigration.base import BaseUserMigration
 from opengever.usermigration.exceptions import UserMigrationException
 import logging
 
@@ -10,17 +11,7 @@ import logging
 logger = logging.getLogger('opengever.usermigration')
 
 
-class OGDSMigrator(object):
-
-    def __init__(self, portal, principal_mapping, mode='move', strict=True):
-        self.portal = portal
-        self.principal_mapping = principal_mapping
-
-        if mode != 'move':
-            raise NotImplementedError(
-                "OGDSMigrator only supports 'move' mode")
-        self.mode = mode
-        self.strict = strict
+class OGDSMigrator(BaseUserMigration):
 
     def _verify_group(self, groupid):
         ogds_group = ogds_service().fetch_group(groupid)

--- a/opengever/usermigration/ogds_references.py
+++ b/opengever/usermigration/ogds_references.py
@@ -24,9 +24,9 @@ logger = logging.getLogger('opengever.usermigration')
 
 class OGDSUserReferencesMigrator(BaseUserMigration):
 
-    def __init__(self, portal, principal_mapping, mode='move', strict=True):
+    def __init__(self, portal, principal_mapping, mode='move'):
         super(OGDSUserReferencesMigrator, self).__init__(
-            portal, principal_mapping, mode=mode, strict=strict
+            portal, principal_mapping, mode=mode
         )
         self.session = create_session()
 

--- a/opengever/usermigration/ogds_references.py
+++ b/opengever/usermigration/ogds_references.py
@@ -1,14 +1,3 @@
-"""
-Migrate user ID references in OGDS SQL tables:
-
-- activity actors
-- watcher actors
-- notification user IDs
-- task principals
-- task issuers
-- task responsibles
-"""
-
 from opengever.activity.model import Activity
 from opengever.activity.model import Notification
 from opengever.activity.model import Watcher

--- a/opengever/usermigration/ogds_references.py
+++ b/opengever/usermigration/ogds_references.py
@@ -7,6 +7,7 @@ from opengever.base.model.favorite import Favorite
 from opengever.globalindex.model.reminder_settings import ReminderSetting
 from opengever.globalindex.model.task import Task
 from opengever.globalindex.model.task import TaskPrincipal
+from opengever.meeting.model import Meeting
 from opengever.ogds.models.service import ogds_service
 from opengever.ogds.models.user import User
 from opengever.ogds.models.user_settings import UserSettings
@@ -43,6 +44,7 @@ class OGDSUserReferencesMigrator(object):
         self.user_settings_moved = []
         self.favorites_moved = []
         self.reminders_moved = []
+        self.secretaries_moved = []
 
     def _verify_user(self, userid):
         ogds_user = ogds_service().fetch_user(userid)
@@ -161,6 +163,12 @@ class OGDSUserReferencesMigrator(object):
                     old_userid, new_userid)
                 self.reminders_moved.extend(moved)
 
+                # Migrate meeting secretary
+                moved = self._migrate_sql_column(
+                    Meeting.__table__, 'secretary_id',
+                    old_userid, new_userid)
+                self.secretaries_moved.extend(moved)
+
         results = {
             'activity_actors': {
                 'moved': self.activity_actors_moved,
@@ -200,6 +208,10 @@ class OGDSUserReferencesMigrator(object):
                 'deleted': []},
             'reminders': {
                 'moved': self.reminders_moved,
+                'copied': [],
+                'deleted': []},
+            'secretaries': {
+                'moved': self.secretaries_moved,
                 'copied': [],
                 'deleted': []},
         }

--- a/opengever/usermigration/ogds_references.py
+++ b/opengever/usermigration/ogds_references.py
@@ -4,6 +4,7 @@ from opengever.activity.model import NotificationSetting
 from opengever.activity.model import Watcher
 from opengever.base.model import create_session
 from opengever.base.model.favorite import Favorite
+from opengever.globalindex.model.reminder_settings import ReminderSetting
 from opengever.globalindex.model.task import Task
 from opengever.globalindex.model.task import TaskPrincipal
 from opengever.ogds.models.service import ogds_service
@@ -41,6 +42,7 @@ class OGDSUserReferencesMigrator(object):
         self.task_responsibles_moved = []
         self.user_settings_moved = []
         self.favorites_moved = []
+        self.reminders_moved = []
 
     def _verify_user(self, userid):
         ogds_user = ogds_service().fetch_user(userid)
@@ -153,6 +155,12 @@ class OGDSUserReferencesMigrator(object):
                     old_userid, new_userid)
                 self.favorites_moved.extend(moved)
 
+                # Migrate task reminders
+                moved = self._migrate_sql_column(
+                    ReminderSetting.__table__, 'actor_id',
+                    old_userid, new_userid)
+                self.reminders_moved.extend(moved)
+
         results = {
             'activity_actors': {
                 'moved': self.activity_actors_moved,
@@ -188,6 +196,10 @@ class OGDSUserReferencesMigrator(object):
                 'deleted': []},
             'favorites': {
                 'moved': self.favorites_moved,
+                'copied': [],
+                'deleted': []},
+            'reminders': {
+                'moved': self.reminders_moved,
                 'copied': [],
                 'deleted': []},
         }

--- a/opengever/usermigration/ogds_references.py
+++ b/opengever/usermigration/ogds_references.py
@@ -6,6 +6,7 @@ from opengever.globalindex.model.task import Task
 from opengever.globalindex.model.task import TaskPrincipal
 from opengever.ogds.models.service import ogds_service
 from opengever.ogds.models.user import User
+from opengever.ogds.models.user_settings import UserSettings
 from opengever.usermigration.exceptions import UserMigrationException
 from operator import itemgetter
 from sqlalchemy import select
@@ -35,6 +36,7 @@ class OGDSUserReferencesMigrator(object):
         self.task_principals_moved = []
         self.task_issuers_moved = []
         self.task_responsibles_moved = []
+        self.user_settings_moved = []
 
     def _verify_user(self, userid):
         ogds_user = ogds_service().fetch_user(userid)
@@ -129,6 +131,12 @@ class OGDSUserReferencesMigrator(object):
                     old_userid, new_userid)
                 self.task_responsibles_moved.extend(moved)
 
+                # Migrate user settings
+                moved = self._migrate_sql_column(
+                    UserSettings.__table__, 'userid',
+                    old_userid, new_userid)
+                self.user_settings_moved.extend(moved)
+
         results = {
             'activity_actors': {
                 'moved': self.activity_actors_moved,
@@ -154,6 +162,9 @@ class OGDSUserReferencesMigrator(object):
                 'moved': self.task_responsibles_moved,
                 'copied': [],
                 'deleted': []},
-
+            'user_settings': {
+                'moved': self.user_settings_moved,
+                'copied': [],
+                'deleted': []},
         }
         return results

--- a/opengever/usermigration/ogds_references.py
+++ b/opengever/usermigration/ogds_references.py
@@ -1,5 +1,6 @@
 from opengever.activity.model import Activity
 from opengever.activity.model import Notification
+from opengever.activity.model import NotificationSetting
 from opengever.activity.model import Watcher
 from opengever.base.model import create_session
 from opengever.globalindex.model.task import Task
@@ -33,6 +34,7 @@ class OGDSUserReferencesMigrator(object):
         self.activity_actors_moved = []
         self.watcher_actors_moved = []
         self.notification_userids_moved = []
+        self.notification_setting_userids_moved = []
         self.task_principals_moved = []
         self.task_issuers_moved = []
         self.task_responsibles_moved = []
@@ -107,6 +109,12 @@ class OGDSUserReferencesMigrator(object):
                     old_userid, new_userid)
                 self.notification_userids_moved.extend(moved)
 
+                # Migrate notification settings
+                moved = self._migrate_sql_column(
+                    NotificationSetting.__table__, 'userid',
+                    old_userid, new_userid)
+                self.notification_setting_userids_moved.extend(moved)
+
                 # Migrate watcher actors
                 moved = self._migrate_sql_column(
                     Watcher.__table__, 'actorid',
@@ -148,6 +156,10 @@ class OGDSUserReferencesMigrator(object):
                 'deleted': []},
             'notification_userids': {
                 'moved': self.notification_userids_moved,
+                'copied': [],
+                'deleted': []},
+            'notification_setting_userids': {
+                'moved': self.notification_setting_userids_moved,
                 'copied': [],
                 'deleted': []},
             'task_principals': {

--- a/opengever/usermigration/ogds_references.py
+++ b/opengever/usermigration/ogds_references.py
@@ -8,6 +8,7 @@ from opengever.globalindex.model.reminder_settings import ReminderSetting
 from opengever.globalindex.model.task import Task
 from opengever.globalindex.model.task import TaskPrincipal
 from opengever.meeting.model import Meeting
+from opengever.meeting.model import Proposal
 from opengever.ogds.models.service import ogds_service
 from opengever.ogds.models.user import User
 from opengever.ogds.models.user_settings import UserSettings
@@ -45,6 +46,7 @@ class OGDSUserReferencesMigrator(object):
         self.favorites_moved = []
         self.reminders_moved = []
         self.secretaries_moved = []
+        self.proposal_issuers_moved = []
 
     def _verify_user(self, userid):
         ogds_user = ogds_service().fetch_user(userid)
@@ -169,6 +171,12 @@ class OGDSUserReferencesMigrator(object):
                     old_userid, new_userid)
                 self.secretaries_moved.extend(moved)
 
+                # Migrate proposal issuer
+                moved = self._migrate_sql_column(
+                    Proposal.__table__, 'issuer',
+                    old_userid, new_userid)
+                self.proposal_issuers_moved.extend(moved)
+
         results = {
             'activity_actors': {
                 'moved': self.activity_actors_moved,
@@ -212,6 +220,10 @@ class OGDSUserReferencesMigrator(object):
                 'deleted': []},
             'secretaries': {
                 'moved': self.secretaries_moved,
+                'copied': [],
+                'deleted': []},
+            'proposal_issuers': {
+                'moved': self.proposal_issuers_moved,
                 'copied': [],
                 'deleted': []},
         }

--- a/opengever/usermigration/ogds_references.py
+++ b/opengever/usermigration/ogds_references.py
@@ -3,6 +3,7 @@ from opengever.activity.model import Notification
 from opengever.activity.model import NotificationSetting
 from opengever.activity.model import Watcher
 from opengever.base.model import create_session
+from opengever.base.model.favorite import Favorite
 from opengever.globalindex.model.task import Task
 from opengever.globalindex.model.task import TaskPrincipal
 from opengever.ogds.models.service import ogds_service
@@ -39,6 +40,7 @@ class OGDSUserReferencesMigrator(object):
         self.task_issuers_moved = []
         self.task_responsibles_moved = []
         self.user_settings_moved = []
+        self.favorites_moved = []
 
     def _verify_user(self, userid):
         ogds_user = ogds_service().fetch_user(userid)
@@ -145,6 +147,12 @@ class OGDSUserReferencesMigrator(object):
                     old_userid, new_userid)
                 self.user_settings_moved.extend(moved)
 
+                # Migrate favorites
+                moved = self._migrate_sql_column(
+                    Favorite.__table__, 'userid',
+                    old_userid, new_userid)
+                self.favorites_moved.extend(moved)
+
         results = {
             'activity_actors': {
                 'moved': self.activity_actors_moved,
@@ -176,6 +184,10 @@ class OGDSUserReferencesMigrator(object):
                 'deleted': []},
             'user_settings': {
                 'moved': self.user_settings_moved,
+                'copied': [],
+                'deleted': []},
+            'favorites': {
+                'moved': self.favorites_moved,
                 'copied': [],
                 'deleted': []},
         }

--- a/opengever/usermigration/plone_tasks.py
+++ b/opengever/usermigration/plone_tasks.py
@@ -26,9 +26,9 @@ class PloneTasksMigrator(BasePloneObjectAttributesMigrator):
     interface_to_query = ITask
     interface_to_adapt = ITask
 
-    def __init__(self, portal, principal_mapping, mode='move', strict=True):
+    def __init__(self, portal, principal_mapping, mode='move'):
         super(PloneTasksMigrator, self).__init__(
-            portal, principal_mapping, mode=mode, strict=strict
+            portal, principal_mapping, mode=mode
         )
 
         self.response_moves = {

--- a/opengever/usermigration/private_folders.py
+++ b/opengever/usermigration/private_folders.py
@@ -2,6 +2,7 @@
 Migrate private folders and their contents for renamed users.
 """
 
+from opengever.usermigration.base import BaseUserMigration
 from plone import api
 import logging
 
@@ -13,17 +14,7 @@ def objpath(obj):
     return '/'.join(obj.getPhysicalPath())
 
 
-class PrivateFoldersMigrator(object):
-
-    def __init__(self, portal, principal_mapping, mode='move', strict=True):
-        self.portal = portal
-        self.principal_mapping = principal_mapping
-
-        if mode != 'move':
-            raise NotImplementedError(
-                "PrivateFoldersMigrator only supports 'move' mode")
-        self.mode = mode
-        self.strict = strict
+class PrivateFoldersMigrator(BaseUserMigration):
 
     def migrate(self):
         mtool = api.portal.get_tool('portal_membership')

--- a/opengever/usermigration/proposals.py
+++ b/opengever/usermigration/proposals.py
@@ -1,0 +1,9 @@
+from opengever.meeting.proposal import IBaseProposal
+from opengever.usermigration.base import BasePloneObjectAttributesMigrator
+
+
+class ProposalsMigrator(BasePloneObjectAttributesMigrator):
+
+    fields_to_migrate = ('issuer',)
+    interface_to_query = IBaseProposal
+    interface_to_adapt = IBaseProposal

--- a/opengever/usermigration/recently_touched.py
+++ b/opengever/usermigration/recently_touched.py
@@ -1,0 +1,46 @@
+from opengever.base.touched import RECENTLY_TOUCHED_KEY
+from zope.annotation import IAnnotations
+import logging
+
+
+logger = logging.getLogger('opengever.usermigration')
+
+
+class RecentlyTouchedMigrator(object):
+
+    def __init__(self, portal, principal_mapping, mode='move', strict=True):
+        self.portal = portal
+        self.principal_mapping = principal_mapping
+
+        if mode != 'move':
+            raise NotImplementedError(
+                "RecentlyTouchedMigrator only supports 'move' mode")
+        self.mode = mode
+        self.strict = strict
+
+    def migrate(self):
+        annotations = IAnnotations(self.portal)
+        touched_store = annotations.get(RECENTLY_TOUCHED_KEY)
+        if not touched_store:
+            return
+
+        recently_touched_moves = []
+
+        for old_userid, new_userid in self.principal_mapping.items():
+            if old_userid not in touched_store:
+                continue
+
+            touched_store[new_userid] = touched_store[old_userid]
+            del touched_store[old_userid]
+
+            recently_touched_moves.append(
+                ('recently_touched', old_userid, new_userid)
+            )
+
+        results = {
+            'recently_touched': {
+                'moved': recently_touched_moves,
+                'copied': [],
+                'deleted': []},
+        }
+        return results

--- a/opengever/usermigration/recently_touched.py
+++ b/opengever/usermigration/recently_touched.py
@@ -1,4 +1,5 @@
 from opengever.base.touched import RECENTLY_TOUCHED_KEY
+from opengever.usermigration.base import BaseUserMigration
 from zope.annotation import IAnnotations
 import logging
 
@@ -6,17 +7,7 @@ import logging
 logger = logging.getLogger('opengever.usermigration')
 
 
-class RecentlyTouchedMigrator(object):
-
-    def __init__(self, portal, principal_mapping, mode='move', strict=True):
-        self.portal = portal
-        self.principal_mapping = principal_mapping
-
-        if mode != 'move':
-            raise NotImplementedError(
-                "RecentlyTouchedMigrator only supports 'move' mode")
-        self.mode = mode
-        self.strict = strict
+class RecentlyTouchedMigrator(BaseUserMigration):
 
     def migrate(self):
         annotations = IAnnotations(self.portal)

--- a/opengever/usermigration/task_templates.py
+++ b/opengever/usermigration/task_templates.py
@@ -1,84 +1,10 @@
-from opengever.ogds.models.service import ogds_service
 from opengever.tasktemplates.content.tasktemplate import ITaskTemplate
-from opengever.usermigration.exceptions import UserMigrationException
-from plone import api
-import logging
+from opengever.usermigration.base import BasePloneObjectAttributesMigrator
 
 
-logger = logging.getLogger('opengever.usermigration')
-
-FIELDS_TO_CHECK = ('responsible', 'issuer')
-
-
-class TaskTemplateMigrator(object):
+class TaskTemplateMigrator(BasePloneObjectAttributesMigrator):
     """Migrate the `issuer` and `responsible` fields on task templates."""
 
-    def __init__(self, portal, principal_mapping, mode='move', strict=True):
-        self.portal = portal
-        self.principal_mapping = principal_mapping
-
-        if mode != 'move':
-            raise NotImplementedError(
-                "TaskTemplateMigrator only supports 'move' mode")
-        self.mode = mode
-        self.strict = strict
-
-        # Keep track of tasktemplates that need reindexing
-        self.to_reindex = set()
-
-        self.task_moves = {
-            'responsible': [],
-            'issuer': [],
-        }
-
-    def _verify_user(self, userid):
-        ogds_user = ogds_service().fetch_user(userid)
-        if ogds_user is None:
-            msg = "User '{}' not found in OGDS!".format(userid)
-            raise UserMigrationException(msg)
-
-    def _migrate_plone_task(self, obj):
-        task = ITaskTemplate(obj)
-
-        for field_name in FIELDS_TO_CHECK:
-            # Check 'responsible' and 'issuer' fields
-            old_userid = getattr(task, field_name, None)
-
-            if old_userid in self.principal_mapping:
-                path = '/'.join(obj.getPhysicalPath())
-                logger.info('Fixing %r for %s' % (field_name, path))
-                new_userid = self.principal_mapping[old_userid]
-                setattr(task, field_name, new_userid)
-                self.to_reindex.add(obj)
-                self.task_moves[field_name].append(
-                    (path, old_userid, new_userid))
-
-    def migrate(self):
-        catalog = api.portal.get_tool('portal_catalog')
-
-        # Verify all new users exist before doing anything
-        for old_userid, new_userid in self.principal_mapping.items():
-            self._verify_user(new_userid)
-
-        all_tasks = [b.getObject() for b in catalog.unrestrictedSearchResults(
-            object_provides=ITaskTemplate.__identifier__)]
-
-        for obj in all_tasks:
-            self._migrate_plone_task(obj)
-
-        for obj in self.to_reindex:
-            # Reindex 'responsible' and 'issuer' for changed objects.
-            logger.info('Reindexing %s' % '/'.join(obj.getPhysicalPath()))
-            obj.reindexObject(idxs=FIELDS_TO_CHECK)
-
-        results = {
-            'task_issuers': {
-                'moved': self.task_moves['issuer'],
-                'copied': [],
-                'deleted': []},
-            'task_responsibles': {
-                'moved': self.task_moves['responsible'],
-                'copied': [],
-                'deleted': []},
-        }
-        return results
+    fields_to_migrate = ('responsible', 'issuer')
+    interface_to_query = ITaskTemplate
+    interface_to_adapt = ITaskTemplate

--- a/opengever/usermigration/task_templates.py
+++ b/opengever/usermigration/task_templates.py
@@ -1,0 +1,84 @@
+from opengever.ogds.models.service import ogds_service
+from opengever.tasktemplates.content.tasktemplate import ITaskTemplate
+from opengever.usermigration.exceptions import UserMigrationException
+from plone import api
+import logging
+
+
+logger = logging.getLogger('opengever.usermigration')
+
+FIELDS_TO_CHECK = ('responsible', 'issuer')
+
+
+class TaskTemplateMigrator(object):
+    """Migrate the `issuer` and `responsible` fields on task templates."""
+
+    def __init__(self, portal, principal_mapping, mode='move', strict=True):
+        self.portal = portal
+        self.principal_mapping = principal_mapping
+
+        if mode != 'move':
+            raise NotImplementedError(
+                "TaskTemplateMigrator only supports 'move' mode")
+        self.mode = mode
+        self.strict = strict
+
+        # Keep track of tasktemplates that need reindexing
+        self.to_reindex = set()
+
+        self.task_moves = {
+            'responsible': [],
+            'issuer': [],
+        }
+
+    def _verify_user(self, userid):
+        ogds_user = ogds_service().fetch_user(userid)
+        if ogds_user is None:
+            msg = "User '{}' not found in OGDS!".format(userid)
+            raise UserMigrationException(msg)
+
+    def _migrate_plone_task(self, obj):
+        task = ITaskTemplate(obj)
+
+        for field_name in FIELDS_TO_CHECK:
+            # Check 'responsible' and 'issuer' fields
+            old_userid = getattr(task, field_name, None)
+
+            if old_userid in self.principal_mapping:
+                path = '/'.join(obj.getPhysicalPath())
+                logger.info('Fixing %r for %s' % (field_name, path))
+                new_userid = self.principal_mapping[old_userid]
+                setattr(task, field_name, new_userid)
+                self.to_reindex.add(obj)
+                self.task_moves[field_name].append(
+                    (path, old_userid, new_userid))
+
+    def migrate(self):
+        catalog = api.portal.get_tool('portal_catalog')
+
+        # Verify all new users exist before doing anything
+        for old_userid, new_userid in self.principal_mapping.items():
+            self._verify_user(new_userid)
+
+        all_tasks = [b.getObject() for b in catalog.unrestrictedSearchResults(
+            object_provides=ITaskTemplate.__identifier__)]
+
+        for obj in all_tasks:
+            self._migrate_plone_task(obj)
+
+        for obj in self.to_reindex:
+            # Reindex 'responsible' and 'issuer' for changed objects.
+            logger.info('Reindexing %s' % '/'.join(obj.getPhysicalPath()))
+            obj.reindexObject(idxs=FIELDS_TO_CHECK)
+
+        results = {
+            'task_issuers': {
+                'moved': self.task_moves['issuer'],
+                'copied': [],
+                'deleted': []},
+            'task_responsibles': {
+                'moved': self.task_moves['responsible'],
+                'copied': [],
+                'deleted': []},
+        }
+        return results

--- a/opengever/usermigration/tests/test_creator_migrator.py
+++ b/opengever/usermigration/tests/test_creator_migrator.py
@@ -65,20 +65,12 @@ class TestCreatorMigrator(FunctionalTestCase):
         self.assertEquals('new.user', obj2brain(self.dossier).Creator)
         self.assertEquals('new.user', obj2brain(self.doc).Creator)
 
-    def test_raises_if_strict_and_user_doesnt_exist(self):
+    def test_raises_if_user_doesnt_exist(self):
         migrator = CreatorMigrator(
             self.portal, {'old.user': 'doesnt.exist'}, 'move')
 
         with self.assertRaises(UserMigrationException):
             migrator.migrate()
-
-    def test_doesnt_raise_if_not_strict_and_user_doesnt_exist(self):
-        migrator = CreatorMigrator(
-            self.portal, {'old.user': 'doesnt.exist'}, 'move', strict=False)
-
-        migrator.migrate()
-        self.assertEquals(('doesnt.exist', ), self.dossier.creators)
-        self.assertEquals(('doesnt.exist', ), self.doc.creators)
 
     def test_returns_proper_results_for_moving_creator(self):
         migrator = CreatorMigrator(

--- a/opengever/usermigration/tests/test_dictstorage_migrator.py
+++ b/opengever/usermigration/tests/test_dictstorage_migrator.py
@@ -51,7 +51,7 @@ class TestDictstorageMigrator(FunctionalTestCase):
         self.assertEquals('ftw.tabbedview-foo-tabbedview_view-bar-new-user',
                           entry.key)
 
-    def test_raises_if_strict_and_user_doesnt_exist(self):
+    def test_raises_if_user_doesnt_exist(self):
         entry = DictStorageModel(key='foo-old.user', value='{}')
         self.session.add(entry)
         migrator = DictstorageMigrator(
@@ -60,20 +60,11 @@ class TestDictstorageMigrator(FunctionalTestCase):
         with self.assertRaises(UserMigrationException):
             migrator.migrate()
 
-    def test_doesnt_raise_if_not_strict_and_user_doesnt_exist(self):
-        entry = DictStorageModel(key='bar-old.user', value='{}')
-        self.session.add(entry)
-        migrator = DictstorageMigrator(
-            self.portal, {'old.user': 'doesnt.exist'}, 'move', strict=False)
-
-        migrator.migrate()
-        self.assertEquals('bar-doesnt.exist', entry.key)
-
     def test_returns_proper_results_for_moving_keys(self):
         entry = DictStorageModel(key='baz-old.user', value='{}')
         self.session.add(entry)
         migrator = DictstorageMigrator(
-            self.portal, {'old.user': 'new.user'}, 'move', strict=False)
+            self.portal, {'old.user': 'new.user'}, 'move')
 
         results = migrator.migrate()
         self.assertIn(

--- a/opengever/usermigration/tests/test_dossier_migrator.py
+++ b/opengever/usermigration/tests/test_dossier_migrator.py
@@ -43,19 +43,12 @@ class TestDossierMigratorForResponsible(FunctionalTestCase):
         # Metadata should be up to date
         self.assertEquals('new.user', obj2brain(self.dossier).responsible)
 
-    def test_raises_if_strict_and_user_doesnt_exist(self):
+    def test_raises_if_user_doesnt_exist(self):
         migrator = DossierMigrator(
             self.portal, {'old.user': 'doesnt.exist'}, 'move')
 
         with self.assertRaises(UserMigrationException):
             migrator.migrate()
-
-    def test_doesnt_raise_if_not_strict_and_user_doesnt_exist(self):
-        migrator = DossierMigrator(
-            self.portal, {'old.user': 'doesnt.exist'}, 'move', strict=False)
-
-        migrator.migrate()
-        self.assertEquals('doesnt.exist', IDossier(self.dossier).responsible)
 
     def test_returns_proper_results_for_moving_responsibles(self):
         migrator = DossierMigrator(
@@ -136,22 +129,12 @@ class TestDossierMigratorForParticipants(FunctionalTestCase):
         self.assertEquals('contact:old-contact',
                           self.phandler.get_participations()[-1].contact)
 
-    def test_raises_if_strict_and_user_doesnt_exist(self):
+    def test_raises_if_user_doesnt_exist(self):
         migrator = DossierMigrator(
             self.portal, {'old.participant': 'doesnt.exist'}, 'move')
 
         with self.assertRaises(UserMigrationException):
             migrator.migrate()
-
-    def test_doesnt_raise_if_not_strict_and_user_doesnt_exist(self):
-        migrator = DossierMigrator(
-            self.portal, {'old.participant': 'doesnt.exist'},
-            'move', strict=False)
-
-        migrator.migrate()
-
-        self.assertEquals('doesnt.exist',
-                          self.phandler.get_participations()[0].contact)
 
     def test_returns_proper_results_for_moving_participants(self):
         migrator = DossierMigrator(

--- a/opengever/usermigration/tests/test_migration.py
+++ b/opengever/usermigration/tests/test_migration.py
@@ -1,0 +1,100 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from ftw.usermigration.tests.test_migration_form import make_mapping
+from opengever.document.interfaces import ICheckinCheckoutManager
+from opengever.dossier.behaviors.dossier import IDossier
+from opengever.testing import IntegrationTestCase
+from opengever.testing import obj2brain
+from zope.component import getMultiAdapter
+
+
+PRE_MIGRATION_HOOKS = [
+    'GEVER: Checked out documents (checked_out_by and WebDAV locks)',
+    'GEVER: Creators (obj.creators for all objects)',
+    'GEVER: Dictstorage (SQL)',
+    'GEVER: Dossiers (responsibles and participations)',
+    'GEVER: OGDS Groups (users and inbox groups on OrgUnits)',
+    'GEVER: OGDS User References (activities, tasks)',
+    'GEVER: Plone Tasks (issuers, responsibles, responses)',
+    'GEVER: Private Folders',
+    'GEVER: Proposals and submitted proposals',
+    'GEVER: Recently touched objects',
+    'GEVER: Tasks templates (issuers, responsibles)',
+]
+
+
+class TestUserMigrationForm(IntegrationTestCase):
+
+    maxDiff = None
+
+    def setUp(self):
+        super(TestUserMigrationForm, self).setUp()
+
+        self.new_user = create(Builder('user')
+            .named('Hans', 'Muster')
+            .with_roles(['Member'])
+        )
+        self.new_ogds_user = create(Builder('ogds_user')
+            .id(self.new_user.getId())
+            .having(active=True)
+        )
+
+    @browsing
+    def test_lists_all_pre_migration_hooks(self, browser):
+        self.login(self.manager, browser=browser)
+        browser.visit(view='user-migration')
+        self.assertItemsEqual(
+            PRE_MIGRATION_HOOKS,
+            browser.css('#form-widgets-pre_migration_hooks .option').text,
+        )
+
+    @browsing
+    def test_runs_pre_migrations_via_browser(self, browser):
+        self.login(self.dossier_responsible)
+        ci_co_manager = getMultiAdapter((self.document, self.request),
+                                  ICheckinCheckoutManager)
+        ci_co_manager.checkout()
+
+        self.login(self.manager, browser=browser)
+        browser.visit(view='user-migration')
+
+        mapping = make_mapping(
+            {
+                self.dossier_responsible.getId(): self.new_user.getId(),
+            }
+        )
+        browser.fill(
+            {'Manual Principal Mapping': mapping,
+             'Migrations': ['globalroles', 'localroles'],
+             'Pre-Migration Hooks': PRE_MIGRATION_HOOKS}
+        ).submit()
+
+        self.assertEqual('hans.muster', ci_co_manager.get_checked_out_by())
+        self.assertEqual('hans.muster', obj2brain(self.document).checked_out)
+
+        self.assertIn('hans.muster', self.document.creators)
+        self.assertIn('hans.muster', self.dossier.creators)
+
+        self.assertEqual('hans.muster', self.proposal.issuer)
+        self.assertEqual('hans.muster', self.proposal.load_model().issuer)
+        self.assertEqual('hans.muster', self.submitted_proposal.issuer)
+        self.assertEqual('hans.muster', self.submitted_proposal.load_model().issuer)
+
+        self.assertEqual('hans.muster', self.task.issuer)
+        self.assertEqual('hans.muster', self.task.get_sql_object().issuer)
+        self.assertEqual('hans.muster', self.meeting_task.issuer)
+        self.assertEqual('hans.muster', self.meeting_task.get_sql_object().issuer)
+        self.assertEqual('hans.muster', self.inbox_task.issuer)
+        self.assertEqual('hans.muster', self.inbox_task.get_sql_object().issuer)
+
+        self.assertEqual('hans.muster', self.inbox_forwarding.issuer)
+        self.assertEqual('hans.muster', self.inbox_forwarding.get_sql_object().issuer)
+
+        self.assertEqual('hans.muster', IDossier(self.dossier).responsible)
+        self.assertEqual('hans.muster', IDossier(self.expired_dossier).responsible)
+        self.assertEqual('hans.muster', IDossier(self.inactive_dossier).responsible)
+        self.assertEqual('hans.muster', IDossier(self.offered_dossier_to_archive).responsible)
+        self.assertEqual('hans.muster', IDossier(self.offered_dossier_for_sip).responsible)
+        self.assertEqual('hans.muster', IDossier(self.offered_dossier_to_destroy).responsible)
+        self.assertEqual('hans.muster', IDossier(self.protected_dossier).responsible)

--- a/opengever/usermigration/tests/test_ogds_references_migrator.py
+++ b/opengever/usermigration/tests/test_ogds_references_migrator.py
@@ -137,3 +137,17 @@ class TestOGDSUserReferencesMigrator(FunctionalTestCase):
 
         create_session().refresh(favorite)
         self.assertEqual(favorite.userid, 'hans.muster')
+
+    def test_migrates_reminder_settings(self):
+        task = create(Builder('task'))
+        reminder = create(
+            Builder('reminder_setting_model')
+            .for_object(task)
+            .having(actor_id='HANS.MUSTER')
+        )
+
+        OGDSUserReferencesMigrator(
+            self.portal, {'HANS.MUSTER': 'hans.muster'}, 'move').migrate()
+
+        create_session().refresh(reminder)
+        self.assertEqual('hans.muster', reminder.actor_id)

--- a/opengever/usermigration/tests/test_ogds_references_migrator.py
+++ b/opengever/usermigration/tests/test_ogds_references_migrator.py
@@ -2,6 +2,8 @@ from ftw.builder import Builder
 from ftw.builder import create
 from opengever.activity.model.settings import NotificationSetting
 from opengever.base.model import create_session
+from opengever.base.model.favorite import Favorite
+from opengever.base.oguid import Oguid
 from opengever.ogds.models.user_settings import UserSettings
 from opengever.testing import FunctionalTestCase
 from opengever.usermigration.ogds_references import OGDSUserReferencesMigrator
@@ -119,3 +121,19 @@ class TestOGDSUserReferencesMigrator(FunctionalTestCase):
         self.assertEqual(1, len(settings))
         setting = settings[0]
         self.assertEqual(setting.userid, 'hans.muster')
+
+    def test_migrates_favorites(self):
+        favorite = Favorite(
+            oguid=Oguid.parse('fd:123'),
+            userid='HANS.MUSTER',
+            title=u'fixture fav 01',
+            plone_uid='1234'
+        )
+        create_session().add(favorite)
+        create_session().flush()
+
+        OGDSUserReferencesMigrator(
+            self.portal, {'HANS.MUSTER': 'hans.muster'}, 'move').migrate()
+
+        create_session().refresh(favorite)
+        self.assertEqual(favorite.userid, 'hans.muster')

--- a/opengever/usermigration/tests/test_ogds_references_migrator.py
+++ b/opengever/usermigration/tests/test_ogds_references_migrator.py
@@ -163,3 +163,14 @@ class TestOGDSUserReferencesMigrator(FunctionalTestCase):
 
         create_session().refresh(meeting)
         self.assertEqual('hans.muster', meeting.secretary_id)
+
+    def test_migrates_proposal_issuer(self):
+        proposal = create(Builder('proposal_model').having(
+            issuer='HANS.MUSTER')
+        )
+
+        OGDSUserReferencesMigrator(
+            self.portal, {'HANS.MUSTER': 'hans.muster'}, 'move').migrate()
+
+        create_session().refresh(proposal)
+        self.assertEqual('hans.muster', proposal.issuer)

--- a/opengever/usermigration/tests/test_ogds_references_migrator.py
+++ b/opengever/usermigration/tests/test_ogds_references_migrator.py
@@ -1,5 +1,6 @@
 from ftw.builder import Builder
 from ftw.builder import create
+from opengever.activity.model.settings import NotificationSetting
 from opengever.base.model import create_session
 from opengever.ogds.models.user_settings import UserSettings
 from opengever.testing import FunctionalTestCase
@@ -102,3 +103,19 @@ class TestOGDSUserReferencesMigrator(FunctionalTestCase):
         setting = settings[0]
         self.assertEqual(setting.userid, 'hans.muster')
         self.assertTrue(setting.notify_own_actions)
+
+    def test_migrates_notification_settings(self):
+        create(Builder('notification_setting')
+               .having(kind='task-added-or-reassigned',
+                       userid='HANS.MUSTER',
+                       mail_notification_roles=[],
+                       badge_notification_roles=[],
+                       digest_notification_roles=[]))
+
+        OGDSUserReferencesMigrator(
+            self.portal, {'HANS.MUSTER': 'hans.muster'}, 'move').migrate()
+
+        settings = NotificationSetting.query.all()
+        self.assertEqual(1, len(settings))
+        setting = settings[0]
+        self.assertEqual(setting.userid, 'hans.muster')

--- a/opengever/usermigration/tests/test_ogds_references_migrator.py
+++ b/opengever/usermigration/tests/test_ogds_references_migrator.py
@@ -151,3 +151,15 @@ class TestOGDSUserReferencesMigrator(FunctionalTestCase):
 
         create_session().refresh(reminder)
         self.assertEqual('hans.muster', reminder.actor_id)
+
+    def test_migrates_meeting_secretary(self):
+        committee = create(Builder('committee_model'))
+        meeting = create(Builder('meeting').having(
+            committee=committee, secretary=self.old_ogds_user)
+        )
+
+        OGDSUserReferencesMigrator(
+            self.portal, {'HANS.MUSTER': 'hans.muster'}, 'move').migrate()
+
+        create_session().refresh(meeting)
+        self.assertEqual('hans.muster', meeting.secretary_id)

--- a/opengever/usermigration/tests/test_proposals_migrator.py
+++ b/opengever/usermigration/tests/test_proposals_migrator.py
@@ -1,0 +1,26 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.testing import IntegrationTestCase
+from opengever.usermigration.proposals import ProposalsMigrator
+
+
+class TestProposalsMigrator(IntegrationTestCase):
+
+    def setUp(self):
+        super(TestProposalsMigrator, self).setUp()
+
+        self.new_ogds_user = create(Builder('ogds_user')
+                                    .id('hans.muster')
+                                    .having(active=True))
+
+    def test_migrates_proposal_issuers(self):
+        self.login(self.manager)
+
+        ProposalsMigrator(
+            self.portal,
+            {self.dossier_responsible.getId(): 'hans.muster'},
+            'move'
+        ).migrate()
+
+        self.assertEquals('hans.muster', self.proposal.issuer)
+        self.assertEquals('hans.muster', self.submitted_proposal.issuer)

--- a/opengever/usermigration/tests/test_recently_touched_migrator.py
+++ b/opengever/usermigration/tests/test_recently_touched_migrator.py
@@ -1,0 +1,24 @@
+from opengever.base.touched import ObjectTouchedHandler
+from opengever.base.touched import RECENTLY_TOUCHED_KEY
+from opengever.testing import FunctionalTestCase
+from opengever.usermigration.recently_touched import RecentlyTouchedMigrator
+from zope.annotation import IAnnotations
+
+
+class TestRecentlyTouchedMigrator(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestRecentlyTouchedMigrator, self).setUp()
+        self.portal = self.layer['portal']
+
+        ObjectTouchedHandler().ensure_log_initialized('HANS.MUSTER')
+
+    def test_migrates_recently_touched(self):
+        RecentlyTouchedMigrator(
+            self.portal, {'HANS.MUSTER': 'hans.muster'}, 'move').migrate()
+
+        annotations = IAnnotations(self.portal)
+        touched_store = annotations.get(RECENTLY_TOUCHED_KEY)
+
+        self.assertIn('hans.muster', touched_store)
+        self.assertNotIn('HANS.MUSTER', touched_store)

--- a/opengever/usermigration/tests/test_task_template_migrator.py
+++ b/opengever/usermigration/tests/test_task_template_migrator.py
@@ -1,0 +1,36 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.testing import FunctionalTestCase
+from opengever.usermigration.task_templates import TaskTemplateMigrator
+
+
+class TestTaskTemplateMigrator(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestTaskTemplateMigrator, self).setUp()
+        self.portal = self.layer['portal']
+
+        self.old_ogds_user = create(Builder('ogds_user')
+                                    .id('HANS.MUSTER')
+                                    .having(active=False))
+        self.new_ogds_user = create(Builder('ogds_user')
+                                    .id('hans.muster')
+                                    .having(active=True))
+
+    def test_migrates_plone_tasktemplate_responsibles(self):
+        tasktemplate = create(Builder('tasktemplate')
+                      .having(responsible='HANS.MUSTER'))
+
+        TaskTemplateMigrator(
+            self.portal, {'HANS.MUSTER': 'hans.muster'}, 'move').migrate()
+
+        self.assertEquals('hans.muster', tasktemplate.responsible)
+
+    def test_migrates_plone_tasktemplate_issuers(self):
+        tasktemplate = create(Builder('tasktemplate')
+                      .having(issuer='HANS.MUSTER'))
+
+        TaskTemplateMigrator(
+            self.portal, {'HANS.MUSTER': 'hans.muster'}, 'move').migrate()
+
+        self.assertEquals('hans.muster', tasktemplate.issuer)


### PR DESCRIPTION
This PR adds support for additional usermigrations using `ftw.usermigration` pre migration hooks.

The following migrations are added:
- `UserSettings` `userid`
- `NotificationSetting` `userid`
- `Favorite` `userid`
- Recently touched objects in Plone site annotations
- Task reminders stored in tasks and ogds
- `TaskTemplate` `responsible`
- `Meeting` `secretary`
- `Proposal` and `SubmittedProposal` `issuer`

We also improve by:
- Adding a base class for all migrations
- Adding a base migration class for plone content object attribute migrations
- Running a migration against the test fixture (currently for one user only)
- Yank out an unused `strict` argument. Pre-migration hooks are called with just mapping and mode https://github.com/4teamwork/ftw.usermigration/blob/9fc23a52dc6e3c95b10e89e6c2d043663cd650dd/ftw/usermigration/browser/migration.py#L299 so the argument has been unusable for quite a while

✅   &nbsp;Did a localtestrun via the `@@user-migration` view for all above cases.

Jira: https://4teamwork.atlassian.net/browse/CA-2016

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._
