### PR TITLE
Fix trashing of workspace folders containing trashed objects

### DIFF
--- a/opengever/trash/tests/test_trash.py
+++ b/opengever/trash/tests/test_trash.py
@@ -811,3 +811,25 @@ class TestWorkspaceFolderTrasher(IntegrationTestCase):
         noLongerProvides(self.workspace_folder, ITrashed)
         self.assertTrue(subfolder_trasher.verify_may_untrash())
         self.assertTrue(document_trasher.verify_may_untrash())
+
+    def test_cannot_trash_trashed_workspace_folder(self):
+        self.login(self.manager)
+        trasher = ITrasher(self.workspace_folder)
+        trasher.trash()
+
+        with self.assertRaises(TrashError) as exc:
+            trasher.trash()
+        self.assertEqual('Already trashed', str(exc.exception))
+
+    def test_can_trash_workspace_folder_containing_trashed_objects(self):
+        self.login(self.manager)
+        subfolder = create(Builder('workspace folder')
+                           .titled(u'Subfolder')
+                           .within(self.workspace_folder))
+
+        ITrasher(self.workspace_document).trash()
+        ITrasher(subfolder).trash()
+
+        trasher = ITrasher(self.workspace_folder)
+        trasher.trash()
+        self.assertTrue(ITrashed.providedBy(self.workspace_folder))

--- a/opengever/trash/tests/test_trash.py
+++ b/opengever/trash/tests/test_trash.py
@@ -483,13 +483,6 @@ class TestTrasher(IntegrationTestCase):
         trasher.trash()
         self.assertTrue(ITrashed.providedBy(obj))
 
-    def test_private_document_can_be_trashed(self):
-        self.login(self.manager)
-        obj = self.private_document
-        trasher = ITrasher(obj)
-        trasher.trash()
-        self.assertTrue(ITrashed.providedBy(obj))
-
     def test_private_mail_can_be_trashed(self):
         self.login(self.manager)
         obj = self.private_mail

--- a/opengever/trash/trash.py
+++ b/opengever/trash/trash.py
@@ -179,10 +179,14 @@ class DefaultContentTrasher(object):
 @adapter(IPloneSiteRoot)
 class PloneSiteRootTrasher(DefaultContentTrasher):
 
-    def verify_may_trash(self):
+    def verify_may_trash(self, raise_on_violations=True):
+        if raise_on_violations:
+            raise Unauthorized()
         return False
 
-    def verify_may_untrash(self):
+    def verify_may_untrash(self, raise_on_violations=True):
+        if raise_on_violations:
+            raise Unauthorized()
         return False
 
 

--- a/opengever/trash/trash.py
+++ b/opengever/trash/trash.py
@@ -83,6 +83,8 @@ class DefaultContentTrasher(object):
         self._trash()
 
     def _trash(self):
+        if ITrashed.providedBy(self.context):
+            return
         alsoProvides(self.context, ITrashed)
         self.reindex()
         notify(TrashedEvent(self.context))
@@ -97,6 +99,13 @@ class DefaultContentTrasher(object):
         notify(UntrashedEvent(self.context))
 
     def verify_may_trash(self, raise_on_violations=True):
+        if self.is_trashed():
+            if raise_on_violations:
+                raise TrashError('Already trashed')
+            return False
+        return self._verify_may_trash(raise_on_violations)
+
+    def _verify_may_trash(self, raise_on_violations=True):
         if not self.is_trashable():
             if raise_on_violations:
                 raise TrashError('Not trashable')
@@ -105,11 +114,6 @@ class DefaultContentTrasher(object):
         if not self.check_trash_permission():
             if raise_on_violations:
                 raise Unauthorized()
-            return False
-
-        if self.is_trashed():
-            if raise_on_violations:
-                raise TrashError('Already trashed')
             return False
 
         if self.is_locked():
@@ -187,8 +191,8 @@ class DocumentTrasher(DefaultContentTrasher):
     """An object which handles trashing/untrashing documents.
     """
 
-    def verify_may_trash(self, raise_on_violations=True):
-        if not super(DocumentTrasher, self).verify_may_trash(raise_on_violations):
+    def _verify_may_trash(self, raise_on_violations=True):
+        if not super(DocumentTrasher, self)._verify_may_trash(raise_on_violations):
             return False
 
         if self.is_checked_out():
@@ -230,11 +234,11 @@ class WorkspaceFolderTrasher(DefaultContentTrasher):
     """An object which handles trashing/untrashing workspace folders.
     """
 
-    def verify_may_trash(self, raise_on_violations=True):
-        if not super(WorkspaceFolderTrasher, self).verify_may_trash(raise_on_violations):
+    def _verify_may_trash(self, raise_on_violations=True):
+        if not super(WorkspaceFolderTrasher, self)._verify_may_trash(raise_on_violations):
             return False
         for obj in self.context.objectValues():
-            if not ITrasher(obj).verify_may_trash(raise_on_violations):
+            if not ITrasher(obj)._verify_may_trash(raise_on_violations):
                 return False
         return True
 


### PR DESCRIPTION
Follow-up of https://github.com/4teamwork/opengever.core/pull/7045. We forbid to trashed already trashed objects, but that check should not happen recursively. Indeed it should be allowed to trash a document in a folder, and later decide to trash that folder too. We fix this with this PR.

For https://4teamwork.atlassian.net/browse/CA-981

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] Changelog entry -> No CL necessary IMO
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)