### PR TITLE
Add oneoffix "Funktionsvorlagen" to the whitelisted template types.

### DIFF
--- a/changes/CA-2476.other
+++ b/changes/CA-2476.other
@@ -1,0 +1,1 @@
+Add OneOffixx "Funktionsvorlagen" to the whitelisted template types. [phgross]

--- a/opengever/oneoffixx/utils.py
+++ b/opengever/oneoffixx/utils.py
@@ -10,5 +10,9 @@ whitelisted_template_types = {
     'a2c9b700-86cd-4481-a17f-533fe9c504a2': {
         'content-type': 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
         'extension': 'pptx',
+    },
+    '0a3ac64d-ec36-4bcd-b057-41379a502fed': {
+        'content-type': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'extension': 'docx',
     }
 }


### PR DESCRIPTION
Currently OneOffixx Funktionsvorlagen gets filtered out by our own templatetype-whitelist, but these are also desired.

See https://4teamwork.atlassian.net/browse/CA-2476

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

