### PR TITLE
Always return error message in @trash endpoint if content is not trashable

### DIFF
--- a/changes/CA-2472.bugfix
+++ b/changes/CA-2472.bugfix
@@ -1,0 +1,1 @@
+Always return error message in @trash endpoint if content is not trashable. [tinagerber]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -10,6 +10,7 @@ Breaking Changes
 ^^^^^^^^^^^^^^^^
 
 - ``@role-assignments``: Return a fixed list of roles at the key ``referenced_roles``.
+- ``@trash``: Always return error message if content is not trashable.
 
 
 Other Changes

--- a/opengever/api/tests/test_trash.py
+++ b/opengever/api/tests/test_trash.py
@@ -43,6 +43,20 @@ class TestTrashAPI(IntegrationTestCase):
             u'Cannot trash a checked-out document')
 
     @browsing
+    def test_trash_excerpt_gives_bad_request(self, browser):
+        self.activate_feature('meeting')
+        self.login(self.meeting_user, browser)
+
+        excerpt = self.decided_proposal.get_excerpt()
+
+        with browser.expect_http_error(code=400, reason='Bad Request'):
+            browser.open(excerpt.absolute_url() + '/@trash',
+                         method='POST', headers={'Accept': 'application/json'})
+        self.assertEqual(
+            browser.json[u'error'][u'message'],
+            u'Cannot trash a document that has been returned as excerpt')
+
+    @browsing
     def test_trashing_non_trashable_object_raises_bad_request(self, browser):
         self.login(self.manager, browser=browser)
 

--- a/opengever/api/trash.py
+++ b/opengever/api/trash.py
@@ -34,7 +34,17 @@ class TrashPost(Service):
                     'type': 'Bad Request',
                     'message': 'Cannot trash a locked document',
                 }}
+            elif exc.message == 'The document has been returned as excerpt':
+                return {'error': {
+                    'type': 'Bad Request',
+                    'message': 'Cannot trash a document that has been returned as excerpt',
+                }}
             elif exc.message == 'Not trashable':
+                return {'error': {
+                    'type': 'Bad Request',
+                    'message': 'Object is not trashable',
+                }}
+            else:
                 return {'error': {
                     'type': 'Bad Request',
                     'message': 'Object is not trashable',


### PR DESCRIPTION
Since the error message `The document has been returned as excerpt` was not caught, a `204 No content` was returned in this case.

Now an error message is always returned in case of an error.

For [CA-2472]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [x] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed

[CA-2472]: https://4teamwork.atlassian.net/browse/CA-2472