### PR TITLE
Improve error handling when quota limit gets exceeded on API requests.

### DIFF
--- a/changes/CA-2247.bugfix
+++ b/changes/CA-2247.bugfix
@@ -1,0 +1,1 @@
+Improve error handling when quota limit gets exceeded on API requests. [phgross]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -13,6 +13,7 @@ Breaking Changes
 Other Changes
 ^^^^^^^^^^^^^
 
+- Return specific error messages when quota gets exceeded in the private repository.
 - Add support for the ``stats`` component to the ``@solrsearch`` endpoint.
 - ``@watchers``: The endpoint is now also available for documents. (see :ref:`docs <watchers>`)
 - `@trash` and `@untrash` endpoints now also work for WorkspaceFolders.

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -1197,6 +1197,15 @@
       />
 
   <plone:service
+      method="PATCH"
+      name="@tus-upload"
+      for="Products.CMFCore.interfaces.IContentish"
+      factory=".tus.GeverUploadPatch"
+      permission="zope2.View"
+      layer="opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
+  <plone:service
       method="POST"
       name="@save-document-as-pdf"
       for="opengever.dossier.behaviors.dossier.IDossierMarker"

--- a/opengever/quota/browser/error.py
+++ b/opengever/quota/browser/error.py
@@ -1,3 +1,4 @@
+from plone.rest.interfaces import IAPIRequest
 from Products.Five import BrowserView
 from Products.statusmessages.interfaces import IStatusMessage
 from zExceptions import Redirect
@@ -7,6 +8,9 @@ import transaction
 class ForbiddenByQuotaView(BrowserView):
 
     def __call__(self):
+        if IAPIRequest.providedBy(self.request):
+            return
+
         # this is an error, we must not commit
         transaction.abort()
         IStatusMessage(self.request).addStatusMessage(


### PR DESCRIPTION
Fixes https://4teamwork.atlassian.net/browse/CA-2247, different from what is described in the JIRA issue, I also corrected the TUS upload, because that is the one that is used in the gever-ui.

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] API Changelog entry 