### PR TITLE
Fix update of favorites when trashing / deleting an object.

### DIFF
--- a/changes/CA-2468.bugfix
+++ b/changes/CA-2468.bugfix
@@ -1,0 +1,1 @@
+Favorite positions get updated correctly when trashing / deleting an object. [njohner]

--- a/opengever/base/handlers.py
+++ b/opengever/base/handlers.py
@@ -3,6 +3,7 @@ from DateTime import DateTime
 from ftw.upgrade.helpers import update_security_for
 from opengever.base.behaviors.changed import IChanged
 from opengever.base.date_time import utcnow_tz_aware
+from opengever.base.favorite import FavoriteManager
 from opengever.base.model import create_session
 from opengever.base.model.favorite import Favorite
 from opengever.base.oguid import Oguid
@@ -122,13 +123,11 @@ def remove_favorites(context, event):
     if IPloneSiteRoot.providedBy(event.object):
         return
 
+    manager = FavoriteManager()
     oguid = Oguid.for_object(context)
-
-    stmt = Favorite.__table__.delete().where(Favorite.oguid == oguid)
-
-    session = create_session()
-    session.execute(stmt)
-    mark_changed(session)
+    to_delete = Favorite.query.filter_by(oguid=oguid)
+    for favorite in to_delete:
+        manager.delete(favorite.userid, favorite.favorite_id)
 
 
 def is_title_changed(descriptions):

--- a/opengever/base/tests/test_favorite.py
+++ b/opengever/base/tests/test_favorite.py
@@ -278,6 +278,41 @@ class TestHandlers(IntegrationTestCase):
 
         self.assertEquals(1, Favorite.query.count())
 
+    def test_favorite_positions_are_updated_when_deleting_object(self):
+        self.login(self.manager)
+
+        create(Builder('favorite')
+               .for_object(self.document)
+               .for_user(self.administrator))
+
+        create(Builder('favorite')
+               .for_object(self.subdocument)
+               .for_user(self.administrator))
+
+        create(Builder('favorite')
+               .for_object(self.empty_repofolder)
+               .for_user(self.administrator))
+
+        create(Builder('favorite')
+               .for_object(self.subdossier)
+               .for_user(self.administrator))
+
+        create(Builder('favorite')
+               .for_object(self.empty_dossier)
+               .for_user(self.administrator))
+
+        self.assertEquals(5, Favorite.query.count())
+        self.assertItemsEqual(
+            [(each.position, each.favorite_id) for each in Favorite.query.all()],
+            [(0, 1), (1, 2), (2, 3), (3, 4), (4, 5)])
+
+        api.content.delete(obj=self.subdossier)
+
+        self.assertEquals(3, Favorite.query.count())
+        self.assertItemsEqual(
+            [(each.position, each.favorite_id) for each in Favorite.query.all()],
+            [(0, 1), (1, 3), (2, 5)])
+
     @browsing
     def test_titles_of_favorites_get_updated(self, browser):
         self.login(self.regular_user, browser=browser)

--- a/opengever/core/upgrades/20210806151730_fix_favorite_positions/upgrade.py
+++ b/opengever/core/upgrades/20210806151730_fix_favorite_positions/upgrade.py
@@ -1,0 +1,19 @@
+from opengever.core.upgrade import SQLUpgradeStep
+from opengever.base.model.favorite import Favorite
+
+
+class FixFavoritePositions(SQLUpgradeStep):
+    """Fix favorite positions.
+    """
+
+    def migrate(self):
+        users_with_favorites = [r[0] for r in self.session.query(
+            Favorite.userid.distinct())]
+
+        for userid in users_with_favorites:
+            favorites = Favorite.query.by_userid(userid).order_by(
+                Favorite.position)
+
+            for i, favorite in enumerate(favorites):
+                if favorite.position != i:
+                    favorite.position = i

--- a/opengever/core/upgrades/20210806151730_fix_favorite_positions/upgrade.py
+++ b/opengever/core/upgrades/20210806151730_fix_favorite_positions/upgrade.py
@@ -1,8 +1,8 @@
-from opengever.core.upgrade import SQLUpgradeStep
+from opengever.core.upgrade import SchemaMigration
 from opengever.base.model.favorite import Favorite
 
 
-class FixFavoritePositions(SQLUpgradeStep):
+class FixFavoritePositions(SchemaMigration):
     """Fix favorite positions.
     """
 


### PR DESCRIPTION
When an object is deleted or trashed, the associated favorites get deleted. This led to the position of the favorites for the concerned users to not be a gapless sequence from 0 to n, which in turn breaks reordering of the favorites.
This is fixed here by ensuring that favorite positions get updated when an object is trashed or deleted. We also add an upgrade step to fix broken `Favorite.position` sequences.
Note that I made the upgrade step a `SchemaMigration` so that it only happens once.

For [CA-2468]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- Upgrade steps (changes in profile):
  - [x] Make it deferrable if possible
  - [x] Execute as much as possible conditionally

[CA-2468]: https://4teamwork.atlassian.net/browse/CA-2468