### PR TITLE
Provide field unspecific mail download view

### DIFF
--- a/changes/CA-2528.feature
+++ b/changes/CA-2528.feature
@@ -1,0 +1,1 @@
+Provide field unspecific mail download view. [phgross]

--- a/opengever/mail/browser/download.py
+++ b/opengever/mail/browser/download.py
@@ -1,3 +1,4 @@
+from ftw.mail.mail import IMail
 from opengever.document.browser.download import DocumentishDownload
 from opengever.mail.interfaces import IMailDownloadSettings
 from opengever.mail.mail import IOGMail
@@ -31,6 +32,18 @@ class MailDownload(DocumentishDownload):
     for the download.
     """
 
+    def publishTraverse(self, request, name):
+        """Do not raise NotFound error if fieldname and filename is not
+        specified.
+        """
+
+        if self.fieldname is None:  # ../@@download/fieldname
+            self.fieldname = name
+        elif self.filename is None:  # ../@@download/fieldname/filename
+            self.filename = name
+
+        return self
+
     def convert_line_endings(self, filename):
         lines = []
         with open(filename, 'r') as _file:
@@ -41,6 +54,15 @@ class MailDownload(DocumentishDownload):
                 lines.append(line)
 
         return ''.join(lines)
+
+    def _getFile(self):
+        if not self.fieldname:
+            if self.context.original_message:
+                self.fieldname = IOGMail['original_message'].getName()
+            else:
+                self.fieldname = IMail['message'].getName()
+
+        return super(MailDownload, self)._getFile()
 
     def stream_data(self, named_file):
         if self.fieldname == IOGMail['original_message'].getName():

--- a/opengever/mail/tests/test_mail_download.py
+++ b/opengever/mail/tests/test_mail_download.py
@@ -157,3 +157,28 @@ class TestMailDownload(IntegrationTestCase):
              'content-type': 'application/pkcs7-mime',
              'content-disposition': 'attachment; filename="Hello.foo"'},
             browser.headers)
+
+    @browsing
+    def test_download_with_unspecified_fieldname_prefers_original_message(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        # msg
+        browser.visit(self.mail_msg, view='download')
+
+        self.assertEquals(self.mail_msg.original_message.data,
+                          browser.contents)
+        self.assertDictContainsSubset(
+            {'content-length': str(len(browser.contents)),
+             'content-type': 'application/vnd.ms-outlook',
+             'content-disposition': 'attachment; filename="No Subject.msg"'},
+            browser.headers)
+
+        # eml only
+        browser.visit(self.mail_eml, view='download')
+
+        self.assertEquals(self.mail_eml.message.data, browser.contents)
+        self.assertDictContainsSubset(
+            {'content-length': str(len(browser.contents)),
+             'content-type': 'message/rfc822',
+             'content-disposition': 'attachment; filename="Die Buergschaft.eml"'},
+            browser.headers)

--- a/opengever/mail/tests/test_mail_download.py
+++ b/opengever/mail/tests/test_mail_download.py
@@ -14,7 +14,7 @@ MAIL_DATA_LF = resource_string('opengever.mail.tests', 'mail_lf.txt')
 MAIL_DATA_CRLF = resource_string('opengever.mail.tests', 'mail_crlf.txt')
 
 
-class TestMailDownloadCopy(IntegrationTestCase):
+class TestMailDownload(IntegrationTestCase):
     """Test downloading a mail works."""
 
     @browsing


### PR DESCRIPTION
The view decides independently whether original message or eml file is returned and does no longer require a fieldname as additional url paramenter. This allows the frontend to just call a view and not handle the businesslogic by them self.

For https://4teamwork.atlassian.net/browse/CA-2528 

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
