### PR TITLE
Remove ftw.tika dependency from the policytemplate.

### DIFF
--- a/changes/CA-1213.other
+++ b/changes/CA-1213.other
@@ -1,0 +1,1 @@
+Remove ftw.tika dependency from the policytemplate.

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/setup.py.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/setup.py.bob
@@ -41,7 +41,6 @@ setup(name='opengever.{{{package.name}}}',
         'setuptools',
         'z3c.autoinclude',
         'opengever.core',
-        'ftw.tika',
         'ftw.upgrade',
         # We not depend directly on ftw.inflator to avoid ConfigurationConflictError.
         # 'ftw.inflator',


### PR DESCRIPTION
I'm currently removing all the tika dependencies from our saas policies, so the policytemplate should not create new ones 😉 

Part of CA-1213

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Removing and uninstalling tika will follow in a separate PR_