### PR TITLE
Fix updating document title in favorites with API.

### DIFF
--- a/changes/CA-2688.bugfix
+++ b/changes/CA-2688.bugfix
@@ -1,0 +1,1 @@
+Fix updating document title in favorites when document title is changed via API. [deiferni]

--- a/opengever/base/handlers.py
+++ b/opengever/base/handlers.py
@@ -133,7 +133,7 @@ def remove_favorites(context, event):
 def is_title_changed(descriptions):
     for desc in descriptions:
         for attr in desc.attributes:
-            if attr in ['IOpenGeverBase.title', 'title']:
+            if attr in ['IDocumentSchema.title', 'IOpenGeverBase.title', 'title']:
                 return True
     return False
 
@@ -181,6 +181,7 @@ def update_favorites_title(context, event):
     """Event handler which updates the titles of all existing favorites for the
     current context, unless the title is personalized.
     """
+
     if IContainerModifiedEvent.providedBy(event):
         return
 

--- a/opengever/base/tests/test_favorite.py
+++ b/opengever/base/tests/test_favorite.py
@@ -364,6 +364,32 @@ class TestHandlers(IntegrationTestCase):
         )
 
     @browsing
+    def test_titles_of_dossier_favorites_get_updated_on_api_patch(self, browser):
+        self.login(self.regular_user, browser=browser)
+        favorite = create(Builder('favorite')
+                          .for_object(self.dossier)
+                          .for_user(self.regular_user))
+        self.assertEqual(
+            u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
+            favorite.title
+        )
+
+        data={'title': u'\xc4nderig'}
+        browser.open(
+            self.dossier,
+            data=json.dumps(data),
+            method='PATCH',
+            headers=self.api_headers,
+        )
+
+        self.assertEqual(browser.status_code, 204)
+        self.assertEqual(self.dossier.title, u'\xc4nderig')
+        self.assertEqual(
+            u'\xc4nderig',
+            Favorite.query.get(favorite.favorite_id).title
+        )
+
+    @browsing
     def test_titles_of_document_favorites_get_updated_when_title_synced_to_filename(self, browser):
         self.login(self.regular_user, browser=browser)
 


### PR DESCRIPTION
Fix updating document title in favorites when document title is changed via API request. The api seems to choose a different interface here (IMO the correct one) and our changed detection heuristic did not pick it up correctly.

I am also adding a separate test for dossier favorite titles which can also change. This should cover the two most important use-cases. Task titles can't really change and repo favorites are handled differently anyway.

For https://4teamwork.atlassian.net/browse/CA-2688

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
