### PR TITLE
Fix selecting all items for Solr based listings.

### DIFF
--- a/changes/CA-2553.bugfix
+++ b/changes/CA-2553.bugfix
@@ -1,0 +1,1 @@
+Fix selecting all items for solr based listings in the classical UI. [deiferni]

--- a/opengever/dossier/tests/test_documents_tab.py
+++ b/opengever/dossier/tests/test_documents_tab.py
@@ -32,3 +32,43 @@ class TestDocumentsTab(SolrIntegrationTestCase):
             '/vertrage-und-vereinbarungen/dossier-1/dossier-2/document-22'
         )
         self.assertEqual(expected_url, items.first.get('href'))
+
+    @browsing
+    def test_document_listing_select_all(self, browser):
+        self.login(self.regular_user, browser)
+
+        # check amount of total items
+        browser.open(
+            self.branch_repofolder,
+            view='tabbed_view/listing?view_name=documents-proxy&pagesize=10000'
+        )
+        self.assertEqual(19, len(browser.css('table.listing tbody tr')))
+
+        # load page 2 with pagesize of 3
+        browser.open(
+            self.branch_repofolder,
+            view='tabbed_view/select_all?view_name=documents-proxy&pagesize=3&pagenumber=2&selected_count=3'
+        )
+        # 3 before + 3 already loaded + 13 after = 19 total
+        self.assertEqual(3, len(browser.css('#above_visibles input')))
+        self.assertEqual(13, len(browser.css('#beneath_visibles input')))
+
+    @browsing
+    def test_document_listing_select_all_with_search(self, browser):
+        self.login(self.regular_user, browser)
+
+        # check amount of total items with text "vertrag"
+        browser.open(
+            self.branch_repofolder,
+            view='tabbed_view/listing?view_name=documents-proxy&pagesize=10000&searchable_text=vertrag'
+        )
+        self.assertEqual(8, len(browser.css('table.listing tbody tr')))
+
+        # load page 2 with pagesize of 3  with text "vertrag"
+        browser.open(
+            self.branch_repofolder,
+            view='tabbed_view/select_all?view_name=documents-proxy&pagesize=3&pagenumber=2&selected_count=3&searchable_text=vertrag'
+        )
+        # 3 before + 3 already loaded + 2 after = 8 total
+        self.assertEqual(3, len(browser.css('#above_visibles input')))
+        self.assertEqual(2, len(browser.css('#beneath_visibles input')))

--- a/opengever/tabbedview/browser/base_tabs.py
+++ b/opengever/tabbedview/browser/base_tabs.py
@@ -171,6 +171,14 @@ class GeverTabMixin(object):
 
         return filters
 
+    def select_all(self, pagenumber, selected_count):
+        if getattr(self.table_source, 'use_solr', False):
+            self.table_source.select_all = True
+
+        return super(GeverTabMixin, self).select_all(
+            pagenumber, selected_count
+        )
+
 
 class BaseListingTab(GeverTabMixin, ListingView):
     """Base listing tab."""

--- a/opengever/tabbedview/browser/tabs.py
+++ b/opengever/tabbedview/browser/tabs.py
@@ -100,7 +100,11 @@ class BaseTabProxy(BaseCatalogListingTab):
         # Fetch contents from the preferred_view (gallery or listing view)
         # to use the query of the really display tabbedview.
         view = self.context.restrictedTraverse(self.preferred_view_name)
+        if getattr(view.table_source, 'use_solr', False):
+            view.table_source.select_all = True
         view.update()
+        # update self with relevant attributes of delegate.
+        self.pagesize = view.pagesize
 
         above, beneath = self._select_all_remove_visibles(
             view.contents, pagenumber, selected_count)

--- a/opengever/tabbedview/tests/test_dossier_listing.py
+++ b/opengever/tabbedview/tests/test_dossier_listing.py
@@ -313,3 +313,43 @@ class TestDossierListing(SolrIntegrationTestCase):
         self.open_repo_with_filter(
             browser, self.leaf_repofolder, 'filter_all', ['Alpha Beta'])
         self.assertEqual(1, len(browser.css('.listing tbody tr')))
+
+    @browsing
+    def test_dossier_listing_select_all(self, browser):
+        self.login(self.regular_user, browser)
+
+        # check amount of total items
+        browser.open(
+            self.branch_repofolder,
+            view='tabbed_view/listing?view_name=dossiers&pagesize=10000'
+        )
+        self.assertEqual(8, len(browser.css('table.listing tbody tr')))
+
+        # load page 2 with pagesize of 3
+        browser.open(
+            self.branch_repofolder,
+            view='tabbed_view/select_all?view_name=dossiers&pagesize=3&pagenumber=2&selected_count=3'
+        )
+        # 3 before + 3 already loaded + 2 after = 8 total
+        self.assertEqual(3, len(browser.css('#above_visibles input')))
+        self.assertEqual(2, len(browser.css('#beneath_visibles input')))
+
+    @browsing
+    def test_dossier_listing_select_all_with_search(self, browser):
+        self.login(self.regular_user, browser)
+
+        # check amount of total items with text "sitzung"
+        browser.open(
+            self.branch_repofolder,
+            view='tabbed_view/listing?view_name=dossiers&pagesize=10000&searchable_text=sitzung'
+        )
+        self.assertEqual(4, len(browser.css('table.listing tbody tr')))
+
+        # load page 2 with pagesize of 3 with text "sitzung"
+        browser.open(
+            self.branch_repofolder,
+            view='tabbed_view/select_all?view_name=dossiers&pagesize=2&pagenumber=2&selected_count=2&searchable_text=sitzung'
+        )
+        # 2 before + 2 already loaded + 0 after = 4 total
+        self.assertEqual(2, len(browser.css('#above_visibles input')))
+        self.assertEqual(0, len(browser.css('#beneath_visibles input')))


### PR DESCRIPTION
The provided fix just fixes the issue for tabbedview/table based listings in the classical UI.

It works around the fact that the Solr based source does not always have all contents loaded to apply batching but uses Solr side batching. This breaks an assumption in the catalog based "select all" functionality which seems to expect an unbatched list of all brains being available.

As a workaround we tell the source that we want all results. The query will be optimized and will only query for the `path` field. I have tested it locally on a dossier with 20k documents. Returning the selected paths to the frontend seems performant enough so that i can bump the hard-coded maximum to 100k.

Jira: https://4teamwork.atlassian.net/browse/CA-2553

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

