### PR TITLE
Add API endpoint to unlink a workspace from a dossier.

### DIFF
--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -18,6 +18,7 @@ Breaking Changes
 Other Changes
 ^^^^^^^^^^^^^
 
+- Add new endpoint ``@unlink-workspace`` (see :ref:`docs <linked-workspaces>`)
 - Almost all content type serializers provide additional key ``sequence_number``.
 - Add new endpoint ``@accept-remote-forwarding`` (see :ref:`docs <accept-remote-forwarding>`)
 - ``@workflow``: Add ``transition_response`` if it exists.

--- a/docs/public/dev-manual/api/linked_workspaces.rst
+++ b/docs/public/dev-manual/api/linked_workspaces.rst
@@ -1,3 +1,5 @@
+.. _linked-workspaces:
+
 Verknüpfte Arbeitsräume
 =======================
 
@@ -86,6 +88,30 @@ Ein Dosser kann über den Endpoint ``@link-to-workspace`` mit einem bestehenden 
   .. sourcecode:: http
 
     POST /ordnungssystem/dossier-23/@link-to-workspace HTTP/1.1
+    Accept: application/json
+    Content-Type: application/json
+
+    {
+      "workspace_uid": "c11627f492b6447fb61617bb06b9a21a"
+    }
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 204 No Content
+
+
+Teamraum Verknüpfung entfernen
+------------------------------
+
+Eine bestehende Verknüpfung eines Teamraums kann mit dem ``@unlink-workspace`` Endpoint entfernt werden. Dabei werden auch bestehende Locks auf verlinkten Dokumenten aufgehoben. Der Teamraum bleibt aber bestehen.
+
+**Beispiel-Request**:
+
+  .. sourcecode:: http
+
+    POST /ordnungssystem/dossier-23/@unlink-workspace HTTP/1.1
     Accept: application/json
     Content-Type: application/json
 

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -1010,6 +1010,14 @@
       />
 
   <plone:service
+      method="POST"
+      name="@unlink-workspace"
+      for="opengever.dossier.behaviors.dossier.IDossierMarker"
+      factory=".linked_workspaces.UnlinkWorkspacePost"
+      permission="opengever.workspaceclient.UseWorkspaceClient"
+      />
+
+  <plone:service
       method="GET"
       name="@allowed-roles-and-principals"
       for="Products.CMFCore.interfaces.IContentish"

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -1002,6 +1002,14 @@
       />
 
   <plone:service
+      method="GET"
+      name="@list-linked-gever-documents-uids"
+      for="opengever.workspace.interfaces.IWorkspace"
+      factory=".linked_workspaces.ListLinkedDocumentUIDsFromWorkspace"
+      permission="opengever.workspaceclient.UseWorkspaceClient"
+      />
+
+  <plone:service
       method="POST"
       name="@copy-document-from-workspace"
       for="opengever.dossier.behaviors.dossier.IDossierMarker"

--- a/opengever/api/linked_workspaces.py
+++ b/opengever/api/linked_workspaces.py
@@ -321,3 +321,16 @@ class CopyDocumentFromWorkspacePost(LinkedWorkspacesService):
             raise BadRequest("Property 'document_uid' is required")
         as_new_version = bool(data.get('as_new_version', False))
         return workspace_uid, document_uid, as_new_version
+
+
+class ListLinkedDocumentUIDsFromWorkspace(Service):
+
+    def reply(self):
+        catalog = api.portal.get_tool('portal_catalog')
+        brains = catalog(path='/'.join(self.context.getPhysicalPath()),
+                         object_provides=IBaseDocument.__identifier__)
+
+        uids = [brain.gever_doc_uid for brain in brains
+                if brain.gever_doc_uid]
+
+        return {'gever_doc_uids': uids}

--- a/opengever/api/linked_workspaces.py
+++ b/opengever/api/linked_workspaces.py
@@ -185,6 +185,27 @@ class LinkToWorkspacePost(LinkedWorkspacesService):
         return self.reply_no_content()
 
 
+class UnlinkWorkspacePost(LinkedWorkspacesService):
+    """API Endpoint to unlink a dossier from an existing workspace.
+    """
+
+    def render(self):
+        if not self.context.is_open():
+            raise Unauthorized
+        return super(UnlinkWorkspacePost, self).render()
+
+    @request_error_handler
+    def reply(self):
+        alsoProvides(self.request, IDisableCSRFProtection)
+        data = json_body(self.request)
+        workspace_uid = data.get('workspace_uid')
+        if not workspace_uid:
+            raise BadRequest("Property 'workspace_uid' is required")
+
+        ILinkedWorkspaces(self.context).unlink_workspace(workspace_uid)
+        return self.reply_no_content()
+
+
 class CopyDocumentToWorkspacePost(LinkedWorkspacesService):
     """API Endpoint to copy a document to a linked workspace.
     """

--- a/opengever/api/tests/test_actions.py
+++ b/opengever/api/tests/test_actions.py
@@ -1240,10 +1240,16 @@ class TestWorkspaceClientFolderActions(FunctionalWorkspaceClientTestCase):
         u'title': u'Copy back documents from workspace',
         u'icon': u''}
 
+    unlink_workspace_action = {
+        u'id': u'unlink_workspace',
+        u'title': u'Unlink workspace',
+        u'icon': u''}
+
     workspace_actions = [list_workspaces_action,
                          link_to_workspace_action,
                          copy_documents_to_workspace_action,
-                         copy_documents_from_workspace_action]
+                         copy_documents_from_workspace_action,
+                         unlink_workspace_action]
 
     def get_actions(self, browser, context):
         browser.open(context.absolute_url() + '/@actions',
@@ -1367,6 +1373,21 @@ class TestWorkspaceClientFolderActions(FunctionalWorkspaceClientTestCase):
 
             self.assert_workspace_actions(browser, self.dossier,
                                           [self.list_workspaces_action])
+
+    @browsing
+    def test_unlink_actions_available_in_dossier_with_linked_workspaces(self, browser):
+        browser.login()
+        with self.workspace_client_env():
+            self.link_workspace(self.dossier)
+            actions = self.get_actions(browser, self.dossier)
+            self.assertIn(self.unlink_workspace_action, actions)
+
+    @browsing
+    def test_unlink_action_not_available_in_dossier_without_linked_workspaces(self, browser):
+        browser.login()
+        with self.workspace_client_env():
+            actions = self.get_actions(browser, self.dossier)
+            self.assertNotIn(self.unlink_workspace_action, actions)
 
 
 class TestObjectButtonsGetForDocuments(ObjectButtonsTestBase):

--- a/opengever/base/browser/folder_buttons_availability.py
+++ b/opengever/base/browser/folder_buttons_availability.py
@@ -116,6 +116,11 @@ class FolderButtonsAvailabilityView(BrowserView):
                 and self._can_use_workspace_client()
                 and self._can_modify_dossier())
 
+    def is_unlink_workspace_available(self):
+        return (self._is_main_dossier()
+                and self._can_modify_dossier()
+                and self._has_linked_workspaces())
+
     def is_move_items_available(self):
         if self._is_dossier() and not self._is_open_dossier():
             return False
@@ -155,3 +160,10 @@ class FolderButtonsAvailabilityView(BrowserView):
 
     def is_attach_documents_available(self):
         return not self._is_template_area()
+
+    def _has_linked_workspaces(self):
+        if not self._can_use_workspace_client():
+            return False
+
+        linked_workspaces_manager = ILinkedWorkspaces(self.context.get_main_dossier())
+        return linked_workspaces_manager.has_linked_workspaces()

--- a/opengever/base/tests/test_solr.py
+++ b/opengever/base/tests/test_solr.py
@@ -117,6 +117,7 @@ class TestSolr(IntegrationTestCase):
             'title_de',
             'title_fr',
             'title_en',
+            'gever_doc_uid',
         ]
 
         for metadata in catalog.schema():

--- a/opengever/core/hooks.py
+++ b/opengever/core/hooks.py
@@ -16,6 +16,7 @@ import opengever.repository.hooks
 import opengever.tabbedview.hooks
 import opengever.task.hooks
 import opengever.trash.hooks
+import opengever.workspaceclient.hooks
 import re
 
 
@@ -104,6 +105,7 @@ def trigger_subpackage_hooks(site):
     opengever.quota.hooks.policy_installed(site)
     # Added after the profile merge
     opengever.repository.hooks.installed(site)
+    opengever.workspaceclient.hooks.installed(site)
 
 
 def enable_secure_flag_for_cookies(context):

--- a/opengever/core/hooks.py
+++ b/opengever/core/hooks.py
@@ -74,9 +74,9 @@ def avoid_profile_reinstallation(event):
 
 def should_prevent_duplicate_installation(profile):
     return (
-        profile.startswith('opengever.') or
-        profile.startswith('ftw.') or
-        profile.startswith('plonetheme.teamraum')
+        profile.startswith('opengever.')
+        or profile.startswith('ftw.')
+        or profile.startswith('plonetheme.teamraum')
     )
 
 

--- a/opengever/core/locales/de/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/de/LC_MESSAGES/opengever.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-06-17 08:50+0000\n"
+"POT-Creation-Date: 2021-08-02 06:06+0000\n"
 "PO-Revision-Date: 2017-09-18 15:21+0200\n"
 "Last-Translator: Philippe Gross <p.gross@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -147,6 +147,7 @@ msgid "Export as Zip"
 msgstr "Als Zip-Datei exportieren"
 
 #: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20210702082528_add_export_proposals_action/actions.xml
 msgid "Export selection"
 msgstr "Auswahl exportieren"
 
@@ -344,6 +345,11 @@ msgid "Toggle orgunit selector"
 msgstr "Amtswechsler umschalten"
 
 #: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20210728095648_add_unlink_workspace_action/actions.xml
+msgid "Unlink workspace"
+msgstr "Teamraum Verknüpfung entfernen"
+
+#: ./opengever/core/profiles/default/actions.xml
 msgid "Unlock unused repository prefixes."
 msgstr "Freigabe von ungebrauchten Aktenzeichen Prefixen."
 
@@ -414,6 +420,7 @@ msgid "trash_content"
 msgstr "In den Papierkorb verschieben"
 
 #: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20210611160146_rename_trashed_view/actions.xml
 msgid "untrash_content"
 msgstr "Reaktivieren"
 

--- a/opengever/core/locales/en/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/en/LC_MESSAGES/opengever.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-06-17 08:50+0000\n"
+"POT-Creation-Date: 2021-08-02 06:06+0000\n"
 "PO-Revision-Date: 2017-09-18 15:21+0200\n"
 "Last-Translator: Philippe Gross <p.gross@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -176,6 +176,7 @@ msgstr "Export as ZIP file"
 
 #. German translation: Auswahl exportieren
 #: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20210702082528_add_export_proposals_action/actions.xml
 msgid "Export selection"
 msgstr "Export selection"
 
@@ -416,6 +417,11 @@ msgstr "To-do list"
 msgid "Toggle orgunit selector"
 msgstr "Switch organization / department"
 
+#: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20210728095648_add_unlink_workspace_action/actions.xml
+msgid "Unlink workspace"
+msgstr "Unlink workspace"
+
 #. German translation: Freigabe von ungebrauchten Aktenzeichen Prefixen.
 #: ./opengever/core/profiles/default/actions.xml
 msgid "Unlock unused repository prefixes."
@@ -501,6 +507,7 @@ msgstr "Move to trash"
 
 #. German translation: Reaktivieren
 #: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20210611160146_rename_trashed_view/actions.xml
 msgid "untrash_content"
 msgstr "Restore from trash"
 

--- a/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-06-17 08:50+0000\n"
+"POT-Creation-Date: 2021-08-02 06:06+0000\n"
 "PO-Revision-Date: 2013-03-27 10:44+0100\n"
 "Last-Translator: Philippe Gross <p.gross@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -144,6 +144,7 @@ msgid "Export as Zip"
 msgstr "Exporter comme fichier ZIP"
 
 #: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20210702082528_add_export_proposals_action/actions.xml
 msgid "Export selection"
 msgstr "Exporter la sélection"
 
@@ -339,6 +340,11 @@ msgid "Toggle orgunit selector"
 msgstr "commuter l'agent public"
 
 #: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20210728095648_add_unlink_workspace_action/actions.xml
+msgid "Unlink workspace"
+msgstr ""
+
+#: ./opengever/core/profiles/default/actions.xml
 msgid "Unlock unused repository prefixes."
 msgstr "Déblocage de préfixes de référence inutilisés."
 
@@ -409,6 +415,7 @@ msgid "trash_content"
 msgstr "Déplacer dans la corbeille"
 
 #: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20210611160146_rename_trashed_view/actions.xml
 msgid "untrash_content"
 msgstr "Réactiver"
 

--- a/opengever/core/locales/opengever.core.pot
+++ b/opengever/core/locales/opengever.core.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-06-17 08:50+0000\n"
+"POT-Creation-Date: 2021-08-02 06:06+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -147,6 +147,7 @@ msgid "Export as Zip"
 msgstr ""
 
 #: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20210702082528_add_export_proposals_action/actions.xml
 msgid "Export selection"
 msgstr ""
 
@@ -342,6 +343,11 @@ msgid "Toggle orgunit selector"
 msgstr ""
 
 #: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20210728095648_add_unlink_workspace_action/actions.xml
+msgid "Unlink workspace"
+msgstr ""
+
+#: ./opengever/core/profiles/default/actions.xml
 msgid "Unlock unused repository prefixes."
 msgstr ""
 
@@ -412,6 +418,7 @@ msgid "trash_content"
 msgstr ""
 
 #: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20210611160146_rename_trashed_view/actions.xml
 msgid "untrash_content"
 msgstr ""
 

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -605,6 +605,15 @@
       <property name="visible">True</property>
     </object>
 
+    <object name="unlink_workspace" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Unlink workspace</property>
+      <property name="description">Gever-UI action</property>
+      <property name="url_expr" />
+      <property name="icon_expr" />
+      <property name="available_expr">object/@@folder_buttons_availability/is_unlink_workspace_available</property>
+      <property name="visible">True</property>
+    </object>
+
     <object name="edit_items" meta_type="CMF Action" i18n:domain="opengever.core">
       <property name="title" i18n:translate="">Edit metadata</property>
       <property name="description">Gever-UI action</property>

--- a/opengever/core/profiles/default/catalog.xml
+++ b/opengever/core/profiles/default/catalog.xml
@@ -58,4 +58,7 @@
   <!-- TRASH -->
   <column value="trashed" />
 
+  <!-- WORKSPACE -->
+  <column value="gever_doc_uid" />
+
 </object>

--- a/opengever/core/upgrades/20210728095648_add_unlink_workspace_action/actions.xml
+++ b/opengever/core/upgrades/20210728095648_add_unlink_workspace_action/actions.xml
@@ -1,0 +1,16 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="portal_actions" meta_type="Plone Actions Tool">
+
+  <object name="folder_actions" meta_type="CMF Action Category">
+
+    <object name="unlink_workspace" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Unlink workspace</property>
+      <property name="description">Gever-UI action</property>
+      <property name="url_expr" />
+      <property name="icon_expr" />
+      <property name="available_expr">object/@@folder_buttons_availability/is_unlink_workspace_available</property>
+      <property name="visible">True</property>
+    </object>
+
+  </object>
+
+</object>

--- a/opengever/core/upgrades/20210728095648_add_unlink_workspace_action/upgrade.py
+++ b/opengever/core/upgrades/20210728095648_add_unlink_workspace_action/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddUnlinkWorkspaceAction(UpgradeStep):
+    """Add unlink_workspace action.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/core/upgrades/20210730105957_add_gever_doc_uid_catalog_index/catalog.xml
+++ b/opengever/core/upgrades/20210730105957_add_gever_doc_uid_catalog_index/catalog.xml
@@ -1,0 +1,5 @@
+<object name="portal_catalog">
+
+  <column value="gever_doc_uid" />
+
+</object>

--- a/opengever/core/upgrades/20210730105957_add_gever_doc_uid_catalog_index/upgrade.py
+++ b/opengever/core/upgrades/20210730105957_add_gever_doc_uid_catalog_index/upgrade.py
@@ -1,0 +1,31 @@
+from ftw.upgrade import UpgradeStep
+from opengever.document.behaviors import IBaseDocument
+from plone import api
+
+
+class AddGeverDocUidCatalogIndex(UpgradeStep):
+    """Add gever_doc_uid catalog index.
+    """
+
+    index_name = 'gever_doc_uid'
+
+    deferrable = True
+
+    def __call__(self):
+        self.install_upgrade_profile()
+
+        if not self.catalog_has_index(self.index_name):
+            self.catalog_add_index(self.index_name, 'FieldIndex')
+
+        catalog = api.portal.get_tool('portal_catalog')
+        workspace_roots = catalog.unrestrictedSearchResults(
+            portal_type='opengever.workspace.root')
+        query = {
+            'object_provides': IBaseDocument.__identifier__,
+            'path': {'query': [root.getPath() for root in workspace_roots]},
+        }
+
+        for obj in self.objects(
+                query, u'Reindex gever_doc_uid for workspace documents'):
+
+            obj.reindexObject(idxs=[self.index_name])

--- a/opengever/document/tests/test_copy_document.py
+++ b/opengever/document/tests/test_copy_document.py
@@ -93,7 +93,8 @@ class TestCopyDocuments(IntegrationTestCase):
                              'containing_subdossier': '',
                              # title and filename
                              'Title': 'Copy of {}'.format(self.subdocument.Title()),
-                             'filename': u'Copy of {}'.format(self.subdocument.get_filename())}
+                             'filename': u'Copy of {}'.format(self.subdocument.get_filename()),
+                             'gever_doc_uid': None}
 
         unchanged_metadata = ['Description',
                               'Subject', 'Type',

--- a/opengever/dossier/tests/test_move_items.py
+++ b/opengever/dossier/tests/test_move_items.py
@@ -181,6 +181,7 @@ class TestMoveItemsUpdatesIndexAndMetadata(IntegrationTestCase, MoveItemsHelper)
                               'firstname',
                               'getContentType',
                               'getIcon',
+                              'gever_doc_uid',
                               'has_sametype_children',
                               'in_response_to',
                               'is_folderish',

--- a/opengever/workspaceclient/client.py
+++ b/opengever/workspaceclient/client.py
@@ -98,6 +98,14 @@ class WorkspaceClient(object):
             workspace.get('@id'),
             json={'external_reference': new_dossier_oguid})
 
+    def unlink_workspace(self, workspace_uid):
+        """Removes external_reference on the workspace"""
+
+        workspace = self.get_by_uid(uid=workspace_uid)
+        self.request.patch(workspace.get('@id'),
+                           json={'external_reference': None})
+        return workspace
+
     def get_by_uid(self, uid, **kwargs):
         """Searches on the remote system for an object having the given UID
         and returns it (serialized).

--- a/opengever/workspaceclient/config.py
+++ b/opengever/workspaceclient/config.py
@@ -1,0 +1,3 @@
+INDEXES = (
+    ('gever_doc_uid', 'FieldIndex'),
+)

--- a/opengever/workspaceclient/configure.zcml
+++ b/opengever/workspaceclient/configure.zcml
@@ -10,6 +10,11 @@
   <adapter factory=".linked_workspaces.LinkedWorkspaces" />
   <adapter factory=".linked_documents.LinkedDocuments" />
 
+  <adapter
+      factory=".indexers.gever_doc_uid"
+      name="gever_doc_uid"
+      />
+
   <i18n:registerTranslations directory="locales" />
 
 </configure>

--- a/opengever/workspaceclient/hooks.py
+++ b/opengever/workspaceclient/hooks.py
@@ -1,0 +1,8 @@
+from opengever.core.catalog import add_catalog_indexes
+from opengever.document.config import INDEXES
+import logging
+
+
+def installed(site):
+    add_catalog_indexes(INDEXES,
+                        logging.getLogger('opengever.workspaceclient'))

--- a/opengever/workspaceclient/indexers.py
+++ b/opengever/workspaceclient/indexers.py
@@ -1,0 +1,10 @@
+from opengever.document.behaviors import IBaseDocument
+from opengever.workspaceclient.interfaces import ILinkedDocuments
+from plone.indexer import indexer
+
+
+@indexer(IBaseDocument)
+def gever_doc_uid(obj):
+    linked_document = ILinkedDocuments(obj).linked_gever_document
+    if linked_document:
+        return linked_document.get('UID')

--- a/opengever/workspaceclient/linked_documents.py
+++ b/opengever/workspaceclient/linked_documents.py
@@ -65,6 +65,7 @@ class LinkedDocuments(object):
 
         gever_doc = PersistentMapping({'UID': gever_doc_uid})
         link_storage['gever_document'] = gever_doc
+        self.document.reindexObject(idxs=['gever_doc_uid'])
 
     def serialize(self):
         data = {

--- a/opengever/workspaceclient/tests/test_client.py
+++ b/opengever/workspaceclient/tests/test_client.py
@@ -4,6 +4,7 @@ from opengever.workspaceclient.client import WorkspaceClient
 from opengever.workspaceclient.exceptions import WorkspaceClientFeatureNotEnabled
 from opengever.workspaceclient.exceptions import WorkspaceURLMissing
 from opengever.workspaceclient.interfaces import ILinkedDocuments
+from opengever.workspaceclient.interfaces import ILinkedWorkspaces
 from opengever.workspaceclient.tests import FunctionalWorkspaceClientTestCase
 from plone import api
 from zExceptions import Unauthorized
@@ -122,3 +123,14 @@ class TestWorkspaceClient(FunctionalWorkspaceClientTestCase):
             self.assertEqual(
                 {'UID': 'UID-1234'},
                 ILinkedDocuments(document).linked_gever_document)
+
+    def test_unlink_workspace(self):
+        dossier_oguid = Oguid.for_object(self.dossier).id
+        with self.workspace_client_env() as client:
+            client.link_to_workspace(self.workspace.UID(), dossier_oguid)
+            transaction.commit()
+            self.assertEqual(dossier_oguid, self.workspace.external_reference)
+
+            client.unlink_workspace(self.workspace.UID())
+            transaction.commit()
+            self.assertEqual(u'', self.workspace.external_reference)

--- a/opengever/workspaceclient/tests/test_linked_documents.py
+++ b/opengever/workspaceclient/tests/test_linked_documents.py
@@ -1,4 +1,5 @@
 from opengever.testing import IntegrationTestCase
+from opengever.testing import obj2brain
 from opengever.workspaceclient.interfaces import ILinkedDocuments
 from opengever.workspaceclient.linked_documents import AlreadyLinkedError
 from opengever.workspaceclient.linked_documents import LinkedDocuments
@@ -76,3 +77,14 @@ class TestLinkedDocumentsAdapter(IntegrationTestCase):
 
         annotations = IAnnotations(self.document)
         self.assertNotIn(adapter.storage_key, annotations.keys())
+
+    def test_gever_doc_uid_is_indexed(self):
+        self.login(self.workspace_member)
+
+        adapter = ILinkedDocuments(self.workspace_document)
+        self.assertIsNone(obj2brain(self.workspace_document).gever_doc_uid)
+
+        adapter.link_gever_document(IUUID(self.document))
+
+        self.assertEqual(IUUID(self.document),
+                         obj2brain(self.workspace_document).gever_doc_uid)

--- a/opengever/workspaceclient/tests/test_linked_workspaces.py
+++ b/opengever/workspaceclient/tests/test_linked_workspaces.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 from ftw.builder import Builder
 from ftw.builder import create
+from mock import patch
 from opengever.base.command import CreateEmailCommand
 from opengever.base.oguid import Oguid
 from opengever.document.interfaces import ICheckinCheckoutManager
@@ -908,3 +909,48 @@ class TestLinkedWorkspacesJournalization(FunctionalWorkspaceClientTestCase):
             'Document added',
             u'Document added: Testdokum\xe4nt',
             entry=-2)
+
+
+class TestUnlinkWorkspace(FunctionalWorkspaceClientTestCase):
+
+    def test_unlink_removes_workspace_uid_from_storage(self):
+        with self.workspace_client_env():
+            manager = ILinkedWorkspaces(self.dossier)
+            manager.storage.add(self.workspace.UID())
+
+            with auto_commit_after_request(manager.client):
+                manager.unlink_workspace(self.workspace.UID())
+
+            self.assertEqual([], manager.storage.list())
+
+    def test_removes_marker_interface_if_no_linked_workspaces_exists(self):
+        with self.workspace_client_env():
+            manager = ILinkedWorkspaces(self.dossier)
+            workspace_2 = create(Builder('workspace')
+                                 .titled(u'A Workspace')
+                                 .within(self.workspace_root))
+
+            with patch('opengever.workspaceclient.client.WorkspaceClient.link_to_workspace') as link_to_workspace:
+                link_to_workspace.return_value = {'UID': self.workspace.UID()}
+                manager.link_to_workspace(self.workspace.UID())
+
+            with patch('opengever.workspaceclient.client.WorkspaceClient.link_to_workspace') as link_to_workspace:
+                link_to_workspace.return_value = {'UID': workspace_2.UID()}
+                manager.link_to_workspace(workspace_2.UID())
+
+            manager.unlink_workspace(self.workspace.UID())
+            self.assertTrue(ILinkedToWorkspace.providedBy(self.dossier))
+
+            manager.unlink_workspace(workspace_2.UID())
+            self.assertFalse(ILinkedToWorkspace.providedBy(self.dossier))
+
+    def test_unlink_is_journalized(self):
+        with self.workspace_client_env():
+            manager = ILinkedWorkspaces(self.dossier)
+            manager.storage.add(self.workspace.UID())
+
+            with auto_commit_after_request(manager.client):
+                manager.unlink_workspace(self.workspace.UID())
+
+            self.assert_journal_entry(self.dossier, 'Unlinked workspace',
+                                      u'Unlink workspace Ein Teamraum.')


### PR DESCRIPTION
I made the following decisions:
- Becuase the "gever-workspace-link" ist not really traversable, I decided against a `DELETE` endpoint and implemented a `@unlink-workspace` POST endpoint.
- We don't remove the linked document, so if a workspcae gets unlinked and linked again, the linked documents can be copied as new version to the GEVER dossier. But existing locks will always be unlocked, when unlinking a workspace.
- Because a GEVER dossier can have multiple linked workspaces, we need to know which documents belongs to which workspace, to make sure only those document-locks get unlocked. Therefore I added a new catalog index and metadata `gever_doc_uid` on the workspace side, which stores the UID of the linked gever document. This allows GEVER with a request on the workspace an a query on the own catalog, to fetch all gever-documents linked with a specific workspace.


Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-2392](https://4teamwork.atlassian.net/browse/CA-2392)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide]- Upgrade steps (changes in profile):
 - Upgradestep
  - [x] Make it deferrable if possible
  - [x] Execute as much as possible conditionally
- New translations
  - [x] All msg-strings are unicode
