### PR TITLE
Add new @reference-numbers endpoint.

### DIFF
--- a/changes/CA-2096.feature
+++ b/changes/CA-2096.feature
@@ -1,0 +1,1 @@
+Add new @reference-numbers endpoint. [njohner]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -15,7 +15,7 @@ Other Changes
 - ``@listing``: Add ``approval_state`` column
 - Include ``committee`` in proposal serialization.
 - Include ``proposal``, ``meeting``, ``submitted_proposal`` and ``submitted_with`` in document serialization.
-
+- New ``@reference-numbers`` endpoint for administrators (see :ref:`docs <reference-numbers>`).
 
 2021.16.0 (2021-08-12)
 ----------------------

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -66,4 +66,5 @@ Inhalt:
    complete_successor_task.rst
    upload_structure.rst
    close_remote_task.rst
+   reference_numbers.rst
    examples/index.rst

--- a/docs/public/dev-manual/api/reference_numbers.rst
+++ b/docs/public/dev-manual/api/reference_numbers.rst
@@ -1,0 +1,48 @@
+.. _reference-numbers:
+
+Ordnungspositionsnummer
+=======================
+
+Ordnungspositionsnummer können von Administratoren auf Stufe Ordnungssystem und Ordnungspositionen mit dem ``@reference-numbers`` Endpoint verwaltet werden.
+
+Eine GET-Request liefert eine Liste von den Ordnungspositionsnummer, welche auf dem Kontext verwendet werden.
+
+  .. sourcecode:: http
+
+    GET /@reference-numbers HTTP/1.1
+    Accept: application/json
+
+  .. sourcecode:: http
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    [
+        {
+            "active": true,
+            "prefix": "1",
+            "title": "Führung"
+        },
+        {
+            "active": true,
+            "prefix": "2",
+            "title": "Rechnungsprüfungskommission"
+        },
+        {
+            "active": false,
+            "prefix": "3",
+            "title": "Spinnännetzregistrar"
+        }
+    ]
+
+DELETE erlaubt eine nicht mehr verwendete Ordnungspositionsnummer freizugeben:
+
+  .. sourcecode:: http
+
+    DELETE /@reference-numbers/3 HTTP/1.1
+    Accept: application/json
+
+  .. sourcecode:: http
+
+    HTTP/1.1 204 No Content
+    Content-Type: application/json

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -12,6 +12,7 @@
   <include package="Products.CMFEditions" file="permissions.zcml" />
   <include package="opengever.contact" file="permissions.zcml" />
   <include package="opengever.document" file="permissions.zcml" />
+  <include package="opengever.repository" file="permissions.zcml" />
   <include package="opengever.trash" file="permissions.zcml" />
   <include package="opengever.webactions" file="permissions.zcml" />
   <include package="opengever.workspace" file="permissions.zcml" />
@@ -1423,6 +1424,22 @@
       name="@upload-structure"
       layer="opengever.base.interfaces.IOpengeverBaseLayer"
       permission="zope2.View"
+      />
+
+  <plone:service
+      method="GET"
+      name="@reference-numbers"
+      for="opengever.repository.interfaces.IRepositoryFolder"
+      factory=".reference_numbers.ReferenceNumbersGet"
+      permission="opengever.repository.UnlockReferencePrefix"
+      />
+
+  <plone:service
+      method="GET"
+      name="@reference-numbers"
+      for="opengever.repository.repositoryroot.IRepositoryRoot"
+      factory=".reference_numbers.ReferenceNumbersGet"
+      permission="opengever.repository.UnlockReferencePrefix"
       />
 
 </configure>

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -1442,4 +1442,21 @@
       permission="opengever.repository.UnlockReferencePrefix"
       />
 
+  <plone:service
+      method="DELETE"
+      name="@reference-numbers"
+      for="opengever.repository.interfaces.IRepositoryFolder"
+      factory=".reference_numbers.ReferenceNumbersDelete"
+      permission="opengever.repository.UnlockReferencePrefix"
+      />
+
+  <plone:service
+      method="DELETE"
+      name="@reference-numbers"
+      for="opengever.repository.repositoryroot.IRepositoryRoot"
+      factory=".reference_numbers.ReferenceNumbersDelete"
+      permission="opengever.repository.UnlockReferencePrefix"
+      />
+
+
 </configure>

--- a/opengever/api/reference_numbers.py
+++ b/opengever/api/reference_numbers.py
@@ -1,0 +1,13 @@
+from opengever.base.adapters import ReferenceNumberPrefixAdpater
+from plone.restapi.services import Service
+
+
+class ReferenceNumbersGet(Service):
+    """API endpoint to get a list of repository numbers used or locked on the
+    current context.
+
+    GET /repository_folder/@reference-numbers
+    """
+
+    def reply(self):
+        return ReferenceNumberPrefixAdpater(self.context).get_number_mapping()

--- a/opengever/api/reference_numbers.py
+++ b/opengever/api/reference_numbers.py
@@ -14,7 +14,8 @@ class ReferenceNumbersGet(Service):
     """
 
     def reply(self):
-        return ReferenceNumberPrefixAdpater(self.context).get_number_mapping()
+        return ReferenceNumberPrefixAdpater(self.context).get_number_mapping(
+            missing_title_as_none=True)
 
 
 class ReferenceNumbersDelete(Service):

--- a/opengever/api/reference_numbers.py
+++ b/opengever/api/reference_numbers.py
@@ -1,5 +1,9 @@
 from opengever.base.adapters import ReferenceNumberPrefixAdpater
+from opengever.base.exceptions import ReferenceNumberCannotBeFreed
 from plone.restapi.services import Service
+from zExceptions import BadRequest
+from zope.interface import implements
+from zope.publisher.interfaces import IPublishTraverse
 
 
 class ReferenceNumbersGet(Service):
@@ -11,3 +15,39 @@ class ReferenceNumbersGet(Service):
 
     def reply(self):
         return ReferenceNumberPrefixAdpater(self.context).get_number_mapping()
+
+
+class ReferenceNumbersDelete(Service):
+    """API endpoint to unlock a repository number on the current context.
+
+    DELETE /repository_folder/@reference-numbers/1 HTTP/1.1
+    """
+
+    implements(IPublishTraverse)
+
+    def __init__(self, context, request):
+        super(ReferenceNumbersDelete, self).__init__(context, request)
+        self.params = []
+
+    def publishTraverse(self, request, number):
+        # Consume any path segments after /@reference-numbers as parameters
+        self.params.append(number)
+        return self
+
+    def read_params(self):
+        if len(self.params) == 0:
+            raise BadRequest("Must supply a reference number as URL path parameter.")
+
+        if len(self.params) > 1:
+            raise BadRequest("Only reference number is supported as URL path parameter.")
+
+        return self.params[0]
+
+    def reply(self):
+        number = self.read_params()
+        manager = ReferenceNumberPrefixAdpater(self.context)
+        try:
+            manager.free_number(number)
+        except ReferenceNumberCannotBeFreed:
+            raise BadRequest("Number still in use.")
+        return self.reply_no_content()

--- a/opengever/api/tests/test_reference_numbers.py
+++ b/opengever/api/tests/test_reference_numbers.py
@@ -1,0 +1,41 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+
+
+class TestReferenceNumbersGet(IntegrationTestCase):
+
+    @browsing
+    def test_get_reference_numbers_on_repository_folder(self, browser):
+        self.login(self.administrator, browser)
+        browser.open(self.branch_repofolder,
+                     view="@reference-numbers",
+                     method='GET',
+                     headers=self.api_headers)
+
+        self.assertEqual(200, browser.status_code)
+        self.assertEqual(
+            [{u'active': True,
+              u'prefix': u'1',
+              u'title': u'Vertr\xe4ge und Vereinbarungen'}],
+            browser.json)
+
+    @browsing
+    def test_get_reference_numbers_on_repository_root(self, browser):
+        self.login(self.administrator, browser)
+        browser.open(self.repository_root,
+                     view="@reference-numbers",
+                     method='GET',
+                     headers=self.api_headers)
+
+        self.assertEqual(200, browser.status_code)
+        self.assertEqual(
+            [{u'active': True,
+              u'prefix': u'1',
+              u'title': u'F\xfchrung'},
+             {u'active': True,
+              u'prefix': u'2',
+              u'title': u'Rechnungspr\xfcfungskommission'},
+             {u'active': True,
+              u'prefix': u'3',
+              u'title': u'Spinn\xe4nnetzregistrar'}],
+            browser.json)

--- a/opengever/api/tests/test_reference_numbers.py
+++ b/opengever/api/tests/test_reference_numbers.py
@@ -1,4 +1,5 @@
 from ftw.testbrowser import browsing
+from opengever.base.adapters import ReferenceNumberPrefixAdpater
 from opengever.testing import IntegrationTestCase
 
 
@@ -38,4 +39,77 @@ class TestReferenceNumbersGet(IntegrationTestCase):
              {u'active': True,
               u'prefix': u'3',
               u'title': u'Spinn\xe4nnetzregistrar'}],
+            browser.json)
+
+
+class TestReferenceNumbersDelete(IntegrationTestCase):
+
+    @browsing
+    def test_raises_when_number_is_missing(self, browser):
+        self.login(self.administrator, browser)
+        with browser.expect_http_error(400):
+            browser.open(self.branch_repofolder,
+                         view="@reference-numbers",
+                         method='DELETE',
+                         headers=self.api_headers)
+
+        self.assertEqual(
+            {u'message': u'Must supply a reference number as URL path parameter.',
+             u'type': u'BadRequest'},
+            browser.json)
+
+    @browsing
+    def test_raises_when_number_is_still_in_use(self, browser):
+        self.login(self.administrator, browser)
+        with browser.expect_http_error(400):
+            browser.open(self.branch_repofolder,
+                         view="@reference-numbers/1",
+                         method='DELETE',
+                         headers=self.api_headers)
+
+        self.assertEqual(
+            {u'message': u'Number still in use.',
+             u'type': u'BadRequest'},
+            browser.json)
+
+    @browsing
+    def test_unlocks_inactive_number(self, browser):
+        self.login(self.administrator, browser)
+
+        # move repo1 to prefix 3 which leaves prefix 1 unused
+        manager = ReferenceNumberPrefixAdpater(self.branch_repofolder)
+        manager.set_number(self.leaf_repofolder, 3)
+
+        browser.open(self.branch_repofolder,
+                     view="@reference-numbers",
+                     method='GET',
+                     headers=self.api_headers)
+
+        self.assertEqual(200, browser.status_code)
+        self.assertEqual(
+            [{u'active': False,
+              u'prefix': u'1',
+              u'title': u'Vertr\xe4ge und Vereinbarungen'},
+             {u'active': True,
+              u'prefix': u'3',
+              u'title': u'Vertr\xe4ge und Vereinbarungen'}],
+            browser.json)
+
+        browser.open(self.branch_repofolder,
+                     view="@reference-numbers/1",
+                     method='DELETE',
+                     headers=self.api_headers)
+
+        self.assertEqual(204, browser.status_code)
+
+        browser.open(self.branch_repofolder,
+                     view="@reference-numbers",
+                     method='GET',
+                     headers=self.api_headers)
+
+        self.assertEqual(200, browser.status_code)
+        self.assertEqual(
+            [{u'active': True,
+              u'prefix': u'3',
+              u'title': u'Vertr\xe4ge und Vereinbarungen'}],
             browser.json)

--- a/opengever/base/adapters.py
+++ b/opengever/base/adapters.py
@@ -195,7 +195,7 @@ class ReferenceNumberPrefixAdpater(object):
 
         return prefix in self.get_reference_mapping()['reference_prefix'].values()
 
-    def get_number_mapping(self):
+    def get_number_mapping(self, missing_title_as_none=False):
         items = []
         intid_util = getUtility(IIntIds)
 
@@ -211,8 +211,11 @@ class ReferenceNumberPrefixAdpater(object):
                 # be in the list, because it should be available to remove
                 # via the reference prefix manager.
                 active = False
-                title = _('label_already_removed',
-                          '-- Already removed object --')
+                if missing_title_as_none:
+                    title = None
+                else:
+                    title = _('label_already_removed',
+                              '-- Already removed object --')
 
             items.append({'prefix': prefix, 'title': title, 'active': active})
 

--- a/opengever/base/adapters.py
+++ b/opengever/base/adapters.py
@@ -2,6 +2,7 @@ from Acquisition import aq_base
 from opengever.base import _
 from opengever.base.behaviors.translated_title import ITranslatedTitle
 from opengever.base.behaviors.utils import split_string_by_numbers
+from opengever.base.exceptions import ReferenceNumberCannotBeFreed
 from opengever.base.interfaces import IMovabilityChecker
 from opengever.base.interfaces import IReferenceNumberPrefix
 from opengever.base.interfaces import IReferenceNumberSettings
@@ -226,7 +227,7 @@ class ReferenceNumberPrefixAdpater(object):
             prefix = unicode(prefix)
 
         if self.is_prefix_used(prefix):
-            raise Exception("Prefix is in use.")
+            raise ReferenceNumberCannotBeFreed("Prefix is in use.")
 
         if prefix in self.get_child_mapping().keys():
             self.get_child_mapping().pop(prefix)

--- a/opengever/base/adapters.py
+++ b/opengever/base/adapters.py
@@ -8,6 +8,7 @@ from opengever.base.interfaces import IReferenceNumberPrefix
 from opengever.base.interfaces import IReferenceNumberSettings
 from opengever.base.protect import unprotected_write
 from opengever.dossier.behaviors.dossier import IDossierMarker
+from opengever.repository.events import RepositoryPrefixUnlocked
 from persistent.dict import PersistentDict
 from plone.dexterity.interfaces import IDexterityContent
 from plone.registry.interfaces import IRegistry
@@ -16,6 +17,7 @@ from zope.annotation.interfaces import IAnnotations
 from zope.app.intid.interfaces import IIntIds
 from zope.component import adapter
 from zope.component import getUtility
+from zope.event import notify
 from zope.interface import implementer
 import re
 
@@ -231,6 +233,8 @@ class ReferenceNumberPrefixAdpater(object):
 
         if prefix in self.get_child_mapping().keys():
             self.get_child_mapping().pop(prefix)
+
+        notify(RepositoryPrefixUnlocked(self.context, prefix))
 
 
 @implementer(IMovabilityChecker)

--- a/opengever/base/exceptions.py
+++ b/opengever/base/exceptions.py
@@ -29,3 +29,9 @@ class NonRemoteOguid(Exception):
 class IncorrectConfigurationError(Exception):
     """Exception raised when Gever is not configured correctly
     """
+
+
+class ReferenceNumberCannotBeFreed(Exception):
+    """Exception raised when trying to free a reference number
+    that is still in use.
+    """

--- a/opengever/repository/browser/referenceprefix_manager.py
+++ b/opengever/repository/browser/referenceprefix_manager.py
@@ -1,9 +1,7 @@
 from opengever.base.adapters import ReferenceNumberPrefixAdpater
 from opengever.base.exceptions import ReferenceNumberCannotBeFreed
 from opengever.repository import _
-from opengever.repository.events import RepositoryPrefixUnlocked
 from plone import api
-from zope.event import notify
 from zope.publisher.browser import BrowserView
 
 
@@ -29,7 +27,6 @@ class ReferencePrefixManager(BrowserView):
                 type="error")
             return
 
-        notify(RepositoryPrefixUnlocked(self.context, prefix_num))
         api.portal.show_message(
             _("statmsg_prefix_unlocked",
               default=u"Reference prefix has been unlocked."),

--- a/opengever/repository/browser/referenceprefix_manager.py
+++ b/opengever/repository/browser/referenceprefix_manager.py
@@ -1,4 +1,5 @@
 from opengever.base.adapters import ReferenceNumberPrefixAdpater
+from opengever.base.exceptions import ReferenceNumberCannotBeFreed
 from opengever.repository import _
 from opengever.repository.events import RepositoryPrefixUnlocked
 from plone import api
@@ -18,7 +19,9 @@ class ReferencePrefixManager(BrowserView):
     def free_reference_prefix(self, prefix_num):
         refs = ReferenceNumberPrefixAdpater(self.context)
 
-        if refs.is_prefix_used(prefix_num):
+        try:
+            refs.free_number(prefix_num)
+        except ReferenceNumberCannotBeFreed:
             api.portal.show_message(
                 _(u'statmsg_prefix_unlock_failure',
                   default='The reference you try to unlock is still in use.'),
@@ -26,7 +29,6 @@ class ReferencePrefixManager(BrowserView):
                 type="error")
             return
 
-        refs.free_number(prefix_num)
         notify(RepositoryPrefixUnlocked(self.context, prefix_num))
         api.portal.show_message(
             _("statmsg_prefix_unlocked",


### PR DESCRIPTION
Add new @reference-numbers `GET` and `DELETE` endpoints for administrators. The `GET` returns a list of all reserved positions on a given context, while the `DELETE` endpoint allows to liberate an inactive position (position that was previously in use but is not used any longer).

For [CA-2096]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed

[CA-2096]: https://4teamwork.atlassian.net/browse/CA-2096