### PR TITLE
Add script to create service users

### DIFF
--- a/changes/HG-1488.other
+++ b/changes/HG-1488.other
@@ -1,0 +1,1 @@
+Add script to create service users. [deiferni]

--- a/opengever/setup/serviceuser.py
+++ b/opengever/setup/serviceuser.py
@@ -1,0 +1,141 @@
+from App.config import getConfiguration
+from ftw.tokenauth.service_keys.browser.issue import create_json_keyfile
+from opengever.core.debughelpers import get_first_plone_site
+from opengever.core.debughelpers import setup_plone
+from plone import api
+from random import SystemRandom
+import argparse
+import logging
+import os
+import string
+import sys
+import transaction
+from argparse import ArgumentTypeError
+
+
+log = logging.getLogger("opengever.setup.serviceuser")
+log.setLevel(logging.INFO)
+
+
+def make_random_password():
+    random = SystemRandom()
+    chars = string.ascii_letters + string.digits
+    return "".join(random.choice(chars) for i in range(32))
+
+
+def new_user(username):
+    username = username.strip()
+    acl_users = api.portal.get_tool("acl_users")
+    user = acl_users.getUser(username)
+    if user is not None:
+        raise ArgumentTypeError(u"User {} already exists.".format(username))
+    return username
+
+
+def parse_args(argv):
+    """Parse arguments and insert defaults."""
+
+    # Discard the first two arguments, because they're not "actual" arguments
+    # but cruft that we get because of the way bin/instance [zopectl_cmd]
+    # scripts work.
+    argv = argv[2:]
+
+    acl_users = api.portal.get_tool("acl_users")
+    allowed_roles = list(acl_users.portal_role_manager.listRoleIds())
+
+    parser = argparse.ArgumentParser(description="Create a service user.")
+    parser.add_argument(
+        "username", help="Username of the service user.", type=new_user
+    )
+    parser.add_argument(
+        "--roles",
+        nargs="+",
+        default=[],
+        required=False,
+        choices=allowed_roles,
+        help="The roles of the service user. Will always inlcude the "
+        "`ServiceKeyUser` role.",
+    )
+    parser.add_argument(
+        "--service-key-title",
+        default=None,
+        required=False,
+        help="Title for the service key. Uses <username> by default.",
+    )
+
+    parsed_args = parser.parse_args(argv)
+
+    # service users must always have the `ServiceKeyUser` role.
+    roles = set(parsed_args.roles)
+    roles.add("ServiceKeyUser")
+    parsed_args.roles = sorted(roles)
+
+    if not parsed_args.service_key_title:
+        parsed_args.service_key_title = parsed_args.username
+
+    return parsed_args
+
+
+def add_user(parsed_args):
+    """Create the user in `acl_users`."""
+
+    acl_users = api.portal.get_tool("acl_users")
+    username = parsed_args.username
+    roles = parsed_args.roles
+
+    # we don't use a domain
+    domains = []
+    # We don't want to directly login with this user but just via its token.
+    password = make_random_password()
+
+    log.info(
+        u"Creating user {} with roles {}.".format(username, ", ".join(roles))
+    )
+    user = acl_users._doAddUser(username, password, roles, domains)
+    if not user:
+        log.error(u"Could not create user {}".format(username))
+        sys.exit(1)
+
+    log.info(u"User {} has been created.".format(user.getId()))
+    return user
+
+
+def setup_token_auth(user, parsed_args):
+    """Set up token auth for the user and write its key to the file system."""
+
+    acl_users = api.portal.get_tool("acl_users")
+    token_auth = acl_users["token_auth"]
+    user_id = user.getId()
+    service_key_title = parsed_args.service_key_title
+
+    private_key, service_key = token_auth.issue_keypair(
+        user_id, service_key_title, ip_range=None
+    )
+    json_keyfile = create_json_keyfile(private_key, service_key)
+
+    cfg = getConfiguration()
+    outdir = cfg.clienthome
+    filename = u"{}.json".format(user_id)
+    filepath = os.path.join(outdir, filename)
+    log.info(u"Writing key to {}".format(filepath))
+    with open(filepath, "w") as fp:
+        fp.write(json_keyfile)
+
+
+def create_service_user_zopectl_handler(app, args):
+    """Handler for the 'bin/instance create_service_user' zopectl command."""
+    setup_logging()
+    setup_plone(get_first_plone_site(app))
+
+    parsed_args = parse_args(args)
+    user = add_user(parsed_args)
+    setup_token_auth(user, parsed_args)
+    transaction.commit()
+
+
+def setup_logging():
+    """Set Zope's default StreamHandler's level to INFO (default is WARNING)
+    to make sure output gets logged on console.
+    """
+    stream_handler = logging.root.handlers[0]
+    stream_handler.setLevel(logging.INFO)

--- a/opengever/setup/tests/test_serviceuser.py
+++ b/opengever/setup/tests/test_serviceuser.py
@@ -1,0 +1,125 @@
+from App.config import getConfiguration
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.tokenauth.pas.storage import CredentialStorage
+from opengever.setup.serviceuser import create_service_user_zopectl_handler
+from opengever.setup.serviceuser import parse_args
+from opengever.testing import FunctionalTestCase
+from opengever.testing.helpers import CapturingLogHandler
+from plone import api
+import json
+import logging
+import os
+
+
+class TestCreateServiceUserZopectlHandler(FunctionalTestCase):
+
+    use_default_fixture = False
+
+    def setUp(self):
+        super(TestCreateServiceUserZopectlHandler, self).setUp()
+        self.args = ["-c", "ignored"]
+
+        self.logger = logging.getLogger("opengever.setup.serviceuser")
+        self.logger.setLevel(logging.INFO)
+        self.log_handler = CapturingLogHandler()
+        self.logger.addHandler(self.log_handler)
+
+    def test_parse_args_default_arguments(self):
+        self.args.append("some_user")
+        parsed_args = parse_args(self.args)
+
+        self.assertEqual(["ServiceKeyUser"], parsed_args.roles)
+        self.assertEqual("some_user", parsed_args.service_key_title)
+
+    def test_create_service_user(self):
+        username = "default"
+        self.args.extend([username, "--service-key-title", "some app"])
+        create_service_user_zopectl_handler(self.app, self.args)
+
+        cfg = getConfiguration()
+        outdir = cfg.clienthome
+        filename = u"{}.json".format(username)
+        filepath = os.path.join(outdir, filename)
+
+        self.assertEqual(
+            [
+                u"Creating user default with roles ServiceKeyUser.",
+                u"User default has been created.",
+                u"Writing key to {}".format(filepath),
+            ],
+            self.log_handler.msgs,
+        )
+
+        pas = api.portal.get_tool("acl_users")
+        user = pas.getUser(username)
+        self.assertIsNotNone(user)
+
+        role_manager = pas.portal_role_manager
+        self.assertItemsEqual(
+            ["ServiceKeyUser"], role_manager.getRolesForPrincipal(user)
+        )
+
+        with open(filepath) as fp:
+            json_data = json.load(fp)
+        self.assertIn("private_key", json_data)
+        self.assertEqual(username, json_data["user_id"])
+
+        storage = CredentialStorage(pas["token_auth"])
+        keys = storage.list_service_keys(username)
+        self.assertEqual(1, len(keys))
+        self.assertDictContainsSubset(
+            {
+                "user_id": "default",
+                "title": "some app",
+                "ip_range": None,
+            },
+            keys[0],
+        )
+
+    def test_create_service_user_with_additional_roles(self):
+        username = "moreRoles"
+        self.args.extend([username, "--roles", "Member", "Impersonator"])
+        create_service_user_zopectl_handler(self.app, self.args)
+
+        self.assertEqual(
+            u"Creating user moreRoles with roles Impersonator, Member, "
+            u"ServiceKeyUser.",
+            self.log_handler.msgs[0],
+        )
+
+        pas = api.portal.get_tool("acl_users")
+        user = pas.getUser(username)
+        self.assertIsNotNone(user)
+
+        role_manager = pas.portal_role_manager
+        self.assertItemsEqual(
+            ["Impersonator", "Member", "ServiceKeyUser"],
+            role_manager.getRolesForPrincipal(user),
+        )
+
+    def test_prevents_adding_existing_user(self):
+        create(
+            Builder("user")
+            .having(firstname="Hugo", lastname="Boss")
+            .with_userid("hugo.boss")
+        )
+
+        username = "hugo.boss"
+        self.args.append(username)
+
+        # parse_args will exit in case of invalid arguments
+        # we refrain from lookint at stdout/stderr too much and just
+        # test this in a very generic way
+        with self.assertRaises(SystemExit):
+            create_service_user_zopectl_handler(self.app, self.args)
+
+    def test_prevents_using_invalid_roles(self):
+        username = "foo"
+        self.args.extend([username, "--roles", "invalid"])
+
+        # parse_args will exit in case of invalid arguments
+        # we refrain from lookint at stdout/stderr too much and just
+        # test this in a very generic way
+        with self.assertRaises(SystemExit):
+            create_service_user_zopectl_handler(self.app, self.args)

--- a/setup.py
+++ b/setup.py
@@ -203,18 +203,18 @@ setup(name='opengever.core',
 
       [zopectl.command]
       create_service_user = opengever.setup.serviceuser:create_service_user_zopectl_handler
-      sync_ogds = opengever.ogds.base:sync_ogds_zopectl_handler
       dump_schemas = opengever.base.schemadump:dump_schemas_zopectl_handler
-      import = opengever.bundle.console:import_oggbundle
-      send_digest = opengever.activity:send_digest_zopectl_handler
       generate_overdue_notifications = opengever.dossier.cronjobs:generate_overdue_notifications_zopectl_handler
       generate_remind_notifications = opengever.task.reminder.cronjobs:generate_remind_notifications_zopectl_handler
+      import = opengever.bundle.console:import_oggbundle
       run_nightly_jobs = opengever.nightlyjobs.cronjobs:run_nightly_jobs_handler
+      send_digest = opengever.activity:send_digest_zopectl_handler
+      sync_ogds = opengever.ogds.base:sync_ogds_zopectl_handler
 
       [console_scripts]
+      create-bundle = opengever.bundle.factory:main
       create-policy = opengever.policytemplates.cli:main
       pyxbgen = opengever.disposition.ech0160.pyxbgen:main
-      create-bundle = opengever.bundle.factory:main
       toggle-readonly = opengever.readonly.cli:main
       """,
       )

--- a/setup.py
+++ b/setup.py
@@ -202,6 +202,7 @@ setup(name='opengever.core',
       target = plone
 
       [zopectl.command]
+      create_service_user = opengever.setup.serviceuser:create_service_user_zopectl_handler
       sync_ogds = opengever.ogds.base:sync_ogds_zopectl_handler
       dump_schemas = opengever.base.schemadump:dump_schemas_zopectl_handler
       import = opengever.bundle.console:import_oggbundle


### PR DESCRIPTION
Currently creating a service user involves some manual steps to be done through a web interface. With this PR we add a script to easily create a service user and merge the following separate steps into one command to be called on the command line:

- create a user in plone with a random password
- assign the user to some predefined roles
- create a service key (`ftw.tokenauth`) and store it in a `*.json` file

The command

```bin/instance create_service_user workspace.app --roles Member WorkspaceAdmin Impersonator --service-key-title "teamraum connect"```

will automatically create a user `workspace.app` and also create a corresponding key. They key will be written to a json file in `$CLIENTHOME` (`.var/instance/workspace.app.json`) on a dev machine. They key will be available for the new user and be visible in its token auth control panel.

![Screenshot 2021-07-14 at 16 34 02](https://user-images.githubusercontent.com/736583/125640488-fbcf4f38-aebf-4a25-a127-3ac50fd0d7a5.png)

These changes lay the groundwork for future automation and ease setting up a connected RIS and teamraum Connect (https://4teamwork.atlassian.net/browse/CA-1249).

Jira: https://4teamwork.atlassian.net/browse/HG-1488


## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._
