### PR TITLE
Extract attachments from mail inside submitted proposal into parent.

### DIFF
--- a/changes/CA-1822.bugfix
+++ b/changes/CA-1822.bugfix
@@ -1,0 +1,1 @@
+Extract attachments from mail inside submitted proposal into parent. [njohner]

--- a/opengever/document/base.py
+++ b/opengever/document/base.py
@@ -46,6 +46,10 @@ class BaseDocumentMixin(object):
     def css_class(self):
         return get_css_class(self)
 
+    def get_parent_submitted_proposal(self):
+        if self.is_inside_a_submitted_proposal():
+            return aq_parent(aq_inner(self))
+
     def get_parent_dossier(self):
         """Return the document's parent dossier.
 
@@ -150,6 +154,10 @@ class BaseDocumentMixin(object):
     @property
     def is_trashed(self):
         return ITrashed.providedBy(self)
+
+    def is_inside_a_submitted_proposal(self):
+        parent = aq_parent(aq_inner(self))
+        return ISubmittedProposal.providedBy(parent)
 
     def is_inside_a_proposal(self):
         parent = aq_parent(aq_inner(self))

--- a/opengever/mail/mail.py
+++ b/opengever/mail/mail.py
@@ -164,8 +164,8 @@ class OGMail(Mail, BaseDocumentMixin):
 
     def get_extraction_parent(self):
         """Return the parent that accepts extracted attachments."""
-        return self.get_parent_dossier() or self.get_parent_inbox() or \
-            self.get_parent_workspace_container()
+        return self.get_parent_submitted_proposal() or self.get_parent_dossier() or \
+            self.get_parent_inbox() or self.get_parent_workspace_container()
 
     def get_attachments(self, unextracted_only=False):
         """Returns a list of dicts describing the attachements.


### PR DESCRIPTION
Mail attachments for mails inside a submitted proposal got extracted into the proposal dossier, which does not make sense. Instead we extract the attachments into the submitted proposal.

For [CA-1822]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-1822]: https://4teamwork.atlassian.net/browse/CA-1822