### PR TITLE
Allow deleting repository folders over the REST-API.

### DIFF
--- a/changes/CA-2108.feature
+++ b/changes/CA-2108.feature
@@ -1,0 +1,1 @@
+Allow deleting repository folders over the REST-API. [njohner]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -12,6 +12,8 @@ Breaking Changes
 Other Changes
 ^^^^^^^^^^^^^
 
+- Allow deleting repository folders over the REST-API.
+
 
 2021.15.0 (2021-07-30)
 ----------------------

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -104,6 +104,14 @@
       />
 
   <plone:service
+      method="DELETE"
+      for="opengever.repository.repositoryfolder.IRepositoryFolderSchema"
+      layer="opengever.base.interfaces.IOpengeverBaseLayer"
+      factory=".repositoryfolder.DeleteRepositoryFolder"
+      permission="zope2.View"
+      />
+
+  <plone:service
       method="POST"
       name="@assign-to-dossier"
       for="opengever.inbox.forwarding.IForwarding"

--- a/opengever/api/tests/test_delete.py
+++ b/opengever/api/tests/test_delete.py
@@ -85,6 +85,33 @@ class DeleteGeverObjects(IntegrationTestCase, APITestDeleteMixin):
         obj.manage_permission("Delete objects", roles=["Records Manager"])
         self.assert_can_delete(obj, browser)
 
+    @browsing
+    def test_deleting_repository_root_is_not_allowed(self, browser):
+        self.login(self.manager, browser)
+        self.assert_cannot_delete(self.repository_root, browser, code=403)
+        self.assertEqual(
+            u'Deleting repository folders and roots is not allowed',
+            browser.json['message'])
+
+    @browsing
+    def test_deleting_repository_folder_requires_delete_objects_permission(self, browser):
+        self.login(self.records_manager, browser)
+        obj = self.empty_repofolder
+
+        self.assert_cannot_delete(obj, browser, code=403)
+
+        obj.manage_permission("Delete objects", roles=["Records Manager"])
+        self.assert_can_delete(obj, browser)
+
+    @browsing
+    def test_can_only_delete_empty_repository_folders(self, browser):
+        self.login(self.manager, browser)
+
+        self.assert_cannot_delete(self.leaf_repofolder, browser, code=403)
+        self.assertEqual(u'Repository is not empty.', browser.json['message'])
+
+        self.assert_can_delete(self.empty_repofolder, browser)
+
 
 class TestDeleteTeamraumObjects(IntegrationTestCase, APITestDeleteMixin):
 

--- a/opengever/dossier/handlers.py
+++ b/opengever/dossier/handlers.py
@@ -8,8 +8,6 @@ from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.indexers import TYPES_WITH_CONTAINING_SUBDOSSIER_INDEX
 from opengever.globalindex.handlers.task import sync_task
-from opengever.globalindex.handlers.task import TaskSqlSyncer
-from opengever.meeting.handlers import ProposalSqlSyncer
 from opengever.task.task import ITask
 from opengever.workspaceclient.interfaces import ILinkedToWorkspace
 from opengever.workspaceclient.interfaces import ILinkedWorkspaces

--- a/opengever/repository/configure.zcml
+++ b/opengever/repository/configure.zcml
@@ -53,13 +53,13 @@
   <subscriber
       for="opengever.repository.interfaces.IRepositoryFolder
            opengever.sharing.interfaces.ILocalRolesAcquisitionBlocked"
-      handler=".handlers.reindex_blocked_local_roles"
+      handler=".subscribers.reindex_blocked_local_roles"
       />
 
   <subscriber
       for="opengever.repository.interfaces.IRepositoryFolder
            opengever.sharing.interfaces.ILocalRolesAcquisitionActivated"
-      handler=".handlers.reindex_blocked_local_roles"
+      handler=".subscribers.reindex_blocked_local_roles"
       />
 
   <subscriber

--- a/opengever/repository/handlers.py
+++ b/opengever/repository/handlers.py
@@ -1,3 +1,0 @@
-def reindex_blocked_local_roles(repofolder, event):
-    """Reindex blocked_local_roles upon the acquisition blockedness changing."""
-    repofolder.reindexObject(idxs=['blocked_local_roles'])

--- a/opengever/repository/subscribers.py
+++ b/opengever/repository/subscribers.py
@@ -6,6 +6,11 @@ from zExceptions import Forbidden
 from zope.container.interfaces import IContainerModifiedEvent
 
 
+def reindex_blocked_local_roles(repofolder, event):
+    """Reindex blocked_local_roles upon the acquisition blockedness changing."""
+    repofolder.reindexObject(idxs=['blocked_local_roles'])
+
+
 def is_reference_number_prefix_changed(descriptions):
     for desc in descriptions:
         for attr in desc.attributes:


### PR DESCRIPTION
We enable deletion of empty repository folder over the REST-API.

For [CA-2108]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed

[CA-2108]: https://4teamwork.atlassian.net/browse/CA-2108