### PR TITLE
Fix permission issue when unlinking a workspace.

### DIFF
--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -1014,7 +1014,7 @@
       name="@list-linked-gever-documents-uids"
       for="opengever.workspace.interfaces.IWorkspace"
       factory=".linked_workspaces.ListLinkedDocumentUIDsFromWorkspace"
-      permission="opengever.workspaceclient.UseWorkspaceClient"
+      permission="zope2.View"
       />
 
   <plone:service

--- a/opengever/api/linked_workspaces.py
+++ b/opengever/api/linked_workspaces.py
@@ -327,8 +327,9 @@ class ListLinkedDocumentUIDsFromWorkspace(Service):
 
     def reply(self):
         catalog = api.portal.get_tool('portal_catalog')
-        brains = catalog(path='/'.join(self.context.getPhysicalPath()),
-                         object_provides=IBaseDocument.__identifier__)
+        brains = catalog.unrestrictedSearchResults(
+            path='/'.join(self.context.getPhysicalPath()),
+            object_provides=IBaseDocument.__identifier__)
 
         uids = [brain.gever_doc_uid for brain in brains
                 if brain.gever_doc_uid]

--- a/opengever/api/tests/test_list_linked_documents_from_workspace.py
+++ b/opengever/api/tests/test_list_linked_documents_from_workspace.py
@@ -1,0 +1,43 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+from opengever.workspaceclient.interfaces import ILinkedDocuments
+
+
+class TestListLinkedDocumentUIDsFromWorkspace(IntegrationTestCase):
+
+    @browsing
+    def test_returns_a_dict_with_a_list_of_gever_uids(self, browser):
+        self.login(self.workspace_guest, browser=browser)
+
+        ILinkedDocuments(self.workspace_document).link_gever_document('GEVER_UID_1')
+        ILinkedDocuments(self.workspace_mail).link_gever_document('GEVER_UID_2')
+
+        url = '{}/@list-linked-gever-documents-uids'.format(
+            self.workspace.absolute_url())
+        browser.open(url, method='GET', headers=self.api_headers)
+
+        self.assertEquals(
+            {'gever_doc_uids': ['GEVER_UID_1', 'GEVER_UID_2']},
+            browser.json)
+
+    @browsing
+    def test_query_is_unrestricted(self, browser):
+        self.login(self.workspace_admin, browser=browser)
+
+        protected_document = create(Builder('document')
+                                    .within(self.workspace_folder))
+        ILinkedDocuments(protected_document).link_gever_document('GEVER_UID_1')
+        self.workspace_folder.__ac_local_roles_block__ = True
+        self.workspace_folder.reindexObjectSecurity()
+        self.workspace_folder.reindexObject(idxs=['blocked_local_roles'])
+
+        self.login(self.workspace_guest, browser=browser)
+        url = '{}/@list-linked-gever-documents-uids'.format(
+            self.workspace.absolute_url())
+        browser.open(url, method='GET', headers=self.api_headers)
+
+        self.assertEquals(
+            {'gever_doc_uids': ['GEVER_UID_1']},
+            browser.json)


### PR DESCRIPTION
Follow up for PR #7102  Make API endpoint `@list-linked-gever-documents-uids` accessible for all with view permission. GEVER Users does not have the role `WorkspaceClientUser` on the teamraum side in a regular GEVER <-> temraum setup, but only in the development setup. Also the endpoint queries the UIDs now unrestricted to make sure every linked documents gets unlocked.

If the gever user does not have permission on all linked gever documents, the method raises an `BadRequest`, so unlinking is not possible for this user.

For [CA-2392]

- Changelog already added in the previous commit.

[CA-2392]: https://4teamwork.atlassian.net/browse/CA-2392