### PR TITLE
Redirect to notification resource while resolving.

### DIFF
--- a/changes/CA-2235.other
+++ b/changes/CA-2235.other
@@ -1,0 +1,1 @@
+Always redirect to notification resource in `@@resolve_oguid` if user has permission to view. [deiferni]

--- a/opengever/activity/model/notification.py
+++ b/opengever/activity/model/notification.py
@@ -1,5 +1,6 @@
 from opengever.base.model import Base
 from opengever.base.model import USER_ID_LENGTH
+from opengever.readonly import is_in_readonly_mode
 from sqlalchemy import Boolean
 from sqlalchemy import Column
 from sqlalchemy import ForeignKey
@@ -32,6 +33,15 @@ class Notification(Base):
             self.notification_id,
             repr(self.userid),
             repr(self.activity.resource))
+
+    def belongs_to(self, user):
+        return self.userid == user.getId()
+
+    def mark_as_read(self):
+        if is_in_readonly_mode():
+            return
+
+        self.is_read = True
 
     def serialize(self, portal_url):
         data = self.activity.serialize()

--- a/opengever/activity/tests/test_resolve.py
+++ b/opengever/activity/tests/test_resolve.py
@@ -76,8 +76,16 @@ class TestResolveNotificationView(IntegrationTestCase):
         self.assertTrue(self.notification.is_read)
 
     @browsing
-    def test_raises_unauthorized_when_notification_is_not_for_the_current_user(self, browser):
+    def test_just_redirects_to_object_when_notification_is_not_for_the_current_user(self, browser):
         self.login(self.dossier_responsible, browser)
+        view = 'resolve_notification?notification_id={}'.format(self.notification.notification_id)
+        browser.open(self.portal, view=view)
+        self.assertEquals(self.task.absolute_url(), browser.url)
+        self.assertFalse(self.notification.is_read)
+
+    @browsing
+    def test_raises_unauthorized_when_notification_object_cannot_be_accessed(self, browser):
+        self.login(self.foreign_contributor, browser)
         with browser.expect_unauthorized():
             view = 'resolve_notification?notification_id={}'.format(self.notification.notification_id)
             browser.open(self.portal, view=view)


### PR DESCRIPTION
Change the current behavior to always redirect to notification resource in `@@resolve_oguid` if user has permission to view the resource, even for foreign notifications. The  previous behavior was to return an error if the notification was not visible for the current user. The change adds more convenience in case the link to the notification is
shared between users unintentionally (e.g by forwarding a mail).

For https://4teamwork.atlassian.net/browse/CA-2235

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

