### PR TITLE
Add comment in inefficient upgrade steps.

### DIFF
--- a/opengever/core/upgrades/20200501143003_populate_additional_metadata_of_favorites/upgrade.py
+++ b/opengever/core/upgrades/20200501143003_populate_additional_metadata_of_favorites/upgrade.py
@@ -36,6 +36,9 @@ class PopulateAdditionalMetadataOfFavorites(SQLUpgradeStep):
         plone_uids = [row[0] for row in rows]
 
         for plone_uid in plone_uids:
+            # Do not duplicate this upgrade step as is. Querying the catalog
+            # for each object will trigger flushing of the indexing queue,
+            # i.e. the indexing queue gets processed for every object...
             brains = self.catalog_unrestricted_search({'UID': plone_uid})
             if len(brains) != 1:
                 LOG.error(

--- a/opengever/core/upgrades/20200730094255_fix_docs_only_partially_indexed_in_solr/upgrade.py
+++ b/opengever/core/upgrades/20200730094255_fix_docs_only_partially_indexed_in_solr/upgrade.py
@@ -71,6 +71,9 @@ class FixDocsOnlyPartiallyIndexedInSolr(UpgradeStep):
         """Reindex all fields/indexes for a broken solr document.
         """
         plone_uid = doc[u'UID']
+        # Do not duplicate this upgrade step as is. Querying the catalog
+        # for each object will trigger flushing of the indexing queue,
+        # i.e. the indexing queue gets processed for every object...
         brains = self.catalog_unrestricted_search({u'UID': plone_uid})
         if len(brains) != 1:
             logger.error(

--- a/opengever/core/upgrades/20200817143709_reindex_container_modified_during_bundle_import/upgrade.py
+++ b/opengever/core/upgrades/20200817143709_reindex_container_modified_during_bundle_import/upgrade.py
@@ -48,6 +48,9 @@ class ReindexContainerModifiedDuringBundleImport(UpgradeStep):
         not_in_sync = [item[0] for item in catalog_modified - solr_modified]
 
         for plone_uid in not_in_sync:
+            # Do not duplicate this upgrade step as is. Querying the catalog
+            # for each object will trigger flushing of the indexing queue,
+            # i.e. the indexing queue gets processed for every object...
             brains = self.catalog_unrestricted_search({'UID': plone_uid})
             if len(brains) != 1:
                 LOG.error(


### PR DESCRIPTION
A not very smart upgrade step, triggering the processing of the indexing queue for every object reindexed, has already been copied twice. To avoid copying it again in the future, I've added a comment in these upgrade steps.

For https://4teamwork.atlassian.net/browse/CA-2091

## Checklist

- [ ] Changelog entry -> no CL needed IMO
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)