### PR TITLE
Include SPV metadata in document and proposal serialization

### DIFF
--- a/changes/CA-2543_1.feature
+++ b/changes/CA-2543_1.feature
@@ -1,0 +1,1 @@
+Include committee in proposal serialization. [tinagerber]

--- a/changes/CA-2543_2.feature
+++ b/changes/CA-2543_2.feature
@@ -1,0 +1,1 @@
+Include proposal, meeting, submitted_proposal and submitted_with in document serialization. [tinagerber]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -12,6 +12,8 @@ Breaking Changes
 Other Changes
 ^^^^^^^^^^^^^
 
+- Include ``committee`` in proposal serialization.
+
 
 2021.16.0 (2021-08-12)
 ----------------------

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -13,6 +13,7 @@ Other Changes
 ^^^^^^^^^^^^^
 
 - Include ``committee`` in proposal serialization.
+- Include ``proposal``, ``meeting``, ``submitted_proposal`` and ``submitted_with`` in document serialization.
 
 
 2021.16.0 (2021-08-12)

--- a/docs/public/dev-manual/api/proposals.rst
+++ b/docs/public/dev-manual/api/proposals.rst
@@ -52,6 +52,10 @@ Auch Anträge können via REST API bedient werden. Die Erstellung eines Antrags 
           "title": "Kommission für Rechtsfragen",
           "token": "fd:1722088772"
         },
+        "committee": {
+          "@id": "http://example.org/sitzungen/committee-1",
+          "title": "Kommission für Rechtsfragen"
+        },
         "issuer": {
           "title": "Boss Hugo (hugo.boss)",
           "token": "hugo.boss"

--- a/opengever/api/proposal.py
+++ b/opengever/api/proposal.py
@@ -63,12 +63,16 @@ class SerializeSubmittedProposalToJson(GeverSerializeFolderToJson):
         else:
             result[u'excerpt'] = None
 
-        meeting = self.context.load_model().get_meeting()
+        proposal_model = self.context.load_model()
+        result['committee'] = {'title': proposal_model.committee.title,
+                               '@id': proposal_model.committee.get_url()}
+
+        meeting = proposal_model.get_meeting()
         if meeting:
             result[u'meeting'] = {
                 'title': meeting.title,
                 '@id': meeting.get_url(view=None)
-                }
+            }
         else:
             result[u'meeting'] = None
 

--- a/opengever/api/tests/test_proposal.py
+++ b/opengever/api/tests/test_proposal.py
@@ -38,6 +38,13 @@ class TestProposalSerialization(IntegrationTestCase):
             responses[0])
 
     @browsing
+    def test_proposal_contains_committee(self, browser):
+        self.login(self.committee_responsible, browser)
+        browser.open(self.proposal, method="GET", headers=self.api_headers)
+        self.assertEqual({u'@id': self.committee.absolute_url(),
+                          u'title': self.committee.title}, browser.json['committee'])
+
+    @browsing
     def test_getting_specific_response_from_proposal(self, browser):
         self.login(self.regular_user, browser=browser)
 


### PR DESCRIPTION
In the metadata overview of proposals and documents in the new frontend, some metadata concerning the SPV is still missing. In order to display them, some additional fields are needed.

For [CA-2543]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))

[CA-2543]: https://4teamwork.atlassian.net/browse/CA-2543