### PR TITLE
Fix retrieving lazy initial version for documents.

### DIFF
--- a/changes/CA-2623.bugfix
+++ b/changes/CA-2623.bugfix
@@ -1,0 +1,1 @@
+Fix ``@versions`` for documents that do not have an initial version yet (lazy initial version). [deiferni]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -40,12 +40,9 @@ Other Changes
 - ``@navigation``: Add ``review_state`` and ``include_context`` parameters (see :ref:`docs <navigation>`)
 - Added ``@submit-additional-documents`` endpoint. (see :ref:`docs <submit-additional-documents>`)
 
+
 2021.13.0 (2021-06-25)
 ----------------------
-
-Breaking Changes
-^^^^^^^^^^^^^^^^
-
 
 Other Changes
 ^^^^^^^^^^^^^
@@ -56,6 +53,7 @@ Other Changes
 - `@trash` and `@untrash` endpoints now also work for WorkspaceFolders.
 - Trashed workspace documents and folders can be deleted. (see :ref:`docs <trash>`)
 - Prevent changing the ``is_private`` field of existing tasks.
+
 
 2021.11.0 (2021-05-28)
 ----------------------
@@ -82,6 +80,7 @@ Other Changes
 - Added ``@listing-custom-fields`` endpoint and allow retrieving custom properties in ``@listing``. (see :ref:`docs <listing-property_sheets>`)
 - Added ``@upload-structure`` endpoint. (see :ref:`docs <upload-structure>`)
 
+
 2021.9.0 (2021-04-29)
 ---------------------
 
@@ -99,6 +98,7 @@ Breaking Changes
 ^^^^^^^^^^^^^^^^
 
 - Deserialization: Years before 1900 will now get rejected for date and datetime fields.
+
 
 2021.7.0 (2021-04-01)
 ---------------------

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -20,6 +20,8 @@ Other Changes
 
 - Add new endpoint ``@accept-remote-forwarding`` (see :ref:`docs <accept-remote-forwarding>`)
 - ``@workflow``: Add ``transition_response`` if it exists.
+- Fix ``@versions`` for documents that do not have an initial version yet (lazy initial version).
+
 
 2021.14.0 (2021-07-16)
 ----------------------

--- a/opengever/api/document.py
+++ b/opengever/api/document.py
@@ -6,6 +6,7 @@ from opengever.base.helpers import display_name
 from opengever.base.interfaces import IReferenceNumber
 from opengever.document.behaviors import IBaseDocument
 from opengever.document.interfaces import ICheckinCheckoutManager
+from opengever.document.versioner import Versioner
 from opengever.workspaceclient.interfaces import ILinkedDocuments
 from plone.restapi.deserializer import json_body
 from plone.restapi.interfaces import ISerializeToJson
@@ -62,6 +63,14 @@ class SerializeDocumentToJson(GeverSerializeToJson):
 
         result.update(additional_metadata)
         return result
+
+    def getVersion(self, version):
+        """Return context when no lazy initial version exists."""
+
+        if not Versioner(self.context).has_initial_version():
+            return self.context
+
+        return super(SerializeDocumentToJson, self).getVersion(version)
 
 
 class DocumentPatch(ContentPatch):

--- a/opengever/api/tests/test_history.py
+++ b/opengever/api/tests/test_history.py
@@ -285,6 +285,21 @@ class TestVersionsGetEndpointForDocuments(IntegrationTestCase):
                          [each['version'] for each in browser.json['items']])
 
     @browsing
+    def test_returns_initial_version_details_for_lazy_initial_version(self, browser):
+        self.login(self.regular_user, browser)
+        versioner = Versioner(self.document)
+        self.assertFalse(versioner.has_initial_version())
+
+        browser.open(self.document,
+                     view='@versions/0',
+                     method='GET',
+                     headers=self.api_headers)
+
+        resp = browser.json
+        self.assertEqual(0, resp[u'current_version_id'])
+        self.assertEqual(u'0', resp[u"version"])
+
+    @browsing
     def test_returns_initial_version_even_when_it_does_not_exist_yet(self, browser):
         self.login(self.regular_user, browser)
         versioner = Versioner(self.document)


### PR DESCRIPTION
The initial version is created lazily so documents that have not been touched in any way after adding do not have an initial version. We handle this case by returning the document itself as the initial version.

For https://4teamwork.atlassian.net/browse/CA-2623

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))

