### PR TITLE
Cleanup mail workflow_history for mail created before 2016.

### DIFF
--- a/changes/CA-2095.bugfix
+++ b/changes/CA-2095.bugfix
@@ -1,0 +1,1 @@
+Cleanup mail workflow_history for mails created before 2016. [phgross]

--- a/opengever/core/upgrades/20210611084449_fix_mail_review_history/upgrade.py
+++ b/opengever/core/upgrades/20210611084449_fix_mail_review_history/upgrade.py
@@ -1,0 +1,49 @@
+from ftw.upgrade import UpgradeStep
+from plone import api
+from Products.CMFCore.WorkflowCore import WorkflowException
+from datetime import datetime
+from DateTime import DateTime
+
+
+
+class FixMailReviewHistory(UpgradeStep):
+    """Fix mail review_history.
+    """
+
+    deferrable = True
+
+    def __call__(self):
+        wftool = api.portal.get_tool('portal_workflow')
+        catalog = api.portal.get_tool('portal_catalog')
+
+        # The problem has been fixed on 20 Now 2014 with the commit
+        # 3cf26ce1edf9bb665d0df6719d95b9aad32d3d53, so we calculate two
+        # additional years to make sure the change has been installed in
+        # production
+        query = {'portal_type': 'ftw.mail.mail',
+                 'created': {'query': DateTime(2016, 11, 20), 'range':'max'}}
+
+        for mail in self.objects(query, 'Fix mail review_history'):
+            try:
+                history = wftool.getInfoFor(mail, "review_history")
+            except WorkflowException:
+                continue
+
+            self.fix_workflow_history(mail)
+
+    def fix_workflow_history(self, mail):
+        wf_history = mail.workflow_history
+        if not wf_history:
+            return
+
+        if 'opengever_mail_workflow' not in wf_history:
+            return
+
+        new_history = []
+        for entry in wf_history.get('opengever_mail_workflow'):
+            if 'state' in entry.keys():
+                entry['review_state'] = entry.pop('state')
+
+            new_history.append(entry)
+
+        wf_history['opengever_mail_workflow'] = tuple(new_history)


### PR DESCRIPTION
In earlier years of GEVER the opengever_mail_workflow had used `state` instead of `review_state` as state_variable. This leads to an KeyError in plone.restapis WorklowInfo service (see https://sentry.4teamwork.ch/organizations/sentry/issues/69441). This PR adds an upgradestep which fixe the workflow_history for those mails.

https://4teamwork.atlassian.net/browse/CA-2095

The bug has been introduced with 0820123893dd8a4abf85aa3ac3cea78793035be9 and fixed with 3cf26ce1edf9bb665d0df6719d95b9aad32d3d53 so we add additional two years to make sure that the fix has been installed in production.

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

