### PR TITLE
Fix download lazy initial version for documents.

### DIFF
--- a/changes/CA-2623-1.bugfix
+++ b/changes/CA-2623-1.bugfix
@@ -1,0 +1,1 @@
+Fix downloading lazy initial versions for documents. [deiferni]

--- a/opengever/virusscan/tests/test_virusscan_validator.py
+++ b/opengever/virusscan/tests/test_virusscan_validator.py
@@ -353,6 +353,10 @@ class TestVirusScanValidator(IntegrationTestCase):
 
 class TestVirusScanDownloadValidator(IntegrationTestCase):
 
+    headers = {
+        'Accept': 'application/json',
+    }
+
     def setUp(self):
         super(TestVirusScanDownloadValidator, self).setUp()
         register_mock_av_scanner()
@@ -508,7 +512,7 @@ class TestVirusScanDownloadValidator(IntegrationTestCase):
 
         self.mail_eml.message.data = EICAR
         with browser.expect_http_error(code=400):
-            browser.open(self.mail_eml, view='download', headers=self.api_headers)
+            browser.open(self.mail_eml, view='download', headers=self.headers)
 
         self.assertEqual(
             u'file_infected',
@@ -533,15 +537,12 @@ class TestVirusScanDownloadValidator(IntegrationTestCase):
     def test_download_versioned_copy_over_api_scans_file_if_enabled(self, browser):
         self.login(self.regular_user, browser)
         Versioner(self.document).create_version('Initial version')
-        payload = {'version_id': '0'}
 
         with browser.expect_http_error(code=400):
-            browser.open(
-                "{}/download_file_version".format(self.document.absolute_url()),
-                data=json.dumps(payload),
-                method='POST',
-                headers=self.api_headers)
-
+            browser.open(self.document,
+                         view='download_file_version',
+                         data={'version_id': 0},
+                         headers=self.headers)
         self.assertEqual(
             u'file_infected',
             browser.json['message'])
@@ -550,13 +551,11 @@ class TestVirusScanDownloadValidator(IntegrationTestCase):
     def test_download_versioned_copy_over_api_with_virusscan_enabled(self, browser):
         self.login(self.regular_user, browser)
         Versioner(self.subdocument).create_version('Initial version')
-        payload = {'version_id': '0'}
 
-        browser.open(
-            "{}/download_file_version".format(self.subdocument.absolute_url()),
-            data=json.dumps(payload),
-            method='POST',
-            headers=self.api_headers)
+        browser.open(self.subdocument,
+                     view='download_file_version',
+                     data={'version_id': 0},
+                     headers=self.headers)
         self.assertEqual(
             'attachment; filename="Uebersicht der Vertraege von 2016.xlsx"',
             browser.headers.get('content-disposition'))


### PR DESCRIPTION
The initial version is created lazily so documents that have not been touched in any way after adding do not have an initial version. We handle this case by retrieving the file version from the document itself.

I've seen that input validation in the view has not been done so nicely and could result in 500 range server side errors. I have amended to turn them into 400 client side errors where possible.

This is a follow-up for https://github.com/4teamwork/opengever.core/pull/7097 which only fixes one part of the issue.

For https://4teamwork.atlassian.net/browse/CA-2623

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
