### PR TITLE
Include information about the current admin_unit in the config endpoint.

### DIFF
--- a/changes/CA-2338.feature
+++ b/changes/CA-2338.feature
@@ -1,0 +1,1 @@
+Include information about the curren admin_unit in the config endpoint. [phgross]

--- a/opengever/api/config.py
+++ b/opengever/api/config.py
@@ -4,11 +4,14 @@ from opengever.base.colorization import get_color
 from opengever.base.interfaces import IGeverSettings
 from opengever.inbox.utils import get_current_inbox
 from opengever.officeconnector.helpers import is_client_ip_in_office_connector_disallowed_ip_ranges
+from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.ogds.base.utils import get_current_org_unit
 from opengever.ogds.models.service import ogds_service
 from opengever.private import get_private_folder_url
 from opengever.repository.browser.primary_repository_root import PrimaryRepositoryRoot
+from plone.restapi.interfaces import ISerializeToJsonSummary
 from plone.restapi.services import Service
+from zope.component import queryMultiAdapter
 from zope.publisher.interfaces import NotFound
 
 
@@ -18,6 +21,7 @@ class ConfigGet(Service):
     def reply(self):
         config = IGeverSettings(self.context).get_config()
         self.add_additional_infos(config)
+        self.add_current_unit_infos(config)
         return config
 
     def check_permission(self):
@@ -54,3 +58,8 @@ class ConfigGet(Service):
         except NotFound:
             # GEVER deployments without a repository-root raises NotFound
             config['primary_repository'] = None
+
+    def add_current_unit_infos(self, config):
+        admin_unit = get_current_admin_unit()
+        config['current_admin_unit'] = queryMultiAdapter(
+            (admin_unit, self.request), ISerializeToJsonSummary)()

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -29,6 +29,8 @@
   <adapter factory=".serializer.SerializeUserModelToJsonSummary" />
   <adapter factory=".serializer.SerializeGroupModelToJsonSummary" />
   <adapter factory=".serializer.SerializeBrainToJsonSummary" />
+  <adapter factory=".serializer.SerializeAdminUnitModelToJsonSummary" />
+  <adapter factory=".serializer.SerializeOrgUnitModelToJsonSummary" />
 
   <adapter factory=".actors.SerializeActorToJson" />
   <adapter factory=".repositoryfolder.DeserializeRepositoryFolderFromJson" />

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -338,3 +338,32 @@ class TestConfig(IntegrationTestCase):
 
         browser.open(self.config_url, headers=self.api_headers)
         self.assertTrue(browser.json['features']['filing_number'])
+
+    @browsing
+    def test_contains_the_current_admin_unit(self, browser):
+        self.login(self.regular_user, browser)
+
+        browser.open(self.config_url, headers=self.api_headers)
+
+        self.assertEqual(
+            {u'@id': u'http://nohost/plone/@admin-units/plone',
+             u'@type': u'virtual.ogds.admin_unit',
+             u'abbreviation': u'Client1',
+             u'enabled': True,
+             u'hidden': False,
+             u'public_url': u'http://nohost/plone',
+             u'title': u'Hauptmandant',
+             u'unit_id': u'plone',
+             u'org_units': [{u'@id': u'http://nohost/plone/@org-units/fa',
+                             u'@type': u'virtual.ogds.org_unit',
+                             u'enabled': True,
+                             u'hidden': False,
+                             u'title': u'Finanz\xe4mt',
+                             u'unit_id': u'fa'},
+                            {u'@id': u'http://nohost/plone/@org-units/rk',
+                             u'@type': u'virtual.ogds.org_unit',
+                             u'enabled': True,
+                             u'hidden': False,
+                             u'title': u'Ratskanzl\xc3\xa4i',
+                             u'unit_id': u'rk'}]},
+            browser.json['current_admin_unit'])


### PR DESCRIPTION
Used to display current app information in the gever-ui (see https://4teamwork.atlassian.net/browse/CA-2338).

Currently org_units are not really accessible directly via REST, so the `@id` in the endpoint ist not really an URL - but I think thats not a problem for now.

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
