### PR TITLE
API: Allow for approving documents when resolving a task.

### DIFF
--- a/changes/CA-2269.feature
+++ b/changes/CA-2269.feature
@@ -1,0 +1,1 @@
+API: Allow for approving documents when resolving a task. [lgraf]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -12,6 +12,7 @@ Breaking Changes
 Other Changes
 ^^^^^^^^^^^^^
 
+- ``@workflow``: Transition ``task-transition-in-progress-resolved`` now accepts ``approved_documents`` transition parameter.
 - ``@listing``: Add ``approval_state`` column
 - Include ``committee`` in proposal serialization.
 - Include ``proposal``, ``meeting``, ``submitted_proposal`` and ``submitted_with`` in document serialization.

--- a/docs/public/dev-manual/api/tasks.rst
+++ b/docs/public/dev-manual/api/tasks.rst
@@ -189,7 +189,7 @@ Zusätzliche Metadaten:
 
        :Datentyp: ``Text``
 
-Im Parameter ``approved_documents`` (optional) kann eine Liste von UIDs der genehmigten Dokumente mitgegeben werden. Diese Dokumente müssen sich entweder in der Aufgabe befinden, oder mit einem Verweis von der Aufgabe referenziert sein.
+Der Parameter ``approved_documents`` (optional) wird nur unterstützt für Aufgaben des Typs "Zur Genehmigung" (task_type `approval``). Mit diesem Parameter kann eine Liste von UIDs der genehmigten Dokumente mitgegeben werden, welche beim Abschluss der Aufgabe durch den authentisierten User genehmigt werden. Diese Dokumente müssen sich entweder in der Aufgabe befinden, oder mit einem Verweis von der Aufgabe referenziert sein.
 
 
 Überarbeiten

--- a/docs/public/dev-manual/api/tasks.rst
+++ b/docs/public/dev-manual/api/tasks.rst
@@ -185,6 +185,12 @@ Zusätzliche Metadaten:
 
        :Datentyp: ``Text``
 
+   .. py:attribute:: approved_documents
+
+       :Datentyp: ``Text``
+
+Im Parameter ``approved_documents`` (optional) kann eine Liste von UIDs der genehmigten Dokumente mitgegeben werden. Diese Dokumente müssen sich entweder in der Aufgabe befinden, oder mit einem Verweis von der Aufgabe referenziert sein.
+
 
 Überarbeiten
 ~~~~~~~~~~~~

--- a/opengever/api/tests/test_forwarding.py
+++ b/opengever/api/tests/test_forwarding.py
@@ -27,6 +27,7 @@ class TestForwardingSerialization(SolrIntegrationTestCase):
                 u'is_leafnode': None,
                 u'review_state': u'document-state-draft',
                 u'title': u'Dokument im Eingangsk\xf6rbliweiterleitung'}],
+              u'approved_documents': [],
               u'changes': [],
               u'creator': {
                   u'token': u'nicole.kohler',

--- a/opengever/api/tests/test_task.py
+++ b/opengever/api/tests/test_task.py
@@ -44,6 +44,7 @@ class TestTaskSerialization(SolrIntegrationTestCase):
                   u'review_state': u'task-state-resolved',
                   u'title': self.subtask.title}
              ],
+             u'approved_documents': [],
              u'changes': [],
              u'created': json_compatible(self.subtask.created().utcdatetime()),
              u'creator': {u'title': u'Ziegler Robert', u'token': u'robert.ziegler'},
@@ -108,6 +109,7 @@ class TestTaskSerialization(SolrIntegrationTestCase):
              'response_id': 1481272800000000,
              'response_type': 'comment',
              u'created': u'2016-12-09T09:40:00',
+             u'approved_documents': [],
              u'changes': [],
              u'creator': {
                  u'token': self.regular_user.id,

--- a/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-04-23 10:53+0000\n"
+"POT-Creation-Date: 2021-08-18 08:25+0000\n"
 "PO-Revision-Date: 2015-02-17 18:41+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -272,6 +272,10 @@ msgstr "Wählen Sie die Ordnungsposition aus, in welchem das neue Dossier erstel
 msgid "help_accept_task_response"
 msgstr "Geben Sie einen Text für die automatisch erstellte Antwort ein."
 
+#: ./opengever/task/transition.py
+msgid "help_approved_documents"
+msgstr "Genehmigte Dokumente"
+
 #. Default: "Enter a answer text which will be shown as response on the succesor task."
 #: ./opengever/task/browser/assign_dossier.py
 msgid "help_assign_to_dossier_task_response"
@@ -410,6 +414,11 @@ msgstr "Aufgabe zum Prozess hinzufügen"
 #: ./opengever/task/viewlets/templates/actionmenuviewlet.pt
 msgid "label_agency"
 msgstr "Stellvertretung"
+
+#. Default: "Approved documents"
+#: ./opengever/task/transition.py
+msgid "label_approved_documents"
+msgstr "Genehmigte Dokumente"
 
 #. Default: "Assign to a ..."
 #: ./opengever/task/browser/assign_dossier.py

--- a/opengever/task/locales/en/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/en/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-04-23 10:53+0000\n"
+"POT-Creation-Date: 2021-08-18 08:25+0000\n"
 "PO-Revision-Date: 2015-02-17 18:41+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -327,6 +327,10 @@ msgstr "Select the repository folder in which the dossier should be created."
 msgid "help_accept_task_response"
 msgstr "Enter an answer text that will be shown as the response when the task is accepted."
 
+#: ./opengever/task/transition.py
+msgid "help_approved_documents"
+msgstr "Approved documents"
+
 #. German translation: Geben sie einen Antwort text ein, dieser wird bei der Aufgabenkopie als Antwort hinzugefügt.
 #. Default: "Enter a answer text which will be shown as response on the succesor task."
 #: ./opengever/task/browser/assign_dossier.py
@@ -494,6 +498,11 @@ msgstr "Add task to sequence"
 #: ./opengever/task/viewlets/templates/actionmenuviewlet.pt
 msgid "label_agency"
 msgstr "Deputy settings"
+
+#. Default: "Approved documents"
+#: ./opengever/task/transition.py
+msgid "label_approved_documents"
+msgstr "Approved documents"
 
 #. German translation: Weiterleitung zuweisen an ein ...
 #. Default: "Assign to a ..."

--- a/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-04-23 10:53+0000\n"
+"POT-Creation-Date: 2021-08-18 08:25+0000\n"
 "PO-Revision-Date: 2017-12-03 11:47+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-task/fr/>\n"
@@ -274,6 +274,10 @@ msgstr "Choix du numéro de classement où le dossier doit être créé."
 msgid "help_accept_task_response"
 msgstr "Saisie d'un texte pour la réponse créée automatiquement."
 
+#: ./opengever/task/transition.py
+msgid "help_approved_documents"
+msgstr ""
+
 #. Default: "Enter a answer text which will be shown as response on the succesor task."
 #: ./opengever/task/browser/assign_dossier.py
 msgid "help_assign_to_dossier_task_response"
@@ -412,6 +416,11 @@ msgstr "Ajouter tâche au processus"
 #: ./opengever/task/viewlets/templates/actionmenuviewlet.pt
 msgid "label_agency"
 msgstr "Suppléance"
+
+#. Default: "Approved documents"
+#: ./opengever/task/transition.py
+msgid "label_approved_documents"
+msgstr ""
 
 #. Default: "Assign to a ..."
 #: ./opengever/task/browser/assign_dossier.py

--- a/opengever/task/locales/opengever.task.pot
+++ b/opengever/task/locales/opengever.task.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-04-23 10:53+0000\n"
+"POT-Creation-Date: 2021-08-18 08:25+0000\n"
 "PO-Revision-Date: 2009-02-25 14:39+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -273,6 +273,10 @@ msgstr ""
 msgid "help_accept_task_response"
 msgstr ""
 
+#: ./opengever/task/transition.py
+msgid "help_approved_documents"
+msgstr ""
+
 #. Default: "Enter a answer text which will be shown as response on the succesor task."
 #: ./opengever/task/browser/assign_dossier.py
 msgid "help_assign_to_dossier_task_response"
@@ -409,6 +413,11 @@ msgstr ""
 #. Default: "Agency"
 #: ./opengever/task/viewlets/templates/actionmenuviewlet.pt
 msgid "label_agency"
+msgstr ""
+
+#. Default: "Approved documents"
+#: ./opengever/task/transition.py
+msgid "label_approved_documents"
 msgstr ""
 
 #. Default: "Assign to a ..."

--- a/opengever/task/sources.py
+++ b/opengever/task/sources.py
@@ -1,0 +1,35 @@
+from opengever.document.document import IBaseDocument
+from plone import api
+from plone.uuid.interfaces import IUUID
+from zope.interface import implementer
+from zope.schema.interfaces import IContextSourceBinder
+from zope.schema.interfaces import ISource
+
+
+@implementer(ISource)
+class DocumentsFromTaskSource(object):
+    """Builds UIDs of documents either contained in or related to a task.
+    """
+    def __init__(self, context):
+        self.context = context
+        task_path = '/'.join(self.context.getPhysicalPath())
+        catalog = api.portal.get_tool('portal_catalog')
+
+        related_docs = [rel.to_object for rel in self.context.relatedItems]
+        contained_docs = catalog.unrestrictedSearchResults(
+            path=task_path,
+            object_provides=IBaseDocument.__identifier__,
+        )
+
+        self.all_uids = [b.UID for b in contained_docs] + \
+                        [IUUID(obj) for obj in related_docs]
+
+    def __contains__(self, value):
+        return value in self.all_uids
+
+
+@implementer(IContextSourceBinder)
+class DocumentsFromTaskSourceBinder(object):
+
+    def __call__(self, context):
+        return DocumentsFromTaskSource(context)

--- a/opengever/task/task_response.py
+++ b/opengever/task/task_response.py
@@ -4,6 +4,7 @@ from persistent.list import PersistentList
 from z3c.relationfield.schema import RelationList
 from zope import schema
 from zope.interface import implements
+from zope.schema import List
 
 
 class ITaskResponse(IResponse):
@@ -25,6 +26,9 @@ class ITaskResponse(IResponse):
 
     related_items = RelationList(required=False)
 
+    # Documents approved during task resolution
+    approved_documents = RelationList(required=False)
+
 
 class TaskResponse(Response):
 
@@ -38,6 +42,7 @@ class TaskResponse(Response):
         self.mimetype = ''
         self.added_objects = PersistentList()
         self.related_items = PersistentList()
+        self.approved_documents = PersistentList()
 
     def add_related_item(self, relation):
         self.related_items.append(relation)

--- a/opengever/task/tests/test_sources.py
+++ b/opengever/task/tests/test_sources.py
@@ -1,0 +1,29 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.task.sources import DocumentsFromTaskSource
+from opengever.testing import IntegrationTestCase
+from plone.uuid.interfaces import IUUID
+
+
+class TestTaskSources(IntegrationTestCase):
+
+    def test_docs_from_task_source_contains_related_and_contained(self):
+        self.login(self.dossier_responsible)
+
+        contained_doc = create(
+            Builder('document')
+            .titled(u'Sanierung B\xe4rengraben.docx')
+            .within(self.subtask))
+
+        self.assertEqual(1, len(self.subtask.relatedItems))
+        related_doc = self.subtask.relatedItems[0].to_object
+
+        source = DocumentsFromTaskSource(self.subtask)
+
+        self.assertIn(IUUID(contained_doc), source)
+        self.assertIn(IUUID(related_doc), source)
+
+        self.assertItemsEqual(
+            [IUUID(contained_doc), IUUID(related_doc)],
+            source.all_uids,
+        )

--- a/opengever/task/transition.py
+++ b/opengever/task/transition.py
@@ -29,6 +29,7 @@ from z3c.form import validator
 from z3c.relationfield.relation import RelationValue
 from z3c.relationfield.schema import RelationChoice
 from z3c.relationfield.schema import RelationList
+from zExceptions import BadRequest
 from zope import schema
 from zope.component import adapter
 from zope.component import getUtility
@@ -267,6 +268,11 @@ class ResolveTransitionExtender(DefaultTransitionExtender):
         approved_documents = map(unrestrictedUuidToObject, approved_documents)
 
         if approved_documents:
+            if self.context.task_type != 'approval':
+                raise BadRequest(
+                    "Param 'approved_documents' is only supported for tasks "
+                    "of task_type 'approval'.")
+
             for doc in approved_documents:
                 approvals = IApprovalList(doc)
                 versioner = Versioner(doc)

--- a/opengever/task/transition.py
+++ b/opengever/task/transition.py
@@ -255,10 +255,12 @@ class ResolveTransitionExtender(DefaultTransitionExtender):
     schemas = [IResponse, IApprovedDocuments]
 
     def after_transition_hook(self, transition, disable_sync, transition_params):
-        self.maybe_approve_documents(transition_params)
+        approved_documents = self.maybe_approve_documents(transition_params)
         response = add_simple_response(
             self.context, transition=transition,
-            text=transition_params.get('text'))
+            text=transition_params.get('text'),
+            approved_documents=approved_documents,
+        )
 
         self.save_related_items(response, transition_params.get('relatedItems'))
         self.sync_change(transition, transition_params.get('text'), disable_sync)

--- a/opengever/task/transition.py
+++ b/opengever/task/transition.py
@@ -3,6 +3,9 @@ from opengever.activity.roles import TASK_RESPONSIBLE_ROLE
 from opengever.base.source import DossierPathSourceBinder
 from opengever.base.transition import ITransitionExtender
 from opengever.base.transition import TransitionExtender
+from opengever.base.utils import unrestrictedUuidToObject
+from opengever.document.approvals import IApprovalList
+from opengever.document.versioner import Versioner
 from opengever.ogds.base.sources import AllUsersAndGroupsSourceBinder
 from opengever.ogds.base.sources import AllUsersInboxesAndTeamsSourceBinder
 from opengever.task import _
@@ -17,6 +20,7 @@ from opengever.task.browser.modify_deadline import validate_deadline_changed
 from opengever.task.interfaces import IDeadlineModifier
 from opengever.task.localroles import LocalRolesSetter
 from opengever.task.response_syncer import sync_task_response
+from opengever.task.sources import DocumentsFromTaskSourceBinder
 from opengever.task.task import ITask
 from opengever.task.util import add_simple_response
 from plone import api
@@ -103,6 +107,20 @@ class INewResponsibleSchema(Schema):
         description=_(u'help_responsible_client', default=u''),
         vocabulary='opengever.ogds.base.OrgUnitsVocabularyFactory',
         required=True)
+
+
+class IApprovedDocuments(Schema):
+
+    approved_documents = schema.List(
+        title=_(u"label_approved_documents", default=u"Approved documents"),
+        description=_(u"help_approved_documents", default=u""),
+        value_type=schema.Choice(
+            source=DocumentsFromTaskSourceBinder(),
+            ),
+        required=False,
+        missing_value=[],
+        default=[]
+    )
 
 
 class NoTeamsInProgressStateValidator(validator.SimpleFieldValidator):
@@ -233,15 +251,30 @@ validator.WidgetValidatorDiscriminators(
 @adapter(ITask, IBrowserRequest)
 class ResolveTransitionExtender(DefaultTransitionExtender):
 
-    schemas = [IResponse, ]
+    schemas = [IResponse, IApprovedDocuments]
 
     def after_transition_hook(self, transition, disable_sync, transition_params):
+        self.maybe_approve_documents(transition_params)
         response = add_simple_response(
             self.context, transition=transition,
             text=transition_params.get('text'))
 
         self.save_related_items(response, transition_params.get('relatedItems'))
         self.sync_change(transition, transition_params.get('text'), disable_sync)
+
+    def maybe_approve_documents(self, transition_params):
+        approved_documents = transition_params.get('approved_documents', [])
+        approved_documents = map(unrestrictedUuidToObject, approved_documents)
+
+        if approved_documents:
+            for doc in approved_documents:
+                approvals = IApprovalList(doc)
+                versioner = Versioner(doc)
+                current_version_id = versioner.get_current_version_id(
+                    missing_as_zero=True)
+                approvals.add(current_version_id, self.context)
+
+        return approved_documents
 
 
 @implementer(ITransitionExtender)

--- a/opengever/task/util.py
+++ b/opengever/task/util.py
@@ -94,12 +94,13 @@ def get_task_type_title(task_type, language):
 
 def add_simple_response(task, text='', field_changes=None, added_objects=None,
                         successor_oguid=None, supress_events=False,
-                        supress_activity=False, **kwargs):
+                        supress_activity=False, approved_documents=(), **kwargs):
     """Add a simple response which does (not change the task itself).
     `task`: task context
     `text`: fulltext
     `added_objects`: objects which were added to the task
     `successor_oguid`: an OGUID to a (remote) object which was referenced.
+    `approved_documents`: Documents that have been approved.
     """
 
     response = TaskResponse()
@@ -122,6 +123,12 @@ def add_simple_response(task, text='', field_changes=None, added_objects=None,
         for obj in added_objects:
             iid = intids.getId(obj)
             response.added_objects.append(RelationValue(iid))
+
+    if approved_documents:
+        intids = getUtility(IIntIds)
+        for obj in approved_documents:
+            iid = intids.getId(obj)
+            response.approved_documents.append(RelationValue(iid))
 
     if successor_oguid:
         response.successor_oguid = successor_oguid


### PR DESCRIPTION
This allows to supply an additional transition parameter `approved_documents` with UIDs of documents that should be approved when executing the `@workflow` transition `task-transition-in-progress-resolved` for a task with task_type `approval`.

Example:

```http
POST /dossier-20/task-5/@workflow/task-transition-in-progress-resolved

{
  "text": "Ich genehmige diese Dokumente",
  "approved_documents": [
    "7dce9cda657f41d883b72c66ce718034"
  ]
}
```

Any approved documents will be referenced from the TaskResponse that is generated when resolving the task. The response serialization then includes these approved documents:

_(Responses can be accessed via `task-5/@responses/<response_id>` or as part of the regular task `GET`, like in this example)._ 

```json
{
    "...": "...",
    "responses": [
        {"...": "..."},
        {
            "@id": "http://localhost:8081/fd/ordnungssystem/fuehrung/gemeinderecht/dossier-20/task-5/@responses/1629287754554118",
            "...": "...",
            "approved_documents": [
                {
                    "@id": "http://localhost:8081/fd/ordnungssystem/fuehrung/gemeinderecht/dossier-20/task-5/document-49",
                    "@type": "opengever.document.document",
                    "checked_out": null,
                    "description": "",
                    "file_extension": ".xlsx",
                    "is_leafnode": null,
                    "review_state": "document-state-draft",
                    "title": "Excel"
                }
            ],
            "...": "...",
            "text": "Ich genehmige dieses Dokument",
            "transition": "task-transition-in-progress-resolved"
        }
    ],
    "...": "..."
}
``` 

## Notes / TODO

The cross-client aspects have not been implemented yet, because that's much easier to look at once a basic version is deployed on `dev`. But annotations / the approval list do not just get copied when transporting documents.

From what I can tell from tests, what we therefore would need to do is to create an `IDataCollector` that 

- extracts the `IApprovalList` for each document and serializes it (`extract()`)
- The `task_uid` in the approval list will have to be rewritten so that it matches the other side of the task-pair
- Reconstruct the approval list on the transported document using this information (`insert()`)


For [CA-2269](https://4teamwork.atlassian.net/browse/CA-2269)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
- New functionality:
  - [x] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding` _(not tested, see notes / TODO)_
 
- New translations
  - [x] All msg-strings are unicode

