### PR TITLE
Dossier resolving with filing-number follow-up for e2e tests

### DIFF
--- a/opengever/dossier/resolve.py
+++ b/opengever/dossier/resolve.py
@@ -326,7 +326,8 @@ class StrictDossierResolver(object):
 
         for subdossier in dossier.get_subdossiers(
                 depth=1, sort_on=None, sort_order=None):
-            self._recursive_resolve(subdossier.getObject(), end_date)
+            self._recursive_resolve(
+                subdossier.getObject(), end_date, triggering_dossier=False, **kwargs)
 
         if dossier.is_open():
             self.wft.doActionFor(dossier, 'dossier-transition-resolve', transition_params=kwargs)

--- a/opengever/testing/services.py
+++ b/opengever/testing/services.py
@@ -1,3 +1,5 @@
+from opengever.core.testing import activate_filing_number
+from plone import api
 from plone.protect.interfaces import IDisableCSRFProtection
 from plone.restapi.services import Service
 from zope.interface import alsoProvides
@@ -14,4 +16,10 @@ class WriteOnRead(Service):
         self.context.some_attribute = 'foo'
 
     def check_permission(self):
+        return
+
+
+class InstallFilingNumberProfile(Service):
+    def reply(self):
+        activate_filing_number(api.portal.get())
         return

--- a/opengever/testing/tests.zcml
+++ b/opengever/testing/tests.zcml
@@ -1,6 +1,7 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:plone="http://namespaces.plone.org/plone"
+    xmlns:browser="http://namespaces.zope.org/browser"
     i18n_domain="opengever.testing">
 
   <plone:behavior
@@ -32,6 +33,14 @@
       name="@test-write-on-read"
       for="*"
       factory=".services.WriteOnRead"
+      permission="zope.Public"
+      />
+
+  <plone:service
+      method="POST"
+      name="@install-filing-number-profile"
+      for="*"
+      factory=".services.InstallFilingNumberProfile"
       permission="zope.Public"
       />
 


### PR DESCRIPTION
This PR:
- introduces a new rest-api testing view to install the filing-number profile in e2e tests
- fixes an issue where it was no longer possible to resolve a dossier with subdossiers

Jira: https://4teamwork.atlassian.net/browse/CA-2090

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry => not necessary because a follow-up PR of the same release
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
