### PR TITLE
ContactsSource fallbacks to `ogds_user` type if no type is explicitly given.

### DIFF
--- a/changes/CA-2492.bugfix
+++ b/changes/CA-2492.bugfix
@@ -1,0 +1,1 @@
+ContactsSource falls back to `ogds_user` type if no type is explicitly given. [elioschmutz]

--- a/opengever/contact/tests/test_sources.py
+++ b/opengever/contact/tests/test_sources.py
@@ -84,3 +84,15 @@ class TestContactsSource(FunctionalTestCase):
 
         self.assertTerms(
             [(self.meier_ag, u'Meier AG [2222]')], self.source.search('2222'))
+
+    def test_getTermByToken_falls_back_to_ogds_user_if_not_contact_type_is_given(self):
+
+        self.assertEqual(
+            'ogds_user:test_user_1_',
+            self.source.getTermByToken('ogds_user:test_user_1_').token
+        )
+
+        self.assertEqual(
+            'ogds_user:test_user_1_',
+            self.source.getTermByToken('test_user_1_').token
+        )


### PR DESCRIPTION
Jira: https://4teamwork.atlassian.net/browse/CA-2492

The `ContactSource` object is used by the `@participation` endpoint if the `contact` feature is enabled. Currently, the source requires an id to lookup in a kind of an actor id with `type:id`. But it's not an actor because there are completely custom types used for the source.

In the frontend, 1. we can't use actors since the api does not return actor-ids consistently and 2. using actors would not work, because the contact source does only need a kind of an actor, not an actor 🙈 .

So to go straight, this PR just assumes that we want to lookup an `ogds_user` if there is no given actor prefix.

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
