### PR TITLE
Disable unwrapping of inbound mails.

### DIFF
--- a/changes/CA-2375.other
+++ b/changes/CA-2375.other
@@ -1,0 +1,1 @@
+Disable mail unwrapping for inbound mails. [njohner]

--- a/opengever/core/upgrades/20210611103928_disable_mail_unwrapping/registry.xml
+++ b/opengever/core/upgrades/20210611103928_disable_mail_unwrapping/registry.xml
@@ -1,0 +1,5 @@
+<registry>
+  <records interface="ftw.mail.interfaces.IMailSettings">
+        <value key="unwrap_mail">False</value>
+  </records>
+</registry>

--- a/opengever/core/upgrades/20210611103928_disable_mail_unwrapping/upgrade.py
+++ b/opengever/core/upgrades/20210611103928_disable_mail_unwrapping/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class DisableMailUnwrapping(UpgradeStep):
+    """Disable mail unwrapping.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/profiles/default/registry.xml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/profiles/default/registry.xml.bob
@@ -9,6 +9,10 @@
     <value key="is_auto_refresh_enabled">{{{setup.bumblebee_auto_refresh}}}</value>
   </records>
 
+  <records interface="ftw.mail.interfaces.IMailSettings">
+    <value key="unwrap_mail">False</value>
+  </records>
+
   <records interface="opengever.base.interfaces.ISearchSettings">
     <value key="use_solr">True</value>
   </records>


### PR DESCRIPTION
Unwrapping of inbound mails is rather confusing, notably when there are several attachments to an inbound mail, any of which being an E-mail, it will save that attachment into Gever instead of the whole E-mail. As this behavior is not necessary anymore we simply deactivate it for all deployments.

For https://4teamwork.atlassian.net/browse/CA-2375

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally