### PR TITLE
Allow Reader to revive bumblebee previews.

### DIFF
--- a/changes/CA-2132.other
+++ b/changes/CA-2132.other
@@ -1,0 +1,1 @@
+Allow Reader to revive bumblebee previews. [deiferni]

--- a/opengever/bumblebee/tests/test_revive_bumblebee_preview.py
+++ b/opengever/bumblebee/tests/test_revive_bumblebee_preview.py
@@ -38,9 +38,18 @@ class TestReviveBumblebeePreview(IntegrationTestCase):
             browser.css('.actionMenuContent li').text)
 
     @browsing
-    def test_action_is_enabled_on_bumblebee_document(self, browser):
+    def test_action_is_enabled_for_admin_on_bumblebee_document(self, browser):
         self.login(self.administrator, browser)
+        browser.visit(self.document)
 
+        self.assertTrue(IBumblebeeable.providedBy(self.document))
+        self.assertIn(
+            'Regenerate PDF preview',
+            browser.css('.actionMenuContent li').text)
+
+    @browsing
+    def test_action_is_enabled_for_reader_on_bumblebee_document(self, browser):
+        self.login(self.regular_user, browser)
         browser.visit(self.document)
 
         self.assertTrue(IBumblebeeable.providedBy(self.document))

--- a/opengever/core/profiles/default/rolemap.xml
+++ b/opengever/core/profiles/default/rolemap.xml
@@ -52,6 +52,7 @@
     <permission name="opengever.bumblebee: Revive Preview" acquire="True">
       <role name="Administrator" />
       <role name="Manager" />
+      <role name="Reader" />
     </permission>
 
     <permission name="opengever.api: View AllowedRolesAndPrincipals" acquire="False">

--- a/opengever/core/upgrades/20210818101411_allow_reader_to_revive_bumblebee_previews/rolemap.xml
+++ b/opengever/core/upgrades/20210818101411_allow_reader_to_revive_bumblebee_previews/rolemap.xml
@@ -1,0 +1,11 @@
+<rolemap>
+  <permissions>
+
+    <permission name="opengever.bumblebee: Revive Preview" acquire="True">
+      <role name="Administrator" />
+      <role name="Manager" />
+      <role name="Reader" />
+    </permission>
+
+  </permissions>
+</rolemap>

--- a/opengever/core/upgrades/20210818101411_allow_reader_to_revive_bumblebee_previews/upgrade.py
+++ b/opengever/core/upgrades/20210818101411_allow_reader_to_revive_bumblebee_previews/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AllowReaderToReviveBumblebeePreviews(UpgradeStep):
+    """Allow Reader to revive bumblebee previews.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
Allow users with the `Reader` role to revive bumblebee previews. Previously this was limited to admins and managers but there is not really a reason to do so.

Tests are done with the regular user though as reader must be set up for each test case. Testing with the regular user covers the common use case better and is thus IMO preferrable.

For [CA-2132](https://4teamwork.atlassian.net/browse/CA-2132)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
