### PR TITLE
Fix removing a profile-image with a PATCH request to the `@users/<userid>` endpiont.

### DIFF
--- a/changes/CA-2394.bugfix
+++ b/changes/CA-2394.bugfix
@@ -1,0 +1,1 @@
+Fix removing a profile-image with a PATCH request to the `@users/<userid>` endpiont. [elioschmutz]

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -776,6 +776,15 @@
       />
 
   <plone:service
+      method="PATCH"
+      name="@users"
+      for="Products.CMFCore.interfaces.ISiteRoot"
+      factory=".users.GeverUsersPatch"
+      layer="opengever.base.interfaces.IOpengeverBaseLayer"
+      permission="zope2.View"
+      />
+
+  <plone:service
       method="GET"
       name="@responses"
       for="opengever.base.response.IResponseSupported"


### PR DESCRIPTION
Jira: https://4teamwork.atlassian.net/browse/CA-2394

This PR extends the `@users/<userid>` endpoint to handle profile image deletion.

I did not document it in the api-doc since this is the way how it should work by default.

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
