### PR TITLE
Enable cross-client transitions via API for forwardings.

### DIFF
--- a/changes/CA-2019-1.feature
+++ b/changes/CA-2019-1.feature
@@ -1,0 +1,1 @@
+Add @accept-remote-forwarding endpoint. [tinagerber]

--- a/changes/CA-2019-2.feature
+++ b/changes/CA-2019-2.feature
@@ -1,0 +1,1 @@
+Add transition extender for forwarding-transition-refuse transition. [tinagerber]

--- a/docs/public/dev-manual/api/accept_remote_forwarding.rst
+++ b/docs/public/dev-manual/api/accept_remote_forwarding.rst
@@ -1,0 +1,59 @@
+.. _accept-remote-forwarding:
+
+Remote-Weiterleitung akzeptieren
+================================
+
+Der ``@accept-remote-forwarding`` Endpoint auf Dossiers erlaubt es, eine mandantenübergreifende Weiterleitung im Eingangskorb abzulegen. Optional kann die Weiterleitung einem Dossier zugewiesen werden (es wird eine Aufgabenkopie im angegebenen Dossier erstellt).
+
+Die Remote-Weiterleitung wird über den Parameter ``forwarding_oguid`` im JSON Body angegeben (die Weiterleitung *muss* sich auf einem anderen Mandanten befinden), und optional kann im Parameter ``dossier_oguid`` das Dossier angeben werden, dem die Weiterleitung zugewiesen werden soll und im Parameter ``text`` kann ein Kommentar zum Akzeptieren der Aufgabe angegeben werden.
+
+Im untenstehenden Beispiel ist ``fd`` der Remote-Mandant, und der Benutzer, hugo.boss, will auf seinem lokalen Mandanten, ``rk``, eine Weiterleitung akzeptieren, und eine Kopie der Weiterleitung im ``dossier-17`` auf seinem Mandanten erstellen. Die Weiterleitung ist durch die *forwarding_oguid* ``fd:12345`` identifiziert.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       POST /rk/eingangskorb/@accept-remote-forwarding HTTP/1.1
+       Content-Type: application/json
+       Accept: application/json
+
+       {
+         "dossier_oguid": "rk:12345",
+         "forwarding_oguid": "fd:12345",
+         "text": "Ich akzeptiere diese Weiterleitung in meinem Dossier"
+       }
+
+Die Response enthält das serialisierte Objekt (die soeben erstellte lokale Aufgabenkopie), so wie sie für einen regulären GET request aussehen würde:
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 201 Created
+      Content-Type: application/json
+
+      {
+        "@id": "http://.../dossier-17/task-42",
+        "@type": "opengever.task.task",
+        "oguid": "rk:1451484829",
+        "...": "...",
+        "predecessor": "fd:1451484827",
+        "responses": [
+          {"...": "..."},
+          {
+            "@id": "http://.../dossier-17/task-42/@responses/1598198218402585",
+            "...": "...",
+            "text": "Ich akzeptiere diese Aufgabe via Kopie in meinem Dossier",
+            "transition": "task-transition-open-in-progress"
+          }
+        ],
+        "responsible": {
+          "title": "Ratskanzlei: Boss Hugo (hugo.boss)",
+          "token": "rk:hugo.boss"
+        },
+        "responsible_client": {
+          "title": "Ratskanzlei",
+          "token": "rk"
+        },
+        "review_state": "task-state-in-progress"
+      }

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -15,6 +15,7 @@ Breaking Changes
 Other Changes
 ^^^^^^^^^^^^^
 
+- Add new endpoint ``@accept-remote-forwarding`` (see :ref:`docs <accept-remote-forwarding>`)
 
 2021.14.0 (2021-07-16)
 ----------------------

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -16,6 +16,7 @@ Other Changes
 ^^^^^^^^^^^^^
 
 - Add new endpoint ``@accept-remote-forwarding`` (see :ref:`docs <accept-remote-forwarding>`)
+- ``@workflow``: Add ``transition_response`` if it exists.
 
 2021.14.0 (2021-07-16)
 ----------------------

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -62,6 +62,7 @@ Inhalt:
    trigger_task_template.rst
    remote_workflow.rst
    accept_remote_task.rst
+   accept_remote_forwarding.rst
    complete_successor_task.rst
    upload_structure.rst
    close_remote_task.rst

--- a/opengever/api/accept_remote_forwarding.py
+++ b/opengever/api/accept_remote_forwarding.py
@@ -1,0 +1,73 @@
+from opengever.api.remote_task_base import RemoteTaskBaseService
+from opengever.base.exceptions import MalformedOguid
+from opengever.base.oguid import Oguid
+from opengever.globalindex.model.task import Task
+from opengever.ogds.base.utils import get_current_admin_unit
+from opengever.task.browser.accept.utils import accept_forwarding_with_successor
+from plone.protect.interfaces import IDisableCSRFProtection
+from zExceptions import BadRequest
+from zope.interface import alsoProvides
+from opengever.base.exceptions import InvalidOguidIntIdPart
+
+
+class AcceptRemoteForwardingPost(RemoteTaskBaseService):
+    required_params = ('forwarding_oguid', )
+    optional_params = ('dossier_oguid', 'text', )
+
+    def is_assigned_to_current_admin_unit(self, forwarding):
+        org_unit = forwarding.get_assigned_org_unit()
+        return org_unit.admin_unit == get_current_admin_unit()
+
+    def reply(self):
+        # Disable CSRF protection
+        alsoProvides(self.request, IDisableCSRFProtection)
+
+        # Extract and validate parameters, assign defaults
+        params = self.extract_params()
+
+        raw_forwarding_oguid = params['forwarding_oguid']
+        raw_dossier_oguid = params.get('dossier_oguid')
+        response_text = params.get('text', u'')
+
+        # Validate that Oguid is well-formed and refers to a forwarding that is
+        # actually remote. Turn any Python exceptions into proper
+        # 400 Bad Request responses with details in the JSON body.
+        try:
+            forwarding_oguid = Oguid.parse(raw_forwarding_oguid)
+
+        except MalformedOguid as exc:
+            raise BadRequest(self.format_exception(exc))
+
+        forwarding = Task.query.by_oguid(raw_forwarding_oguid)
+        if not forwarding:
+            raise BadRequest('No object found for forwarding_oguid "{}".'.format(raw_forwarding_oguid))
+
+        if raw_dossier_oguid:
+            try:
+                dossier = Oguid.parse(raw_dossier_oguid).resolve_object()
+            except MalformedOguid as exc:
+                raise BadRequest(self.format_exception(exc))
+            except InvalidOguidIntIdPart:
+                dossier = None
+            # dossier could be None due to exception or as returned by resolve
+            if not dossier:
+                raise BadRequest('No object found for dossier_oguid "{}".'.format(raw_dossier_oguid))
+        else:
+            dossier = None
+
+        if not self.is_assigned_to_current_admin_unit(forwarding):
+            raise BadRequest('Forwarding must be assigned to the current admin unit.')
+
+        if not self.is_remote(forwarding_oguid):
+            raise BadRequest(
+                'Forwarding must be on remote admin unit. '
+                'Oguid %s refers to a local task, however.' % raw_forwarding_oguid)
+
+        successor = accept_forwarding_with_successor(
+            self.context, raw_forwarding_oguid, response_text, dossier)
+
+        self.request.response.setStatus(201)
+        self.request.response.setHeader("Location", successor.absolute_url())
+
+        serialized_successor = self.serialize(successor)
+        return serialized_successor

--- a/opengever/api/accept_remote_task.py
+++ b/opengever/api/accept_remote_task.py
@@ -33,9 +33,6 @@ class AcceptRemoteTaskPost(RemoteTaskBaseService):
     required_params = ('task_oguid', )
     optional_params = ('text', )
 
-    def is_remote(self, oguid):
-        return not oguid.is_on_current_admin_unit
-
     def reply(self):
         # Disable CSRF protection
         alsoProvides(self.request, IDisableCSRFProtection)

--- a/opengever/api/close_remote_task.py
+++ b/opengever/api/close_remote_task.py
@@ -35,9 +35,6 @@ class CloseRemoteTaskPost(RemoteTaskBaseService):
     required_params = ('task_oguid', )
     optional_params = ('text', 'document_oguids', 'dossier_uid')
 
-    def is_remote(self, oguid):
-        return not oguid.is_on_current_admin_unit
-
     def reply(self):
         # Disable CSRF protection
         alsoProvides(self.request, IDisableCSRFProtection)

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -1182,6 +1182,15 @@
 
   <plone:service
       method="POST"
+      name="@accept-remote-forwarding"
+      for="opengever.inbox.inbox.IInbox"
+      factory=".accept_remote_forwarding.AcceptRemoteForwardingPost"
+      permission="zope2.View"
+      layer="opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
+  <plone:service
+      method="POST"
       name="@accept-remote-task"
       for="opengever.dossier.behaviors.dossier.IDossierMarker"
       factory=".accept_remote_task.AcceptRemoteTaskPost"

--- a/opengever/api/remote_task_base.py
+++ b/opengever/api/remote_task_base.py
@@ -16,6 +16,9 @@ class RemoteTaskBaseService(Service):
     required_params = ('transition', )
     optional_params = ('documents', 'text')
 
+    def is_remote(self, oguid):
+        return not oguid.is_on_current_admin_unit
+
     def extract_params(self):
         """Extract and validate required and optional parameters.
 

--- a/opengever/api/tests/test_accept_remote_forwarding.py
+++ b/opengever/api/tests/test_accept_remote_forwarding.py
@@ -1,0 +1,341 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from mock import patch
+from opengever.base.oguid import Oguid
+from opengever.base.response import IResponseContainer
+from opengever.testing import IntegrationTestCase
+from plone import api
+import json
+
+
+class TestAcceptRemoteForwardingPost(IntegrationTestCase):
+
+    def last_response(self, obj):
+        return IResponseContainer(obj).list()[-1]
+
+    @browsing
+    def test_requires_forwarding_oguid_parameter(self, browser):
+        self.login(self.secretariat_user, browser)
+        url = '{}/@accept-remote-forwarding'.format(self.inbox.absolute_url())
+
+        with browser.expect_http_error(code=400):
+            browser.open(url, method='POST', headers=self.api_headers)
+
+        self.assertEqual(
+            {u'type': u'BadRequest',
+             u'message': u'Required parameter "forwarding_oguid" is missing in body'},
+            browser.json)
+
+    @browsing
+    def test_rejects_unexpected_parameters(self, browser):
+        self.login(self.secretariat_user, browser)
+        url = '{}/@accept-remote-forwarding'.format(self.inbox.absolute_url())
+
+        with browser.expect_http_error(code=400):
+            browser.open(
+                url, method='POST',
+                data=json.dumps({
+                    'forwarding_oguid': 'fa:12345',
+                    'unexpected': 'garbage',
+                }),
+                headers=self.api_headers)
+
+        self.assertEqual(
+            {u'type': u'BadRequest',
+             u'message': u'Unexpected parameter(s) in JSON body: ["unexpected"]. '
+                         u'Supported parameters are: ["forwarding_oguid", "dossier_oguid", "text"]'},
+            browser.json)
+
+    @browsing
+    def test_malformed_forwarding_oguid_raises_bad_reqest(self, browser):
+        self.login(self.secretariat_user, browser)
+        url = '{}/@accept-remote-forwarding'.format(self.inbox.absolute_url())
+
+        with browser.expect_http_error(code=400):
+            browser.open(
+                url, method='POST',
+                data=json.dumps({'forwarding_oguid': 'i_am_malformed'}),
+                headers=self.api_headers)
+
+        self.assertEqual(
+            {u'type': u'BadRequest',
+             u'message': u'MalformedOguid: i_am_malformed'},
+            browser.json)
+
+    @browsing
+    def test_invalid_forwarding_oguid_raises_bad_reqest(self, browser):
+        self.login(self.secretariat_user, browser)
+        url = '{}/@accept-remote-forwarding'.format(self.inbox.absolute_url())
+
+        with browser.expect_http_error(code=400):
+            browser.open(
+                url, method='POST',
+                data=json.dumps({'forwarding_oguid': 'fd:101010'}),
+                headers=self.api_headers)
+
+        self.assertEqual(
+            {u'type': u'BadRequest',
+             u'message': u'No object found for forwarding_oguid "fd:101010".'},
+            browser.json)
+
+    @browsing
+    def test_forwarding_not_assigned_to_current_admin_unit_raises_bad_request(self, browser):
+        self.login(self.secretariat_user, browser)
+        url = '{}/@accept-remote-forwarding'.format(self.inbox.absolute_url())
+
+        with patch('opengever.api.accept_remote_forwarding.'
+                   'AcceptRemoteForwardingPost.is_assigned_to_current_admin_unit') as mock_is_remote:
+            mock_is_remote.return_value = False
+
+            with browser.expect_http_error(code=400):
+                browser.open(
+                    url, method='POST',
+                    data=json.dumps({'forwarding_oguid': Oguid.for_object(self.inbox_forwarding).id}),
+                    headers=self.api_headers)
+
+            self.assertEqual(
+                {u'type': u'BadRequest',
+                 u'message': u'Forwarding must be assigned to the current admin unit.'},
+                browser.json)
+
+    @browsing
+    def test_requires_forwarding_oguid_that_refers_to_remote_object(self, browser):
+        self.login(self.secretariat_user, browser)
+        url = '{}/@accept-remote-forwarding'.format(self.inbox.absolute_url())
+
+        with browser.expect_http_error(code=400):
+            browser.open(
+                url, method='POST',
+                data=json.dumps({'forwarding_oguid': Oguid.for_object(self.inbox_forwarding).id}),
+                headers=self.api_headers)
+
+        self.assertEqual(
+            {u'type': u'BadRequest',
+             u'message': u'Forwarding must be on remote admin unit. Oguid {} refers to a local task,'
+                         u' however.'.format(Oguid.for_object(self.inbox_forwarding).id)},
+            browser.json)
+
+    @browsing
+    def test_malformed_dossier_oguid_raises_bad_reqest(self, browser):
+        self.login(self.secretariat_user, browser)
+        url = '{}/@accept-remote-forwarding'.format(self.inbox.absolute_url())
+
+        with browser.expect_http_error(code=400):
+            browser.open(
+                url, method='POST',
+                data=json.dumps({'forwarding_oguid': Oguid.for_object(self.inbox_forwarding).id,
+                                 'dossier_oguid': 'i_am_malformed'}),
+                headers=self.api_headers)
+
+        self.assertEqual(
+            {u'type': u'BadRequest',
+             u'message': u'MalformedOguid: i_am_malformed'},
+            browser.json)
+
+    @browsing
+    def test_invalid_dossier_oguid_raises_bad_reqest(self, browser):
+        self.login(self.secretariat_user, browser)
+        url = '{}/@accept-remote-forwarding'.format(self.inbox.absolute_url())
+
+        with browser.expect_http_error(code=400):
+            browser.open(
+                url, method='POST',
+                data=json.dumps({'forwarding_oguid': Oguid.for_object(self.inbox_forwarding).id,
+                                 'dossier_oguid': 'fd:101010'}),
+                headers=self.api_headers)
+
+        self.assertEqual(
+            {u'type': u'BadRequest',
+             u'message': u'No object found for dossier_oguid "fd:101010".'},
+            browser.json)
+
+    @browsing
+    def test_accept_remote_forwarding_creates_successor(self, browser):
+        self.login(self.secretariat_user, browser)
+
+        forwarding = create(Builder('forwarding')
+                            .within(self.inbox_rk)
+                            .titled(u'F\xf6rw\xe4rding')
+                            .having(responsible_client='fa',
+                                    responsible='inbox:fa',
+                                    issuer='inbox:rk'))
+
+        doc_in_forwarding = create(Builder('document').within(forwarding)
+                                   .titled(u'Dokument im Eingangsk\xf6rbliweiterleitung')
+                                   .with_asset_file('text.txt'))
+
+        sql_forwarding = forwarding.get_sql_object()
+
+        local_url = '/'.join((self.inbox.absolute_url(), '@accept-remote-forwarding'))
+
+        # Need to trick @accept-remote-forwarding into thinking it's a remote forwarding
+        # so that the corresponding check can be bypassed.
+        #
+        # Any further remote / local distinction then is handled by
+        # dispatch_request(), which will just dispatch these requests
+        # internally using restrictedTraverse, but otherwise the
+        # transporting / serialization aspects behave largely the same and
+        # still get exercised.
+        with patch('opengever.api.accept_remote_forwarding.'
+                   'AcceptRemoteForwardingPost.is_remote') as mock_is_remote:
+            mock_is_remote.return_value = True
+
+            request_body = json.dumps({
+                'forwarding_oguid': u'plone:%s' % sql_forwarding.int_id,
+                'text': u'I hereby accept this forwarding.',
+            })
+
+            browser.open(local_url, method='POST', data=request_body, headers=self.api_headers)
+
+        response = browser.json
+        successor = Oguid.parse(response['oguid']).resolve_object()
+
+        # Successor should be in inbox
+        self.assertEqual('opengever.inbox.inbox', successor.aq_parent.portal_type)
+
+        # Forwarding should be closed
+        self.assertEqual(
+            'forwarding-state-closed',
+            api.content.get_state(forwarding))
+
+        # Successor should also be accepted
+        self.assertEqual('forwarding-state-open', api.content.get_state(successor))
+
+        # Successor should be linked to predecessor
+        self.assertEqual(str(forwarding.oguid), successor.predecessor)
+
+        # Responsible should match the responsible of the predecessor
+        self.assertEqual(forwarding.responsible, successor.responsible)
+
+        # Documents should have been copied
+        self.assertEqual(1, len(successor.objectIds()))
+        self.assertEqual(1, len(response['items']))
+
+        doc_in_successor_forwarding = successor.objectValues()[0]
+        self.assertEqual(doc_in_forwarding.title, doc_in_successor_forwarding.title)
+
+        # Response body should contain serialized successor forwarding, including
+        # responses and copied documents
+        self.assertDictContainsSubset({
+            u'@id': successor.absolute_url(),
+            u'@type': u'opengever.inbox.forwarding',
+            u'UID': successor.UID(),
+            u'issuer': {u'token': u'inbox:fa', u'title': u'Inbox: Finanz\xe4mt'},
+            u'oguid': str(successor.oguid),
+            u'predecessor': str(forwarding.oguid),
+            u'responsible': {u'token': u'inbox:fa', u'title': u'Inbox: Finanz\xe4mt'},
+            u'responsible_client': {u'token': u'fa', u'title': u'Finanz\xe4mt'},
+            u'review_state': u'forwarding-state-open',
+            u'task_type': {u'token': u'forwarding_task_type', u'title': u'Forwarding'},
+            u'title': u'F\xf6rw\xe4rding'},
+            browser.json)
+
+        self.assertEqual([{
+            u'@id': doc_in_successor_forwarding.absolute_url(),
+            u'@type': u'opengever.document.document',
+            u'description': u'',
+            u'checked_out': u'',
+            u'file_extension': u'.txt',
+            u'is_leafnode': None,
+            u'review_state': u'document-state-draft',
+            u'title': doc_in_successor_forwarding.title}],
+            response['items'])
+
+    @browsing
+    def test_accept_remote_forwarding_creates_task_in_dossier(self, browser):
+        self.login(self.secretariat_user, browser)
+
+        forwarding = create(Builder('forwarding')
+                            .within(self.inbox_rk)
+                            .titled(u'F\xf6rw\xe4rding')
+                            .having(responsible_client='fa',
+                                    responsible='inbox:fa',
+                                    issuer='inbox:rk'))
+
+        doc_in_forwarding = create(Builder('document').within(forwarding)
+                                   .titled(u'Dokument im Eingangsk\xf6rbliweiterleitung')
+                                   .with_asset_file('text.txt'))
+
+        sql_forwarding = forwarding.get_sql_object()
+
+        local_url = '/'.join((self.inbox.absolute_url(), '@accept-remote-forwarding'))
+
+        # Need to trick @accept-remote-forwarding into thinking it's a remote forwarding
+        # so that the corresponding check can be bypassed.
+        #
+        # Any further remote / local distinction then is handled by
+        # dispatch_request(), which will just dispatch these requests
+        # internally using restrictedTraverse, but otherwise the
+        # transporting / serialization aspects behave largely the same and
+        # still get exercised.
+        with patch('opengever.api.accept_remote_forwarding.'
+                   'AcceptRemoteForwardingPost.is_remote') as mock_is_remote:
+            mock_is_remote.return_value = True
+
+            request_body = json.dumps({
+                'dossier_oguid': Oguid.for_object(self.dossier).id,
+                'forwarding_oguid': u'plone:%s' % sql_forwarding.int_id,
+                'text': u'I hereby accept this forwarding.',
+            })
+
+            browser.open(local_url, method='POST', data=request_body, headers=self.api_headers)
+
+        response = browser.json
+        task = Oguid.parse(response['oguid']).resolve_object()
+        successor = Oguid.parse(task.predecessor).resolve_object()
+
+        # Successor should be in yearfolder
+        self.assertEqual('opengever.inbox.yearfolder', successor.aq_parent.portal_type)
+
+        # Predecessor and successor should be closed
+        self.assertEqual('forwarding-state-closed', api.content.get_state(forwarding))
+        self.assertEqual('forwarding-state-closed', api.content.get_state(successor))
+
+        # Task should alse be accepted
+        self.assertEqual('task-state-open', api.content.get_state(task))
+
+        # Successor should be linked to predecessor
+        self.assertEqual(str(forwarding.oguid), successor.predecessor)
+        self.assertEqual(str(successor.oguid), task.predecessor)
+
+        # Responsible should match the responsible of the predecessor
+        self.assertEqual(forwarding.responsible, successor.responsible)
+        self.assertEqual(forwarding.responsible, task.responsible)
+
+        # Documents should have been copied
+        self.assertEqual(1, len(successor.objectIds()))
+        self.assertEqual(1, len(task.objectIds()))
+        self.assertEqual(1, len(response['items']))
+
+        doc_in_task = task.objectValues()[0]
+        self.assertEqual(doc_in_forwarding.title, doc_in_task.title)
+
+        # Response body should contain serialized task, including
+        # responses and copied documents
+        self.assertDictContainsSubset({
+            u'@id': task.absolute_url(),
+            u'@type': u'opengever.task.task',
+            u'UID': task.UID(),
+            u'issuer': {u'token': u'inbox:fa', u'title': u'Inbox: Finanz\xe4mt'},
+            u'oguid': str(task.oguid),
+            u'predecessor': str(successor.oguid),
+            u'responsible': {u'token': u'inbox:fa', u'title': u'Inbox: Finanz\xe4mt'},
+            u'responsible_client': {u'token': u'fa', u'title': u'Finanz\xe4mt'},
+            u'review_state': u'task-state-open',
+            u'task_type': {u'title': u'For your information', u'token': u'information'},
+            u'title': u'F\xf6rw\xe4rding'},
+            browser.json)
+
+        self.assertEqual([{
+            u'@id': doc_in_task.absolute_url(),
+            u'@type': u'opengever.document.document',
+            u'description': u'',
+            u'checked_out': u'',
+            u'file_extension': u'.txt',
+            u'is_leafnode': None,
+            u'review_state': u'document-state-draft',
+            u'title': doc_in_task.title}],
+            response['items'])
+
+        self.assertEqual(self.dossier.absolute_url(), response['parent']['@id'])

--- a/opengever/inbox/configure.zcml
+++ b/opengever/inbox/configure.zcml
@@ -79,6 +79,11 @@
       />
 
   <adapter
+      factory=".transition.ForwardingRefuseTransitionExtender"
+      name="forwarding-transition-refuse"
+      />
+
+  <adapter
       factory=".transition.ForwardingAssignToDossierTransitionExtender"
       name="forwarding-transition-assign-to-dossier"
       />


### PR DESCRIPTION
Changes in this PR:
- Add `@accept-remote-forwarding` endpoint to accept cross client forwardings
- Move refuse transition functionalities to a transition extender for `forwarding-transition-refuse` transition, this way we can refuse forwardings via API
- Add transition_response to POST `@workflow` endpoint, so that we can return the url of the forwarding that will be created when a forwarding is refused. This allows redirecting to the new forwarding after the transition in the new front end.

For [CA-2019]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))

[CA-2019]: https://4teamwork.atlassian.net/browse/CA-2019