### PR TITLE
Revert merge of upgrade reindexing reference and sortable_reference.

### DIFF
--- a/changes/CA-2350.other
+++ b/changes/CA-2350.other
@@ -1,0 +1,1 @@
+Revert merge of upgrade reindexing reference and sortable_reference. [njohner]

--- a/opengever/core/upgrades/20210205084521_add_sortable_reference_number_index/upgrade.py
+++ b/opengever/core/upgrades/20210205084521_add_sortable_reference_number_index/upgrade.py
@@ -16,14 +16,9 @@ class AddSortableReferenceNumberIndex(UpgradeStep):
         self.index_sortable_reference_number()
 
     def index_sortable_reference_number(self):
-
-        # Disable this upgradestep because it's done by the later upgradestep
-        # 20210601120606_update_reindex_reference_and_sortable_reference_index
-        return
-
-        # manager = getUtility(ISolrConnectionManager)
-        # query = {'object_provides': IDexterityContent.__identifier__}
-        # for obj in self.objects(query, 'Index sortable_reference in Solr'):
-        #     handler = getMultiAdapter((obj, manager), ISolrIndexHandler)
-        #     handler.add(['sortable_reference'])
-        # manager.connection.commit(soft_commit=False, extract_after_commit=False)
+        manager = getUtility(ISolrConnectionManager)
+        query = {'object_provides': IDexterityContent.__identifier__}
+        for obj in self.objects(query, 'Index sortable_reference in Solr'):
+            handler = getMultiAdapter((obj, manager), ISolrIndexHandler)
+            handler.add(['sortable_reference'])
+        manager.connection.commit(soft_commit=False, extract_after_commit=False)

--- a/opengever/core/upgrades/20210205084521_add_sortable_reference_number_index/upgrade.py
+++ b/opengever/core/upgrades/20210205084521_add_sortable_reference_number_index/upgrade.py
@@ -17,8 +17,13 @@ class AddSortableReferenceNumberIndex(UpgradeStep):
 
     def index_sortable_reference_number(self):
         manager = getUtility(ISolrConnectionManager)
+        solr_connection = manager.connection
+
         query = {'object_provides': IDexterityContent.__identifier__}
-        for obj in self.objects(query, 'Index sortable_reference in Solr'):
+        for index, obj in enumerate(
+                self.objects(query, 'Index sortable_reference in Solr'), 1):
             handler = getMultiAdapter((obj, manager), ISolrIndexHandler)
             handler.add(['sortable_reference'])
+            if index % 1000 == 0:
+                solr_connection.commit()
         manager.connection.commit(soft_commit=False, extract_after_commit=False)

--- a/opengever/core/upgrades/20210601180416_update_reindex_reference_and_sortable_reference_index/upgrade.py
+++ b/opengever/core/upgrades/20210601180416_update_reindex_reference_and_sortable_reference_index/upgrade.py
@@ -1,12 +1,8 @@
-from ftw.solr.interfaces import ISolrConnectionManager
-from ftw.solr.interfaces import ISolrIndexHandler
 from ftw.upgrade import UpgradeStep
 from ftw.upgrade.progresslogger import ProgressLogger
 from ftw.upgrade.utils import SavepointIterator
 from opengever.base.interfaces import IReferenceNumber
 from plone.dexterity.interfaces import IDexterityContent
-from zope.component import getMultiAdapter
-from zope.component import getUtility
 
 
 class UpdateReindexReferenceAndSortableReferenceIndex(UpgradeStep):
@@ -19,19 +15,12 @@ class UpdateReindexReferenceAndSortableReferenceIndex(UpgradeStep):
         self.index_sortable_reference_number()
 
     def index_sortable_reference_number(self):
-        manager = getUtility(ISolrConnectionManager)
         brains = self.catalog_unrestricted_search(
             {'object_provides': IDexterityContent.__identifier__})
         iterator = SavepointIterator.build(brains)
-        message = 'Reindex reference and sortable_reference in Solr'
+        message = 'Reindex reference'
         for brain in ProgressLogger(message, iterator):
             # update catalog but only if necessary
             obj = self.catalog_unrestricted_get_object(brain)
             if IReferenceNumber(obj).get_number() != brain.reference:
-                obj.reindexObject(idxs=['reference'])
-
-            # update solr
-            handler = getMultiAdapter((obj, manager), ISolrIndexHandler)
-            handler.add(['reference', 'sortable_reference'])
-
-        manager.connection.commit(soft_commit=False, extract_after_commit=False)
+                obj.reindexObject(idxs=['reference', 'sortable_reference'])


### PR DESCRIPTION
Merging the older upgrade step reindexing sortable_reference with a newer one is counterproductive. Indeed this leads to indexing all sortable_reference numbers in solr a second time for deployments that are on a version between 2021.4 and 2021.12. Indeed the upgrade adding the `sortable_reference` index was included in 2021.4 ( https://github.com/4teamwork/opengever.core/pull/6732) and the upgrade steps were merged in 2021.12 (https://github.com/4teamwork/opengever.core/pull/7029). This is notably the case for SG...

For [CA-2350]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-2350]: https://4teamwork.atlassian.net/browse/CA-2350