### PR TITLE
Add excel role assignment-report generation and download view.

### DIFF
--- a/changes/CA-2362.feature
+++ b/changes/CA-2362.feature
@@ -1,0 +1,1 @@
+Add excel roleassignment-report download view. [phgross]

--- a/opengever/base/browser/configure.zcml
+++ b/opengever/base/browser/configure.zcml
@@ -233,6 +233,13 @@
       />
 
   <browser:page
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      name="download-role-assignment-report"
+      class=".role_assignment_excel_report.RoleAssignmentReportExcelDownload"
+      permission="opengever.api.ManageRoleAssignmentReports"
+      />
+
+  <browser:page
       name="logout"
       for="*"
       class=".logout.LogoutView"

--- a/opengever/base/browser/role_assignment_excel_report.py
+++ b/opengever/base/browser/role_assignment_excel_report.py
@@ -1,0 +1,69 @@
+from opengever.base import _
+from opengever.base.browser.reporting_view import BaseReporterView
+from opengever.base.interfaces import IRoleAssignmentReportsStorage
+from opengever.base.reporter import XLSReporter
+from opengever.sharing.browser.sharing import ROLE_MAPPING
+from plone.app.uuid.utils import uuidToObject
+from zExceptions import BadRequest
+from zExceptions import NotFound
+from zope.interface import implements
+from zope.publisher.interfaces import IPublishTraverse
+
+
+class RoleAssignmentReportExcelDownload(BaseReporterView):
+
+    implements(IPublishTraverse)
+
+    def __init__(self, context, request):
+        super(RoleAssignmentReportExcelDownload, self).__init__(context, request)
+        self.params = []
+
+    def publishTraverse(self, request, name):
+        self.params.append(name)
+        return self
+
+    def __call__(self):
+        storage = IRoleAssignmentReportsStorage(self.context)
+
+        # Expects report_id as path parameter
+        if not len(self.params) == 1:
+            raise NotFound()
+
+        self.report_id = self.params[0]
+        try:
+            report = storage.get(self.report_id)
+        except KeyError:
+            raise BadRequest(u"Invalid report_id '{}'".format(self.report_id))
+
+        items = list(self.prepare_report_for_export(report))
+        reporter = XLSReporter(self.request, self.columns(), items)
+        return self.return_excel(reporter)
+
+    @property
+    def filename(self):
+        return u'{}.xlsx'.format(self.report_id)
+
+    def prepare_report_for_export(self, report):
+        for item in report.get('items'):
+            obj = uuidToObject(item.get('UID'))
+            data = {u'title': obj.Title(), u'url': obj.absolute_url()}
+
+            for role in self.available_roles():
+                data[role] = bool(role in item['roles'])
+
+            yield data
+
+    def available_roles(self):
+        return [item[0] for item in ROLE_MAPPING[0][1]]
+
+    @property
+    def _columns(self):
+        columns = [{'id': 'title',
+                    'title': _('label_title', default=u'Title'),
+                    'hyperlink': lambda value, obj: obj.get('url')}]
+
+        for item in ROLE_MAPPING[0][1]:
+            columns.append({'id': item[0], 'title': item[1],
+                            'transform': lambda value: 'x' if value else ''})
+
+        return columns

--- a/opengever/base/reporter.py
+++ b/opengever/base/reporter.py
@@ -123,10 +123,14 @@ class XLSReporter(object):
             for column, attr in enumerate(self.attributes, 1):
                 cell = sheet.cell(row=self.blank_header_rows + row, column=column)
 
-                if 'default' in attr:
-                    value = getattr(obj, attr.get('id'), attr.get('default'))
+                if isinstance(obj, dict):
+                    value = obj.get(attr.get('id'), attr.get('default'))
                 else:
-                    value = getattr(obj, attr.get('id'))
+                    if 'default' in attr:
+                        value = getattr(obj, attr.get('id'), attr.get('default'))
+                    else:
+                        value = getattr(obj, attr.get('id'))
+
                 if attr.get('callable'):
                     value = value()
                 if attr.get('transform'):

--- a/opengever/base/tests/test_role_assignment_excel_report.py
+++ b/opengever/base/tests/test_role_assignment_excel_report.py
@@ -1,0 +1,60 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+from openpyxl import load_workbook
+from tempfile import NamedTemporaryFile
+import os
+
+
+class TestExcelRoleAssignmentReport(IntegrationTestCase):
+
+    @browsing
+    def test_raises_notfound_if_no_report_id_is_given(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        url = u'{}/download-role-assignment-report'.format(
+            self.portal.absolute_url())
+
+        with browser.expect_http_error(code=404):
+            browser.open(url)
+
+    @browsing
+    def test_raises_badrequest_if_report_does_not_exists(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        with browser.expect_http_error(code=400):
+            url = u'{}/download-role-assignment-report/not-existing'.format(
+                self.portal.absolute_url())
+            browser.open(url)
+
+    @browsing
+    def test_role_assignent_report(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        url = u'{}/download-role-assignment-report/report_0'.format(
+            self.portal.absolute_url())
+        browser.open(url)
+
+        self.assertEquals(
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            browser.headers['content-type'])
+        self.assertEquals(
+            'attachment; filename="report_0.xlsx"',
+            browser.headers['content-disposition'])
+
+        data = browser.contents
+        with NamedTemporaryFile(delete=False, suffix='.xlsx') as tmpfile:
+            tmpfile.write(data)
+            tmpfile.flush()
+            workbook = load_workbook(tmpfile.name)
+            os.remove(tmpfile.name)
+
+        rows = list(workbook.active.rows)
+
+        self.assertSequenceEqual(
+            [[u'Title', u'Read', u'Add dossiers', u'Edit dossiers',
+              u'Resolve dossiers', u'Reactivate dossiers', u'Manage dossiers'],
+             [u'Ordnungssystem', None, u'x', None, None, None, None],
+             [u'Subsubdossier', u'x', None, u'x', u'x', None, None],
+             [u'2. Rechnungspr\xfcfungskommission',
+              None, u'x', None, None, u'x', None]],
+            [[cell.value for cell in row] for row in rows])


### PR DESCRIPTION
For [CA-2362](https://4teamwork.atlassian.net/browse/CA-2362)

Uses the already existing XLSReporter. Because the role-assignment report ist not a real object, I did not register a portal_action, instead the action is defined in the frontend.

## Checklist
- [x] Changelog entry
