### PR TITLE
Allow overriding task and subtask deadline in @trigger-task-template endpoint

### DIFF
--- a/changes/CA-2336.feature
+++ b/changes/CA-2336.feature
@@ -1,0 +1,1 @@
+Allow overriding task and subtask deadline in `@trigger-task-template` endpoint. [tinagerber]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -14,6 +14,7 @@ Breaking Changes
 Other Changes
 ^^^^^^^^^^^^^
 
+- ``@trigger-task-template``: Support overriding the deadline for each task (see :ref:`trigger_task_template` for updated examples).
 
 2021.13.0 (2021-06-25)
 ----------------------

--- a/docs/public/dev-manual/api/trigger_task_template.rst
+++ b/docs/public/dev-manual/api/trigger_task_template.rst
@@ -72,16 +72,17 @@ werden. Es gibt dabei folgende Möglichkeiten:
         }
 
 
-Titel und Beschreibung setzen
------------------------------
+Titel, Beschreibung und Frist setzen
+------------------------------------
 
 Sowohl für die Hauptaufgabe wie auch für jede der ausgewählten Aufgabenvorlage
-kann Titel und Beschreibung der Aufgabe überschrieben werden. Dafür stehen
+kann Titel, Beschreibung und Frist der Aufgabe überschrieben werden. Dafür stehen
 folgende Felder zur Verfügung:
 
 - ``title``: Setzt den Titel der Aufgabe (Default: Titel der Vorlage)
 - ``text``:  Setzt die Beschreibung der Aufgabe (Default: Beschreibung
   der Vorlage, oder Leer für die Hauptaufgabe)
+- ``deadline``: Setzt die Frist der Aufgabe (Default: Frist der Vorlage)
 
 
 **Beispiel-Request**:
@@ -98,6 +99,7 @@ folgende Felder zur Verfügung:
             "tasktemplates": [
                 {
                     "@id": "http://localhost:8080/fd/vorlagen/tasktemplatefolder-1/tasktemplate-1",
+                    "deadline": "2025-12-10",
                     "responsible": "stv:david.erni",
                     "title": "Unteraufgabe",
                     "text": "Noch schneller erledigen!"

--- a/opengever/api/templatefolder.py
+++ b/opengever/api/templatefolder.py
@@ -235,6 +235,8 @@ class TriggerTaskTemplatePost(Service):
             (ITask["title"], self.context, self.request), IFieldDeserializer)
         text_deserializer = queryMultiAdapter(
             (ITask["text"], self.context, self.request), IFieldDeserializer)
+        deadline_deserializer = queryMultiAdapter(
+            (ITask["deadline"], self.context, self.request), IFieldDeserializer)
 
         if "title" in data:
             raw_title = data["title"]
@@ -255,6 +257,16 @@ class TriggerTaskTemplatePost(Service):
                     u'Invalid text "{}"'.format(raw_text))
             else:
                 task_overrides["text"] = text
+
+        if "deadline" in data:
+            raw_deadline = data["deadline"]
+            try:
+                deadline = deadline_deserializer(raw_deadline)
+            except (RequiredMissing, ConstraintNotSatisfied):
+                errors.append(
+                    u'Invalid deadline "{}"'.format(raw_deadline))
+            else:
+                task_overrides["deadline"] = deadline
 
         return task_overrides, errors
 

--- a/opengever/tasktemplates/tasktemplatefolder.py
+++ b/opengever/tasktemplates/tasktemplatefolder.py
@@ -75,6 +75,7 @@ class TaskTemplateFolderTrigger(object):
     def create_main_task(self):
         title = self.main_task_overrides.get("title", self.context.title)
         text = self.main_task_overrides.get("text")
+        deadline = self.main_task_overrides.get("deadline", self.get_main_task_deadline())
         data = dict(
             title=title,
             text=text,
@@ -82,7 +83,7 @@ class TaskTemplateFolderTrigger(object):
             responsible=api.user.get_current().getId(),
             responsible_client=get_current_org_unit().id(),
             task_type='direct-execution',
-            deadline=self.get_main_task_deadline())
+            deadline=deadline)
 
         main_task = self.add_task(self.dossier, data)
 
@@ -118,6 +119,7 @@ class TaskTemplateFolderTrigger(object):
     def create_subtask(self, main_task, template, values):
         title = values.get("title", template.title)
         text = values.get("text", template.text)
+        deadline = values.get("deadline", date.today() + timedelta(template.deadline))
         data = dict(
             title=title,
             issuer=template.issuer,
@@ -126,7 +128,7 @@ class TaskTemplateFolderTrigger(object):
             task_type=template.task_type,
             text=text,
             relatedItems=self.related_documents,
-            deadline=date.today() + timedelta(template.deadline),
+            deadline=deadline,
         )
 
         data.update(values)


### PR DESCRIPTION
Allow overriding task and subtask deadline field in the @trigger-task-template endpoint, so that users can set this attribute in a batch add form in the new UI.

Jira: https://4teamwork.atlassian.net/browse/CA-2336

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))