### PR TITLE
Fix sending additional files to pdflatex service.

### DIFF
--- a/changes/CA-2417.bugfix
+++ b/changes/CA-2417.bugfix
@@ -1,0 +1,1 @@
+Fix sending additional files to pdflatex service (e.g. header logos). [deiferni]

--- a/opengever/latex/builder.py
+++ b/opengever/latex/builder.py
@@ -35,7 +35,9 @@ class Builder(Builder):
         files = {'latex': ('export.tex', latex)}
         for filename in os.listdir(self.build_directory):
             key = 'file.{}'.format(filename)
-            files[key] = os.path.join(self.build_directory, filename)
+            path = os.path.join(self.build_directory, filename)
+            with open(path, 'rb') as fp:
+                files[key] = (filename, fp.read())
 
         resp = None
         try:

--- a/opengever/latex/tests/test_builder.py
+++ b/opengever/latex/tests/test_builder.py
@@ -3,7 +3,9 @@ from ftw.pdfgenerator.interfaces import IBuilderFactory
 from opengever.core.testing import OPENGEVER_INTEGRATION_TESTING
 from opengever.core.testing import PDFLATEX_SERVICE_INTEGRATION_TESTING
 from opengever.testing import IntegrationTestCase
+from StringIO import StringIO
 from unittest import skipIf
+from zipfile import ZipFile
 from zope.component import getUtility
 
 
@@ -23,10 +25,20 @@ class TestPDFBuilderUsingService(IntegrationTestCase):
 
     def test_pdfbuilder_produces_zip_using_service(self):
         builder = getUtility(IBuilderFactory)()
+        builder.add_file('foo.txt', 'I am file.')
         latex = r'\documentclass{article}\begin{document}Hello LaTeX\end{document}'
         archive = builder.build_zip(latex).read()
+
         self.assertTrue(
             archive.startswith('PK\x03\x04'), 'Does not look like a ZIP archive')
+
+        zip_file = ZipFile(StringIO(archive), 'r')
+        self.assertEqual(
+            'I am file.',
+            zip_file.read('foo.txt'),
+            'Additional file "foo.txt" not processed correctly',
+        )
+
 
 
 @skipIf(not HAS_PDFLATEX, 'pdflatex is required')


### PR DESCRIPTION
Fix two bugs with the `pdflatex` service when sending additional files:
- Instead of the file content we would just send the path to the file
- We would not send the filename, leading to every file be prefixed with `.file` upon save. This broke references to the file.

I have opted to read the file myself before passing it to requests to be in control of closing the file once it is read. Requests does not take care of this and reading the files in a context manager guarantees that we are in control of closing. I am expecting the files to be relatively small (logos for headers and footers, for example).

Jira: https://4teamwork.atlassian.net/browse/CA-2417

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
