### PR TITLE
Remove `@@` prefix from links to personal preferences browser view.

### DIFF
--- a/changes/CA-2708.bugfix
+++ b/changes/CA-2708.bugfix
@@ -1,0 +1,1 @@
+Remove `@@` prefix from links to personal preferences browser view. [deiferni]

--- a/opengever/activity/browser/templates/notification_mail_macros.pt
+++ b/opengever/activity/browser/templates/notification_mail_macros.pt
@@ -255,7 +255,7 @@
                           <a href="#"
                              class="button-a"
                              i18n:translate="label_notification_settings"
-                             tal:attributes="href string:${options/public_url}/@@personal-preferences"
+                             tal:attributes="href string:${options/public_url}/personal-preferences"
                              style="font-family: Arial, sans-serif; font-size: 13px; line-height: 110%; text-align: center; text-decoration: none; display: block; border-radius: 3px; font-weight: bold; color: #418195;">
                             Notification settings
                           </a>

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -1063,7 +1063,7 @@
     <object name="preferences" meta_type="CMF Action" i18n:domain="plone">
       <property name="title" i18n:translate="">Preferences</property>
       <property name="description" i18n:translate="" />
-      <property name="url_expr">string:${globals_view/navigationRootUrl}/@@personal-preferences</property>
+      <property name="url_expr">string:${globals_view/navigationRootUrl}/personal-preferences</property>
       <property name="link_target" />
       <property name="icon_expr" />
       <property name="available_expr">python:member is not None</property>

--- a/opengever/core/upgrades/20210812105425_remove_view_atat_prefix_for_personal_preferences_for_new_ui_compatibility/actions.xml
+++ b/opengever/core/upgrades/20210812105425_remove_view_atat_prefix_for_personal_preferences_for_new_ui_compatibility/actions.xml
@@ -1,0 +1,21 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="portal_actions" meta_type="Plone Actions Tool">
+
+  <!-- USER -->
+  <object name="user" meta_type="CMF Action Category">
+
+    <object name="preferences" meta_type="CMF Action" i18n:domain="plone">
+      <property name="title" i18n:translate="">Preferences</property>
+      <property name="description" i18n:translate="" />
+      <property name="url_expr">string:${globals_view/navigationRootUrl}/personal-preferences</property>
+      <property name="link_target" />
+      <property name="icon_expr" />
+      <property name="available_expr">python:member is not None</property>
+      <property name="permissions">
+        <element value="Set own properties" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
+  </object>
+
+</object>

--- a/opengever/core/upgrades/20210812105425_remove_view_atat_prefix_for_personal_preferences_for_new_ui_compatibility/upgrade.py
+++ b/opengever/core/upgrades/20210812105425_remove_view_atat_prefix_for_personal_preferences_for_new_ui_compatibility/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class RemoveViewAtatPrefixForPersonalPreferencesForNewUICompatibility(UpgradeStep):
+    """Remove view atat prefix for personal preferences for new UI compatibility.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
With this PR we drop the `@@` prefix from links to the personal preferences browser view in two places:
- From the link in notification mails
- From the action url displayed in the personal navigation menu

Dropping the prefix will prevent the URL being handled by rewrite rules redirecting requests to the backend regardless of the cookie enabling/disabling the new UI. It is intended to work in combination with https://github.com/4teamwork/gever-ui/pull/1887 and fix/improve URL handling to notification settings in the following cases:
- Links from the mail should work on both the classical and new UI (for GEVER) and for the new UI (for temaraum)
- Handling works when changing the UI from classical to new (We've decided against special handling for the inverted case as this switch is not expected to happen often)

For https://4teamwork.atlassian.net/browse/CA-2708

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
