### PR TITLE
Fix returning translated title in solrsearch and listing endpoints.

### DIFF
--- a/changes/CA-2649.bugfix
+++ b/changes/CA-2649.bugfix
@@ -1,0 +1,1 @@
+Fix returning translated title in solrsearch and listing endpoints. [njohner]

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -5,6 +5,7 @@ from ftw.solr.converters import to_iso8601
 from ftw.solr.interfaces import ISolrSearch
 from ftw.solr.query import escape
 from opengever.base.behaviors.translated_title import ITranslatedTitleSupport
+from opengever.base.behaviors.translated_title import TRANSLATED_TITLE_PORTAL_TYPES
 from opengever.base.helpers import display_name
 from opengever.base.solr import OGSolrContentListing
 from opengever.base.utils import get_preferred_language_code
@@ -102,9 +103,8 @@ def filename(obj):
 
 
 def translated_title(obj):
-    if ITranslatedTitleSupport.providedBy(obj):
-        attr = 'title_{}'.format(get_preferred_language_code())
-        return getattr(obj, attr, obj.Title())
+    if obj.portal_type in TRANSLATED_TITLE_PORTAL_TYPES:
+        return obj.getObject().Title(language=get_preferred_language_code())
     else:
         return obj.Title()
 
@@ -336,7 +336,8 @@ FIELDS_WITH_MAPPING = [
     ListingField('task_type', 'task_type', accessor=translated_task_type, transform=translate_task_type),
     ListingField('thumbnail_url', None, 'preview_image_url', DEFAULT_SORT_INDEX,
                  additional_required_fields=['bumblebee_checksum', 'path']),
-    ListingField('title', 'Title', translated_title, 'sortable_title'),
+    ListingField('title', 'Title', translated_title, 'sortable_title',
+                 additional_required_fields=['portal_type']),
     ListingField('type', 'portal_type', 'PortalType'),
     ListingField('@type', 'portal_type', 'PortalType'),
     ListingField('@id', "path", "getURL"),

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -186,6 +186,26 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
     maxDiff = None
 
     @browsing
+    def test_repository_folders_translatable_title(self, browser):
+        self.enable_languages()
+
+        self.login(self.regular_user, browser=browser)
+        view = '@listing?name=repository_folders&columns:list=title'
+        browser.open(self.repository_root, view=view,
+                     headers={'Accept': 'application/json',
+                              'Accept-Language': 'de-ch'})
+
+        self.assertEqual(browser.json[u'items_total'], 4)
+        self.assertEqual(u'1.1. Vertr\xe4ge und Vereinbarungen',
+                         browser.json['items'][0]['title'])
+
+        browser.open(self.repository_root, view=view,
+                     headers={'Accept': 'application/json',
+                              'Accept-Language': 'fr-ch'})
+        self.assertEqual(u'1.1. Contrats et accords',
+                         browser.json['items'][0]['title'])
+
+    @browsing
     def test_dossier_listing_works_for_responsible_fullname(self, browser):
         self.login(self.regular_user, browser=browser)
         query_string = '&'.join((

--- a/opengever/base/behaviors/translated_title.py
+++ b/opengever/base/behaviors/translated_title.py
@@ -11,6 +11,16 @@ from zope.schema import TextLine
 
 
 TRANSLATED_TITLE_NAMES = ('title_de', 'title_fr', 'title_en')
+TRANSLATED_TITLE_PORTAL_TYPES = (
+    'opengever.dossier.templatefolder',
+    'opengever.repository.repositoryfolder',
+    'opengever.repository.repositoryroot',
+    'opengever.inbox.inbox',
+    'opengever.inbox.container',
+    'opengever.contact.contactfolder',
+    'opengever.meeting.committeecontainer',
+    'opengever.private.root',
+    'opengever.workspace.root')
 
 
 def get_active_languages():

--- a/opengever/base/tests/test_translated_title.py
+++ b/opengever/base/tests/test_translated_title.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
@@ -10,6 +9,7 @@ from opengever.base.behaviors.translated_title import get_inactive_languages
 from opengever.base.behaviors.translated_title import has_translation_behavior
 from opengever.base.behaviors.translated_title import ITranslatedTitle
 from opengever.base.behaviors.translated_title import TRANSLATED_TITLE_NAMES
+from opengever.base.behaviors.translated_title import TRANSLATED_TITLE_PORTAL_TYPES
 from opengever.base.behaviors.translated_title import TranslatedTitle
 from opengever.base.brain import supports_translated_title
 from opengever.testing import IntegrationTestCase
@@ -55,6 +55,17 @@ class TestTranslatedTitleHasTranslationBehavior(IntegrationTestCase):
             ttool["opengever.repository.repositoryfolder"]))
         self.assertTrue(has_translation_behavior(
             ttool["opengever.contact.contactfolder"]))
+
+
+class TestTranslatedTitleBehavior(IntegrationTestCase):
+
+    def test_translated_title_portal_types_list_is_complete(self):
+        types_tool = api.portal.get_tool('portal_types')
+        types_with_behavior = [
+            portal_type for portal_type, fti in types_tool.items()
+            if has_translation_behavior(fti)]
+        self.assertItemsEqual(TRANSLATED_TITLE_PORTAL_TYPES,
+                              types_with_behavior)
 
 
 class TranslatedTitleTestMixin(object):


### PR DESCRIPTION
We fix returning the translated title in the `listing` and `solrsearch` endpoints. The check that we were making to decide whether to return a translated title was never passing, as `OGSolrContentListingObject` does not support `providedBy`.

For [CA-2649]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-2649]: https://4teamwork.atlassian.net/browse/CA-2649