### PR TITLE
Show copy document to workspace action also in subdossiers.

### DIFF
--- a/changes/CA-2670.bugfix
+++ b/changes/CA-2670.bugfix
@@ -1,0 +1,1 @@
+Show copy document to workspace action also in subdossiers. [phgross]

--- a/opengever/api/tests/test_actions.py
+++ b/opengever/api/tests/test_actions.py
@@ -1292,12 +1292,13 @@ class TestWorkspaceClientFolderActions(FunctionalWorkspaceClientTestCase):
                           actions)
 
     @browsing
-    def test_workspace_actions_not_available_in_subdossier(self, browser):
+    def test_workspace_actions_not_available_in_subdossier_except_copy_to_workspace(self, browser):
         browser.login()
         subdossier = create(Builder('dossier').within(self.dossier))
         with self.workspace_client_env():
             self.link_workspace(self.dossier)
-            self.assert_workspace_actions_not_available(browser, subdossier)
+            self.assert_workspace_actions(browser, subdossier,
+                                          [self.copy_documents_to_workspace_action])
 
     @browsing
     def test_copy_documents_actions_not_available_in_dossier_without_linked_workspaces(self, browser):

--- a/opengever/base/browser/folder_buttons_availability.py
+++ b/opengever/base/browser/folder_buttons_availability.py
@@ -81,11 +81,8 @@ class FolderButtonsAvailabilityView(BrowserView):
 
     def _can_copy_between_workspace_and_dossier(self):
         """Only if the workspace_client_feature is enabled and
-        the context is a main dossier with linked workspaces.
+        the main dossier is open with linked workspaces.
         """
-        if not self._is_main_dossier():
-            return False
-
         if not self._is_open_dossier():
             return False
 
@@ -106,7 +103,8 @@ class FolderButtonsAvailabilityView(BrowserView):
 
     def is_copy_documents_from_workspace_available(self):
         return (
-            self._can_copy_between_workspace_and_dossier()
+            self._is_main_dossier()
+            and self._can_copy_between_workspace_and_dossier()
             and self._can_add_content_to_dossier()
         )
 


### PR DESCRIPTION
For [CA-2670]

With https://github.com/4teamwork/gever-ui/pull/1894 the frontend is always calling the endpoints on the main dossier.

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-2670]: https://4teamwork.atlassian.net/browse/CA-2670