### PR TITLE
Fix resolving a subdossier when filing_number feature is enabled.

### DIFF
--- a/changes/CA-2090.bugfix
+++ b/changes/CA-2090.bugfix
@@ -1,0 +1,1 @@
+Fix resolving a subdossier when filing_number feature is enabled. [phgross]

--- a/opengever/dossier/resolve.py
+++ b/opengever/dossier/resolve.py
@@ -93,7 +93,9 @@ class ResolveDossierTransitionExtender(TransitionExtender):
 
     @property
     def schemas(self):
-        if IFilingNumberMarker.providedBy(self.context):
+        if IFilingNumberMarker.providedBy(self.context) and \
+           not self.context.is_subdossier():
+
             return [IFilingFormSchema]
 
         return []

--- a/opengever/dossier/tests/test_archiver.py
+++ b/opengever/dossier/tests/test_archiver.py
@@ -584,3 +584,12 @@ class TestArchivePerAPI(IntegrationTestCase):
         self.assert_workflow_state(
             'dossier-state-resolved', self.resolvable_subdossier)
 
+    @browsing
+    def test_resolving_subdossier_does_not_require_filing_informations(self, browser):
+        self.login(self.secretariat_user, browser)
+        browser.open(self.subdossier, method="POST", headers=self.api_headers,
+                     view='@workflow/dossier-transition-resolve')
+
+        self.assertEqual(200, browser.status_code)
+
+        self.assert_workflow_state('dossier-state-resolved', self.subdossier)


### PR DESCRIPTION
When resolving a subdossier via API on a GEVER with enabled filing_number feature, the filing_number information was wrongly enforced. However, this should only be the case when closing a main dossier.

Fixes https://sentry.4teamwork.ch/organizations/sentry/issues/75815/?project=-1&query=is%3Aunresolved+error_log_id%3A1624881505.230.688737328325&statsPeriod=14d

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

