### PR TITLE
Improve policy templates for Teamraum deployments.

### DIFF
--- a/changes/CA-CA-1885.other
+++ b/changes/CA-CA-1885.other
@@ -1,0 +1,1 @@
+Improve policy templates for Teamraum deployments. [njohner]

--- a/opengever/policytemplates/hooks.py
+++ b/opengever/policytemplates/hooks.py
@@ -210,13 +210,20 @@ def post_adminunit_title(configurator, question, answer):
 
 
 def post_adminunit_id(configurator, question, answer):
+    if configurator.variables['is_teamraum']:
+        admin_group = '{}_administrators'.format(answer)
+        inbox_group = '{}_administrators'.format(answer)
+    else:
+        admin_group = '{}_admins'.format(answer)
+        inbox_group = '{}_inbox'.format(answer)
+
     new_defaults = {
-        'deployment.rolemanager_group': '{}_admins'.format(answer),
-        'deployment.records_manager_group': '{}_admins'.format(answer),
-        'deployment.archivist_group': '{}_admins'.format(answer),
-        'deployment.administrator_group': '{}_admins'.format(answer),
+        'deployment.rolemanager_group': admin_group,
+        'deployment.records_manager_group': admin_group,
+        'deployment.archivist_group': admin_group,
+        'deployment.administrator_group': admin_group,
         'orgunit.users_group': '{}_users'.format(answer),
-        'orgunit.inbox_group': '{}_inbox'.format(answer),
+        'orgunit.inbox_group': inbox_group,
         'orgunit.id': answer.lower()
     }
     update_defaults(configurator, new_defaults)

--- a/opengever/policytemplates/policy_template/.mrbob.ini
+++ b/opengever/policytemplates/policy_template/.mrbob.ini
@@ -221,7 +221,8 @@ deployment.workspace_users_group.default = tr_users
 deployment.workspace_users_group.required = False
 
 setup.invitation_group_dn.question = Invitation Group DN
-setup.invitation_group_dn.required = True
+setup.invitation_group_dn.help = If not set, the OrgUnit's users_group_id is used.
+
 
 setup.geverui.question = Enable new GEVER UI
 setup.geverui.required = True

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/profiles/default/registry.xml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/profiles/default/registry.xml.bob
@@ -141,7 +141,9 @@
 {{% if is_teamraum %}}
   <records interface="opengever.workspace.interfaces.IWorkspaceSettings">
     <value key="is_feature_enabled">True</value>
-    <value key="invitation_group_dn">{{{setup.invitation_group_dn}}}</value>
+    {{% if setup.invitation_group_dn %}}
+        <value key="invitation_group_dn">{{{setup.invitation_group_dn}}}</value>
+    {{% endif %}}
   </records>
 
 {{% if not setup.enable_workspace_meeting_feature %}}


### PR DESCRIPTION
Use correct defaults for groups assignments for Teamraum deployments and make `invitaiton_group_dn` non-mandatory, is this typically should not be set for on-premise deployments where the `invitaiton_group_dn` is different for TEST and PROD deployments. It will anyway correctly default to the users group, i.e. `tr_users` in Gever (see https://github.com/4teamwork/opengever.core/blob/master/opengever/workspace/participation/browser/my_invitations.py#L93-L117).

For [CA-1885]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-1885]: https://4teamwork.atlassian.net/browse/CA-1885