### PR TITLE
Support solr stats component in `@solrsearch`.

### DIFF
--- a/changes/CA-1695.feature
+++ b/changes/CA-1695.feature
@@ -1,0 +1,1 @@
+Support returning results for the solr stats component in the `@solrsearch` endpoint. [deiferni]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -13,6 +13,9 @@ Breaking Changes
 Other Changes
 ^^^^^^^^^^^^^
 
+- Add support for the ``stats`` component to the ``@solrsearch`` endpoint.
+
+
 2021.11.0 (2021-05-28)
 ----------------------
 

--- a/docs/public/dev-manual/api/searching.rst
+++ b/docs/public/dev-manual/api/searching.rst
@@ -214,6 +214,21 @@ Beispiel für ein Suchabfrage mit Facetten für ``responsible`` und ``portal_typ
       "start": 0
     }
 
+
+Statistiken
+~~~~~~~~~~~
+- ``stats``: Muss auf ``true`` gesetzt sein damit Solr die Statistiken zurückgibt.
+- ``stats.field``: Feld für welches Solr Statistiken zurückgeben soll. Kann mehrmals angegeben werden.
+
+.. sourcecode:: http
+
+  GET /plone/@solrsearch?stats=true&stats.field=filesize&stats.field=Creator HTTP/1.1
+
+Eine detaillierte Beschreibung der Stats Komponente ist im
+`Solr Reference Guide <https://solr.apache.org/guide/8_8/the-stats-component.html>`_
+zu finden.
+
+
 Pfadtiefe
 ~~~~~~~~~
 ``depth``: Limitierung der maximalen Pfadtiefe, relativ zum Kontext oder angegebener Pfad (mit ``fq=path:/path/to/container``)


### PR DESCRIPTION
Add support to return simple statistics for numeric, string and date fields as specified in the solr documentation at
https://solr.apache.org/guide/8_8/the-stats-component.html.

As with the facet endpoint the query is passed more or less directly to solr. To receive the stats component in the response to solrsearch both enabling it with `stats=true` and passing all the the desired fields by repeating the `stats.field<fieldname>` parameter is necessary.

We take care to not return any statistics for the blacklisted fields.

Jira: https://4teamwork.atlassian.net/browse/CA-1695

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))