### PR TITLE
Clarify changelog conventions for backports.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+Versions are of the form MAJOR.MINOR.PATCH. Each MINOR release (MAJOR.MINOR.0) includes changes from all previous MINOR releases. Changes in PATCH releases (PATCH version > 0) are backports and are not included in following MINOR and MAJOR releases. Such entries will therefore usually appear more than once in the changelog. Note that this convention is only held starting on 2021-08-06.
+
 .. You should *NOT* be adding new change log entries to this file.
    Create a file in the changes directory instead. Use the issue/ticket number
    as filename and add one of .feature, .bugfix, .other as extension to signify


### PR DESCRIPTION
Every time I do a backport I'm annoyed with our lack of convention concerning backports. I think there is only one way of doing this correctly, which is having dupplicate entries and consider every PATCH version to not be included in the following MAJOR and MINOR versions. This is the only way to reflect the reality of how we work, i.e. with diverging branches for PATCH versions...

For [CA-2690]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] Changelog entry -> nope
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira) 

[CA-2690]: https://4teamwork.atlassian.net/browse/CA-2690