### PR TITLE
Add Solr field approval_state plus corresponding indexer and logic 

### DIFF
--- a/changes/CA-2267.feature
+++ b/changes/CA-2267.feature
@@ -1,0 +1,1 @@
+Add approval_state Solr field and corresponding Plone indexer. [lgraf]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -12,6 +12,7 @@ Breaking Changes
 Other Changes
 ^^^^^^^^^^^^^
 
+- ``@listing``: Add ``approval_state`` column
 - Include ``committee`` in proposal serialization.
 - Include ``proposal``, ``meeting``, ``submitted_proposal`` and ``submitted_with`` in document serialization.
 

--- a/docs/public/dev-manual/api/listings.rst
+++ b/docs/public/dev-manual/api/listings.rst
@@ -67,6 +67,7 @@ Für jede Auflistung können verschiedene Felder (Parameter ``columns``) abgefra
 werden. Folgende Felder stehen zur Verfügung:
 
 - ``@type``: Inhaltstyp
+- ``approval_state``: Genehmigungs-Status
 - ``blocked_local_roles``: Ob Berechtigungen von übergeordneten Ordnern übernommen werden.
 - ``bumblebee_checksum``: SHA-256 Checksumme
 - ``changed``: Änderungsdatum

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -14,6 +14,7 @@ from ZPublisher.HTTPRequest import record
 
 # Fields with no mapping but allowed in the listing endpoint.
 OTHER_ALLOWED_FIELDS = set([
+    'approval_state',
     'blocked_local_roles',
     'changed',
     'checked_out',
@@ -33,11 +34,11 @@ OTHER_ALLOWED_FIELDS = set([
     'firstname',
     'getObjPositionInParent',
     'has_sametype_children',
+    'id',
     'is_subdossier',
     'is_subtask',
-    'id',
-    'lastname',
     'language',
+    'lastname',
     'location',
     'modified',
     'phone_office',

--- a/opengever/document/approvals.py
+++ b/opengever/document/approvals.py
@@ -133,6 +133,10 @@ class ApprovalList(object):
         if current_version is None:
             return self.storage.remove_all()
 
+        # Explicit reindexing of approval_state is not needed here.
+        # The copied object will be indexed in its entirety on paste, during
+        # ObjectAddedEvent, which is fired later than the ObjectCopiedEvent
+        # this method is bound to.
         self.storage.remove_all_except(current_version)
         self.storage.reset_approvals_to_version(0)
 

--- a/opengever/document/approvals.py
+++ b/opengever/document/approvals.py
@@ -109,6 +109,7 @@ class ApprovalList(object):
             approved = datetime.now()
 
         self.storage.add(approved, approver, IUUID(task), version_id)
+        self.context.reindexObject(idxs=['UID', 'approval_state'])
 
     def get(self):
         return list(self)

--- a/opengever/document/checkout/manager.py
+++ b/opengever/document/checkout/manager.py
@@ -356,6 +356,7 @@ class CheckinCheckoutManager(object):
             msg = _(u'Reverted file to version ${version_id}.',
                     mapping=dict(version_id=version_id))
             comment = translate(msg, context=self.request)
+            # This will also update the approval_state index in Solr
             self.versioner.create_version(comment)
 
         # event

--- a/opengever/document/configure.zcml
+++ b/opengever/document/configure.zcml
@@ -346,6 +346,11 @@
       name="watchers"
       />
 
+  <adapter
+      factory=".indexers.approval_state"
+      name="approval_state"
+      />
+
   <adapter factory=".document.UploadValidator" />
 
   <adapter factory=".fileactions.BaseDocumentFileActions" />

--- a/opengever/document/indexers.py
+++ b/opengever/document/indexers.py
@@ -7,6 +7,7 @@ from opengever.base.behaviors.classification import IClassificationMarker
 from opengever.base.interfaces import IReferenceNumber
 from opengever.base.interfaces import ISequenceNumber
 from opengever.base.utils import ensure_str
+from opengever.document.approvals import IApprovalList
 from opengever.document.behaviors import IBaseDocument
 from opengever.document.behaviors.customproperties import IDocumentCustomProperties
 from opengever.document.behaviors.metadata import IDocumentMetadata
@@ -249,3 +250,12 @@ def watchers(obj):
     center = notification_center()
     watchers = center.get_watchers(obj, role=WATCHER_ROLE)
     return [watcher.actorid for watcher in watchers]
+
+
+@indexer(IBaseDocument)
+def approval_state(obj):
+    """Indexer for approval_state Solr index.
+    """
+    approvals = IApprovalList(obj)
+    approval_state = approvals.get_approval_state()
+    return approval_state

--- a/opengever/document/tests/test_indexers.py
+++ b/opengever/document/tests/test_indexers.py
@@ -16,6 +16,7 @@ from opengever.document.checkout.manager import CHECKIN_CHECKOUT_ANNOTATIONS_KEY
 from opengever.document.indexers import DefaultDocumentIndexer
 from opengever.document.indexers import filename as filename_indexer
 from opengever.document.indexers import metadata
+from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.document.interfaces import IDocumentIndexer
 from opengever.document.versioner import Versioner
 from opengever.testing import FunctionalTestCase
@@ -29,6 +30,7 @@ from plone.namedfile.file import NamedBlobFile
 from Products.CMFCore.interfaces import ISiteRoot
 from zope.annotation.interfaces import IAnnotations
 from zope.component import getAdapter
+from zope.component import getMultiAdapter
 from zope.component import getUtility
 from zope.component.hooks import setSite
 import datetime
@@ -382,6 +384,41 @@ class SolrDocumentIndexer(SolrIntegrationTestCase):
 
         self.commit_solr()
         indexed_value = solr_data_for(self.document, 'approval_state')
+        self.assertEqual(APPROVED_IN_OLDER_VERSION, indexed_value)
+
+    def test_approval_state_is_updated_on_revert_to_version(self):
+        self.login(self.regular_user)
+
+        approvals = IApprovalList(self.document)
+        versioner = Versioner(self.document)
+        versioner.create_version('Initial version')
+
+        self.commit_solr()
+        indexed_value = solr_data_for(self.document, 'approval_state')
+        self.assertEqual(None, indexed_value)
+
+        versioner.create_version('Second version')
+        approvals.add(
+            versioner.get_current_version_id(missing_as_zero=True),
+            self.subtask, self.regular_user.id, datetime.datetime(2021, 7, 2))
+
+        self.commit_solr()
+        indexed_value = solr_data_for(self.document, 'approval_state')
+        self.assertEqual(APPROVED_IN_CURRENT_VERSION, indexed_value)
+
+        manager = getMultiAdapter((self.document, self.request),
+                                  ICheckinCheckoutManager)
+
+        manager.revert_to_version(0)
+        self.commit_solr()
+        indexed_value = solr_data_for(self.document, 'approval_state')
+
+        # Currently we only ensure the approval_state is *updated* on revert.
+        # But we might possibly also make sure it's getting *fixed*:
+        # Reverting to a version that was previously approved will currently
+        # result in a new version that isn't approved yet. If we want to
+        # retain that approval, we'd need to copy the approval list when
+        # reverting.
         self.assertEqual(APPROVED_IN_OLDER_VERSION, indexed_value)
 
 

--- a/opengever/document/versioner.py
+++ b/opengever/document/versioner.py
@@ -35,6 +35,7 @@ class Versioner(object):
         """Creates a new version in CMFEditions.
         """
         self.repository.save(obj=self.document, comment=comment)
+        self.document.reindexObject(idxs=['UID', 'approval_state'])
 
     def has_initial_version(self):
         return self.get_history_metadata() != []

--- a/opengever/tabbedview/tests/test_personaloverview.py
+++ b/opengever/tabbedview/tests/test_personaloverview.py
@@ -274,6 +274,7 @@ class TestGlobalTaskListings(IntegrationTestCase):
             u'H\xf6rsaal reservieren',
             u'Diskr\xe4te Dinge',
             u're: Diskr\xe4te Dinge',
+            u'Ein notwendiges \xdcbel',
             ]
         found_tasks = [row.get('Title') for row in browser.css('.listing').first.dicts()]
         self.assertEqual(expected_tasks, found_tasks)
@@ -287,6 +288,7 @@ class TestGlobalTaskListings(IntegrationTestCase):
             u'H\xf6rsaal reservieren',
             u'Diskr\xe4te Dinge',
             u're: Diskr\xe4te Dinge',
+            u'Ein notwendiges \xdcbel',
             ]
         found_tasks = [row.get('Title') for row in browser.css('.listing').first.dicts()]
         self.assertEqual(expected_tasks, found_tasks)

--- a/opengever/task/tests/test_principals.py
+++ b/opengever/task/tests/test_principals.py
@@ -13,4 +13,4 @@ class TestTaskPrincipals(IntegrationTestCase):
         self.login(self.regular_user)
 
         self.assertEqual(
-            [u'kathi.barfuss', u'fa_inbox_users'], self.task_in_protected_dossier.get_principals())
+            [u'kathi.barfuss', u'fa_inbox_users', u'robert.ziegler'], self.task_in_protected_dossier.get_principals())

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -1683,6 +1683,9 @@ class OpengeverContentFixture(object):
                 start=date(2016, 1, 1),
             )
         ))
+        self.set_roles(
+            protected_dossier, self.dossier_responsible.getId(),
+            ['Reader', 'Contributor', 'Editor'])
         protected_dossier.__ac_local_roles_block__ = True
         protected_dossier.reindexObjectSecurity()
         protected_dossier.reindexObject(idxs=['blocked_local_roles'])
@@ -1710,6 +1713,9 @@ class OpengeverContentFixture(object):
                 start=date(2016, 1, 1),
             )
         ))
+        self.set_roles(
+            protected_dossier_with_task, self.dossier_responsible.getId(),
+            ['Reader', 'Contributor', 'Editor'])
         protected_dossier_with_task.__ac_local_roles_block__ = True
         protected_dossier_with_task.reindexObjectSecurity()
         protected_dossier_with_task.reindexObject(idxs=['blocked_local_roles'])

--- a/solr-conf/managed-schema
+++ b/solr-conf/managed-schema
@@ -128,6 +128,7 @@
     <field name="is_folderish" type="boolean" indexed="true" stored="true"/>
 
     <!-- GEVER specific fields -->
+    <field name="approval_state" type="string" indexed="true" stored="false" />
     <field name="attendees" type="string" indexed="true" stored="false" multiValued="true"/>
     <field name="blocked_local_roles" type="boolean" indexed="true" stored="false" />
     <field name="bumblebee_checksum" type="string" indexed="false" stored="false" />


### PR DESCRIPTION
This adds
- a method `ApprovalList.get_approval_state()` to determine the current `approval_state` of a document based on the contents of the approval lists in annotations
- plus the corresponding **Solr index** `approval_state`
- and the **indexer** on the Plone side.

### Caveat: Revert to version

Currently I only made sure the `approval_state` index is _updated_ in Solr when a document gets **reverted**. But we maybe should also fix the approval lists when a document gets reverted to a version that has previously been approved, similar to what is being done when a document is copied. 

⚠️ So right now, reverting to a document version that has previously been approved will not retain that approval state, and the document will therefore be "approved in an older version".  

For [CA-2267](https://4teamwork.atlassian.net/browse/CA-2267)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
- New functionality:
  - [x] for `document` also works for `mail`
