### PR TITLE
Add support for groups in @share-content endpoint.

### DIFF
--- a/changes/CA-1923_1.feature
+++ b/changes/CA-1923_1.feature
@@ -1,0 +1,1 @@
+Add support for groups in @share-content endpoint. [tinagerber]

--- a/changes/CA-1923_2.feature
+++ b/changes/CA-1923_2.feature
@@ -1,0 +1,1 @@
+Include group users and groups in @actual-workspace-members endpoint. [tinagerber]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -9,10 +9,14 @@ API Changelog
 Breaking Changes
 ^^^^^^^^^^^^^^^^
 
+- ``@share-content``: Rename attributes ``users_to`` and ``users_cc`` to ``actors_to`` and ``actors_cc``.
+
 Other Changes
 ^^^^^^^^^^^^^
 
 - ``@workflow``: Transition ``task-transition-in-progress-resolved`` now accepts ``approved_documents`` transition parameter.
+- ``@share-content``: Support groups.
+- ``actual-workspace-members``: Include group users and add ``include_groups`` parameter to include groups.
 - ``@listing``: Add ``approval_state`` column
 - Include ``committee`` in proposal serialization.
 - Include ``proposal``, ``meeting``, ``submitted_proposal`` and ``submitted_with`` in document serialization.

--- a/docs/public/dev-manual/api/workspace/actual_workspace_members.rst
+++ b/docs/public/dev-manual/api/workspace/actual_workspace_members.rst
@@ -42,3 +42,44 @@ Der ``@actual-workspace-members`` Endpoint liefert ein Vokabular aller Mitgliede
           "items_total": 12
         }
 
+Mit dem Parameter ``include_groups`` werden auch die Gruppen zurückgegeben.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       GET /workspace2/@actual-workspace-members?include_groups=true&b_size=3 HTTP/1.1
+       Accept: application/json
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+        {
+          "@id": "http://localhost:8080/fd/workspaces/workspace-2/@actual-workspace-members",
+          "batching": {
+            "@id": "http://localhost:8080/fd/workspaces/workspace-2/@actual-workspace-members?b_size=3",
+            "first": "http://localhost:8080/fd/workspaces/workspace-2/@actual-workspace-members?b_start=0&b_size=3",
+            "last": "http://localhost:8080/fd/workspaces/workspace-2/@actual-workspace-members?b_start=9&b_size=3",
+            "next": "http://localhost:8080/fd/workspaces/workspace-2/@actual-workspace-members?b_start=3&b_size=3"
+          },
+          "items": [
+            {
+              "title": "Baerfuss Kaethi (kathi.barfuss)",
+              "token": "kathi.barfuss"
+            },
+            {
+              "title": "Gruppe A",
+              "token": "gruppe_a"
+            }
+            {
+              "title": "Gruppe B",
+              "token": "gruppe_b"
+            },
+          ],
+          "items_total": 12
+        }
+

--- a/docs/public/dev-manual/api/workspace/share_content.rst
+++ b/docs/public/dev-manual/api/workspace/share_content.rst
@@ -10,7 +10,7 @@ Mit dem ``@share-content`` Endpoint können Teamräume und Inhalte von Teamräum
     Accept: application/json
 
     {
-      "users_to": [
+      "actors_to": [
         {
           "title": "Baerfuss Kaethi (kathi.barfuss)",
           "token": "kathi.barfuss"
@@ -20,7 +20,7 @@ Mit dem ``@share-content`` Endpoint können Teamräume und Inhalte von Teamräum
           "token": "nicole.kohler"
         },
       ],
-      "users_cc": [
+      "actors_cc": [
         {
           "title": "Ziegler Robert (robert.ziegler)",
           "token": "robert.ziegler"

--- a/docs/public/dev-manual/api/workspace/share_content.rst
+++ b/docs/public/dev-manual/api/workspace/share_content.rst
@@ -1,6 +1,6 @@
 Inhalte teilen
 ==============
-Mit dem ``@share-content`` Endpoint können Teamräume und Inhalte von Teamräumen mit anderen Mitgliedern geteilt werden. Die ausgewählten Mitglieder erhalten eine E-Mail mit einem Hinweis zum geteilten Inhalt.
+Mit dem ``@share-content`` Endpoint können Teamräume und Inhalte von Teamräumen mit anderen Mitgliedern geteilt werden. Die ausgewählten Mitglieder erhalten eine E-Mail mit einem Hinweis zum geteilten Inhalt. Es können auch Gruppen ausgewählt werden.
 
 **Beispiel-Request**:
 
@@ -22,8 +22,8 @@ Mit dem ``@share-content`` Endpoint können Teamräume und Inhalte von Teamräum
       ],
       "actors_cc": [
         {
-          "title": "Ziegler Robert (robert.ziegler)",
-          "token": "robert.ziegler"
+          "title": "Gruppe A",
+          "token": "gruppe-a"
         }
       ],
       "comment": "Have you seen this ToDo yet?"

--- a/opengever/api/actual_workspace_members.py
+++ b/opengever/api/actual_workspace_members.py
@@ -1,3 +1,4 @@
+from opengever.ogds.base.sources import ActualWorkspaceGroupsSource
 from opengever.ogds.base.sources import ActualWorkspaceMembersSource
 from opengever.workspace.utils import is_within_workspace
 from plone.restapi.batching import HypermediaBatch
@@ -15,6 +16,11 @@ class ActualWorkspaceMembersGet(Service):
         source = ActualWorkspaceMembersSource(self.context)
         query = safe_unicode(self.request.form.get('query', ''))
         results = source.search(query)
+
+        if self.request.form.get('include_groups'):
+            group_source = ActualWorkspaceGroupsSource(self.context)
+            group_results = group_source.search(query)
+            results.extend(group_results)
 
         batch = HypermediaBatch(self.request, results)
 

--- a/opengever/api/share_content.py
+++ b/opengever/api/share_content.py
@@ -11,20 +11,19 @@ from zope.interface import alsoProvides
 
 class ShareContentPost(Service):
 
-    def get_email_adresses(self, users):
+    def get_email_adresses(self, actors):
         service = ogds_service()
-        emails = []
-        for user in users:
-            emails.append(service.fetch_user(user['token']).email)
+        for actor in actors:
+            emails.append(service.fetch_user(actor['token']).email)
         return ', '.join(emails)
 
     def extract_data(self):
         data = json_body(self.request)
         self.comment = data.get('comment', u'')
-        self.users_to = data.get('users_to', [])
-        if not self.users_to:
-            raise BadRequest("Property 'users_to' is required")
-        self.users_cc = data.get('users_cc', [])
+        self.actors_to = data.get('actors_to', [])
+        if not self.actors_to:
+            raise BadRequest("Property 'actors_to' is required")
+        self.actors_cc = data.get('actors_cc', [])
 
     def reply(self):
         if not is_within_workspace(self.context):
@@ -32,8 +31,8 @@ class ShareContentPost(Service):
         # Disable CSRF protection
         alsoProvides(self.request, IDisableCSRFProtection)
         self.extract_data()
-        emails_to = self.get_email_adresses(self.users_to)
-        emails_cc = self.get_email_adresses(self.users_cc)
+        emails_to = self.get_email_adresses(self.actors_to)
+        emails_cc = self.get_email_adresses(self.actors_cc)
 
         sender_id = api.user.get_current().getId()
         mailer = ContentSharingMailer()

--- a/opengever/api/share_content.py
+++ b/opengever/api/share_content.py
@@ -1,4 +1,4 @@
-from opengever.ogds.base.utils import ogds_service
+from opengever.ogds.base.actor import ActorLookup
 from opengever.workspace.content_sharing_mailer import ContentSharingMailer
 from opengever.workspace.utils import is_within_workspace
 from plone import api
@@ -12,9 +12,11 @@ from zope.interface import alsoProvides
 class ShareContentPost(Service):
 
     def get_email_adresses(self, actors):
-        service = ogds_service()
+        emails = set()
         for actor in actors:
-            emails.append(service.fetch_user(actor['token']).email)
+            for representative in ActorLookup(actor['token']).lookup().representatives():
+                if representative.active:
+                    emails.add(representative.email)
         return ', '.join(emails)
 
     def extract_data(self):

--- a/opengever/api/tests/test_actual_workspace_members.py
+++ b/opengever/api/tests/test_actual_workspace_members.py
@@ -1,5 +1,6 @@
 from ftw.testbrowser import browsing
 from opengever.testing import IntegrationTestCase
+import json
 
 
 class TestActualWorkspaceMembersGet(IntegrationTestCase):
@@ -35,6 +36,29 @@ class TestActualWorkspaceMembersGet(IntegrationTestCase):
                         u'token': u'beatrice.schrodinger'}],
             u'items_total': 1}
         self.assertEqual(expected_json, browser.json)
+
+    @browsing
+    def test_get_actual_workspace_members_includes_group_users(self, browser):
+        self.login(self.workspace_admin, browser=browser)
+        browser.open(self.workspace, view='@actual-workspace-members', method='GET',
+                     headers=self.api_headers)
+        self.assertEqual(4, browser.json['items_total'])
+        self.assertNotIn({u'title': u'Kohler Nicole', u'token': u'nicole.kohler'},
+                         browser.json['items'])
+        self.assertNotIn({u'title': u'M\xfcller Fr\xe4nzi', u'token': u'franzi.muller'},
+                         browser.json['items'])
+
+        data = json.dumps({'participant': 'committee_rpk_group', 'role': 'WorkspaceMember'})
+        browser.open(self.workspace, view='/@participations/committee_rpk_group', method='POST',
+                     headers=self.api_headers, data=data)
+
+        browser.open(self.workspace, view='@actual-workspace-members', method='GET',
+                     headers=self.api_headers)
+        self.assertEqual(6, browser.json['items_total'])
+        self.assertIn({u'title': u'Kohler Nicole', u'token': u'nicole.kohler'},
+                      browser.json['items'])
+        self.assertIn({u'title': u'M\xfcller Fr\xe4nzi', u'token': u'franzi.muller'},
+                      browser.json['items'])
 
     @browsing
     def test_get_actual_workspace_members_outside_a_workspace(self, browser):

--- a/opengever/api/tests/test_actual_workspace_members.py
+++ b/opengever/api/tests/test_actual_workspace_members.py
@@ -61,6 +61,20 @@ class TestActualWorkspaceMembersGet(IntegrationTestCase):
                       browser.json['items'])
 
     @browsing
+    def test_get_actual_workspace_members_includes_groups(self, browser):
+        self.login(self.workspace_admin, browser=browser)
+
+        data = json.dumps({'participant': 'committee_rpk_group', 'role': 'WorkspaceMember'})
+        browser.open(self.workspace, view='/@participations/committee_rpk_group', method='POST',
+                     headers=self.api_headers, data=data)
+
+        browser.open(self.workspace, view='@actual-workspace-members?include_groups=true',
+                     method='GET', headers=self.api_headers)
+
+        self.assertEqual({u'token': u'committee_rpk_group', u'title': u'Test Group'},
+                         browser.json['items'][-1])
+
+    @browsing
     def test_get_actual_workspace_members_outside_a_workspace(self, browser):
         self.login(self.regular_user, browser=browser)
         url = self.document.absolute_url() + '/@actual-workspace-members'

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -46,7 +46,7 @@ class TestConfig(IntegrationTestCase):
         self.assertEqual(browser.status_code, 200)
         self.assertEqual(browser.json['current_user'].get(u'id'), u'kathi.barfuss')
         self.assertEqual(browser.json['current_user'].get(u'fullname'), u'B\xe4rfuss K\xe4thi')
-        self.assertEqual(browser.json['current_user'].get(u'email'), u'kathi.barfuss@gever.local')
+        self.assertEqual(browser.json['current_user'].get(u'email'), u'foo@example.com')
 
     @browsing
     def test_config_contains_features(self, browser):

--- a/opengever/api/tests/test_invitation.py
+++ b/opengever/api/tests/test_invitation.py
@@ -44,7 +44,7 @@ class TestInvitationsPost(IntegrationTestCase):
                 u'@id': u'http://nohost/plone/workspaces/workspace-1/@invitations/{}'.format(iid),
                 u'@type': u'virtual.participations.invitation',
                 u'inviter_fullname': u'Hugentobler Fridolin (fridolin.hugentobler)',
-                u'recipient_email': u'kathi.barfuss@gever.local',
+                u'recipient_email': u'foo@example.com',
                 u'role': {
                     'token': 'WorkspaceGuest',
                     'title': 'Guest',

--- a/opengever/api/tests/test_share_content.py
+++ b/opengever/api/tests/test_share_content.py
@@ -20,8 +20,8 @@ class TestShareContentPost(IntegrationTestCase):
 
         url = '{}/@share-content'.format(self.workspace.absolute_url())
         data = json.dumps({
-            'users_to': [{'token': self.archivist.getId()}],
-            'users_cc': [{'token': self.workspace_admin.getId()}],
+            'actors_to': [{'token': self.archivist.getId()}],
+            'actors_cc': [{'token': self.workspace_admin.getId()}],
             'comment': u'Check out this fantastic w\xf6rkspace!'
         })
 
@@ -46,10 +46,10 @@ class TestShareContentPost(IntegrationTestCase):
 
         url = '{}/@share-content'.format(self.workspace_folder.absolute_url())
         data = json.dumps({
-            'users_to': [{'token': self.archivist.getId()},
-                         {'token': self.workspace_guest.getId()}],
-            'users_cc': [{'token': self.workspace_admin.getId()},
-                         {'token': self.workspace_owner.getId()}],
+            'actors_to': [{'token': self.archivist.getId()},
+                          {'token': self.workspace_guest.getId()}],
+            'actors_cc': [{'token': self.workspace_admin.getId()},
+                          {'token': self.workspace_owner.getId()}],
             'comment': u'Check out this fantastic w\xf6rkspace!'
         })
 
@@ -78,7 +78,7 @@ class TestShareContentPost(IntegrationTestCase):
 
         url = '{}/@share-content'.format(self.workspace.absolute_url())
         data = json.dumps({
-            'users_to': [{'token': self.archivist.getId()}],
+            'actors_to': [{'token': self.archivist.getId()}],
         })
 
         browser.open(url, method='POST', headers=self.api_headers,
@@ -102,7 +102,7 @@ class TestShareContentPost(IntegrationTestCase):
 
         url = '{}/@share-content'.format(doc_in_workspace.absolute_url())
         data = json.dumps({
-            'users_to': [{'token': self.workspace_admin.getId()}],
+            'actors_to': [{'token': self.workspace_admin.getId()}],
         })
         browser.open(url, method='POST', headers=self.api_headers,
                      data=data)
@@ -120,7 +120,7 @@ class TestShareContentPost(IntegrationTestCase):
             browser.json)
 
     @browsing
-    def test_share_content_without_users_to_raises_bad_request(self, browser):
+    def test_share_content_without_actors_to_raises_bad_request(self, browser):
         self.login(self.workspace_member, browser=browser)
         process_mail_queue()
         mailing = Mailing(self.portal)
@@ -129,7 +129,7 @@ class TestShareContentPost(IntegrationTestCase):
         url = '{}/@share-content'.format(self.workspace.absolute_url())
         comment = u'Check out this fantastic w\xf6rkspace!'
         data = json.dumps({
-            'users_cc': [{'token': self.workspace_admin.getId()}],
+            'actors_cc': [{'token': self.workspace_admin.getId()}],
             'comment': comment
         })
 
@@ -138,6 +138,6 @@ class TestShareContentPost(IntegrationTestCase):
                          data=data)
 
         self.assertEqual(
-            {"message": "Property 'users_to' is required",
+            {"message": "Property 'actors_to' is required",
              "type": "BadRequest"},
             browser.json)

--- a/opengever/base/tests/test_configuration_adapter.py
+++ b/opengever/base/tests/test_configuration_adapter.py
@@ -29,7 +29,7 @@ class TestConfigurationAdapter(IntegrationTestCase):
                                           'principal:AuthenticatedUsers',
                                           'principal:fa_users',
                                           'Anonymous']),
-                ('email', u'kathi.barfuss@gever.local'),
+                ('email', u'foo@example.com'),
                 ('location', None),
                 ('portrait', None),
                 ('fullname', u'B\xe4rfuss K\xe4thi'),

--- a/opengever/sharing/tests/test_sharing.py
+++ b/opengever/sharing/tests/test_sharing.py
@@ -391,8 +391,7 @@ class TestOpengeverSharing(IntegrationTestCase):
                      method='Get', headers={'Accept': 'application/json'})
 
         result = browser.json
-
-        self.assertEqual(20, result['items_total'])
+        self.assertEqual(19, result['items_total'])
         self.assertEqual(3, len(result['items']))
         self.assertIn('batching', result)
 

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -2045,7 +2045,11 @@ class OpengeverContentFixture(object):
         )
 
         builder.update_properties()  # updates builder.userid
-        email = '{}@gever.local'.format(builder.userid)
+        if 'email' in kwargs:
+            email = kwargs['email']
+        else:
+            email = '{}@gever.local'.format(builder.userid)
+
         plone_user = create(builder.with_email(email))
 
         create(

--- a/opengever/workspace/tests/test_workspace_sources.py
+++ b/opengever/workspace/tests/test_workspace_sources.py
@@ -101,36 +101,6 @@ class TestActualWorkspaceMembersSource(IntegrationTestCase):
         # User from other admin_unit is also valid
         self.assertIn('peter.meier', source)
 
-    def test_only_users_of_current_admin_unit_are_found_by_search(self):
-        self.login(self.workspace_admin)
-        source = ActualWorkspaceMembersSource(self.workspace)
-
-        admin_unit2 = create(Builder('admin_unit')
-                             .id('additional')
-                             .having(title='additional'))
-
-        org_unit_3 = create(Builder('org_unit')
-                            .id('org-unit-3')
-                            .having(title=u"Org Unit 3", admin_unit=admin_unit2)
-                            .with_default_groups())
-
-        peter = create(Builder('ogds_user').id('peter.meier')
-                       .having(firstname='Peter', lastname='Meier')
-                       .assign_to_org_units([org_unit_3]))
-
-        RoleAssignmentManager(self.workspace).add_or_update(
-            self.regular_user.id, ['WorkspaceGuest'], ASSIGNMENT_VIA_INVITATION)
-        RoleAssignmentManager(self.workspace).add_or_update(
-            peter.userid, ['WorkspaceGuest'], ASSIGNMENT_VIA_INVITATION)
-
-        results = source.search(self.regular_user.id)
-        self.assertEqual(1, len(results))
-        self.assertEqual(self.regular_user.id, results[0].value)
-
-        # User from other admin_unit cannot be found
-        results = source.search('peter.meier')
-        self.assertEqual(0, len(results))
-
     def test_users_with_and_without_local_roles_are_valid(self):
         self.login(self.workspace_admin)
         source = ActualWorkspaceMembersSource(self.workspace)

--- a/opengever/workspace/utils.py
+++ b/opengever/workspace/utils.py
@@ -48,6 +48,10 @@ def get_workspace_user_ids(context, disregard_block=False):
     return get_workspace_actor_ids(context, 'user', disregard_block)
 
 
+def get_workspace_group_ids(context):
+    return get_workspace_actor_ids(context, 'group')
+
+
 def get_workspace_actor_ids(context, actor_type, disregard_block=False, ):
     """ Walks up the Acquisition chain and collects all userids assigned
     to a role with the View permission.

--- a/opengever/workspace/utils.py
+++ b/opengever/workspace/utils.py
@@ -45,6 +45,10 @@ def get_containing_workspace(context):
 
 
 def get_workspace_user_ids(context, disregard_block=False):
+    return get_workspace_actor_ids(context, 'user', disregard_block)
+
+
+def get_workspace_actor_ids(context, actor_type, disregard_block=False, ):
     """ Walks up the Acquisition chain and collects all userids assigned
     to a role with the View permission.
     """
@@ -52,23 +56,23 @@ def get_workspace_user_ids(context, disregard_block=False):
     if not containing_workspace:
         return []
 
-    users = set([])
+    actor_ids = set([])
     allowed_roles_to_view = roles_of_permission(containing_workspace, 'View')
     portal = api.portal.get()
 
-    def is_valid_userid(*args):
-        user, roles, role_type, name = args
-        return role_type == u'user' and set(roles) & set(allowed_roles_to_view)
+    def is_valid_actorid(valid_role_type, actor, roles, role_type, name):
+        return role_type == valid_role_type and set(roles) & set(allowed_roles_to_view)
 
     for content in aq_chain(containing_workspace):
         if aq_base(content) == aq_base(portal):
             break
-        userroles = portal.acl_users._getLocalRolesForDisplay(content)
-        users = users.union(set(
+        actorroles = portal.acl_users._getLocalRolesForDisplay(content)
+        actor_ids = actor_ids.union(set(
             map(itemgetter(0),
-                filter(lambda args: is_valid_userid(*args), userroles))))
+                filter(lambda args: is_valid_actorid(actor_type, *args), actorroles))))
+
         if getattr(aq_base(containing_workspace), '__ac_local_roles_block__', None) \
                 and not disregard_block:
             break
 
-    return list(users)
+    return list(actor_ids)

--- a/opengever/workspace/vocabularies.py
+++ b/opengever/workspace/vocabularies.py
@@ -69,7 +69,7 @@ class ActualWorkspaceMembersVocabulary(object):
     def __call__(self, context):
         terms = []
         query = ActualWorkspaceMembersSource(context).search_query
-        query = query.filter_by(active=True)
+        query = query.filter(User.active == True)  # noqa
         query = query.order_by(asc(func.lower(User.lastname)),
                                asc(func.lower(User.firstname)))
 


### PR DESCRIPTION
Changes in this PR:
- The `ActualWorkspaceMembersSource` is extended so that the users of groups are also included
- With the parameter `include_groups` groups can now be included in the `@actual-workspace-members` endpoint
-  The `@share-content` endpoint can now handle groups

For [CA-1923]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [x] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed

[CA-1923]: https://4teamwork.atlassian.net/browse/CA-1923