### PR TITLE
Fix setting reminder over accept form.

### DIFF
--- a/changes/CA-2683.bugfix
+++ b/changes/CA-2683.bugfix
@@ -1,0 +1,1 @@
+Fix setting reminder over accept form. [njohner]

--- a/opengever/core/upgrades/20210809142703_sync_task_reminders/upgrade.py
+++ b/opengever/core/upgrades/20210809142703_sync_task_reminders/upgrade.py
@@ -1,0 +1,12 @@
+from ftw.upgrade import UpgradeStep
+
+
+class SyncTaskReminders(UpgradeStep):
+    """Sync task reminders.
+    """
+
+    def __call__(self):
+        query = {'object_provides': 'opengever.task.task.ITask',
+                 'review_state': 'task-state-in-progress'}
+        for task in self.objects(query, "Sync task reminders."):
+            task.sync_reminders()

--- a/opengever/task/reminder/reminder.py
+++ b/opengever/task/reminder/reminder.py
@@ -72,3 +72,7 @@ class TaskReminderSupport(ReminderSupport):
             reminder = self.get_reminder(user_id=reminder_setting.actor_id)
             new_trigger_date = reminder.calculate_trigger_date(sql_task.deadline)
             reminder_setting.remind_day = new_trigger_date
+
+    def set_reminder(self, reminder, user_id=None):
+        super(TaskReminderSupport, self).set_reminder(reminder, user_id)
+        self.sync_reminders()

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -696,6 +696,11 @@ class Task(Container, TaskReminderSupport):
         """
         return self.get_sql_object().sync_with(self)
 
+    def sync_reminders(self):
+        """Syncs the corresponding SQL task (globalindex).
+        """
+        return self.get_sql_object().sync_reminders(self)
+
     def set_to_planned_state(self):
         """Syncs the corresponding SQL task (globalindex).
         """

--- a/opengever/task/tests/test_reminder.py
+++ b/opengever/task/tests/test_reminder.py
@@ -8,6 +8,7 @@ from opengever.activity.model import Activity
 from opengever.activity.model import Notification
 from opengever.activity.roles import TASK_REMINDER_WATCHER_ROLE
 from opengever.base.interfaces import IDataCollector
+from opengever.globalindex.model.reminder_settings import ReminderSetting
 from opengever.task.activities import TaskReminderActivity
 from opengever.task.reminder import Reminder
 from opengever.task.reminder import ReminderOnDate
@@ -307,6 +308,9 @@ class TestTaskReminderResponseForm(IntegrationTestCase):
         self.login(self.regular_user, browser)
 
         self.assertIsNone(self.task.get_reminder())
+        reminders = ReminderSetting.query.filter_by(
+            task_id=self.task.get_sql_object().task_id).all()
+        self.assertEqual(0, len(reminders))
 
         self.set_workflow_state('task-state-open', self.task)
         browser.open(self.task)
@@ -315,6 +319,9 @@ class TestTaskReminderResponseForm(IntegrationTestCase):
         browser.css('#form-buttons-save').first.click()
 
         self.assertIsInstance(self.task.get_reminder(), ReminderSameDay)
+        reminders = ReminderSetting.query.filter_by(
+            task_id=self.task.get_sql_object().task_id).all()
+        self.assertEqual(1, len(reminders))
 
     @browsing
     def test_set_reminder_absolute_reminder_through_task_accepted_form(self, browser):


### PR DESCRIPTION
Setting a reminder over the accept form was not working correctly, because the reminder was set after the changes to the task were synced (which happens on the `IObjectModifiedEvent`: https://github.com/4teamwork/opengever.core/blob/master/opengever/globalindex/handlers/configure.zcml#L9-L13). This could lead to the notification not being generated if the task wasn't modified, and hence synced again, before the reminder day...
Because this might be an issue in other situations as well, we sync the reminders synchronously every time a reminder is set.

For [CA-2683]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-2683]: https://4teamwork.atlassian.net/browse/CA-2683