### PR TITLE
Remove document watchers feature flag.

### DIFF
--- a/changes/CA-2462.other
+++ b/changes/CA-2462.other
@@ -1,0 +1,1 @@
+Remove document watchers feature flag. [tinagerber]

--- a/docs/public/dev-manual/api/config.rst
+++ b/docs/public/dev-manual/api/config.rst
@@ -65,7 +65,6 @@ GEVER-Mandanten abgefragt werden.
               "disposition_transport_filesystem": false,
               "disposition_transport_ftps": false,
               "doc_properties": true,
-              "document_watchers" false,
               "dossier_templates": true,
               "ech0147_export": true,
               "ech0147_import": true,
@@ -176,9 +175,6 @@ features
 
     doc_properties
         Hinzufügen von DocProperties bei aus Vorlagen erstellten Word-Dokumenten
-
-    document_watchers
-        Beobachter für Dokumente
 
     dossier_templates
         Dossier Vorlagen

--- a/opengever/activity/browser/settings.py
+++ b/opengever/activity/browser/settings.py
@@ -14,7 +14,6 @@ from opengever.activity.roles import WATCHER_ROLE
 from opengever.activity.roles import WORKSPACE_MEMBER_ROLE
 from opengever.base.handlebars import prepare_handlebars_template
 from opengever.base.json_response import JSONResponse
-from opengever.document import is_watcher_feature_enabled
 from opengever.meeting import is_meeting_feature_enabled
 from opengever.ogds.models.user import User
 from opengever.ogds.models.user_settings import UserSettings
@@ -360,7 +359,7 @@ class NotificationSettingsForm(BrowserView):
         return api.user.has_permission('opengever.disposition: Add disposition')
 
     def show_documents_tab(self):
-        return is_watcher_feature_enabled()
+        return True
 
     def show_proposals_tab(self):
         return is_meeting_feature_enabled()

--- a/opengever/activity/handlers.py
+++ b/opengever/activity/handlers.py
@@ -1,6 +1,5 @@
 from opengever.activity import is_activity_feature_enabled
 from opengever.activity import notification_center
-from opengever.document import is_watcher_feature_enabled
 from opengever.document.activities import DocumentWatcherAddedActivity
 from opengever.inbox.activities import ForwardingWatcherAddedActivity
 from opengever.inbox.forwarding import IForwarding
@@ -33,7 +32,4 @@ def notify_watcher(obj, event):
 
 
 def notify_document_watcher(obj, event):
-    if not is_watcher_feature_enabled():
-        return
-
     DocumentWatcherAddedActivity(obj, getRequest(), event.watcherid).record()

--- a/opengever/api/notification_settings.py
+++ b/opengever/api/notification_settings.py
@@ -5,7 +5,6 @@ from opengever.activity.model.settings import NotificationDefault
 from opengever.activity.notification_settings import NotificationSettings
 from opengever.activity.roles import ROLE_TRANSLATIONS
 from opengever.api.validation import get_validation_errors
-from opengever.document import is_watcher_feature_enabled
 from opengever.meeting import is_meeting_feature_enabled
 from opengever.ogds.models.user import User
 from opengever.ogds.models.user_settings import UserSettings
@@ -67,7 +66,7 @@ class NotificationSettingsGet(Service):
             'task': not is_workspace_feature_enabled(),
             'watcher': not is_workspace_feature_enabled(),
             'workspace': is_workspace_feature_enabled() and is_todo_feature_enabled(),
-            'document': is_watcher_feature_enabled(),
+            'document': True,
         }
 
     def general_settings_visibility(self):

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -65,7 +65,6 @@ class TestConfig(IntegrationTestCase):
                 u'disposition_transport_filesystem': False,
                 u'disposition_transport_ftps': False,
                 u'doc_properties': False,
-                u'document_watchers': False,
                 u'dossier_templates': False,
                 u'ech0147_export': False,
                 u'ech0147_import': False,

--- a/opengever/api/tests/test_notification_settings.py
+++ b/opengever/api/tests/test_notification_settings.py
@@ -244,7 +244,8 @@ class TestNotificationSettingsGet(IntegrationTestCase):
 
         self.assertEqual([u'added-as-watcher', u'task-added-or-reassigned',
                           u'task-transition-modify-deadline', u'task-commented',
-                          u'task-status-modified', u'task-reminder', u'dossier-overdue'],
+                          u'task-status-modified', u'task-reminder', u'dossier-overdue',
+                          u'document-modified'],
                          [activity['kind'] for activity in browser.json['activities']['items']])
 
         self.assertEqual({
@@ -274,6 +275,7 @@ class TestNotificationSettingsGet(IntegrationTestCase):
         self.login(self.regular_user, browser=browser)
         browser.open(self.portal, view='/@notification-settings',
                      method='GET', headers=self.api_headers)
+
         self.assertEqual({
             u'@id': u'http://nohost/plone/@notification-settings',
             u'activities': {
@@ -302,7 +304,16 @@ class TestNotificationSettingsGet(IntegrationTestCase):
                      u'mail': {u'todo_responsible_role': False,
                                u'workspace_member_role': False},
                      u'personal': False,
-                     u'title': u'ToDo modified'}]},
+                     u'title': u'ToDo modified'},
+                    {u'@id': u'http://nohost/plone/@notification-settings/activities/document-modified',
+                     u'badge': {u'regular_watcher': True},
+                             u'digest': {u'regular_watcher': False},
+                             u'group': u'document',
+                             u'id': u'document-modified',
+                             u'kind': u'document-modified',
+                             u'mail': {u'regular_watcher': False},
+                             u'personal': False,
+                             u'title': u'Document modified'}]},
             u'general': {
                 u'@id': u'http://nohost/plone/@notification-settings/general',
                 u'items': [{
@@ -319,24 +330,9 @@ class TestNotificationSettingsGet(IntegrationTestCase):
             u'translations': [{
                 u'id': u'todo_responsible_role',
                 u'title': u'ToDo responsible'},
+                {u'id': u'regular_watcher', u'title': u'Watcher'},
                 {u'id': u'workspace_member_role',
                  u'title': u'Workspace member'}]}, browser.json)
-
-    @browsing
-    def test_document_watcher_settings_only_available_if_watcher_feature_enabled(self, browser):
-        self.login(self.regular_user, browser=browser)
-        browser.open(self.portal, view='/@notification-settings',
-                     method='GET', headers=self.api_headers)
-
-        self.assertNotIn('document-modified',
-                         [activity['id'] for activity in browser.json['activities']['items']])
-
-        self.activate_feature('document-watchers')
-        browser.open(self.portal, view='/@notification-settings',
-                     method='GET', headers=self.api_headers)
-
-        self.assertIn('document-modified',
-                      [activity['id'] for activity in browser.json['activities']['items']])
 
 
 class TestNotificationSettingsPatch(IntegrationTestCase):

--- a/opengever/base/configuration.py
+++ b/opengever/base/configuration.py
@@ -144,7 +144,6 @@ class GeverSettingsAdpaterV1(object):
         features['disposition_transport_filesystem'] = api.portal.get_registry_record('enabled', interface=IFilesystemTransportSettings)  # noqa
         features['disposition_transport_ftps'] = api.portal.get_registry_record('enabled', interface=IFTPSTransportSettings)  # noqa
         features['doc_properties'] = api.portal.get_registry_record('create_doc_properties', interface=ITemplateFolderProperties)  # noqa
-        features['document_watchers'] = api.portal.get_registry_record('watcher_feature_enabled', interface=IDocumentSettings)  # noqa
         features['dossier_templates'] = api.portal.get_registry_record('is_feature_enabled', interface=IDossierTemplateSettings)  # noqa
         features['ech0147_export'] = api.portal.get_registry_record('ech0147_export_enabled', interface=IECH0147Settings)
         features['ech0147_import'] = api.portal.get_registry_record('ech0147_import_enabled', interface=IECH0147Settings)

--- a/opengever/base/tests/test_configuration_adapter.py
+++ b/opengever/base/tests/test_configuration_adapter.py
@@ -70,7 +70,6 @@ class TestConfigurationAdapter(IntegrationTestCase):
                 ('disposition_transport_filesystem', False),
                 ('disposition_transport_ftps', False),
                 ('doc_properties', False),
-                ('document_watchers', False),
                 ('dossier_templates', False),
                 ('ech0147_export', False),
                 ('ech0147_import', False),

--- a/opengever/core/upgrades/20210629072407_remove_document_watcher_feature_flag/registry.xml
+++ b/opengever/core/upgrades/20210629072407_remove_document_watcher_feature_flag/registry.xml
@@ -1,0 +1,3 @@
+<registry>
+  <record interface="opengever.document.interfaces.IDocumentSettings" field="watcher_feature_enabled" remove="True" />
+</registry>

--- a/opengever/core/upgrades/20210629072407_remove_document_watcher_feature_flag/upgrade.py
+++ b/opengever/core/upgrades/20210629072407_remove_document_watcher_feature_flag/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class RemoveDocumentWatcherFeatureFlag(UpgradeStep):
+    """Remove document watcher feature flag.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/document/__init__.py
+++ b/opengever/document/__init__.py
@@ -1,9 +1,6 @@
 from opengever.document.extra_mimetypes import register_additional_mimetypes
-from opengever.document.interfaces import IDocumentSettings
 from opengever.document.officeconnector import register_ee_filename_callback
-from plone.registry.interfaces import IRegistry
 from Products.CMFCore.permissions import ManagePortal
-from zope.component import getUtility
 from zope.i18nmessageid import MessageFactory
 
 
@@ -19,15 +16,6 @@ register_additional_mimetypes()
 # Register a callback function for ZEM generation in Products.ExternalEditor
 # to include a document's filename in the metadata.
 register_ee_filename_callback()
-
-
-def is_watcher_feature_enabled():
-    try:
-        registry = getUtility(IRegistry)
-        return registry.forInterface(IDocumentSettings).watcher_feature_enabled
-
-    except (KeyError, AttributeError):
-        return False
 
 
 def initialize(context):

--- a/opengever/document/handlers.py
+++ b/opengever/document/handlers.py
@@ -2,7 +2,6 @@ from opengever.base.browser.helper import get_css_class
 from opengever.base.model.favorite import Favorite
 from opengever.base.oguid import Oguid
 from opengever.base.sentry import log_msg_to_sentry
-from opengever.document import is_watcher_feature_enabled
 from opengever.document.activities import DocumentAuthorChangedActivity
 from opengever.document.activities import DocumentTitleChangedActivity
 from opengever.document.activities import DocumenVersionCreatedActivity
@@ -114,14 +113,10 @@ def _update_favorites_icon_class(context):
 
 
 def document_version_created(context, event):
-    if not is_watcher_feature_enabled():
-        return
     DocumenVersionCreatedActivity(context, getRequest()).record()
 
 
 def author_or_title_changed(context, event):
-    if not is_watcher_feature_enabled():
-        return
     if IContainerModifiedEvent.providedBy(event):
         return
     if ILocalrolesModifiedEvent.providedBy(event):

--- a/opengever/document/interfaces.py
+++ b/opengever/document/interfaces.py
@@ -76,12 +76,6 @@ class IDocumentSettings(Interface):
         default=PRESERVED_AS_PAPER_DEFAULT,
     )
 
-    watcher_feature_enabled = schema.Bool(
-        title=u'Enable watcher feature',
-        description=u'Whether watcher feature is enabled for documents',
-        default=False
-    )
-
 
 class ICheckinCheckoutManager(Interface):
     """Interface for the checkin / checkout manager.

--- a/opengever/document/tests/test_activities.py
+++ b/opengever/document/tests/test_activities.py
@@ -12,7 +12,7 @@ import json
 
 class TestDocumentChangedActivities(IntegrationTestCase):
 
-    features = ('activity', 'document-watchers')
+    features = ('activity',)
 
     @browsing
     def test_document_title_changed_activity(self, browser):
@@ -27,18 +27,6 @@ class TestDocumentChangedActivities(IntegrationTestCase):
         activity = Activity.query.first()
         self.assertEqual(u'document-title-changed', activity.kind)
         self.assertEquals(u'Title changed by B\xe4rfuss K\xe4thi (kathi.barfuss)', activity.summary)
-
-    @browsing
-    def test_document_title_changed_whitout_watchers_feature_enabled(self, browser):
-        self.deactivate_feature('document-watchers')
-        self.login(self.regular_user, browser)
-        self.assertEqual(0, Activity.query.count())
-
-        browser.open(self.document, method='PATCH',
-                     data=json.dumps({u'title': u'A new title'}),
-                     headers=self.api_headers)
-
-        self.assertEqual(0, Activity.query.count())
 
     @browsing
     def test_mail_title_changed_activity(self, browser):
@@ -127,7 +115,7 @@ class TestDocumentChangedActivities(IntegrationTestCase):
 
 class TestDocumentWatcherAddedActivity(IntegrationTestCase):
 
-    features = ('activity', 'document-watchers')
+    features = ('activity',)
 
     def setUp(self):
         super(TestDocumentWatcherAddedActivity, self).setUp()
@@ -155,10 +143,3 @@ class TestDocumentWatcherAddedActivity(IntegrationTestCase):
                                             WATCHER_ROLE)
         notifications = Notification.query.all()
         self.assertEquals(2, len(notifications))
-
-    def test_user_is_not_notified_when_document_watchers_feature_is_disabled(self):
-        self.deactivate_feature('document-watchers')
-        self.login(self.regular_user)
-        self.center.add_watcher_to_resource(self.document, self.meeting_user.getId(), WATCHER_ROLE)
-        notifications = Notification.query.all()
-        self.assertEqual(0, len(notifications))

--- a/opengever/policytemplates/policy_template/.mrbob.ini
+++ b/opengever/policytemplates/policy_template/.mrbob.ini
@@ -158,11 +158,6 @@ setup.preserved_as_paper.required = True
 setup.preserved_as_paper.default = true
 setup.preserved_as_paper.post_ask_question = mrbob.hooks:to_boolean
 
-setup.document_watcher.question = Enable watcher feature for documents
-setup.document_watcher.required = True
-setup.document_watcher.default = false
-setup.document_watcher.post_ask_question = mrbob.hooks:to_boolean
-
 setup.enable_private_folder.question = Enable private folder feature
 setup.enable_private_folder.required = True
 setup.enable_private_folder.default = true

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/profiles/default/registry.xml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/profiles/default/registry.xml.bob
@@ -58,12 +58,6 @@
   </records>
 
 {{% endif %}}
-{{% if setup.document_watcher %}}
-  <records interface="opengever.document.interfaces.IDocumentSettings">
-    <value key="watcher_feature_enabled">True</value>
-  </records>
-
-{{% endif %}}
 {{% if is_gever %}}
 {{% if setup.enable_meeting_feature %}}
   <record interface="opengever.meeting.interfaces.IMeetingSettings" field="is_feature_enabled">

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -68,7 +68,6 @@ FEATURE_FLAGS = {
     'contact': 'opengever.contact.interfaces.IContactSettings.is_feature_enabled',
     'disposition-disregard-retention-period': 'opengever.disposition.interfaces.IDispositionSettings.disregard_retention_period',  # noqa
     'doc-properties': 'opengever.dossier.interfaces.ITemplateFolderProperties.create_doc_properties',
-    'document-watchers': 'opengever.document.interfaces.IDocumentSettings.watcher_feature_enabled',
     'docugate': 'opengever.docugate.interfaces.IDocugateSettings.is_feature_enabled',
     'dossiertemplate': 'opengever.dossier.dossiertemplate.interfaces.IDossierTemplateSettings.is_feature_enabled',
     'ech0147-export': 'opengever.ech0147.interfaces.IECH0147Settings.ech0147_export_enabled',


### PR DESCRIPTION
Document watcher feature flag is no longer needed.

Jira: https://4teamwork.atlassian.net/browse/CA-2462

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))