### PR TITLE
Extend actors endpoint

### DIFF
--- a/changes/CA-1629.feature
+++ b/changes/CA-1629.feature
@@ -1,0 +1,1 @@
+Include @type, active,  portrait_url, representatives and respresents in @actors endpoint. [buchi]

--- a/docs/public/dev-manual/api/actors.rst
+++ b/docs/public/dev-manual/api/actors.rst
@@ -28,10 +28,21 @@ Ein actor ist kein Plone Inhaltstyp, deshalb beinhaltet die Response weniger Inf
 
       {
         "@id": "http://example.org/@actors/peter.mueller",
+        "@type": "virtual.ogds.actor",
+        "active": true,
         "actor_type": "user",
         "identifier": "peter.mueller",
         "label": "Mueller Peter",
-        "portrait_url": "http://example.org/defaultUser.png"
+        "portrait_url": "http://example.org/portraits/peter.mueller.png"
+        "representatives": [
+           {
+               "@id": "http://example.org/@actors/peter.mueller",
+               "identifier": "peter.mueller"
+           },
+        ],
+        "represents": {
+            "@id": "http://example.org/@actors/peter.mueller"
+        }
       }
 
 Via POST können die Daten von mehreren actors mit einem Request abgefragt werden. Im Request-body wird die Liste von actor ID angegeben:
@@ -66,17 +77,39 @@ Via POST können die Daten von mehreren actors mit einem Request abgefragt werde
         "items": [
           {
             "@id": "http://example.org/@actors/peter.mueller",
+            "@type": "virtual.ogds.actor",
+            "active": true,
             "actor_type": "user",
             "identifier": "peter.mueller",
             "label": "Mueller Peter",
-            "portrait_url": "http://example.org/defaultUser.png"
+            "portrait_url": "http://example.org/portraits/peter.mueller.png",
+            "representatives": [
+               {
+                 "@id": "http://example.org/@actors/peter.mueller",
+                 "identifier": "peter.mueller"
+               },
+            ],
+            "represents": {
+               "@id": "http://example.org/@actors/peter.mueller"
+            }
           },
           {
             "@id": "http://example.org/@actors/inbox:fa",
+            "@type": "virtual.ogds.actor",
+            "active": true,
             "actor_type": "inbox",
             "identifier": "inbox:afi",
             "label": "Eingangskorb",
-            "portrait_url": null
+            "portrait_url": null,
+            "representatives": [
+               {
+                 "@id": "http://example.org/@actors/peter.mueller",
+                 "identifier": "peter.mueller"
+               },
+            ],
+            "represents": {
+               "@id": "http://example.org/eingangskorb/eingangskorb_fa"
+            }
           },
           { "...": "..." }
         ]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -21,6 +21,8 @@ Other Changes
 - Include ``committee`` in proposal serialization.
 - Include ``proposal``, ``meeting``, ``submitted_proposal`` and ``submitted_with`` in document serialization.
 - New ``@reference-numbers`` endpoint for administrators (see :ref:`docs <reference-numbers>`).
+- Include ``@type``, ``active``, ``portrait_url``,  ``representatives`` and ``respresents`` in ``@actors`` endpoint.
+
 
 2021.16.0 (2021-08-12)
 ----------------------

--- a/opengever/api/actors.py
+++ b/opengever/api/actors.py
@@ -34,6 +34,9 @@ class SerializeActorToJson(object):
         self.request = request
 
     def __call__(self):
+        represents_url = self.context.represents_url()
+        represents = {'@id': represents_url} if represents_url else None
+
         result = {
             '@id': '{}/@actors/{}'.format(
                 api.portal.get().absolute_url(), self.context.identifier),
@@ -42,6 +45,7 @@ class SerializeActorToJson(object):
             'identifier': self.context.identifier,
             'label': self.context.get_label(with_principal=False),
             'portrait_url': self.context.get_portrait_url(),
+            'represents': represents,
         }
 
         return result

--- a/opengever/api/actors.py
+++ b/opengever/api/actors.py
@@ -40,6 +40,7 @@ class SerializeActorToJson(object):
         result = {
             '@id': '{}/@actors/{}'.format(
                 api.portal.get().absolute_url(), self.context.identifier),
+            '@type': 'virtual.ogds.actor',
             'active': self.context.is_active,
             'actor_type': self.context.actor_type,
             'identifier': self.context.identifier,

--- a/opengever/api/actors.py
+++ b/opengever/api/actors.py
@@ -37,6 +37,7 @@ class SerializeActorToJson(object):
         result = {
             '@id': '{}/@actors/{}'.format(
                 api.portal.get().absolute_url(), self.context.identifier),
+            'active': self.context.is_active,
             'actor_type': self.context.actor_type,
             'identifier': self.context.identifier,
             'label': self.context.get_label(with_principal=False),

--- a/opengever/api/actors.py
+++ b/opengever/api/actors.py
@@ -45,6 +45,10 @@ class SerializeActorToJson(object):
             'identifier': self.context.identifier,
             'label': self.context.get_label(with_principal=False),
             'portrait_url': self.context.get_portrait_url(),
+            'representatives': [
+                serialize_actor_id_to_json_summary(r.userid)
+                for r in self.context.representatives()
+            ],
             'represents': represents,
         }
 

--- a/opengever/api/tests/test_actors.py
+++ b/opengever/api/tests/test_actors.py
@@ -33,17 +33,23 @@ class TestActorsGet(IntegrationTestCase):
         self.assertEqual(200, browser.status_code)
 
         self.assertDictEqual(
-            {u'@id': url,
-             u'active': True,
-             u'actor_type': u'team',
-             u'identifier': actor_id,
-             u'portrait_url': None,
-             u'label': u'Projekt \xdcberbaung Dorfmatte (Finanz\xe4mt)'},
-            browser.json)
+            {
+                u'@id': url,
+                u'active': True,
+                u'actor_type': u'team',
+                u'identifier': actor_id,
+                u'portrait_url': None,
+                u'label': u'Projekt \xdcberbaung Dorfmatte (Finanz\xe4mt)',
+                u'represents': {
+                    u'@id': u'http://nohost/plone/@teams/team:1',
+                },
+            },
+            browser.json,
+        )
 
     @browsing
     def test_actors_response_for_inbox(self, browser):
-        self.login(self.regular_user, browser=browser)
+        self.login(self.secretariat_user, browser=browser)
 
         actor_id = 'inbox:fa'
         url = "{}/{}".format(self.actors_url, actor_id)
@@ -51,13 +57,19 @@ class TestActorsGet(IntegrationTestCase):
         self.assertEqual(200, browser.status_code)
 
         self.assertDictEqual(
-            {u'@id': url,
-             u'active': True,
-             u'actor_type': u'inbox',
-             u'identifier': actor_id,
-             u'portrait_url': None,
-             u'label': u'Inbox: Finanz\xe4mt'},
-            browser.json)
+            {
+                u'@id': url,
+                u'active': True,
+                u'actor_type': u'inbox',
+                u'identifier': actor_id,
+                u'portrait_url': None,
+                u'label': u'Inbox: Finanz\xe4mt',
+                u'represents': {
+                    u'@id': u'http://nohost/plone/eingangskorb/eingangskorb_fa',
+                },
+            },
+            browser.json,
+        )
 
     @browsing
     def test_actors_response_for_contact(self, browser):
@@ -69,13 +81,19 @@ class TestActorsGet(IntegrationTestCase):
         self.assertEqual(200, browser.status_code)
 
         self.assertDictEqual(
-            {u'@id': url,
-             u'active': True,
-             u'actor_type': u'contact',
-             u'identifier': actor_id,
-             u'portrait_url': None,
-             u'label': u'Meier Franz'},
-            browser.json)
+            {
+                u'@id': url,
+                u'active': True,
+                u'actor_type': u'contact',
+                u'identifier': actor_id,
+                u'portrait_url': None,
+                u'label': u'Meier Franz',
+                u'represents': {
+                    u'@id': u'http://nohost/plone/kontakte/meier-franz',
+                },
+            },
+            browser.json
+        )
 
     @browsing
     def test_actors_response_for_committee(self, browser):
@@ -87,12 +105,17 @@ class TestActorsGet(IntegrationTestCase):
         self.assertEqual(200, browser.status_code)
 
         self.assertDictEqual(
-            {u'@id': url,
-             u'active': True,
-             u'actor_type': u'committee',
-             u'identifier': actor_id,
-             u'portrait_url': None,
-             u'label': u'Rechnungspr\xfcfungskommission'},
+            {
+                u'@id': url,
+                u'active': True,
+                u'actor_type': u'committee',
+                u'identifier': actor_id,
+                u'portrait_url': None,
+                u'label': u'Rechnungspr\xfcfungskommission',
+                u'represents': {
+                    u'@id': u'http://nohost/plone/opengever-meeting-committeecontainer/committee-1',
+                },
+            },
             browser.json)
 
     @browsing
@@ -105,12 +128,17 @@ class TestActorsGet(IntegrationTestCase):
         self.assertEqual(200, browser.status_code)
 
         self.assertDictEqual(
-            {u'@id': url,
-             u'active': True,
-             u'actor_type': u'user',
-             u'identifier': actor_id,
-             u'portrait_url': None,
-             u'label': u'K\xf6nig J\xfcrgen'},
+            {
+                u'@id': url,
+                u'active': True,
+                u'actor_type': u'user',
+                u'identifier': actor_id,
+                u'portrait_url': None,
+                u'label': u'K\xf6nig J\xfcrgen',
+                u'represents': {
+                    u'@id': u'http://nohost/plone/@ogds-users/jurgen.konig',
+                },
+            },
             browser.json)
 
     @browsing
@@ -123,12 +151,17 @@ class TestActorsGet(IntegrationTestCase):
         self.assertEqual(200, browser.status_code)
 
         self.assertDictEqual(
-            {u'@id': url,
-             u'active': True,
-             u'actor_type': u'group',
-             u'identifier': actor_id,
-             u'portrait_url': None,
-             u'label': u'Projekt A'},
+            {
+                u'@id': url,
+                u'active': True,
+                u'actor_type': u'group',
+                u'identifier': actor_id,
+                u'portrait_url': None,
+                u'label': u'Projekt A',
+                u'represents': {
+                    u'@id': u'http://nohost/plone/@ogds-groups/projekt_a',
+                },
+            },
             browser.json)
 
     @browsing
@@ -141,13 +174,19 @@ class TestActorsGet(IntegrationTestCase):
         self.assertEqual(200, browser.status_code)
 
         self.assertDictEqual(
-            {u'@id': url,
-             u'active': True,
-             u'actor_type': u'user',
-             u'identifier': actor_id,
-             u'portrait_url': None,
-             u'label': u'admin'},
-            browser.json)
+            {
+                u'@id': url,
+                u'active': True,
+                u'actor_type': u'user',
+                u'identifier': actor_id,
+                u'portrait_url': None,
+                u'label': u'admin',
+                u'represents': {
+                    u'@id': u'http://nohost/plone/@users/admin',
+                },
+            },
+            browser.json,
+        )
 
     @browsing
     def test_raises_bad_request_when_actor_is_missing(self, browser):
@@ -179,13 +218,17 @@ class TestActorsGet(IntegrationTestCase):
         browser.open(self.actors_url + "/foo", headers=self.api_headers)
 
         self.assertDictEqual(
-            {u'@id': self.actors_url + "/foo",
-             u'active': False,
-             u'actor_type': u'null',
-             u'identifier': u'foo',
-             u'portrait_url': None,
-             u'label': u'foo'},
-            browser.json)
+            {
+                u'@id': self.actors_url + "/foo",
+                u'active': False,
+                u'actor_type': u'null',
+                u'identifier': u'foo',
+                u'portrait_url': None,
+                u'label': u'foo',
+                u'represents': None,
+            },
+            browser.json,
+        )
 
 
 class TestActorsGetListPOST(IntegrationTestCase):
@@ -196,7 +239,7 @@ class TestActorsGetListPOST(IntegrationTestCase):
 
     @browsing
     def test_get_list_of_actors(self, browser):
-        self.login(self.regular_user, browser=browser)
+        self.login(self.secretariat_user, browser=browser)
 
         actor_ids = {'actor_ids': ['team:1', 'inbox:fa']}
         browser.open(self.actors_url, method='POST',
@@ -206,20 +249,30 @@ class TestActorsGetListPOST(IntegrationTestCase):
         expected = {
             u'@id': self.actors_url,
             u'items': [
-                {u'@id': self.actors_url + "/team:1",
-                 u'active': True,
-                 u'actor_type': u'team',
-                 u'identifier': u'team:1',
-                 u'portrait_url': None,
-                 u'label': u'Projekt \xdcberbaung Dorfmatte (Finanz\xe4mt)'},
-                {u'@id': self.actors_url + '/inbox:fa',
-                 u'active': True,
-                 u'actor_type': u'inbox',
-                 u'identifier': u'inbox:fa',
-                 u'portrait_url': None,
-                 u'label': u'Inbox: Finanz\xe4mt'}
-                ]
-            }
+                {
+                    u'@id': self.actors_url + "/team:1",
+                    u'active': True,
+                    u'actor_type': u'team',
+                    u'identifier': u'team:1',
+                    u'portrait_url': None,
+                    u'label': u'Projekt \xdcberbaung Dorfmatte (Finanz\xe4mt)',
+                    u'represents': {
+                        u'@id': u'http://nohost/plone/@teams/team:1',
+                    },
+                },
+                {
+                    u'@id': self.actors_url + '/inbox:fa',
+                    u'active': True,
+                    u'actor_type': u'inbox',
+                    u'identifier': u'inbox:fa',
+                    u'portrait_url': None,
+                    u'label': u'Inbox: Finanz\xe4mt',
+                    u'represents': {
+                        u'@id': u'http://nohost/plone/eingangskorb/eingangskorb_fa',
+                    },
+                },
+            ]
+        }
 
         self.assertDictEqual(expected, browser.json)
 
@@ -235,20 +288,28 @@ class TestActorsGetListPOST(IntegrationTestCase):
         expected = {
             u'@id': self.actors_url,
             u'items': [
-                {u'@id': self.actors_url + "/team:1",
-                 u'active': True,
-                 u'actor_type': u'team',
-                 u'identifier': u'team:1',
-                 u'portrait_url': None,
-                 u'label': u'Projekt \xdcberbaung Dorfmatte (Finanz\xe4mt)'},
-                {u'@id': self.actors_url + '/foo',
-                 u'active': False,
-                 u'actor_type': u'null',
-                 u'identifier': u'foo',
-                 u'portrait_url': None,
-                 u'label': u'foo'}
-                ]
-            }
+                {
+                    u'@id': self.actors_url + "/team:1",
+                    u'active': True,
+                    u'actor_type': u'team',
+                    u'identifier': u'team:1',
+                    u'portrait_url': None,
+                    u'label': u'Projekt \xdcberbaung Dorfmatte (Finanz\xe4mt)',
+                    u'represents': {
+                        u'@id': u'http://nohost/plone/@teams/team:1',
+                    },
+                },
+                {
+                    u'@id': self.actors_url + '/foo',
+                    u'active': False,
+                    u'actor_type': u'null',
+                    u'identifier': u'foo',
+                    u'portrait_url': None,
+                    u'label': u'foo',
+                    u'represents': None,
+                },
+            ],
+        }
 
         self.assertDictEqual(expected, browser.json)
 

--- a/opengever/api/tests/test_actors.py
+++ b/opengever/api/tests/test_actors.py
@@ -180,6 +180,36 @@ class TestActorsGet(IntegrationTestCase):
             browser.json)
 
     @browsing
+    def test_actors_response_for_ogds_user_with_orgunit(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        actor_id = 'fa:jurgen.konig'
+        url = "{}/{}".format(self.actors_url, actor_id)
+        browser.open(url, headers=self.api_headers)
+        self.assertEqual(200, browser.status_code)
+
+        self.assertDictEqual(
+            {
+                u'@id': url,
+                u'@type': u'virtual.ogds.actor',
+                u'active': True,
+                u'actor_type': u'user',
+                u'identifier': actor_id,
+                u'portrait_url': None,
+                u'label': u'K\xf6nig J\xfcrgen',
+                u'representatives': [
+                    {
+                        u'@id': u'http://nohost/plone/@actors/jurgen.konig',
+                        u'identifier': u'jurgen.konig',
+                    },
+                ],
+                u'represents': {
+                    u'@id': u'http://nohost/plone/@ogds-users/jurgen.konig',
+                },
+            },
+            browser.json)
+
+    @browsing
     def test_actors_response_for_group(self, browser):
         self.login(self.regular_user, browser=browser)
 

--- a/opengever/api/tests/test_actors.py
+++ b/opengever/api/tests/test_actors.py
@@ -35,6 +35,7 @@ class TestActorsGet(IntegrationTestCase):
         self.assertDictEqual(
             {
                 u'@id': url,
+                u'@type': u'virtual.ogds.actor',
                 u'active': True,
                 u'actor_type': u'team',
                 u'identifier': actor_id,
@@ -69,6 +70,7 @@ class TestActorsGet(IntegrationTestCase):
         self.assertDictEqual(
             {
                 u'@id': url,
+                u'@type': u'virtual.ogds.actor',
                 u'active': True,
                 u'actor_type': u'inbox',
                 u'identifier': actor_id,
@@ -99,6 +101,7 @@ class TestActorsGet(IntegrationTestCase):
         self.assertDictEqual(
             {
                 u'@id': url,
+                u'@type': u'virtual.ogds.actor',
                 u'active': True,
                 u'actor_type': u'contact',
                 u'identifier': actor_id,
@@ -124,6 +127,7 @@ class TestActorsGet(IntegrationTestCase):
         self.assertDictEqual(
             {
                 u'@id': url,
+                u'@type': u'virtual.ogds.actor',
                 u'active': True,
                 u'actor_type': u'committee',
                 u'identifier': actor_id,
@@ -157,6 +161,7 @@ class TestActorsGet(IntegrationTestCase):
         self.assertDictEqual(
             {
                 u'@id': url,
+                u'@type': u'virtual.ogds.actor',
                 u'active': True,
                 u'actor_type': u'user',
                 u'identifier': actor_id,
@@ -186,6 +191,7 @@ class TestActorsGet(IntegrationTestCase):
         self.assertDictEqual(
             {
                 u'@id': url,
+                u'@type': u'virtual.ogds.actor',
                 u'active': True,
                 u'actor_type': u'group',
                 u'identifier': actor_id,
@@ -219,6 +225,7 @@ class TestActorsGet(IntegrationTestCase):
         self.assertDictEqual(
             {
                 u'@id': url,
+                u'@type': u'virtual.ogds.actor',
                 u'active': True,
                 u'actor_type': u'user',
                 u'identifier': actor_id,
@@ -264,6 +271,7 @@ class TestActorsGet(IntegrationTestCase):
         self.assertDictEqual(
             {
                 u'@id': self.actors_url + "/foo",
+                u'@type': u'virtual.ogds.actor',
                 u'active': False,
                 u'actor_type': u'null',
                 u'identifier': u'foo',
@@ -296,6 +304,7 @@ class TestActorsGetListPOST(IntegrationTestCase):
             u'items': [
                 {
                     u'@id': self.actors_url + "/team:1",
+                    u'@type': u'virtual.ogds.actor',
                     u'active': True,
                     u'actor_type': u'team',
                     u'identifier': u'team:1',
@@ -317,6 +326,7 @@ class TestActorsGetListPOST(IntegrationTestCase):
                 },
                 {
                     u'@id': self.actors_url + '/inbox:fa',
+                    u'@type': u'virtual.ogds.actor',
                     u'active': True,
                     u'actor_type': u'inbox',
                     u'identifier': u'inbox:fa',
@@ -351,6 +361,7 @@ class TestActorsGetListPOST(IntegrationTestCase):
             u'items': [
                 {
                     u'@id': self.actors_url + "/team:1",
+                    u'@type': u'virtual.ogds.actor',
                     u'active': True,
                     u'actor_type': u'team',
                     u'identifier': u'team:1',
@@ -372,6 +383,7 @@ class TestActorsGetListPOST(IntegrationTestCase):
                 },
                 {
                     u'@id': self.actors_url + '/foo',
+                    u'@type': u'virtual.ogds.actor',
                     u'active': False,
                     u'actor_type': u'null',
                     u'identifier': u'foo',

--- a/opengever/api/tests/test_actors.py
+++ b/opengever/api/tests/test_actors.py
@@ -34,6 +34,7 @@ class TestActorsGet(IntegrationTestCase):
 
         self.assertDictEqual(
             {u'@id': url,
+             u'active': True,
              u'actor_type': u'team',
              u'identifier': actor_id,
              u'portrait_url': None,
@@ -51,6 +52,7 @@ class TestActorsGet(IntegrationTestCase):
 
         self.assertDictEqual(
             {u'@id': url,
+             u'active': True,
              u'actor_type': u'inbox',
              u'identifier': actor_id,
              u'portrait_url': None,
@@ -68,6 +70,7 @@ class TestActorsGet(IntegrationTestCase):
 
         self.assertDictEqual(
             {u'@id': url,
+             u'active': True,
              u'actor_type': u'contact',
              u'identifier': actor_id,
              u'portrait_url': None,
@@ -85,6 +88,7 @@ class TestActorsGet(IntegrationTestCase):
 
         self.assertDictEqual(
             {u'@id': url,
+             u'active': True,
              u'actor_type': u'committee',
              u'identifier': actor_id,
              u'portrait_url': None,
@@ -102,6 +106,7 @@ class TestActorsGet(IntegrationTestCase):
 
         self.assertDictEqual(
             {u'@id': url,
+             u'active': True,
              u'actor_type': u'user',
              u'identifier': actor_id,
              u'portrait_url': u'http://nohost/plone/defaultUser.png',
@@ -119,6 +124,7 @@ class TestActorsGet(IntegrationTestCase):
 
         self.assertDictEqual(
             {u'@id': url,
+             u'active': True,
              u'actor_type': u'group',
              u'identifier': actor_id,
              u'portrait_url': None,
@@ -136,6 +142,7 @@ class TestActorsGet(IntegrationTestCase):
 
         self.assertDictEqual(
             {u'@id': url,
+             u'active': True,
              u'actor_type': u'user',
              u'identifier': actor_id,
              u'portrait_url': 'http://nohost/plone/defaultUser.png',
@@ -173,6 +180,7 @@ class TestActorsGet(IntegrationTestCase):
 
         self.assertDictEqual(
             {u'@id': self.actors_url + "/foo",
+             u'active': False,
              u'actor_type': u'null',
              u'identifier': u'foo',
              u'portrait_url': None,
@@ -199,11 +207,13 @@ class TestActorsGetListPOST(IntegrationTestCase):
             u'@id': self.actors_url,
             u'items': [
                 {u'@id': self.actors_url + "/team:1",
+                 u'active': True,
                  u'actor_type': u'team',
                  u'identifier': u'team:1',
                  u'portrait_url': None,
                  u'label': u'Projekt \xdcberbaung Dorfmatte (Finanz\xe4mt)'},
                 {u'@id': self.actors_url + '/inbox:fa',
+                 u'active': True,
                  u'actor_type': u'inbox',
                  u'identifier': u'inbox:fa',
                  u'portrait_url': None,
@@ -226,11 +236,13 @@ class TestActorsGetListPOST(IntegrationTestCase):
             u'@id': self.actors_url,
             u'items': [
                 {u'@id': self.actors_url + "/team:1",
+                 u'active': True,
                  u'actor_type': u'team',
                  u'identifier': u'team:1',
                  u'portrait_url': None,
                  u'label': u'Projekt \xdcberbaung Dorfmatte (Finanz\xe4mt)'},
                 {u'@id': self.actors_url + '/foo',
+                 u'active': False,
                  u'actor_type': u'null',
                  u'identifier': u'foo',
                  u'portrait_url': None,

--- a/opengever/api/tests/test_actors.py
+++ b/opengever/api/tests/test_actors.py
@@ -40,6 +40,16 @@ class TestActorsGet(IntegrationTestCase):
                 u'identifier': actor_id,
                 u'portrait_url': None,
                 u'label': u'Projekt \xdcberbaung Dorfmatte (Finanz\xe4mt)',
+                u'representatives': [
+                    {
+                        u'@id': u'http://nohost/plone/@actors/kathi.barfuss',
+                        u'identifier': u'kathi.barfuss',
+                    },
+                    {
+                        u'@id': u'http://nohost/plone/@actors/robert.ziegler',
+                        u'identifier': u'robert.ziegler',
+                    },
+                ],
                 u'represents': {
                     u'@id': u'http://nohost/plone/@teams/team:1',
                 },
@@ -64,6 +74,12 @@ class TestActorsGet(IntegrationTestCase):
                 u'identifier': actor_id,
                 u'portrait_url': None,
                 u'label': u'Inbox: Finanz\xe4mt',
+                u'representatives': [
+                    {
+                        u'@id': u'http://nohost/plone/@actors/jurgen.konig',
+                        u'identifier': u'jurgen.konig',
+                    },
+                ],
                 u'represents': {
                     u'@id': u'http://nohost/plone/eingangskorb/eingangskorb_fa',
                 },
@@ -88,6 +104,7 @@ class TestActorsGet(IntegrationTestCase):
                 u'identifier': actor_id,
                 u'portrait_url': None,
                 u'label': u'Meier Franz',
+                u'representatives': [],
                 u'represents': {
                     u'@id': u'http://nohost/plone/kontakte/meier-franz',
                 },
@@ -112,6 +129,16 @@ class TestActorsGet(IntegrationTestCase):
                 u'identifier': actor_id,
                 u'portrait_url': None,
                 u'label': u'Rechnungspr\xfcfungskommission',
+                u'representatives': [
+                    {
+                        u'@id': u'http://nohost/plone/@actors/franzi.muller',
+                        u'identifier': u'franzi.muller',
+                    },
+                    {
+                        u'@id': u'http://nohost/plone/@actors/nicole.kohler',
+                        u'identifier': u'nicole.kohler',
+                    },
+                ],
                 u'represents': {
                     u'@id': u'http://nohost/plone/opengever-meeting-committeecontainer/committee-1',
                 },
@@ -135,6 +162,12 @@ class TestActorsGet(IntegrationTestCase):
                 u'identifier': actor_id,
                 u'portrait_url': None,
                 u'label': u'K\xf6nig J\xfcrgen',
+                u'representatives': [
+                    {
+                        u'@id': u'http://nohost/plone/@actors/jurgen.konig',
+                        u'identifier': u'jurgen.konig',
+                    },
+                ],
                 u'represents': {
                     u'@id': u'http://nohost/plone/@ogds-users/jurgen.konig',
                 },
@@ -158,6 +191,16 @@ class TestActorsGet(IntegrationTestCase):
                 u'identifier': actor_id,
                 u'portrait_url': None,
                 u'label': u'Projekt A',
+                u'representatives': [
+                    {
+                        'identifier': u'kathi.barfuss',
+                        '@id': 'http://nohost/plone/@actors/kathi.barfuss',
+                    },
+                    {
+                        'identifier': u'robert.ziegler',
+                        '@id': 'http://nohost/plone/@actors/robert.ziegler',
+                    },
+                ],
                 u'represents': {
                     u'@id': u'http://nohost/plone/@ogds-groups/projekt_a',
                 },
@@ -181,6 +224,7 @@ class TestActorsGet(IntegrationTestCase):
                 u'identifier': actor_id,
                 u'portrait_url': None,
                 u'label': u'admin',
+                u'representatives': [],
                 u'represents': {
                     u'@id': u'http://nohost/plone/@users/admin',
                 },
@@ -225,6 +269,7 @@ class TestActorsGet(IntegrationTestCase):
                 u'identifier': u'foo',
                 u'portrait_url': None,
                 u'label': u'foo',
+                u'representatives': [],
                 u'represents': None,
             },
             browser.json,
@@ -256,6 +301,16 @@ class TestActorsGetListPOST(IntegrationTestCase):
                     u'identifier': u'team:1',
                     u'portrait_url': None,
                     u'label': u'Projekt \xdcberbaung Dorfmatte (Finanz\xe4mt)',
+                    u'representatives': [
+                        {
+                            u'@id': u'http://nohost/plone/@actors/kathi.barfuss',
+                            u'identifier': u'kathi.barfuss',
+                        },
+                        {
+                            u'@id': u'http://nohost/plone/@actors/robert.ziegler',
+                            u'identifier': u'robert.ziegler',
+                        },
+                    ],
                     u'represents': {
                         u'@id': u'http://nohost/plone/@teams/team:1',
                     },
@@ -267,6 +322,12 @@ class TestActorsGetListPOST(IntegrationTestCase):
                     u'identifier': u'inbox:fa',
                     u'portrait_url': None,
                     u'label': u'Inbox: Finanz\xe4mt',
+                    u'representatives': [
+                        {
+                            u'@id': u'http://nohost/plone/@actors/jurgen.konig',
+                            u'identifier': u'jurgen.konig',
+                        },
+                    ],
                     u'represents': {
                         u'@id': u'http://nohost/plone/eingangskorb/eingangskorb_fa',
                     },
@@ -295,6 +356,16 @@ class TestActorsGetListPOST(IntegrationTestCase):
                     u'identifier': u'team:1',
                     u'portrait_url': None,
                     u'label': u'Projekt \xdcberbaung Dorfmatte (Finanz\xe4mt)',
+                    u'representatives': [
+                        {
+                            u'@id': u'http://nohost/plone/@actors/kathi.barfuss',
+                            u'identifier': u'kathi.barfuss',
+                        },
+                        {
+                            u'@id': u'http://nohost/plone/@actors/robert.ziegler',
+                            u'identifier': u'robert.ziegler',
+                        },
+                    ],
                     u'represents': {
                         u'@id': u'http://nohost/plone/@teams/team:1',
                     },
@@ -306,6 +377,7 @@ class TestActorsGetListPOST(IntegrationTestCase):
                     u'identifier': u'foo',
                     u'portrait_url': None,
                     u'label': u'foo',
+                    u'representatives': [],
                     u'represents': None,
                 },
             ],

--- a/opengever/api/tests/test_actors.py
+++ b/opengever/api/tests/test_actors.py
@@ -109,7 +109,7 @@ class TestActorsGet(IntegrationTestCase):
              u'active': True,
              u'actor_type': u'user',
              u'identifier': actor_id,
-             u'portrait_url': u'http://nohost/plone/defaultUser.png',
+             u'portrait_url': None,
              u'label': u'K\xf6nig J\xfcrgen'},
             browser.json)
 
@@ -145,7 +145,7 @@ class TestActorsGet(IntegrationTestCase):
              u'active': True,
              u'actor_type': u'user',
              u'identifier': actor_id,
-             u'portrait_url': 'http://nohost/plone/defaultUser.png',
+             u'portrait_url': None,
              u'label': u'admin'},
             browser.json)
 

--- a/opengever/inbox/utils.py
+++ b/opengever/inbox/utils.py
@@ -1,5 +1,6 @@
 from Acquisition import aq_chain
 from opengever.inbox.inbox import IInbox
+from opengever.repository.behaviors.responsibleorg import IResponsibleOrgUnit
 from plone import api
 
 
@@ -16,6 +17,26 @@ def get_current_inbox(context):
         contentFilter={'portal_type': 'opengever.inbox.inbox'})
 
     return inbox[0] if inbox else None
+
+
+def get_inbox_for_org_unit(org_unit_id):
+    portal = api.portal.get()
+
+    inbox_container = portal.listFolderContents(
+        contentFilter={'portal_type': 'opengever.inbox.container'})
+
+    if inbox_container:
+        inboxes = inbox_container[0].listFolderContents(
+            contentFilter={'portal_type': 'opengever.inbox.inbox'})
+    else:
+        inboxes = portal.listFolderContents(
+            contentFilter={'portal_type': 'opengever.inbox.inbox'})
+
+    inboxes_by_org_unit = {
+        IResponsibleOrgUnit(inbox).responsible_org_unit: inbox
+        for inbox in inboxes
+    }
+    return inboxes_by_org_unit.get(org_unit_id)
 
 
 def is_within_inbox(context):

--- a/opengever/ogds/base/actor.py
+++ b/opengever/ogds/base/actor.py
@@ -26,6 +26,7 @@ For known actor types use:
 
 from opengever.base.utils import escape_html
 from opengever.contact.utils import get_contactfolder_url
+from opengever.inbox.utils import get_inbox_for_org_unit
 from opengever.ogds.base import _
 from opengever.ogds.base.browser.userdetails import UserDetails
 from opengever.ogds.base.interfaces import IActor
@@ -152,6 +153,9 @@ class Actor(object):
     def represents(self):
         raise NotImplementedError()
 
+    def represents_url(self):
+        raise NotImplementedError()
+
     def representatives(self):
         raise NotImplementedError()
 
@@ -184,6 +188,9 @@ class NullActor(object):
         return False
 
     def represents(self):
+        return None
+
+    def represents_url(self):
         return None
 
     def representatives(self):
@@ -219,6 +226,9 @@ class SystemActor(object):
         return u''
 
     def represents(self):
+        return None
+
+    def represents_url(self):
         return None
 
     def representatives(self):
@@ -268,6 +278,13 @@ class InboxActor(Actor):
     def represents(self):
         return self.org_unit
 
+    def represents_url(self):
+        inbox = get_inbox_for_org_unit(self.org_unit.id())
+        if inbox is not None:
+            return inbox.absolute_url()
+        else:
+            return None
+
     def get_portrait_url(self):
         return None
 
@@ -306,6 +323,10 @@ class TeamActor(Actor):
     def represents(self):
         return self.team
 
+    def represents_url(self):
+        return '{}/@teams/{}'.format(
+            api.portal.getSite().absolute_url(), self.identifier)
+
     def get_portrait_url(self):
         return None
 
@@ -340,6 +361,9 @@ class CommitteeActor(Actor):
 
     def represents(self):
         return self.committee
+
+    def represents_url(self):
+        return self.represents().resolve_committee().absolute_url()
 
     def get_portrait_url(self):
         return None
@@ -379,6 +403,9 @@ class ContactActor(Actor):
     def represents(self):
         return self.contact
 
+    def represents_url(self):
+        return self.represents().getURL()
+
     def get_portrait_url(self):
         return None
 
@@ -411,6 +438,10 @@ class PloneUserActor(Actor):
 
     def represents(self):
         return self.user
+
+    def represents_url(self):
+        return '{}/@users/{}'.format(
+            api.portal.getSite().absolute_url(), self.identifier)
 
     def get_portrait_url(self):
         mtool = api.portal.get_tool('portal_membership')
@@ -451,6 +482,10 @@ class OGDSUserActor(Actor):
 
     def represents(self):
         return self.user
+
+    def represents_url(self):
+        return '{}/@ogds-users/{}'.format(
+            api.portal.get().absolute_url(), self.identifier)
 
     def get_portrait_url(self):
         mtool = api.portal.get_tool('portal_membership')
@@ -494,6 +529,10 @@ class OGDSGroupActor(Actor):
     def represents(self):
         return self.group
 
+    def represents_url(self):
+        return '{}/@ogds-groups/{}'.format(
+            api.portal.get().absolute_url(), self.group.groupid)
+
     def get_portrait_url(self):
         return None
 
@@ -524,6 +563,9 @@ class InteractiveActor(Actor):
         return u''
 
     def represents(self):
+        return None
+
+    def represents_url(self):
         return None
 
     def representatives(self):

--- a/opengever/ogds/base/actor.py
+++ b/opengever/ogds/base/actor.py
@@ -138,6 +138,10 @@ class Actor(object):
 
         return link
 
+    @property
+    def is_active(self):
+        return True
+
     def corresponds_to(self, user):
         raise NotImplementedError()
 
@@ -174,6 +178,10 @@ class NullActor(object):
 
     def get_link(self, with_icon=False):
         return self.identifier or u''
+
+    @property
+    def is_active(self):
+        return False
 
     def represents(self):
         return None
@@ -247,6 +255,10 @@ class InboxActor(Actor):
         return translate(label, context=getRequest())
 
     @property
+    def is_active(self):
+        return self.org_unit.enabled
+
+    @property
     def permission_identifier(self):
         return self.org_unit.inbox_group.groupid
 
@@ -281,6 +293,10 @@ class TeamActor(Actor):
         return self.team.label()
 
     @property
+    def is_active(self):
+        return self.team.active
+
+    @property
     def permission_identifier(self):
         return self.team.group.groupid
 
@@ -312,6 +328,10 @@ class CommitteeActor(Actor):
 
     def get_label(self, with_principal=None):
         return self.committee.title
+
+    @property
+    def is_active(self):
+        return self.committee.is_active()
 
     def representatives(self):
         # Avoid circular imports
@@ -415,6 +435,10 @@ class OGDSUserActor(Actor):
         return UserDetails.url_for(self.user.userid)
 
     @property
+    def is_active(self):
+        return self.user.active
+
+    @property
     def permission_identifier(self):
         return self.identifier
 
@@ -449,6 +473,10 @@ class OGDSGroupActor(Actor):
 
     def get_profile_url(self):
         return groupmembers_url(self.group.groupid)
+
+    @property
+    def is_active(self):
+        return self.group.active
 
     @property
     def permission_identifier(self):

--- a/opengever/ogds/base/actor.py
+++ b/opengever/ogds/base/actor.py
@@ -485,7 +485,7 @@ class OGDSUserActor(Actor):
 
     def represents_url(self):
         return '{}/@ogds-users/{}'.format(
-            api.portal.get().absolute_url(), self.identifier)
+            api.portal.get().absolute_url(), self.identifier.split(':')[-1])
 
     def get_portrait_url(self):
         mtool = api.portal.get_tool('portal_membership')
@@ -641,7 +641,8 @@ class ActorLookup(object):
         return IPropertiedUser.providedBy(user) or IMemberData.providedBy(user)
 
     def load_user(self):
-        user = ogds_service().fetch_user(self.identifier)
+        userid = self.identifier.split(':')[-1]
+        user = ogds_service().fetch_user(userid)
         if not user:
             portal = getSite()
             portal_membership = getToolByName(portal, 'portal_membership')

--- a/opengever/ogds/base/actor.py
+++ b/opengever/ogds/base/actor.py
@@ -413,9 +413,13 @@ class PloneUserActor(Actor):
         return self.user
 
     def get_portrait_url(self):
-        portrait = self.user.getPersonalPortrait()
-        if portrait:
-            return portrait.absolute_url()
+        mtool = api.portal.get_tool('portal_membership')
+        portrait = mtool.getPersonalPortrait(self.user.id)
+        portrait_url = portrait.absolute_url()
+        if not portrait_url.endswith('/defaultUser.png'):
+            return portrait_url
+        else:
+            return None
 
 
 @implementer(IActor)
@@ -450,10 +454,12 @@ class OGDSUserActor(Actor):
 
     def get_portrait_url(self):
         mtool = api.portal.get_tool('portal_membership')
-        member = mtool.getMemberById(self.user.userid)
-        portrait = member.getPersonalPortrait()
-        if portrait:
-            return portrait.absolute_url()
+        portrait = mtool.getPersonalPortrait(self.user.userid)
+        portrait_url = portrait.absolute_url()
+        if not portrait_url.endswith('/defaultUser.png'):
+            return portrait_url
+        else:
+            return None
 
 
 @implementer(IActor)


### PR DESCRIPTION
Include the following properties in the `@actors` endpoint:
- `@type`
- `active`
- `portrait_url`
- `representatives`
- `respresents`

This allows us to use a generic Actor component in the frontend which resolves additional information using the `@actors` endpoint for displaying actors (users, groups, inboxes, teams, ...).

JIRA: https://4teamwork.atlassian.net/browse/CA-1629

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry

