### PR TITLE
Prevent changing the is_private field of existing tasks via API.

### DIFF
--- a/changes/CA-438.bugfix
+++ b/changes/CA-438.bugfix
@@ -1,0 +1,1 @@
+Prevent changing the is_private field of existing tasks via API. [phgross]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -17,6 +17,7 @@ Other Changes
 - ``@watchers``: The endpoint is now also available for documents. (see :ref:`docs <watchers>`)
 - `@trash` and `@untrash` endpoints now also work for WorkspaceFolders.
 - Trashed workspace documents and folders can be deleted. (see :ref:`docs <trash>`)
+- Prevent changing the ``is_private`` field of existing tasks.
 
 2021.11.0 (2021-05-28)
 ----------------------

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -839,6 +839,13 @@
       />
 
   <plone:service
+      method="PATCH"
+      for="opengever.task.task.ITask"
+      factory=".task.TaskPatch"
+      permission="cmf.ModifyPortalContent"
+      />
+
+  <plone:service
       method="GET"
       name="@notification-settings"
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"

--- a/opengever/api/task.py
+++ b/opengever/api/task.py
@@ -24,6 +24,8 @@ from plone.restapi.interfaces import IExpandableElement
 from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.interfaces import ISerializeToJsonSummary
 from plone.restapi.services import Service
+from plone.restapi.services.content.update import ContentPatch
+from zExceptions import BadRequest
 from zExceptions import BadRequest
 from zExceptions import Unauthorized
 from zope.component import adapter
@@ -302,3 +304,17 @@ class TaskPost(FolderPost):
                 raise BadRequest("Could not parse `position` attribute")
 
             self.context.add_task_to_tasktemplate_order(position, self.obj)
+
+
+class TaskPatch(ContentPatch):
+    """Specific Patch service for tasks, to prevent changing the
+    is_private field."""
+
+    def reply(self):
+        current_is_private_value = self.context.is_private
+        data = super(TaskPatch, self).reply()
+
+        if self.context.is_private != current_is_private_value:
+            raise BadRequest("It's not allowed to change the is_private option"
+                             " of an existing task.")
+        return data

--- a/opengever/api/tests/test_task.py
+++ b/opengever/api/tests/test_task.py
@@ -497,6 +497,23 @@ class TestTaskPatch(IntegrationTestCase):
         self.assertEqual('rk', self.task.responsible_client)
         self.assertEqual('james.bond', self.task.responsible)
 
+    @browsing
+    def test_changing_is_private_raise_bad_request(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        # no change
+        browser.open(self.task, json.dumps({"is_private": False}),
+                     method="PATCH", headers=self.api_headers)
+
+        browser.exception_bubbling = True
+        with self.assertRaises(BadRequest) as cm:
+            browser.open(self.task, json.dumps({"is_private": True}),
+                         method="PATCH", headers=self.api_headers)
+
+        self.assertEqual(
+            "It's not allowed to change the is_private option of an existing task.",
+            str(cm.exception))
+
 
 class TestTaskTransitions(IntegrationTestCase):
 


### PR DESCRIPTION
By registering a specific PATCH service for tasks, which raises if the is_private changes.

Fixes https://4teamwork.atlassian.net/browse/CA-438

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- [x] API Changelog entry