### PR TITLE
Fix upgrade step.

### DIFF
--- a/opengever/core/upgrades/20210609085047_add_document_watcher_feature_flag/upgrade.py
+++ b/opengever/core/upgrades/20210609085047_add_document_watcher_feature_flag/upgrade.py
@@ -6,4 +6,5 @@ class AddDocumentWatcherFeatureFlag(UpgradeStep):
     """
 
     def __call__(self):
-        self.install_upgrade_profile()
+        # self.install_upgrade_profile()
+        pass


### PR DESCRIPTION
Follow up for https://github.com/4teamwork/opengever.core/pull/7067

Since the feature flag has been removed again, this upgrade step no longer works because the field no longer exists on the IDocumentSettings interface.