### PR TITLE
Add new @submit-additional-documents endpoint.

### DIFF
--- a/changes/CA-2036.feature
+++ b/changes/CA-2036.feature
@@ -1,0 +1,1 @@
+Add @submit-additional-documents endpoint. [njohner]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -18,6 +18,7 @@ Other Changes
 - ``@config`` endpoint extended with current admin_unit information.
 - ``@trigger-task-template``: Support overriding the deadline for each task (see :ref:`trigger_task_template` for updated examples).
 - ``@navigation``: Add ``review_state`` and ``include_context`` parameters (see :ref:`docs <navigation>`)
+- Added ``@submit-additional-documents`` endpoint. (see :ref:`docs <submit-additional-documents>`)
 
 2021.13.0 (2021-06-25)
 ----------------------

--- a/docs/public/dev-manual/api/proposals.rst
+++ b/docs/public/dev-manual/api/proposals.rst
@@ -112,3 +112,40 @@ Der Verlauf eines Antrags ist in der GET Repräsentation eines Antrags unter dem
         "...": "...",
       }
 
+Zusätzliche Beilagen einreichen
+-------------------------------
+
+Nach dem einreichen eines Antrags können mit dem ``@submit-additional-documents`` zusätzliche Beilagen oder eine neue Version von einer existierender Beilage eingereicht werden. Als Body wird eine Liste von Dokumente (UID) im Attribut ``documents`` erwartet.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       POST dossier-1/proposal-1/@submit-additional-documents HTTP/1.1
+       Accept: application/json
+
+       {
+        "documents": ["00040acaba70487a98d15b832cc1f99a", "001dbd36feec4df1a106047d3fa884b4"]
+       }
+
+Die Response ist eine Liste die für jede Beilage die folgenden Informationen zurückliefert:
+``source``: URL der Beilage
+``action``: "copied" wenn es sich um eine neu Beilage die in den eingereichten Antrag kopiert wurde, "udapted" wenn eine neue Version der Beilage erstellt wurde oder "null" wenn diese Beilage bereits in dieser Version eingereicht wurde.
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      [
+          {
+              "action": "copied",
+              "source": "dossier-1/proposal-1/document-75"
+          },
+          {
+              "action": null,
+              "source": "dossier-1/proposal-1/document-76"
+          }
+      ]

--- a/docs/public/dev-manual/api/proposals.rst
+++ b/docs/public/dev-manual/api/proposals.rst
@@ -112,6 +112,8 @@ Der Verlauf eines Antrags ist in der GET Repräsentation eines Antrags unter dem
         "...": "...",
       }
 
+.. _submit-additional-documents:
+
 Zusätzliche Beilagen einreichen
 -------------------------------
 

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -1343,6 +1343,13 @@
       layer="opengever.base.interfaces.IOpengeverBaseLayer"
       />
 
+  <plone:service
+      method="POST"
+      name="@submit-additional-documents"
+      for="opengever.meeting.proposal.IProposal"
+      factory=".proposal.SubmitAdditionalDocuments"
+      permission="zope2.View"
+      />
 
   <adapter factory=".upload_structure.DefaultUploadStructureAnalyser" />
   <adapter factory=".upload_structure.DossierUploadStructureAnalyser" />

--- a/opengever/api/task.py
+++ b/opengever/api/task.py
@@ -26,7 +26,6 @@ from plone.restapi.interfaces import ISerializeToJsonSummary
 from plone.restapi.services import Service
 from plone.restapi.services.content.update import ContentPatch
 from zExceptions import BadRequest
-from zExceptions import BadRequest
 from zExceptions import Unauthorized
 from zope.component import adapter
 from zope.component import getMultiAdapter

--- a/opengever/api/tests/test_proposal.py
+++ b/opengever/api/tests/test_proposal.py
@@ -283,7 +283,7 @@ class TestSubmitAdditionalDocumentsNJ(IntegrationTestCase):
         previously_submitted = model.resolve_submitted_documents()[0]
 
         data = json.dumps({
-            'documents': [self.subdocument.UID(), self.subsubdocument.UID()]
+            'documents': [self.subdocument.UID(), self.mail_eml.UID()]
         })
 
         with self.observe_children(self.submitted_proposal) as children:
@@ -295,13 +295,13 @@ class TestSubmitAdditionalDocumentsNJ(IntegrationTestCase):
             [{u'action': u'copied',
               u'source': self.subdocument.absolute_url()},
              {u'action': u'copied',
-              u'source': self.subsubdocument.absolute_url()}],
+              u'source': self.mail_eml.absolute_url()}],
             browser.json)
 
         self.assertEqual(2, len(children["added"]))
         self.assertEqual(3, len(model.submitted_documents))
         self.assertItemsEqual(list(children['added']) + [previously_submitted],
-                             model.resolve_submitted_documents())
+                              model.resolve_submitted_documents())
 
     @browsing
     def test_submitting_additional_document_already_up_to_date(self, browser):

--- a/opengever/meeting/browser/submitdocuments.py
+++ b/opengever/meeting/browser/submitdocuments.py
@@ -35,6 +35,17 @@ from zope.schema import TextLine
 import json
 
 
+additional_documents_source = DossierPathSourceBinder(
+                portal_type=("opengever.document.document", "ftw.mail.mail"),
+                navigation_tree_query={
+                    'object_provides':
+                        ['opengever.dossier.behaviors.dossier.IDossierMarker',
+                         'opengever.document.document.IDocumentSchema',
+                         'opengever.task.task.ITask',
+                         'ftw.mail.mail.IMail', ],
+                    })
+
+
 class ISubmitAdditionalDocuments(model.Schema):
     """Meeting model schema interface."""
 
@@ -44,15 +55,7 @@ class ISubmitAdditionalDocuments(model.Schema):
         missing_value=[],
         value_type=RelationChoice(
             title=u"Related",
-            source=DossierPathSourceBinder(
-                portal_type=("opengever.document.document", "ftw.mail.mail"),
-                navigation_tree_query={
-                    'object_provides':
-                        ['opengever.dossier.behaviors.dossier.IDossierMarker',
-                         'opengever.document.document.IDocumentSchema',
-                         'opengever.task.task.ITask',
-                         'ftw.mail.mail.IMail', ],
-                    }),
+            source=additional_documents_source,
             ),
         required=True,
         )

--- a/opengever/meeting/command.py
+++ b/opengever/meeting/command.py
@@ -460,6 +460,10 @@ class NullUpdateSubmittedDocumentCommand(object):
             portal.REQUEST,
             type='warning')
 
+    def api_response(self):
+        return {"source": self.document.absolute_url(),
+                "action": None}
+
 
 class UpdateSubmittedDocumentCommand(object):
 
@@ -503,6 +507,10 @@ class UpdateSubmittedDocumentCommand(object):
               mapping=dict(title=self.document.title)),
             portal.REQUEST)
 
+    def api_response(self):
+        return {"source": self.document.absolute_url(),
+                "action": "updated"}
+
 
 class CopyProposalDocumentCommand(object):
     """Copy documents attached to a proposal to the proposal's associated
@@ -538,6 +546,10 @@ class CopyProposalDocumentCommand(object):
             _(u'Additional document ${title} has been submitted successfully.',
               mapping=dict(title=self.document.title)),
             portal.REQUEST)
+
+    def api_response(self):
+        return {"source": self.document.absolute_url(),
+                "action": "copied"}
 
     def add_database_entry(self, reponse, target_admin_unit_id):
         session = create_session()


### PR DESCRIPTION
We add a new `@submit-additional-documents` endpoint.
The endpoint takes as input parameter a list of document UIDs. This avoids the whole problem with dealing with absolute urls and should not be a problem for the frontend, which also has the UIDs from the content selector.
I was a bit more indecisive regarding the response. Because depending on whether a given document was already submitted or not, the document will either be copied to the submitted proposal, updated with a new version or nothing will be done, I deemed it necessary to include the performed action for each document in the response. The response is there fore a list of dictionaries. For each document it returns its URL and the performed action:
```
[{"source" : url, "action": "copied"}]
``` 
The URL is under the "source" key, because we might want to include the "target" (i.e. information about the document on the submitted proposal side) in the future? I wonder whether it would be cleaner and more flexible to return a dictionary under "source" instead, something like:
```
[{"source" : {`@id`:url, `UID`: uid}, "action": "copied"}]
```
Input welcome.

For https://4teamwork.atlassian.net/browse/CA-2036

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide]
- New functionality:
  - [x] for `document` also works for `mail`