### PR TITLE
Restrict document move via API

### DIFF
--- a/changes/CA-2424.bugfix
+++ b/changes/CA-2424.bugfix
@@ -1,0 +1,1 @@
+Do not allow to move documents via API if they are inside a task, proposal or closed dossier. [tinagerber]

--- a/changes/CA-2450.bugfix
+++ b/changes/CA-2450.bugfix
@@ -1,0 +1,1 @@
+Prevent documents from being moved from repository to the templates or private root via API. [tinagerber]

--- a/changes/CA-2450.bugfix
+++ b/changes/CA-2450.bugfix
@@ -1,1 +1,1 @@
-Prevent documents from being moved from repository to the templates or private root via API. [tinagerber]
+Prevent documents from being moved from repository or inbox to the templates or private root via API. [tinagerber]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -9,6 +9,7 @@ API Changelog
 Breaking Changes
 ^^^^^^^^^^^^^^^^
 
+- ``@move``: Restrict moving of documents via API according to the same rules as in the classic UI.
 
 Other Changes
 ^^^^^^^^^^^^^

--- a/opengever/api/move.py
+++ b/opengever/api/move.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 from Acquisition import aq_parent
-from Products.CMFCore.utils import getToolByName
+from opengever.base.interfaces import IMovabilityChecker
 from plone.restapi.deserializer import json_body
 from plone.restapi.services.copymove.copymove import Move
+from Products.CMFCore.utils import getToolByName
 from zExceptions import BadRequest
 from zope.interface import alsoProvides
 from zope.security import checkPermission
@@ -57,6 +58,7 @@ class Move(Move):
                 #         self.request.response.setStatus(403)
                 #         return
                 parent = aq_parent(obj)
+                IMovabilityChecker(obj).validate_movement(self.context)
                 if parent in parents_ids:
                     parents_ids[parent].append(obj.getId())
                 else:

--- a/opengever/api/tests/test_move.py
+++ b/opengever/api/tests/test_move.py
@@ -79,3 +79,78 @@ class TestMove(IntegrationTestCase):
             {u'type': u'Forbidden', u'message':
              u'Documents within the repository cannot be moved to the private repository.'},
             browser.json)
+
+    @browsing
+    def test_document_inside_a_task_cannot_be_moved(self, browser):
+        self.login(self.regular_user, browser)
+
+        with browser.expect_http_error(code=403):
+            browser.open(self.dossier, view='/@move',
+                         data=json.dumps({"source": self.taskdocument.absolute_url()}),
+                         method='POST', headers=self.api_headers)
+
+        self.assertEqual({u'type': u'Forbidden', u'message':
+                          u'Documents inside a task cannot be moved.'}, browser.json)
+
+    @browsing
+    def test_mail_inside_a_task_cannot_be_moved(self, browser):
+        self.login(self.regular_user, browser)
+        mail = create(Builder('mail').titled('Good news').within(self.task))
+
+        with browser.expect_http_error(code=403):
+            browser.open(self.dossier, view='/@move',
+                         data=json.dumps({"source": mail.absolute_url()}),
+                         method='POST', headers=self.api_headers)
+
+        self.assertEqual({u'type': u'Forbidden', u'message':
+                          u'Documents inside a task cannot be moved.'}, browser.json)
+
+    @browsing
+    def test_document_inside_a_proposal_cannot_be_moved(self, browser):
+        self.login(self.regular_user, browser)
+
+        with browser.expect_http_error(code=403):
+            browser.open(self.dossier, view='/@move',
+                         data=json.dumps({"source": self.proposaldocument.absolute_url()}),
+                         method='POST', headers=self.api_headers)
+
+        self.assertEqual({u'type': u'Forbidden', u'message':
+                          u'Documents inside a proposal cannot be moved.'}, browser.json)
+
+    @browsing
+    def test_mail_inside_a_proposal_cannot_be_moved(self, browser):
+        self.login(self.regular_user, browser)
+        mail = create(Builder('mail').titled('Good news').within(self.proposal))
+
+        with browser.expect_http_error(code=403):
+            browser.open(self.dossier, view='/@move',
+                         data=json.dumps({"source": mail.absolute_url()}),
+                         method='POST', headers=self.api_headers)
+
+        self.assertEqual({u'type': u'Forbidden', u'message':
+                          u'Documents inside a proposal cannot be moved.'}, browser.json)
+
+    @browsing
+    def test_document_inside_a_closed_dossier_cannot_be_moved(self, browser):
+        self.login(self.regular_user, browser)
+
+        with browser.expect_http_error(code=403):
+            browser.open(self.dossier, view='/@move',
+                         data=json.dumps({"source": self.expired_document.absolute_url()}),
+                         method='POST', headers=self.api_headers)
+
+        self.assertEqual({u'type': u'Forbidden', u'message':
+                          u'Documents inside a closed dossier cannot be moved.'}, browser.json)
+
+    @browsing
+    def test_mail_inside_a_closed_dossier_cannot_be_moved(self, browser):
+        self.login(self.regular_user, browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
+
+        with browser.expect_http_error(code=403):
+            browser.open(self.empty_dossier, view='/@move',
+                         data=json.dumps({"source": self.mail_eml.absolute_url()}),
+                         method='POST', headers=self.api_headers)
+
+        self.assertEqual({u'type': u'Forbidden', u'message':
+                          u'Documents inside a closed dossier cannot be moved.'}, browser.json)

--- a/opengever/api/tests/test_move.py
+++ b/opengever/api/tests/test_move.py
@@ -1,3 +1,5 @@
+from ftw.builder import Builder
+from ftw.builder import create
 from ftw.testbrowser import browsing
 from opengever.testing import IntegrationTestCase
 import json
@@ -21,3 +23,59 @@ class TestMove(IntegrationTestCase):
         )
         self.assertEqual(200, browser.status_code)
         self.assertIn(doc_id, self.subdossier)
+
+    @browsing
+    def test_move_document_within_templatefolder_is_possible(self, browser):
+        self.login(self.administrator, browser)
+        doc_id = self.dossiertemplatedocument.getId()
+        browser.open(
+            self.templates, view='@move',
+            data=json.dumps({"source": self.dossiertemplatedocument.absolute_url()}),
+            method='POST', headers=self.api_headers,
+        )
+        self.assertEqual(200, browser.status_code)
+        self.assertIn(doc_id, self.templates)
+
+    @browsing
+    def test_document_within_repository_cannot_be_moved_to_templates(self, browser):
+        self.login(self.administrator, browser)
+
+        with browser.expect_http_error(code=403):
+            browser.open(self.templates, view='/@move',
+                         data=json.dumps({"source": self.document.absolute_url()}),
+                         method='POST', headers=self.api_headers)
+
+        self.assertEqual({u'type': u'Forbidden', u'message':
+                          u'Documents within the repository cannot be moved to the templates.'},
+                         browser.json)
+
+    @browsing
+    def test_move_document_within_private_folder_is_possible(self, browser):
+        self.login(self.regular_user, browser)
+        dossier = create(
+            Builder('private_dossier')
+            .within(self.private_folder))
+
+        doc_id = self.private_document.getId()
+
+        browser.open(
+            dossier, view='@move',
+            data=json.dumps({"source": self.private_document.absolute_url()}),
+            method='POST', headers=self.api_headers,
+        )
+        self.assertEqual(200, browser.status_code)
+        self.assertIn(doc_id, dossier)
+
+    @browsing
+    def test_document_within_repository_cannot_be_moved_to_private_dossier(self, browser):
+        self.login(self.regular_user, browser)
+
+        with browser.expect_http_error(code=403):
+            browser.open(self.private_dossier, view='/@move',
+                         data=json.dumps({"source": self.document.absolute_url()}),
+                         method='POST', headers=self.api_headers)
+
+        self.assertEqual(
+            {u'type': u'Forbidden', u'message':
+             u'Documents within the repository cannot be moved to the private repository.'},
+            browser.json)

--- a/opengever/base/adapters.py
+++ b/opengever/base/adapters.py
@@ -2,11 +2,13 @@ from Acquisition import aq_base
 from opengever.base import _
 from opengever.base.behaviors.translated_title import ITranslatedTitle
 from opengever.base.behaviors.utils import split_string_by_numbers
+from opengever.base.interfaces import IMovabilityChecker
 from opengever.base.interfaces import IReferenceNumberPrefix
 from opengever.base.interfaces import IReferenceNumberSettings
 from opengever.base.protect import unprotected_write
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from persistent.dict import PersistentDict
+from plone.dexterity.interfaces import IDexterityContent
 from plone.registry.interfaces import IRegistry
 from Products.CMFCore.interfaces._content import IFolderish
 from zope.annotation.interfaces import IAnnotations
@@ -228,3 +230,14 @@ class ReferenceNumberPrefixAdpater(object):
 
         if prefix in self.get_child_mapping().keys():
             self.get_child_mapping().pop(prefix)
+
+
+@implementer(IMovabilityChecker)
+@adapter(IDexterityContent)
+class DefaultMovabilityChecker(object):
+
+    def __init__(self, context):
+        self.context = context
+
+    def validate_movement(self, target):
+        return

--- a/opengever/base/adapters.py
+++ b/opengever/base/adapters.py
@@ -107,7 +107,7 @@ class ReferenceNumberPrefixAdpater(object):
                 pass
 
             # .. otherwise try to increment the last numeric part
-            xpr = re.compile('\d+')
+            xpr = re.compile(r'\d+')
             matches = tuple(xpr.finditer(lastnumber))
             if len(matches) > 0:
                 span = matches[-1].span()

--- a/opengever/base/configure.zcml
+++ b/opengever/base/configure.zcml
@@ -175,6 +175,8 @@
 
   <adapter factory=".sequence.DefaultSequenceNumberGenerator" />
 
+  <adapter factory=".adapters.DefaultMovabilityChecker" />
+
   <adapter factory=".adapters.ReferenceNumberPrefixAdpater" />
 
   <adapter

--- a/opengever/base/interfaces.py
+++ b/opengever/base/interfaces.py
@@ -454,6 +454,13 @@ class IRoleAssignmentReportsStorage(Interface):
         """
 
 
+class IMovabilityChecker(Interface):
+
+    def validate_movement(target):
+        """Raises an error if object cannot be moved.
+        """
+
+
 class IPortalSettings(Interface):
 
     portal_url = schema.TextLine(

--- a/opengever/document/configure.zcml
+++ b/opengever/document/configure.zcml
@@ -252,6 +252,8 @@
       provides="zope.filerepresentation.interfaces.IRawWriteFile"
       />
 
+  <adapter factory=".move.DocumentMovabiliyChecker" />
+
   <adapter factory=".quick_upload.QuickUploadFileUpdater" />
 
   <adapter factory=".sequence.BaseDocumentSequenceNumberGenerator" />

--- a/opengever/document/move.py
+++ b/opengever/document/move.py
@@ -1,6 +1,7 @@
 from opengever.base.adapters import DefaultMovabilityChecker
 from opengever.document.behaviors import IBaseDocument
 from opengever.dossier.templatefolder.utils import is_within_templates
+from opengever.inbox.utils import is_within_inbox
 from opengever.private.utils import is_within_private_root
 from opengever.repository.utils import is_within_repository
 from zExceptions import Forbidden
@@ -25,3 +26,12 @@ class DocumentMovabiliyChecker(DefaultMovabilityChecker):
             if is_within_private_root(target):
                 raise Forbidden(
                     u'Documents within the repository cannot be moved to the private repository.')
+            return
+
+        if is_within_inbox(self.context):
+            if is_within_templates(target):
+                raise Forbidden(
+                    u'Documents within the inbox cannot be moved to the templates.')
+            if is_within_private_root(target):
+                raise Forbidden(
+                    u'Documents within the inbox cannot be moved to the private repository.')

--- a/opengever/document/move.py
+++ b/opengever/document/move.py
@@ -1,0 +1,20 @@
+from opengever.base.adapters import DefaultMovabilityChecker
+from opengever.document.behaviors import IBaseDocument
+from opengever.dossier.templatefolder.utils import is_within_templates
+from opengever.private.utils import is_within_private_root
+from opengever.repository.utils import is_within_repository
+from zExceptions import Forbidden
+from zope.component import adapter
+
+
+@adapter(IBaseDocument)
+class DocumentMovabiliyChecker(DefaultMovabilityChecker):
+
+    def validate_movement(self, target):
+        if is_within_repository(self.context):
+            if is_within_templates(target):
+                raise Forbidden(
+                    u'Documents within the repository cannot be moved to the templates.')
+            if is_within_private_root(target):
+                raise Forbidden(
+                    u'Documents within the repository cannot be moved to the private repository.')

--- a/opengever/document/move.py
+++ b/opengever/document/move.py
@@ -11,6 +11,13 @@ from zope.component import adapter
 class DocumentMovabiliyChecker(DefaultMovabilityChecker):
 
     def validate_movement(self, target):
+        if self.context.is_inside_a_task():
+            raise Forbidden(u'Documents inside a task cannot be moved.')
+        if self.context.is_inside_a_proposal():
+            raise Forbidden(u'Documents inside a proposal cannot be moved.')
+        if self.context.is_inside_a_closed_dossier():
+            raise Forbidden(u'Documents inside a closed dossier cannot be moved.')
+
         if is_within_repository(self.context):
             if is_within_templates(target):
                 raise Forbidden(

--- a/opengever/document/move.py
+++ b/opengever/document/move.py
@@ -1,9 +1,11 @@
+from OFS.CopySupport import ResourceLockedError
 from opengever.base.adapters import DefaultMovabilityChecker
 from opengever.document.behaviors import IBaseDocument
 from opengever.dossier.templatefolder.utils import is_within_templates
 from opengever.inbox.utils import is_within_inbox
 from opengever.private.utils import is_within_private_root
 from opengever.repository.utils import is_within_repository
+from plone.locking.interfaces import ILockable
 from zExceptions import Forbidden
 from zope.component import adapter
 
@@ -18,6 +20,8 @@ class DocumentMovabiliyChecker(DefaultMovabilityChecker):
             raise Forbidden(u'Documents inside a proposal cannot be moved.')
         if self.context.is_inside_a_closed_dossier():
             raise Forbidden(u'Documents inside a closed dossier cannot be moved.')
+        if ILockable(self.context).locked():
+            raise ResourceLockedError(u'Locked documents cannot be moved.')
 
         if is_within_repository(self.context):
             if is_within_templates(target):

--- a/opengever/dossier/templatefolder/utils.py
+++ b/opengever/dossier/templatefolder/utils.py
@@ -1,0 +1,9 @@
+from Acquisition import aq_chain
+from opengever.dossier.templatefolder.interfaces import ITemplateFolder
+
+
+def is_within_templates(context):
+    """ Checks, if the content is within the templates.
+    """
+
+    return bool(filter(ITemplateFolder.providedBy, aq_chain(context)))

--- a/opengever/dossier/tests/test_move_items.py
+++ b/opengever/dossier/tests/test_move_items.py
@@ -749,16 +749,14 @@ class TestMoveItemsWithTestbrowser(IntegrationTestCase):
 
     @browsing
     def test_move_items_within_templatefolder_is_possible(self, browser):
-        self.login(self.regular_user, browser)
-        # if the template folders are not in a valid root, this does not work
-        # No idea why it used to work in the functional test?
-        templatefolder = create(Builder('templatefolder').within(self.repository_root))
-        subtemplatefolder = create(
-            Builder('templatefolder').within(templatefolder))
-        document = create(Builder('document').within(templatefolder))
-        self.move_items(browser, src=templatefolder,
-                        obj=document, target=subtemplatefolder)
-        self.assertIn(document, subtemplatefolder.objectValues())
+        self.login(self.administrator, browser)
+        doc_intid = getUtility(IIntIds).getId(self.dossiertemplatedocument)
+
+        self.move_items(browser, src=self.dossiertemplate,
+                        obj=self.dossiertemplatedocument, target=self.templates)
+        doc = getUtility(IIntIds).getObject(doc_intid)
+
+        self.assertIn(doc, self.templates.objectValues())
 
     @browsing
     def test_paste_action_not_visible_for_closed_dossiers(self, browser):

--- a/opengever/dossier/tests/test_move_items.py
+++ b/opengever/dossier/tests/test_move_items.py
@@ -635,7 +635,7 @@ class TestMoveItemsWithTestbrowser(IntegrationTestCase):
         if path:
             payload['paths:list'] = [path]
 
-        browser.login().open(src, payload, view='move_items')
+        browser.open(src, payload, view='move_items')
 
         if not browser.url.endswith('move_items'):
             # Might have been redirected because of an error
@@ -646,7 +646,7 @@ class TestMoveItemsWithTestbrowser(IntegrationTestCase):
 
     @browsing
     def test_redirects_to_context_and_show_statusmessage_when_obj_cant_be_found(self, browser):
-        self.login(self.regular_user)
+        self.login(self.regular_user, browser)
         self.move_items(
             browser, src=self.dossier,
             obj='/invalid/path', target=self.empty_dossier)
@@ -658,7 +658,7 @@ class TestMoveItemsWithTestbrowser(IntegrationTestCase):
 
     @browsing
     def test_document_inside_a_task_is_not_movable(self, browser):
-        self.login(self.regular_user)
+        self.login(self.regular_user, browser)
         self.move_items(
             browser, src=self.task,
             obj=self.taskdocument, target=self.empty_dossier)
@@ -671,7 +671,7 @@ class TestMoveItemsWithTestbrowser(IntegrationTestCase):
 
     @browsing
     def test_mail_inside_a_task_is_not_movable(self, browser):
-        self.login(self.regular_user)
+        self.login(self.regular_user, browser)
         mail = create(Builder('mail').titled('Good news').within(self.task))
         self.move_items(browser, src=self.task, obj=mail, target=self.empty_dossier)
 
@@ -682,7 +682,7 @@ class TestMoveItemsWithTestbrowser(IntegrationTestCase):
 
     @browsing
     def test_document_inside_closed_dossier_is_not_movable(self, browser):
-        self.login(self.dossier_manager)
+        self.login(self.dossier_manager, browser)
         self.move_items(
             browser, src=self.expired_dossier,
             obj=self.expired_document, target=self.empty_dossier)
@@ -697,7 +697,7 @@ class TestMoveItemsWithTestbrowser(IntegrationTestCase):
 
     @browsing
     def test_document_inside_inactive_dossier_is_not_movable(self, browser):
-        self.login(self.dossier_manager)
+        self.login(self.dossier_manager, browser)
         self.move_items(
             browser, src=self.inactive_dossier,
             obj=self.inactive_document, target=self.empty_dossier)
@@ -712,7 +712,7 @@ class TestMoveItemsWithTestbrowser(IntegrationTestCase):
 
     @browsing
     def test_task_inside_closed_dossier_is_not_movable(self, browser):
-        self.login(self.dossier_manager)
+        self.login(self.dossier_manager, browser)
         self.move_items(
             browser, src=self.expired_dossier,
             task=self.expired_task, target=self.empty_dossier)
@@ -725,7 +725,7 @@ class TestMoveItemsWithTestbrowser(IntegrationTestCase):
 
     @browsing
     def test_mail_inside_closed_dossier_is_not_movable(self, browser):
-        self.login(self.dossier_manager)
+        self.login(self.dossier_manager, browser)
         self.set_workflow_state('dossier-state-resolved', self.dossier)
         self.move_items(
             browser, src=self.dossier,
@@ -739,7 +739,7 @@ class TestMoveItemsWithTestbrowser(IntegrationTestCase):
 
     @browsing
     def test_task_are_handled_correctly(self, browser):
-        self.login(self.regular_user)
+        self.login(self.regular_user, browser)
         task_intid = getUtility(IIntIds).getId(self.subtask)
         self.move_items(
             browser, src=self.task,

--- a/opengever/inbox/utils.py
+++ b/opengever/inbox/utils.py
@@ -1,3 +1,5 @@
+from Acquisition import aq_chain
+from opengever.inbox.inbox import IInbox
 from plone import api
 
 
@@ -14,3 +16,9 @@ def get_current_inbox(context):
         contentFilter={'portal_type': 'opengever.inbox.inbox'})
 
     return inbox[0] if inbox else None
+
+
+def is_within_inbox(context):
+    """ Checks, if the content is within the inbox.
+    """
+    return bool(filter(IInbox.providedBy, aq_chain(context)))

--- a/opengever/private/utils.py
+++ b/opengever/private/utils.py
@@ -1,0 +1,9 @@
+from Acquisition import aq_chain
+from opengever.private.root import IPrivateRoot
+
+
+def is_within_private_root(context):
+    """ Checks, if the content is within the private root.
+    """
+
+    return bool(filter(IPrivateRoot.providedBy, aq_chain(context)))

--- a/opengever/repository/utils.py
+++ b/opengever/repository/utils.py
@@ -1,0 +1,9 @@
+from Acquisition import aq_chain
+from opengever.repository.repositoryroot import IRepositoryRoot
+
+
+def is_within_repository(context):
+    """ Checks, if the content is within the repository.
+    """
+
+    return bool(filter(IRepositoryRoot.providedBy, aq_chain(context)))


### PR DESCRIPTION
Until now, documents could be moved via API even though they were in a task, for example. This is now restricted.

Jira: https://4teamwork.atlassian.net/browse/CA-2424 and https://4teamwork.atlassian.net/browse/CA-2450

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [x] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [x] for `document` also works for `mail`