### PR TITLE
Fix storing text when accepting a forwarding.

### DIFF
--- a/changes/CA-2627.bugfix
+++ b/changes/CA-2627.bugfix
@@ -1,0 +1,1 @@
+Fix storing transition text when accepting forwarding. [deiferni]

--- a/opengever/inbox/configure.zcml
+++ b/opengever/inbox/configure.zcml
@@ -74,6 +74,11 @@
       />
 
   <adapter
+      factory=".transition.ForwardingDefaultTransitionExtender"
+      name="forwarding-transition-accept"
+      />
+
+  <adapter
       factory=".transition.ForwardingCloseTransitionExtender"
       name="forwarding-transition-close"
       />

--- a/opengever/inbox/tests/test_accept.py
+++ b/opengever/inbox/tests/test_accept.py
@@ -1,5 +1,6 @@
 from ftw.builder import Builder
 from ftw.builder import create
+from opengever.base.response import IResponseContainer
 from opengever.task.browser.accept.utils import accept_forwarding_with_successor
 from opengever.testing import FunctionalTestCase
 from plone.app.testing import TEST_USER_ID
@@ -16,6 +17,10 @@ class TestForwardingAccepting(FunctionalTestCase):
                                     issuer='hugo.boss')
                             .within(inbox))
         task = accept_forwarding_with_successor(
-            self.portal, forwarding.oguid.id, 'OK, thx.', dossier=dossier)
+            self.portal, forwarding.oguid.id, u'OK, thx.', dossier=dossier)
 
         self.assertEquals('information', task.task_type)
+
+        responses = IResponseContainer(forwarding)
+        self.assertEqual(1, len(responses))
+        self.assertEqual(u'OK, thx.', responses.list()[0].text)

--- a/opengever/inbox/tests/test_accept.py
+++ b/opengever/inbox/tests/test_accept.py
@@ -24,3 +24,7 @@ class TestForwardingAccepting(FunctionalTestCase):
         responses = IResponseContainer(forwarding)
         self.assertEqual(1, len(responses))
         self.assertEqual(u'OK, thx.', responses.list()[0].text)
+
+        responses = IResponseContainer(task)
+        self.assertEqual(1, len(responses))
+        self.assertEqual(u'OK, thx.', responses.list()[0].text)

--- a/opengever/inbox/tests/test_activities.py
+++ b/opengever/inbox/tests/test_activities.py
@@ -127,7 +127,7 @@ class TestForwardingActivites(FunctionalTestCase):
 
         task = accept_forwarding_with_successor(
             self.portal, forwarding.oguid.id,
-            'OK. That is something for me.', dossier=dossier)
+            u'OK. That is something for me.', dossier=dossier)
 
         forwarding_resource = self.center.fetch_resource(forwarding)
         task_resource = self.center.fetch_resource(task)

--- a/opengever/inbox/tests/test_transition_extender.py
+++ b/opengever/inbox/tests/test_transition_extender.py
@@ -1,0 +1,35 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.base.transition import ITransitionExtender
+from opengever.testing import FunctionalTestCase
+from plone import api
+from zope.component import queryMultiAdapter
+
+
+class TestForwardingTransitionExtendersRegistered(FunctionalTestCase):
+
+    OK_TRANSITIONS_WITHOUT_EXTENDER = []
+
+    def test_forwarding_transition_extenders_registered(self):
+        forwarding = create(Builder("forwarding"))
+
+        wftool = api.portal.get_tool("portal_workflow")
+        chain = wftool.getChainForPortalType("opengever.inbox.forwarding")[0]
+        workflow = wftool.get(chain)
+
+        for transition_name in list(workflow.transitions):
+            extender = queryMultiAdapter(
+                (forwarding, self.request),
+                ITransitionExtender,
+                transition_name,
+            )
+            if (
+                not extender
+                and transition_name not in self.OK_TRANSITIONS_WITHOUT_EXTENDER
+            ):
+                self.fail(
+                    "Could not find a transition extender for forwarding "
+                    "workflow transition '{}'. Either register an "
+                    "'ITransitionExtender' or add the transition to the "
+                    "whitelist.".format(transition_name)
+                )

--- a/opengever/task/browser/store.py
+++ b/opengever/task/browser/store.py
@@ -5,6 +5,7 @@ from opengever.base.utils import ok_response
 from opengever.task.interfaces import IYearfolderStorer
 from opengever.task.util import change_task_workflow_state
 from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser import BrowserView
 from zExceptions import Unauthorized
 
@@ -24,7 +25,7 @@ class StoreForwardingInYearfolderView(BrowserView):
 
         successor_oguid = self.request.get('successor_oguid')
         transition = self.request.get('transition')
-        response_text = self.request.get('response_text')
+        response_text = safe_unicode(self.request.get('response_text'))
 
         if transition:
             change_task_workflow_state(self.context,

--- a/opengever/task/tests/test_transition_extender.py
+++ b/opengever/task/tests/test_transition_extender.py
@@ -1,0 +1,40 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.base.transition import ITransitionExtender
+from opengever.testing import FunctionalTestCase
+from plone import api
+from zope.component import queryMultiAdapter
+
+
+class TestTaskTransitionExtendersRegistered(FunctionalTestCase):
+
+    OK_TRANSITIONS_WITHOUT_EXTENDER = [
+        # this transition is executed automatically when creating tasks from
+        # a task template. No user input can be made at any point an thus we
+        # dont need a transition extender
+        "task-transition-open-planned",
+    ]
+
+    def test_task_transition_extenders_registered(self):
+        task = create(Builder("task"))
+
+        wftool = api.portal.get_tool("portal_workflow")
+        chain = wftool.getChainForPortalType("opengever.task.task")[0]
+        workflow = wftool.get(chain)
+
+        for transition_name in list(workflow.transitions):
+            extender = queryMultiAdapter(
+                (task, self.request),
+                ITransitionExtender,
+                transition_name,
+            )
+            if (
+                not extender
+                and transition_name not in self.OK_TRANSITIONS_WITHOUT_EXTENDER
+            ):
+                self.fail(
+                    "Could not find a transition extender for task "
+                    "workflow transition '{}'. Either register an "
+                    "'ITransitionExtender' or add the transition to the "
+                    "whitelist.".format(transition_name)
+                )


### PR DESCRIPTION
The transition extender was not registered for that transition so user input text was discarded.

I have also added a quick test for all task and forwarding transitions to make sure we have extenders registered correctly for all other transitions. Luckily this seems to be the case (or not required for one task transition).

For https://4teamwork.atlassian.net/browse/CA-2627

The text is now persisted ans shows up as expected:
![Screenshot 2021-07-21 at 14 37 01](https://user-images.githubusercontent.com/736583/126489618-6b45d0ed-4921-49ca-a1eb-8ed051f84019.png)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- New functionality:
  - [x] for `task` also works for `forwarding`