### PR TITLE
Fix solr indexing of customproperties assigned to a specific dossier_type

### DIFF
--- a/changes/CA-2406.bugfix
+++ b/changes/CA-2406.bugfix
@@ -1,0 +1,1 @@
+Fix solr indexing of customproperties assigned to a specific dossier_type. [phgross]

--- a/opengever/core/upgrades/20210615143823_reindex_customproperties_for_dossier/upgrade.py
+++ b/opengever/core/upgrades/20210615143823_reindex_customproperties_for_dossier/upgrade.py
@@ -1,0 +1,39 @@
+from ftw.solr.interfaces import ISolrConnectionManager
+from ftw.solr.interfaces import ISolrIndexHandler
+from ftw.upgrade import UpgradeStep
+from opengever.dossier.behaviors.dossier import IDossierMarker
+from opengever.propertysheets.assignment import get_dossier_assignment_slots
+from opengever.propertysheets.storage import PropertySheetSchemaStorage
+from zope.component import getMultiAdapter
+from zope.component import getUtility
+
+
+class ReindexCustompropertiesForDossier(UpgradeStep):
+    """Reindex customproperties for dossier.
+    """
+
+    deferrable = True
+
+    def __call__(self):
+        # We only need to reindex, if there are propertysheeets registered for
+        # dossiers
+        if not self.has_dossier_propertysheet_registered():
+            return
+
+        manager = getUtility(ISolrConnectionManager)
+        query = {'object_provides': IDossierMarker.__identifier__}
+        for obj in self.objects(query, 'Reindex solr customproperties'):
+            handler = getMultiAdapter((obj, manager), ISolrIndexHandler)
+            handler.add([])
+
+        manager.connection.commit(soft_commit=False, extract_after_commit=False)
+
+    def has_dossier_propertysheet_registered(self):
+        storage = PropertySheetSchemaStorage()
+        slots = get_dossier_assignment_slots()
+
+        for slot in slots:
+            if storage.query(slot):
+                return True
+
+        return False

--- a/opengever/dossier/behaviors/customproperties.py
+++ b/opengever/dossier/behaviors/customproperties.py
@@ -1,6 +1,7 @@
 from opengever.dossier import _
-from opengever.propertysheets.assignment import get_dossier_assignment_slots
+from opengever.dossier.behaviors.dossier import IDossier
 from opengever.propertysheets.assignment import DOSSIER_DEFAULT_ASSIGNMENT_SLOT
+from opengever.propertysheets.assignment import get_dossier_assignment_slots
 from opengever.propertysheets.field import PropertySheetField
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.supermodel import model
@@ -12,6 +13,7 @@ class IDossierCustomProperties(model.Schema):
     custom_properties = PropertySheetField(
         request_key='form.widgets.IDossier.dossier_type',
         attribute_name='dossier_type',
+        schema_interface=IDossier,
         assignemnt_prefix='IDossier.dossier_type',
         valid_assignment_slots_factory=get_dossier_assignment_slots,
         default_slot=DOSSIER_DEFAULT_ASSIGNMENT_SLOT,

--- a/opengever/dossier/tests/test_indexer.py
+++ b/opengever/dossier/tests/test_indexer.py
@@ -191,7 +191,7 @@ class TestDossierIndexers(SolrIntegrationTestCase):
             .assigned_to_slots(u"IDossier.dossier_type.businesscase")
             .with_field("text", u"f1", u"Field 1", u"", False)
         )
-        self.dossier.dossier_type = u"businesscase"
+        IDossier(self.dossier).dossier_type = u"businesscase"
         IDossierCustomProperties(self.dossier).custom_properties = {
             "IDossier.dossier_type.businesscase": {"f1": "indexme-businescase"},
             "IDossier.dossier_type.meeting": {"f1": "noindex-meeting"},
@@ -219,7 +219,7 @@ class TestDossierIndexers(SolrIntegrationTestCase):
             .with_field("text", u"text", u"Some lines of text", u"", True)
             .with_field("textline", u"textline", u"A line of text", u"", True)
         )
-        self.dossier.dossier_type = u"businesscase"
+        IDossier(self.dossier).dossier_type = u"businesscase"
         IDossierCustomProperties(self.dossier).custom_properties = {
             "IDossier.dossier_type.businesscase": {
                 "yesorno": False,

--- a/opengever/propertysheets/field.py
+++ b/opengever/propertysheets/field.py
@@ -49,10 +49,12 @@ class PropertySheetField(Field):
         assignemnt_prefix,
         valid_assignment_slots_factory,
         default_slot,
+        schema_interface=None,
         **kwargs
     ):
         self.request_key = request_key
         self.attribute_name = attribute_name
+        self.schema_interface = schema_interface
         self.assignemnt_prefix = assignemnt_prefix
         self.valid_assignment_slots_factory = valid_assignment_slots_factory
         self.default_slot = default_slot
@@ -96,6 +98,14 @@ class PropertySheetField(Field):
         if self.request_key in request:
             value_name = request.get(self.request_key)[0]
         elif context:
+            if self.schema_interface:
+                try:
+                    context = self.schema_interface(context)
+                except TypeError:
+                    # This happens during context creation in the old ui
+                    # when z3c forms gets initalized the context is the parent
+                    pass
+
             value_name = getattr(context, self.attribute_name, None)
 
         if not value_name:

--- a/opengever/propertysheets/tests/test_solr.py
+++ b/opengever/propertysheets/tests/test_solr.py
@@ -2,6 +2,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from opengever.document.behaviors.customproperties import IDocumentCustomProperties
 from opengever.dossier.behaviors.customproperties import IDossierCustomProperties
+from opengever.dossier.behaviors.dossier import IDossier
 from opengever.testing import solr_data_for
 from opengever.testing import SolrIntegrationTestCase
 
@@ -69,7 +70,7 @@ class TestCustomPropertiesIndexHandler(SolrIntegrationTestCase):
             .assigned_to_slots(u"IDossier.dossier_type.businesscase")
             .with_field("textline", u"f1", u"Field 1", u"", False)
         )
-        self.dossier.dossier_type = u"businesscase"
+        IDossier(self.dossier).dossier_type = u"businesscase"
         IDossierCustomProperties(self.dossier).custom_properties = {
             "IDossier.dossier_type.businesscase": {"f1": "indexme-businesscase"},
             "IDossier.default": {"additional_title": "indexme-default"},


### PR DESCRIPTION
The customproperty field tried to access the dossier_type field directly on the dossier object. But this is not possible because it is part of the IDossier behavior, wich uses AnnotationStorage. So I introduced an additional parameter attribute_interface for the customproperty field.

Fixes https://4teamwork.atlassian.net/browse/CA-2406

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- Upgrade steps:
  - [x] Make it deferrable if possible
  - [x] Execute as much as possible conditionally
