### PR TITLE
Add watcher functionalities for document changes.

### DIFF
--- a/changes/CA-1744.feature
+++ b/changes/CA-1744.feature
@@ -1,0 +1,1 @@
+Add watcher functionalities for document changes. [tinagerber]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -14,6 +14,7 @@ Other Changes
 ^^^^^^^^^^^^^
 
 - Add support for the ``stats`` component to the ``@solrsearch`` endpoint.
+- ``@watchers``: The endpoint is now also available for documents. (see :ref:`docs <watchers>`)
 
 
 2021.11.0 (2021-05-28)

--- a/docs/public/dev-manual/api/config.rst
+++ b/docs/public/dev-manual/api/config.rst
@@ -65,6 +65,7 @@ GEVER-Mandanten abgefragt werden.
               "disposition_transport_filesystem": false,
               "disposition_transport_ftps": false,
               "doc_properties": true,
+              "document_watchers" false,
               "dossier_templates": true,
               "ech0147_export": true,
               "ech0147_import": true,
@@ -175,6 +176,9 @@ features
 
     doc_properties
         Hinzufügen von DocProperties bei aus Vorlagen erstellten Word-Dokumenten
+
+    document_watchers
+        Beobachter für Dokumente
 
     dossier_templates
         Dossier Vorlagen

--- a/docs/public/dev-manual/api/schemas/opengever.repository.repositoryroot.inc
+++ b/docs/public/dev-manual/api/schemas/opengever.repository.repositoryroot.inc
@@ -34,6 +34,16 @@
        
 
 
+   .. py:attribute:: reference_number_addendum
+
+       :Feldname: :field-title:`Aktenzeichen Zusatz`
+       :Datentyp: ``TextLine``
+       
+       
+       :Beschreibung: Achtung: Änderung erfordert Neuindexierung von "reference" und "sortable_reference".
+       
+
+
    .. py:attribute:: title_de
 
        :Feldname: :field-title:`Titel (deutsch)`

--- a/docs/public/dev-manual/api/watchers.rst
+++ b/docs/public/dev-manual/api/watchers.rst
@@ -1,14 +1,16 @@
+.. _watchers:
+
 Beobachter
 ==========
 
-Der ``@watchers`` Endpoint dient dazu, für Aufgaben und Weiterleitungen Beobachter zu registrieren.
+Der ``@watchers`` Endpoint dient dazu, für Dokumente, Aufgaben und Weiterleitungen Beobachter zu registrieren.
 
 Diese Endpoints liefern zur Zeit sowohl ``referenced_users`` als auch ``referenced_actors`` zurück. ``referenced_users`` wird in einer späteren Version jedoch nicht mehr unterstützt werden, und wird durch ``referenced_actors`` abgelöst.
 
 Auflistung
 ----------
 
-Ein Beobachter kann verschiedene Rollen haben, beispielsweise die Rollen Auftraggeber (``task_issuer``), Auftragnehmer (``task_responsible``) oder Beobachter (``regular_watcher``). Mittels eines GET-Requests können alle Beobachter und alle Rollen einer Aufgabe abgefragt werden.
+Ein Beobachter kann verschiedene Rollen haben, beispielsweise die Rollen Auftraggeber (``task_issuer``), Auftragnehmer (``task_responsible``) oder Beobachter (``regular_watcher``). Mittels eines GET-Requests können alle Beobachter und alle Rollen eines Inhalts abgefragt werden.
 
 **Beispiel-Request**:
 
@@ -78,7 +80,7 @@ Ein Beobachter kann verschiedene Rollen haben, beispielsweise die Rollen Auftrag
 Beobachter als erweiterbare Komponente
 --------------------------------------
 
-Die Beobachter können als Kompomente einer Aufgabe direkt über den ``expand``-Parameter eingebettet werden, so dass keine zusätzliche Abfrage nötig ist.
+Die Beobachter können als Komponente eines Inhalts direkt über den ``expand``-Parameter eingebettet werden, so dass keine zusätzliche Abfrage nötig ist.
 
 **Beispiel-Request**:
 
@@ -112,7 +114,7 @@ Die Beobachter können als Kompomente einer Aufgabe direkt über den ``expand``-
 Beobachter hinzufügen
 ---------------------
 
-Ein Benutzer kann mittels POST-Requests als Beobachter mit der Rolle ``regular_watcher`` bei einer Aufgabe registriert werden.
+Ein Benutzer kann mittels POST-Requests als Beobachter mit der Rolle ``regular_watcher`` bei einem Inhalt registriert werden.
 
 
 **Beispiel-Request**:
@@ -136,7 +138,7 @@ Ein Benutzer kann mittels POST-Requests als Beobachter mit der Rolle ``regular_w
 Beobachter entfernen
 --------------------
 
-Mittels DELETE-Requests kann die Rolle ``regular_watcher`` eines Beobachters von einer Aufgabe wieder entfernt werden.
+Mittels DELETE-Requests kann die Rolle ``regular_watcher`` eines Beobachters von einem Inhalt wieder entfernt werden.
 
 **Beispiel-Request**:
 

--- a/opengever/activity/__init__.py
+++ b/opengever/activity/__init__.py
@@ -184,4 +184,7 @@ ACTIVITY_TRANSLATIONS = {
     'document-version-created': _(
         'document-version-created',
         default=u'New document version created'),
+    'document-watcher-added': _(
+        'document-watcher-added',
+        default=u'Added as watcher to document'),
 }

--- a/opengever/activity/__init__.py
+++ b/opengever/activity/__init__.py
@@ -175,4 +175,13 @@ ACTIVITY_TRANSLATIONS = {
     'todo-modified': _(
         'todo-modified',
         default=u'ToDo modified'),
+    'document-author-changed': _(
+        'document-author-changed',
+        default=u'Document author changed'),
+    'document-title-changed': _(
+        'document-title-changed',
+        default=u'Document title changed'),
+    'document-version-created': _(
+        'document-version-created',
+        default=u'New document version created'),
 }

--- a/opengever/activity/browser/resources/settings.js
+++ b/opengever/activity/browser/resources/settings.js
@@ -116,6 +116,12 @@
            activities: this.filterActivitiesByType(values, 'disposition')
         });
       }
+      if (this.getDataAttribute('show-documents') == 'True') {
+        tabs.push({tabId: 'document',
+           tabTitle: this.getDataAttribute('tab-title-documents'),
+           activities: this.filterActivitiesByType(values, 'document')
+        });
+      }
       return this.template({
         tabs: tabs,
         translations: data.translations,

--- a/opengever/activity/browser/settings.py
+++ b/opengever/activity/browser/settings.py
@@ -14,6 +14,7 @@ from opengever.activity.roles import WATCHER_ROLE
 from opengever.activity.roles import WORKSPACE_MEMBER_ROLE
 from opengever.base.handlebars import prepare_handlebars_template
 from opengever.base.json_response import JSONResponse
+from opengever.document import is_watcher_feature_enabled
 from opengever.meeting import is_meeting_feature_enabled
 from opengever.ogds.models.user import User
 from opengever.ogds.models.user_settings import UserSettings
@@ -88,6 +89,11 @@ NOTIFICATION_SETTING_TABS = [
      'settings': [
          'todo-assigned',
          'todo-modified'
+     ]},
+    {'id': 'document',
+     'roles': [WATCHER_ROLE],
+     'settings': [
+         'document-modified',
      ]},
 ]
 
@@ -344,11 +350,17 @@ class NotificationSettingsForm(BrowserView):
     def tab_title_dossiers(self):
         return _('label_dossiers', default=u'Dossiers')
 
+    def tab_title_documents(self):
+        return _('label_documents', default=u'Documents')
+
     def tab_title_workspaces(self):
         return _('label_workspaces', default=u'Workspaces')
 
     def show_disposition_tab(self):
         return api.user.has_permission('opengever.disposition: Add disposition')
+
+    def show_documents_tab(self):
+        return is_watcher_feature_enabled()
 
     def show_proposals_tab(self):
         return is_meeting_feature_enabled()

--- a/opengever/activity/browser/templates/settings.pt
+++ b/opengever/activity/browser/templates/settings.pt
@@ -32,11 +32,13 @@
                            data-tab-title-general view/tab_title_general;
                            data-tab-title-task view/tab_title_task;
                            data-tab-title-dossiers view/tab_title_dossiers;
+                           data-tab-title-documents view/tab_title_documents;
                            data-tab-title-proposals view/tab_title_proposals;
                            data-tab-title-reminders view/tab_title_reminders;
                            data-tab-title-dispositions view/tab_title_dispositions;
                            data-tab-title-workspaces view/tab_title_workspaces;
                            data-show-disposition view/show_disposition_tab;
+                           data-show-documents view/show_documents_tab;
                            data-show-proposals view/show_proposals_tab;
                            data-show-workspaces view/show_workspaces_tab;">
 

--- a/opengever/activity/configure.zcml
+++ b/opengever/activity/configure.zcml
@@ -33,4 +33,10 @@
       handler=".handlers.notify_watcher"
       />
 
+  <subscriber
+      for="opengever.document.behaviors.IBaseDocument
+           opengever.activity.interfaces.IWatcherAddedEvent"
+      handler=".handlers.notify_document_watcher"
+      />
+
 </configure>

--- a/opengever/activity/handlers.py
+++ b/opengever/activity/handlers.py
@@ -1,5 +1,7 @@
 from opengever.activity import is_activity_feature_enabled
 from opengever.activity import notification_center
+from opengever.document import is_watcher_feature_enabled
+from opengever.document.activities import DocumentWatcherAddedActivity
 from opengever.inbox.activities import ForwardingWatcherAddedActivity
 from opengever.inbox.forwarding import IForwarding
 from opengever.task.activities import TaskWatcherAddedActivity
@@ -28,3 +30,10 @@ def notify_watcher(obj, event):
     elif ITask.providedBy(obj):
         activity = TaskWatcherAddedActivity(obj, getRequest(), event.watcherid)
     activity.record()
+
+
+def notify_document_watcher(obj, event):
+    if not is_watcher_feature_enabled():
+        return
+
+    DocumentWatcherAddedActivity(obj, getRequest(), event.watcherid).record()

--- a/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-06-09 13:25+0000\n"
+"POT-Creation-Date: 2021-06-16 06:03+0000\n"
 "PO-Revision-Date: 2015-02-24 08:40+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -122,6 +122,11 @@ msgstr "Titel des Dokuments geändert"
 #: ./opengever/activity/__init__.py
 msgid "document-version-created"
 msgstr "Neue Dokumentversion erstellt"
+
+#. Default: "Added as watcher to document"
+#: ./opengever/activity/__init__.py
+msgid "document-watcher-added"
+msgstr "Als Beobachter hinzugefügt zu Dokument"
 
 #. Default: "Overdue dossier"
 #: ./opengever/activity/__init__.py

--- a/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
@@ -103,10 +103,25 @@ msgstr "Zur Archivierung angeboten"
 msgid "disposition-transition-refuse"
 msgstr "Angebot abgelehnt"
 
+#. Default: "Document author changed"
+#: ./opengever/activity/__init__.py
+msgid "document-author-changed"
+msgstr "Autor des Dokuments geändert"
+
 #. Default: "Document modified"
 #: ./opengever/activity/notification_settings.py
 msgid "document-modified"
 msgstr "Dokument verändert"
+
+#. Default: "Document title changed"
+#: ./opengever/activity/__init__.py
+msgid "document-title-changed"
+msgstr "Titel des Dokuments geändert"
+
+#. Default: "New document version created"
+#: ./opengever/activity/__init__.py
+msgid "document-version-created"
+msgstr "Neue Dokumentversion erstellt"
 
 #. Default: "Overdue dossier"
 #: ./opengever/activity/__init__.py

--- a/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-08 11:40+0000\n"
+"POT-Creation-Date: 2021-06-09 13:25+0000\n"
 "PO-Revision-Date: 2015-02-24 08:40+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -103,6 +103,11 @@ msgstr "Zur Archivierung angeboten"
 msgid "disposition-transition-refuse"
 msgstr "Angebot abgelehnt"
 
+#. Default: "Document modified"
+#: ./opengever/activity/notification_settings.py
+msgid "document-modified"
+msgstr "Dokument verändert"
+
 #. Default: "Overdue dossier"
 #: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
@@ -178,6 +183,11 @@ msgstr "Tageszusammenfassung"
 #: ./opengever/activity/browser/settings.py
 msgid "label_dispositions"
 msgstr "Aussonderung"
+
+#. Default: "Documents"
+#: ./opengever/activity/browser/settings.py
+msgid "label_documents"
+msgstr "Dokumente"
 
 #. Default: "Dossiers"
 #: ./opengever/activity/browser/settings.py

--- a/opengever/activity/locales/en/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/en/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-06-09 13:25+0000\n"
+"POT-Creation-Date: 2021-06-16 06:03+0000\n"
 "PO-Revision-Date: 2015-02-24 08:40+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -138,6 +138,11 @@ msgstr "Document title changed"
 #: ./opengever/activity/__init__.py
 msgid "document-version-created"
 msgstr "New document version created"
+
+#. Default: "Added as watcher to document"
+#: ./opengever/activity/__init__.py
+msgid "document-watcher-added"
+msgstr "Added as watcher to document"
 
 #. German translation: Überfälliges Dossier
 #. Default: "Overdue dossier"

--- a/opengever/activity/locales/en/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/en/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-11 15:53+0000\n"
+"POT-Creation-Date: 2021-06-09 13:25+0000\n"
 "PO-Revision-Date: 2015-02-24 08:40+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -119,6 +119,11 @@ msgstr "Offered for archival"
 msgid "disposition-transition-refuse"
 msgstr "Disposition refused"
 
+#. Default: "Document modified"
+#: ./opengever/activity/notification_settings.py
+msgid "document-modified"
+msgstr "Document modified"
+
 #. German translation: Überfälliges Dossier
 #. Default: "Overdue dossier"
 #: ./opengever/activity/__init__.py
@@ -209,6 +214,11 @@ msgstr "Daily Digest"
 #: ./opengever/activity/browser/settings.py
 msgid "label_dispositions"
 msgstr "Dispositions"
+
+#. Default: "Documents"
+#: ./opengever/activity/browser/settings.py
+msgid "label_documents"
+msgstr "Documents"
 
 #. German translation: Dossiers
 #. Default: "Dossiers"

--- a/opengever/activity/locales/en/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/en/LC_MESSAGES/opengever.activity.po
@@ -119,10 +119,25 @@ msgstr "Offered for archival"
 msgid "disposition-transition-refuse"
 msgstr "Disposition refused"
 
+#. Default: "Document author changed"
+#: ./opengever/activity/__init__.py
+msgid "document-author-changed"
+msgstr "Document author changed"
+
 #. Default: "Document modified"
 #: ./opengever/activity/notification_settings.py
 msgid "document-modified"
 msgstr "Document modified"
+
+#. Default: "Document title changed"
+#: ./opengever/activity/__init__.py
+msgid "document-title-changed"
+msgstr "Document title changed"
+
+#. Default: "New document version created"
+#: ./opengever/activity/__init__.py
+msgid "document-version-created"
+msgstr "New document version created"
 
 #. German translation: Überfälliges Dossier
 #. Default: "Overdue dossier"

--- a/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-06-09 13:25+0000\n"
+"POT-Creation-Date: 2021-06-16 06:03+0000\n"
 "PO-Revision-Date: 2017-12-03 16:14+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-activity/fr/>\n"
@@ -124,6 +124,11 @@ msgstr "Titre du document modifié"
 #: ./opengever/activity/__init__.py
 msgid "document-version-created"
 msgstr "Nouvelle version du document créée"
+
+#. Default: "Added as watcher to document"
+#: ./opengever/activity/__init__.py
+msgid "document-watcher-added"
+msgstr "Ajouté comme observateur à un document"
 
 #. Default: "Overdue dossier"
 #: ./opengever/activity/__init__.py

--- a/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
@@ -105,10 +105,25 @@ msgstr "Proposé pour archivage"
 msgid "disposition-transition-refuse"
 msgstr "Offre refusée"
 
+#. Default: "Document author changed"
+#: ./opengever/activity/__init__.py
+msgid "document-author-changed"
+msgstr "Auteur du document modifié"
+
 #. Default: "Document modified"
 #: ./opengever/activity/notification_settings.py
 msgid "document-modified"
 msgstr "Document modifié"
+
+#. Default: "Document title changed"
+#: ./opengever/activity/__init__.py
+msgid "document-title-changed"
+msgstr "Titre du document modifié"
+
+#. Default: "New document version created"
+#: ./opengever/activity/__init__.py
+msgid "document-version-created"
+msgstr "Nouvelle version du document créée"
 
 #. Default: "Overdue dossier"
 #: ./opengever/activity/__init__.py

--- a/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-08 11:40+0000\n"
+"POT-Creation-Date: 2021-06-09 13:25+0000\n"
 "PO-Revision-Date: 2017-12-03 16:14+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-activity/fr/>\n"
@@ -105,6 +105,11 @@ msgstr "Proposé pour archivage"
 msgid "disposition-transition-refuse"
 msgstr "Offre refusée"
 
+#. Default: "Document modified"
+#: ./opengever/activity/notification_settings.py
+msgid "document-modified"
+msgstr "Document modifié"
+
 #. Default: "Overdue dossier"
 #: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
@@ -180,6 +185,11 @@ msgstr "Résumé quotidien"
 #: ./opengever/activity/browser/settings.py
 msgid "label_dispositions"
 msgstr "Offres"
+
+#. Default: "Documents"
+#: ./opengever/activity/browser/settings.py
+msgid "label_documents"
+msgstr "Documents"
 
 #. Default: "Dossiers"
 #: ./opengever/activity/browser/settings.py

--- a/opengever/activity/locales/opengever.activity.pot
+++ b/opengever/activity/locales/opengever.activity.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-06-09 13:25+0000\n"
+"POT-Creation-Date: 2021-06-16 06:03+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -121,6 +121,11 @@ msgstr ""
 #. Default: "New document version created"
 #: ./opengever/activity/__init__.py
 msgid "document-version-created"
+msgstr ""
+
+#. Default: "Added as watcher to document"
+#: ./opengever/activity/__init__.py
+msgid "document-watcher-added"
 msgstr ""
 
 #. Default: "Overdue dossier"

--- a/opengever/activity/locales/opengever.activity.pot
+++ b/opengever/activity/locales/opengever.activity.pot
@@ -103,9 +103,24 @@ msgstr ""
 msgid "disposition-transition-refuse"
 msgstr ""
 
+#. Default: "Document author changed"
+#: ./opengever/activity/__init__.py
+msgid "document-author-changed"
+msgstr ""
+
 #. Default: "Document modified"
 #: ./opengever/activity/notification_settings.py
 msgid "document-modified"
+msgstr ""
+
+#. Default: "Document title changed"
+#: ./opengever/activity/__init__.py
+msgid "document-title-changed"
+msgstr ""
+
+#. Default: "New document version created"
+#: ./opengever/activity/__init__.py
+msgid "document-version-created"
 msgstr ""
 
 #. Default: "Overdue dossier"

--- a/opengever/activity/locales/opengever.activity.pot
+++ b/opengever/activity/locales/opengever.activity.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-08 11:40+0000\n"
+"POT-Creation-Date: 2021-06-09 13:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -103,6 +103,11 @@ msgstr ""
 msgid "disposition-transition-refuse"
 msgstr ""
 
+#. Default: "Document modified"
+#: ./opengever/activity/notification_settings.py
+msgid "document-modified"
+msgstr ""
+
 #. Default: "Overdue dossier"
 #: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
@@ -177,6 +182,11 @@ msgstr ""
 #. Default: "Dispositions"
 #: ./opengever/activity/browser/settings.py
 msgid "label_dispositions"
+msgstr ""
+
+#. Default: "Documents"
+#: ./opengever/activity/browser/settings.py
+msgid "label_documents"
 msgstr ""
 
 #. Default: "Dossiers"

--- a/opengever/activity/notification_settings.py
+++ b/opengever/activity/notification_settings.py
@@ -243,6 +243,14 @@ NOTIFICATION_CONFIGURATION = [
             'digest_notification_roles': [WORKSPACE_MEMBER_ROLE],
         }
     },
+    {
+        'id': 'document-modified',
+        'title': _('document-modified', default=u'Document modified'),
+        'activities': [],
+        'default_settings': {
+            'badge_notification_roles': [WATCHER_ROLE],
+        }
+    },
 ]
 
 

--- a/opengever/activity/notification_settings.py
+++ b/opengever/activity/notification_settings.py
@@ -87,7 +87,7 @@ NOTIFICATION_CONFIGURATION = [
     {
         'id': 'added-as-watcher',
         'title': _('added-as-watcher', default=u'Added as watcher'),
-        'activities': ['task-watcher-added', 'forwarding-watcher-added'],
+        'activities': ['task-watcher-added', 'forwarding-watcher-added', 'document-watcher-added'],
         'default_settings': {
             'badge_notification_roles': [WATCHER_ROLE],
         },

--- a/opengever/activity/notification_settings.py
+++ b/opengever/activity/notification_settings.py
@@ -246,7 +246,9 @@ NOTIFICATION_CONFIGURATION = [
     {
         'id': 'document-modified',
         'title': _('document-modified', default=u'Document modified'),
-        'activities': [],
+        'activities': ['document-title-changed',
+                       'document-author-changed',
+                       'document-version-created'],
         'default_settings': {
             'badge_notification_roles': [WATCHER_ROLE],
         }

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -1018,9 +1018,25 @@
       />
 
   <plone:service
+      method="GET"
+      name="@watchers"
+      for="opengever.document.behaviors.IBaseDocument"
+      factory=".watchers.WatchersGet"
+      permission="zope2.View"
+      />
+
+  <plone:service
       method="POST"
       name="@watchers"
       for="opengever.task.task.ITask"
+      factory=".watchers.WatchersPost"
+      permission="zope2.View"
+      />
+
+  <plone:service
+      method="POST"
+      name="@watchers"
+      for="opengever.document.behaviors.IBaseDocument"
       factory=".watchers.WatchersPost"
       permission="zope2.View"
       />
@@ -1034,6 +1050,14 @@
       />
 
   <plone:service
+      method="DELETE"
+      name="@watchers"
+      for="opengever.document.behaviors.IBaseDocument"
+      factory=".watchers.WatchersDelete"
+      permission="zope2.View"
+      />
+
+  <plone:service
       method="GET"
       name="@possible-watchers"
       for="opengever.task.task.ITask"
@@ -1041,9 +1065,24 @@
       permission="zope2.View"
       />
 
+  <plone:service
+      method="GET"
+      name="@possible-watchers"
+      for="opengever.document.behaviors.IBaseDocument"
+      factory=".watchers.PossibleWatchers"
+      permission="zope2.View"
+      />
+
   <adapter
       factory=".watchers.Watchers"
       name="watchers"
+      for="opengever.task.task.ITask opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
+  <adapter
+      factory=".watchers.Watchers"
+      name="watchers"
+      for="opengever.document.behaviors.IBaseDocument opengever.base.interfaces.IOpengeverBaseLayer"
       />
 
   <plone:service

--- a/opengever/api/notification_settings.py
+++ b/opengever/api/notification_settings.py
@@ -5,6 +5,7 @@ from opengever.activity.model.settings import NotificationDefault
 from opengever.activity.notification_settings import NotificationSettings
 from opengever.activity.roles import ROLE_TRANSLATIONS
 from opengever.api.validation import get_validation_errors
+from opengever.document import is_watcher_feature_enabled
 from opengever.meeting import is_meeting_feature_enabled
 from opengever.ogds.models.user import User
 from opengever.ogds.models.user_settings import UserSettings

--- a/opengever/api/notification_settings.py
+++ b/opengever/api/notification_settings.py
@@ -67,6 +67,7 @@ class NotificationSettingsGet(Service):
             'task': not is_workspace_feature_enabled(),
             'watcher': not is_workspace_feature_enabled(),
             'workspace': is_workspace_feature_enabled() and is_todo_feature_enabled(),
+            'document': is_watcher_feature_enabled(),
         }
 
     def general_settings_visibility(self):

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -65,6 +65,7 @@ class TestConfig(IntegrationTestCase):
                 u'disposition_transport_filesystem': False,
                 u'disposition_transport_ftps': False,
                 u'doc_properties': False,
+                u'document_watchers': False,
                 u'dossier_templates': False,
                 u'ech0147_export': False,
                 u'ech0147_import': False,

--- a/opengever/api/tests/test_notification_settings.py
+++ b/opengever/api/tests/test_notification_settings.py
@@ -322,6 +322,22 @@ class TestNotificationSettingsGet(IntegrationTestCase):
                 {u'id': u'workspace_member_role',
                  u'title': u'Workspace member'}]}, browser.json)
 
+    @browsing
+    def test_document_watcher_settings_only_available_if_watcher_feature_enabled(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.portal, view='/@notification-settings',
+                     method='GET', headers=self.api_headers)
+
+        self.assertNotIn('document-modified',
+                         [activity['id'] for activity in browser.json['activities']['items']])
+
+        self.activate_feature('document-watchers')
+        browser.open(self.portal, view='/@notification-settings',
+                     method='GET', headers=self.api_headers)
+
+        self.assertIn('document-modified',
+                      [activity['id'] for activity in browser.json['activities']['items']])
+
 
 class TestNotificationSettingsPatch(IntegrationTestCase):
     features = ('activity', )

--- a/opengever/api/watchers.py
+++ b/opengever/api/watchers.py
@@ -4,9 +4,7 @@ from opengever.activity.roles import ROLE_TRANSLATIONS
 from opengever.activity.roles import WATCHER_ROLE
 from opengever.activity.sources import PossibleWatchersSource
 from opengever.api.actors import serialize_actor_id_to_json_summary
-from opengever.base.interfaces import IOpengeverBaseLayer
 from opengever.ogds.base.actor import ActorLookup
-from opengever.task.task import ITask
 from plone import api
 from plone.protect.interfaces import IDisableCSRFProtection
 from plone.restapi.batching import HypermediaBatch
@@ -16,7 +14,6 @@ from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.services import Service
 from Products.CMFPlone.utils import safe_unicode
 from zExceptions import BadRequest
-from zope.component import adapter
 from zope.component import getMultiAdapter
 from zope.i18n import translate
 from zope.interface import alsoProvides
@@ -24,7 +21,6 @@ from zope.interface import implementer
 
 
 @implementer(IExpandableElement)
-@adapter(ITask, IOpengeverBaseLayer)
 class Watchers(object):
     def __init__(self, context, request):
         self.context = context

--- a/opengever/base/configuration.py
+++ b/opengever/base/configuration.py
@@ -143,6 +143,7 @@ class GeverSettingsAdpaterV1(object):
         features['disposition_transport_filesystem'] = api.portal.get_registry_record('enabled', interface=IFilesystemTransportSettings)  # noqa
         features['disposition_transport_ftps'] = api.portal.get_registry_record('enabled', interface=IFTPSTransportSettings)  # noqa
         features['doc_properties'] = api.portal.get_registry_record('create_doc_properties', interface=ITemplateFolderProperties)  # noqa
+        features['document_watchers'] = api.portal.get_registry_record('watcher_feature_enabled', interface=IDocumentSettings)  # noqa
         features['dossier_templates'] = api.portal.get_registry_record('is_feature_enabled', interface=IDossierTemplateSettings)  # noqa
         features['ech0147_export'] = api.portal.get_registry_record('ech0147_export_enabled', interface=IECH0147Settings)
         features['ech0147_import'] = api.portal.get_registry_record('ech0147_import_enabled', interface=IECH0147Settings)

--- a/opengever/base/tests/test_configuration_adapter.py
+++ b/opengever/base/tests/test_configuration_adapter.py
@@ -70,6 +70,7 @@ class TestConfigurationAdapter(IntegrationTestCase):
                 ('disposition_transport_filesystem', False),
                 ('disposition_transport_ftps', False),
                 ('doc_properties', False),
+                ('document_watchers', False),
                 ('dossier_templates', False),
                 ('ech0147_export', False),
                 ('ech0147_import', False),

--- a/opengever/core/upgrades/20210609085047_add_document_watcher_feature_flag/registry.xml
+++ b/opengever/core/upgrades/20210609085047_add_document_watcher_feature_flag/registry.xml
@@ -1,0 +1,5 @@
+<registry>
+  <records interface="opengever.document.interfaces.IDocumentSettings">
+    <value key="watcher_feature_enabled">False</value>
+  </records>
+</registry>

--- a/opengever/core/upgrades/20210609085047_add_document_watcher_feature_flag/upgrade.py
+++ b/opengever/core/upgrades/20210609085047_add_document_watcher_feature_flag/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddDocumentWatcherFeatureFlag(UpgradeStep):
+    """Add document watcher feature flag.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/core/upgrades/20210609111310_add_document_modified_notification_default/upgrade.py
+++ b/opengever/core/upgrades/20210609111310_add_document_modified_notification_default/upgrade.py
@@ -1,0 +1,40 @@
+from opengever.activity.roles import WATCHER_ROLE
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy.schema import Sequence
+from sqlalchemy.sql.expression import column
+from sqlalchemy.sql.expression import table
+import json
+
+
+SETTING = {
+     'kind': 'document-modified',
+     'badge_notification_roles': [WATCHER_ROLE],
+     'mail_notification_roles': [],
+     'digest_notification_roles': []
+}
+
+defaults_table = table(
+    "notification_defaults",
+    column("id"),
+    column("kind"),
+    column("badge_notification_roles"),
+    column("mail_notification_roles"),
+    column("digest_notification_roles"))
+
+
+class AddDocumentModifiedNotificationDefault(SchemaMigration):
+    """Add document modified notification default.
+    """
+
+    def migrate(self):
+        self.insert_notification_defaults()
+
+    def insert_notification_defaults(self):
+        seq = Sequence('notification_defaults_id_seq')
+        self.execute(defaults_table
+                     .insert()
+                     .values(id=self.execute(seq),
+                             kind=SETTING['kind'],
+                             badge_notification_roles=json.dumps(SETTING['badge_notification_roles']),
+                             mail_notification_roles=json.dumps(SETTING['mail_notification_roles']),
+                             digest_notification_roles=json.dumps(SETTING['digest_notification_roles'])))

--- a/opengever/document/__init__.py
+++ b/opengever/document/__init__.py
@@ -1,6 +1,9 @@
 from opengever.document.extra_mimetypes import register_additional_mimetypes
+from opengever.document.interfaces import IDocumentSettings
 from opengever.document.officeconnector import register_ee_filename_callback
+from plone.registry.interfaces import IRegistry
 from Products.CMFCore.permissions import ManagePortal
+from zope.component import getUtility
 from zope.i18nmessageid import MessageFactory
 
 
@@ -16,6 +19,15 @@ register_additional_mimetypes()
 # Register a callback function for ZEM generation in Products.ExternalEditor
 # to include a document's filename in the metadata.
 register_ee_filename_callback()
+
+
+def is_watcher_feature_enabled():
+    try:
+        registry = getUtility(IRegistry)
+        return registry.forInterface(IDocumentSettings).watcher_feature_enabled
+
+    except (KeyError, AttributeError):
+        return False
 
 
 def initialize(context):

--- a/opengever/document/activities.py
+++ b/opengever/document/activities.py
@@ -65,3 +65,33 @@ class DocumenVersionCreatedActivity(BaseActivity):
     @property
     def description(self):
         return {}
+
+
+class DocumentWatcherAddedActivity(BaseActivity):
+    """Activity representation for a watcher being added to a document.
+    """
+
+    kind = 'document-watcher-added'
+
+    def __init__(self, context, request, watcherid):
+        super(DocumentWatcherAddedActivity, self).__init__(context, request)
+        self.watcherid = watcherid
+
+    @property
+    def summary(self):
+        return self.translate_to_all_languages(
+            _('summary_document_watcher_added', u'Added as watcher of the document by ${user}',
+              mapping={'user': Actor.lookup(self.actor_id).get_link()}))
+
+    @property
+    def description(self):
+        return {}
+
+    @property
+    def label(self):
+        msg = _('label_document_watcher_added', u'Added as watcher of the document')
+        return self.translate_to_all_languages(msg)
+
+    def add_activity(self):
+        return super(DocumentWatcherAddedActivity, self).add_activity(
+            notification_recipients=[self.watcherid])

--- a/opengever/document/activities.py
+++ b/opengever/document/activities.py
@@ -1,0 +1,67 @@
+from opengever.activity import ACTIVITY_TRANSLATIONS
+from opengever.activity.base import BaseActivity
+from opengever.document import _
+from opengever.ogds.base.actor import Actor
+
+
+class DocumentTitleChangedActivity(BaseActivity):
+    """Activity representation for changing a document title.
+    """
+    kind = 'document-title-changed'
+
+    @property
+    def summary(self):
+        return self.translate_to_all_languages(
+            _(u'summary_document_title_changed',
+              u'Title changed by ${user}',
+              mapping={'user': Actor.lookup(self.actor_id).get_label()}))
+
+    @property
+    def label(self):
+        return self.translate_to_all_languages(ACTIVITY_TRANSLATIONS[self.kind])
+
+    @property
+    def description(self):
+        return {}
+
+
+class DocumentAuthorChangedActivity(BaseActivity):
+    """Activity representation for changing a document author.
+    """
+    kind = 'document-author-changed'
+
+    @property
+    def summary(self):
+        return self.translate_to_all_languages(
+            _(u'summary_document_author_changed',
+              u'Author changed by ${user}',
+              mapping={'user': Actor.lookup(self.actor_id).get_label()}))
+
+    @property
+    def label(self):
+        return self.translate_to_all_languages(ACTIVITY_TRANSLATIONS[self.kind])
+
+    @property
+    def description(self):
+        return {}
+
+
+class DocumenVersionCreatedActivity(BaseActivity):
+    """Activity representation for adding a new document version.
+    """
+    kind = 'document-version-created'
+
+    @property
+    def summary(self):
+        return self.translate_to_all_languages(
+            _(u'summary_document_version_created',
+              u'New document version created by ${user}',
+              mapping={'user': Actor.lookup(self.actor_id).get_label()}))
+
+    @property
+    def label(self):
+        return self.translate_to_all_languages(ACTIVITY_TRANSLATIONS[self.kind])
+
+    @property
+    def description(self):
+        return {}

--- a/opengever/document/configure.zcml
+++ b/opengever/document/configure.zcml
@@ -222,6 +222,24 @@
       handler=".subscribers.set_copyname"
       />
 
+  <subscriber
+      for="opengever.document.behaviors.IBaseDocument
+           zope.lifecycleevent.interfaces.IObjectModifiedEvent"
+      handler=".handlers.author_or_title_changed"
+      />
+
+  <subscriber
+      for="opengever.document.document.IDocumentSchema
+           opengever.document.interfaces.IObjectRevertedToVersion"
+      handler=".handlers.document_version_created"
+      />
+
+  <subscriber
+      for="opengever.document.document.IDocumentSchema
+           opengever.document.interfaces.IObjectCheckedInEvent"
+      handler=".handlers.document_version_created"
+      />
+
   <adapter
       for="opengever.document.document.IDocumentSchema"
       factory=".webdav.DocumentReadFile"

--- a/opengever/document/configure.zcml
+++ b/opengever/document/configure.zcml
@@ -315,6 +315,11 @@
       name="file_extension"
       />
 
+  <adapter
+      factory=".indexers.watchers"
+      name="watchers"
+      />
+
   <adapter factory=".document.UploadValidator" />
 
   <adapter factory=".fileactions.BaseDocumentFileActions" />

--- a/opengever/document/indexers.py
+++ b/opengever/document/indexers.py
@@ -1,5 +1,7 @@
 from Acquisition import aq_inner
 from collective import dexteritytextindexer
+from opengever.activity import notification_center
+from opengever.activity.roles import WATCHER_ROLE
 from opengever.base.behaviors.classification import IClassification
 from opengever.base.behaviors.classification import IClassificationMarker
 from opengever.base.interfaces import IReferenceNumber
@@ -239,3 +241,11 @@ def file_extension(obj):
     extension of the original_message file if exists.
     """
     return obj.get_file_extension()
+
+
+@indexer(IBaseDocument)
+def watchers(obj):
+    """Index all userids that watch this document in the default watcher role."""
+    center = notification_center()
+    watchers = center.get_watchers(obj, role=WATCHER_ROLE)
+    return [watcher.actorid for watcher in watchers]

--- a/opengever/document/interfaces.py
+++ b/opengever/document/interfaces.py
@@ -76,6 +76,12 @@ class IDocumentSettings(Interface):
         default=PRESERVED_AS_PAPER_DEFAULT,
     )
 
+    watcher_feature_enabled = schema.Bool(
+        title=u'Enable watcher feature',
+        description=u'Whether watcher feature is enabled for documents',
+        default=False
+    )
+
 
 class ICheckinCheckoutManager(Interface):
     """Interface for the checkin / checkout manager.

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-03-01 18:36+0000\n"
+"POT-Creation-Date: 2021-06-15 06:28+0000\n"
 "PO-Revision-Date: 2017-10-13 14:27+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -715,6 +715,21 @@ msgstr "Keine Datei"
 #: ./opengever/document/browser/templates/macros.pt
 msgid "oc_unsupported_message"
 msgstr "Dieses Dokumentformat wird vom Office Connector nicht unterstützt und kann deshalb nicht direkt bearbeitet werden."
+
+#. Default: "Author changed by ${user}"
+#: ./opengever/document/activities.py
+msgid "summary_document_author_changed"
+msgstr "Autor geändert durch ${user}"
+
+#. Default: "Title changed by ${user}"
+#: ./opengever/document/activities.py
+msgid "summary_document_title_changed"
+msgstr "Titel geändert durch ${user}"
+
+#. Default: "New document version created by ${user}"
+#: ./opengever/document/activities.py
+msgid "summary_document_version_created"
+msgstr "Neue Dokumentversion erstellt durch ${user}"
 
 #. Default: "Save PDF of ${title} under ${destination}"
 #: ./opengever/document/browser/save_pdf_document_under.py

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-06-15 06:28+0000\n"
+"POT-Creation-Date: 2021-06-16 05:59+0000\n"
 "PO-Revision-Date: 2017-10-13 14:27+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -482,6 +482,11 @@ msgstr "Laufnummer"
 msgid "label_document_type"
 msgstr "Dokumenttyp"
 
+#. Default: "Added as watcher of the document"
+#: ./opengever/document/activities.py
+msgid "label_document_watcher_added"
+msgstr "Als Beobachter des Dokuments hinzugefügt"
+
 #: ./opengever/document/browser/report.py
 msgid "label_dossier_title"
 msgstr "Dossier-Titel"
@@ -730,6 +735,11 @@ msgstr "Titel geändert durch ${user}"
 #: ./opengever/document/activities.py
 msgid "summary_document_version_created"
 msgstr "Neue Dokumentversion erstellt durch ${user}"
+
+#. Default: "Added as watcher of the document by ${user}"
+#: ./opengever/document/activities.py
+msgid "summary_document_watcher_added"
+msgstr "Als Beobachter des Dokuments hinzugefügt durch ${user}"
 
 #. Default: "Save PDF of ${title} under ${destination}"
 #: ./opengever/document/browser/save_pdf_document_under.py

--- a/opengever/document/locales/en/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/en/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-03-01 18:36+0000\n"
+"POT-Creation-Date: 2021-06-15 06:28+0000\n"
 "PO-Revision-Date: 2017-10-13 14:27+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -864,6 +864,21 @@ msgstr "No file"
 #: ./opengever/document/browser/templates/macros.pt
 msgid "oc_unsupported_message"
 msgstr "This file format is not supported by Office Connector and therefore can't be edited directly."
+
+#. Default: "Author changed by ${user}"
+#: ./opengever/document/activities.py
+msgid "summary_document_author_changed"
+msgstr "Author changed by ${user}"
+
+#. Default: "Title changed by ${user}"
+#: ./opengever/document/activities.py
+msgid "summary_document_title_changed"
+msgstr "Title changed by ${user}"
+
+#. Default: "New document version created by ${user}"
+#: ./opengever/document/activities.py
+msgid "summary_document_version_created"
+msgstr "New document version created by ${user}"
 
 #. German translation: PDF von ${title} speichern unter ${destination}
 #. Default: "Save PDF of ${title} under ${destination}"

--- a/opengever/document/locales/en/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/en/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-06-15 06:28+0000\n"
+"POT-Creation-Date: 2021-06-16 05:59+0000\n"
 "PO-Revision-Date: 2017-10-13 14:27+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -583,6 +583,11 @@ msgstr "Sequence number"
 msgid "label_document_type"
 msgstr "Document type"
 
+#. Default: "Added as watcher of the document"
+#: ./opengever/document/activities.py
+msgid "label_document_watcher_added"
+msgstr "Added as watcher of document"
+
 #. German translation: Dossier-Titel
 #: ./opengever/document/browser/report.py
 msgid "label_dossier_title"
@@ -879,6 +884,11 @@ msgstr "Title changed by ${user}"
 #: ./opengever/document/activities.py
 msgid "summary_document_version_created"
 msgstr "New document version created by ${user}"
+
+#. Default: "Added as watcher of the document by ${user}"
+#: ./opengever/document/activities.py
+msgid "summary_document_watcher_added"
+msgstr "Added as watcher of document by ${user}"
 
 #. German translation: PDF von ${title} speichern unter ${destination}
 #. Default: "Save PDF of ${title} under ${destination}"

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-06-15 06:28+0000\n"
+"POT-Creation-Date: 2021-06-16 05:59+0000\n"
 "PO-Revision-Date: 2017-09-03 08:50+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-document/fr/>\n"
@@ -479,6 +479,11 @@ msgstr "Numéro courant"
 msgid "label_document_type"
 msgstr "Type de document"
 
+#. Default: "Added as watcher of the document"
+#: ./opengever/document/activities.py
+msgid "label_document_watcher_added"
+msgstr "Ajouté en tant qu'observateur du document"
+
 #: ./opengever/document/browser/report.py
 msgid "label_dossier_title"
 msgstr "Titre du dossier"
@@ -727,6 +732,11 @@ msgstr "Titre modifié par ${user}"
 #: ./opengever/document/activities.py
 msgid "summary_document_version_created"
 msgstr "Nouvelle version du document créée par ${user}"
+
+#. Default: "Added as watcher of the document by ${user}"
+#: ./opengever/document/activities.py
+msgid "summary_document_watcher_added"
+msgstr "Ajouté en tant qu'observateur du document par ${user}"
 
 #. Default: "Save PDF of ${title} under ${destination}"
 #: ./opengever/document/browser/save_pdf_document_under.py

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-01 18:36+0000\n"
+"POT-Creation-Date: 2021-06-15 06:28+0000\n"
 "PO-Revision-Date: 2017-09-03 08:50+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-document/fr/>\n"
@@ -712,6 +712,21 @@ msgstr "Aucun fichier trouvé"
 #: ./opengever/document/browser/templates/macros.pt
 msgid "oc_unsupported_message"
 msgstr "Ce format de document n'est pas supporté par Office Connector et ne peut donc pas être directement édité."
+
+#. Default: "Author changed by ${user}"
+#: ./opengever/document/activities.py
+msgid "summary_document_author_changed"
+msgstr "Auteur modifié par ${user}"
+
+#. Default: "Title changed by ${user}"
+#: ./opengever/document/activities.py
+msgid "summary_document_title_changed"
+msgstr "Titre modifié par ${user}"
+
+#. Default: "New document version created by ${user}"
+#: ./opengever/document/activities.py
+msgid "summary_document_version_created"
+msgstr "Nouvelle version du document créée par ${user}"
 
 #. Default: "Save PDF of ${title} under ${destination}"
 #: ./opengever/document/browser/save_pdf_document_under.py

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-01 18:36+0000\n"
+"POT-Creation-Date: 2021-06-15 06:28+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -709,6 +709,21 @@ msgstr ""
 #. Default: "Office connector unsupported type"
 #: ./opengever/document/browser/templates/macros.pt
 msgid "oc_unsupported_message"
+msgstr ""
+
+#. Default: "Author changed by ${user}"
+#: ./opengever/document/activities.py
+msgid "summary_document_author_changed"
+msgstr ""
+
+#. Default: "Title changed by ${user}"
+#: ./opengever/document/activities.py
+msgid "summary_document_title_changed"
+msgstr ""
+
+#. Default: "New document version created by ${user}"
+#: ./opengever/document/activities.py
+msgid "summary_document_version_created"
 msgstr ""
 
 #. Default: "Save PDF of ${title} under ${destination}"

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-06-15 06:28+0000\n"
+"POT-Creation-Date: 2021-06-16 05:59+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -477,6 +477,11 @@ msgstr ""
 msgid "label_document_type"
 msgstr ""
 
+#. Default: "Added as watcher of the document"
+#: ./opengever/document/activities.py
+msgid "label_document_watcher_added"
+msgstr ""
+
 #: ./opengever/document/browser/report.py
 msgid "label_dossier_title"
 msgstr ""
@@ -724,6 +729,11 @@ msgstr ""
 #. Default: "New document version created by ${user}"
 #: ./opengever/document/activities.py
 msgid "summary_document_version_created"
+msgstr ""
+
+#. Default: "Added as watcher of the document by ${user}"
+#: ./opengever/document/activities.py
+msgid "summary_document_watcher_added"
 msgstr ""
 
 #. Default: "Save PDF of ${title} under ${destination}"

--- a/opengever/document/tests/test_activities.py
+++ b/opengever/document/tests/test_activities.py
@@ -1,0 +1,124 @@
+from ftw.testbrowser import browsing
+from opengever.activity import notification_center
+from opengever.activity.model import Activity
+from opengever.activity.model import Notification
+from opengever.activity.roles import WATCHER_ROLE
+from opengever.document.interfaces import ICheckinCheckoutManager
+from opengever.testing import IntegrationTestCase
+from zope.component import getMultiAdapter
+import json
+
+
+class TestDocumentChangedActivities(IntegrationTestCase):
+
+    features = ('activity', 'document-watchers')
+
+    @browsing
+    def test_document_title_changed_activity(self, browser):
+        self.login(self.regular_user, browser)
+        self.assertEqual(0, Activity.query.count())
+
+        browser.open(self.document, method='PATCH',
+                     data=json.dumps({u'title': u'A new title'}),
+                     headers=self.api_headers)
+
+        self.assertEqual(1, Activity.query.count())
+        activity = Activity.query.first()
+        self.assertEqual(u'document-title-changed', activity.kind)
+        self.assertEquals(u'Title changed by B\xe4rfuss K\xe4thi (kathi.barfuss)', activity.summary)
+
+    @browsing
+    def test_document_title_changed_whitout_watchers_feature_enabled(self, browser):
+        self.deactivate_feature('document-watchers')
+        self.login(self.regular_user, browser)
+        self.assertEqual(0, Activity.query.count())
+
+        browser.open(self.document, method='PATCH',
+                     data=json.dumps({u'title': u'A new title'}),
+                     headers=self.api_headers)
+
+        self.assertEqual(0, Activity.query.count())
+
+    @browsing
+    def test_mail_title_changed_activity(self, browser):
+        self.login(self.regular_user, browser)
+        self.assertEqual(0, Activity.query.count())
+
+        browser.open(self.mail_eml, method='PATCH',
+                     data=json.dumps({u'title': u'A new title'}),
+                     headers=self.api_headers)
+
+        self.assertEqual(1, Activity.query.count())
+        activity = Activity.query.first()
+        self.assertEqual(u'document-title-changed', activity.kind)
+        self.assertEquals(u'Title changed by B\xe4rfuss K\xe4thi (kathi.barfuss)', activity.summary)
+
+    @browsing
+    def test_document_author_changed_activity(self, browser):
+        self.login(self.regular_user, browser)
+        self.assertEqual(0, Activity.query.count())
+
+        browser.open(self.document, method='PATCH',
+                     data=json.dumps({u'document_author': u'James Bond'}),
+                     headers=self.api_headers)
+
+        self.assertEqual(1, Activity.query.count())
+        activity = Activity.query.first()
+        self.assertEqual(u'document-author-changed', activity.kind)
+        self.assertEquals(
+            u'Author changed by B\xe4rfuss K\xe4thi (kathi.barfuss)', activity.summary)
+
+    @browsing
+    def test_mail_author_changed_activity(self, browser):
+        self.login(self.regular_user, browser)
+        self.assertEqual(0, Activity.query.count())
+
+        browser.open(self.mail_eml, method='PATCH',
+                     data=json.dumps({u'document_author': u'James Bond'}),
+                     headers=self.api_headers)
+
+        self.assertEqual(1, Activity.query.count())
+        activity = Activity.query.first()
+        self.assertEqual(u'document-author-changed', activity.kind)
+        self.assertEquals(
+            u'Author changed by B\xe4rfuss K\xe4thi (kathi.barfuss)', activity.summary)
+
+    @browsing
+    def test_document_version_created_activity(self, browser):
+        self.login(self.regular_user, browser)
+        self.assertEqual(0, Activity.query.count())
+        manager = getMultiAdapter(
+            (self.document, self.request),
+            ICheckinCheckoutManager)
+        manager.checkout()
+        manager.checkin()
+
+        self.assertEqual(1, Activity.query.count())
+        manager.revert_to_version(0)
+        self.assertEqual(2, Activity.query.count())
+
+        activities = Activity.query.all()
+        self.assertEqual([u'document-version-created', u'document-version-created'],
+                         [activity.kind for activity in activities])
+
+        self.assertEqual([u'New document version created by B\xe4rfuss K\xe4thi (kathi.barfuss)',
+                          u'New document version created by B\xe4rfuss K\xe4thi (kathi.barfuss)'],
+                         [activity.summary for activity in activities])
+
+    @browsing
+    def test_change_document_title_notifies_watcher(self, browser):
+        self.login(self.regular_user, browser)
+        notification_center().add_watcher_to_resource(
+            self.document, self.meeting_user.getId(),
+            WATCHER_ROLE)
+
+        self.assertEqual(0, Notification.query.count())
+
+        browser.open(self.document, method='PATCH',
+                     data=json.dumps({u'title': u'A new title'}),
+                     headers=self.api_headers)
+
+        self.assertEqual(1, Notification.query.count())
+        notification = Notification.query.first()
+        self.assertEqual(u'document-title-changed', notification.activity.kind)
+        self.assertEqual(self.meeting_user.getId(), notification.userid)

--- a/opengever/policytemplates/policy_template/.mrbob.ini
+++ b/opengever/policytemplates/policy_template/.mrbob.ini
@@ -158,6 +158,11 @@ setup.preserved_as_paper.required = True
 setup.preserved_as_paper.default = true
 setup.preserved_as_paper.post_ask_question = mrbob.hooks:to_boolean
 
+setup.document_watcher.question = Enable watcher feature for documents
+setup.document_watcher.required = True
+setup.document_watcher.default = false
+setup.document_watcher.post_ask_question = mrbob.hooks:to_boolean
+
 setup.enable_private_folder.question = Enable private folder feature
 setup.enable_private_folder.required = True
 setup.enable_private_folder.default = true

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/profiles/default/registry.xml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/profiles/default/registry.xml.bob
@@ -58,6 +58,12 @@
   </records>
 
 {{% endif %}}
+{{% if setup.document_watcher %}}
+  <records interface="opengever.document.interfaces.IDocumentSettings">
+    <value key="watcher_feature_enabled">True</value>
+  </records>
+
+{{% endif %}}
 {{% if is_gever %}}
 {{% if setup.enable_meeting_feature %}}
   <record interface="opengever.meeting.interfaces.IMeetingSettings" field="is_feature_enabled">

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -68,6 +68,7 @@ FEATURE_FLAGS = {
     'contact': 'opengever.contact.interfaces.IContactSettings.is_feature_enabled',
     'disposition-disregard-retention-period': 'opengever.disposition.interfaces.IDispositionSettings.disregard_retention_period',  # noqa
     'doc-properties': 'opengever.dossier.interfaces.ITemplateFolderProperties.create_doc_properties',
+    'document-watchers': 'opengever.document.interfaces.IDocumentSettings.watcher_feature_enabled',
     'docugate': 'opengever.docugate.interfaces.IDocugateSettings.is_feature_enabled',
     'dossiertemplate': 'opengever.dossier.dossiertemplate.interfaces.IDossierTemplateSettings.is_feature_enabled',
     'ech0147-export': 'opengever.ech0147.interfaces.IECH0147Settings.ech0147_export_enabled',


### PR DESCRIPTION
With this PR a new feature `document-watchers` is implemented.
When the feature is enabled, watchers of a document are notified when the title or author of a document is changed, or when a new version is created. The ability to watch documents is also new.

Jira: https://4teamwork.atlassian.net/browse/CA-1744


## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
- New functionality:
  - [x] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- DB-Schema migration
  - [x] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [x] Constraint names are shorter than 30 characters (`Oracle`)
- New translations
  - [x] All msg-strings are unicode