### PR TITLE
Allow authenticated users to access vocabularies via API.

### DIFF
--- a/changes/CA-2338-2.feature
+++ b/changes/CA-2338-2.feature
@@ -1,0 +1,1 @@
+Allow authenticated users to access vocabularies via API. [phgross]

--- a/opengever/api/tests/test_vocabularies.py
+++ b/opengever/api/tests/test_vocabularies.py
@@ -135,9 +135,15 @@ class TestNonSensitiveVocabularies(IntegrationTestCase):
             'Please validate that the newly introduced vocabularies do not contain '
             'protectable entries and update the list of NON_SENSITIVE_VOCABUALRIES.')
 
-    def assert_permission_for_non_sensitive_vocabulaires(self, browser, role):
-        self.login(self.regular_user, browser)
-        api.user.grant_roles(user=api.user.get_current(), roles=[role])
+    def assert_permission_for_non_sensitive_vocabulaires(self, browser, role=None, user=None):
+        if not user:
+            user = self.regular_user
+
+        self.login(user, browser)
+
+        if role:
+            api.user.grant_roles(user=api.user.get_current(), roles=[role])
+
         browser.raise_http_errors = False
         not_accessable = []
 
@@ -162,6 +168,10 @@ class TestNonSensitiveVocabularies(IntegrationTestCase):
     @browsing
     def test_all_non_sensitive_vocabularies_are_accessable_by_a_member(self, browser):
         self.assert_permission_for_non_sensitive_vocabulaires(browser, 'Member')
+
+    @browsing
+    def test_all_non_sensitive_vocabularies_are_accessable_by_an_authenticated_user(self, browser):
+        self.assert_permission_for_non_sensitive_vocabulaires(browser, user=self.foreign_contributor)
 
     @browsing
     def test_all_non_sensitive_vocabularies_are_accessable_by_a_contributor(self, browser):

--- a/opengever/core/profiles/default/rolemap.xml
+++ b/opengever/core/profiles/default/rolemap.xml
@@ -345,6 +345,7 @@
       <role name="Contributor" />
       <role name="Manager" />
       <role name="Member" />
+      <role name="Authenticated" />
     </permission>
 
     <permission name="plone.restapi: Access Plone user information" acquire="True">

--- a/opengever/core/upgrades/20210705111629_allow_authenticated_users_to_access_vocabularies_via_api/rolemap.xml
+++ b/opengever/core/upgrades/20210705111629_allow_authenticated_users_to_access_vocabularies_via_api/rolemap.xml
@@ -1,0 +1,14 @@
+<rolemap>
+
+  <permissions>
+
+    <permission name="plone.restapi: Access Plone vocabularies" acquire="True">
+      <role name="Contributor" />
+      <role name="Manager" />
+      <role name="Member" />
+      <role name="Authenticated" />
+    </permission>
+
+  </permissions>
+
+</rolemap>

--- a/opengever/core/upgrades/20210705111629_allow_authenticated_users_to_access_vocabularies_via_api/upgrade.py
+++ b/opengever/core/upgrades/20210705111629_allow_authenticated_users_to_access_vocabularies_via_api/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AllowAuthenticatedUsersToAccessVocabulariesViaAPI(UpgradeStep):
+    """Allow Authenticated users to access vocabularies via API.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
With PR #5580 the vocabulary endpoint was made accessible for all Members. But for requests on a foreign admin_unit, the user only has the `Authenticated` Role but still need to access vocabularies, for example the `SupportedContentLanguages` vocabulary. 

Opening the endpoint for AuthenticatedUsers is not problematic, because all critical information (users, groups etc.) are visible for the whole client group anyway or their contents are only visible for users with access rights anyway (see #5449 for more information). Furthermore a test ensures that no new vocabularies with sensitive data are made accessible.

For https://4teamwork.atlassian.net/browse/CA-2338

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
