### PR TITLE
Fix handling of relations when an object is deleted.

### DIFF
--- a/changes/CA-371.bugfix
+++ b/changes/CA-371.bugfix
@@ -1,0 +1,1 @@
+Fix handling of relations when an object is deleted. [njohner]

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -33,6 +33,7 @@
   <adapter factory=".serializer.SerializeBrainToJsonSummary" />
   <adapter factory=".serializer.SerializeAdminUnitModelToJsonSummary" />
   <adapter factory=".serializer.SerializeOrgUnitModelToJsonSummary" />
+  <adapter factory=".serializer.GeverRelationListFieldSerializer" />
 
   <adapter factory=".actors.SerializeActorToJson" />
   <adapter factory=".repositoryfolder.DeserializeRepositoryFolderFromJson" />

--- a/opengever/api/serializer.py
+++ b/opengever/api/serializer.py
@@ -29,17 +29,20 @@ from opengever.repository.interfaces import IRepositoryFolder
 from plone import api
 from plone.dexterity.interfaces import IDexterityContainer
 from plone.dexterity.interfaces import IDexterityContent
+from plone.restapi.interfaces import IFieldSerializer
 from plone.restapi.interfaces import IJsonCompatible
 from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.interfaces import ISerializeToJsonSummary
 from plone.restapi.serializer.converters import json_compatible
 from plone.restapi.serializer.dxcontent import SerializeFolderToJson
 from plone.restapi.serializer.dxcontent import SerializeToJson
+from plone.restapi.serializer.relationfield import RelationListFieldSerializer
 from plone.restapi.serializer.group import SerializeGroupToJson
 from plone.restapi.serializer.summary import DefaultJSONSummarySerializer
 from Products.PlonePAS.interfaces.group import IGroupData
 from Products.ZCatalog.interfaces import ICatalogBrain
 from sqlalchemy import func
+from z3c.relationfield.interfaces import IRelationList
 from zc.relation.interfaces import ICatalog
 from zope.component import adapter
 from zope.component import getMultiAdapter
@@ -50,7 +53,6 @@ from zope.interface import implementer
 from zope.interface import Interface
 from zope.intid.interfaces import IIntIds
 import logging
-
 
 logger = logging.getLogger('opengever.api.serializer')
 
@@ -161,6 +163,15 @@ class GeverSerializeFolderToJson(SerializeFolderToJson):
 
         drop_inactive_language_fields(result)
         return result
+
+
+@adapter(IRelationList, IDexterityContent, IOpengeverBaseLayer)
+@implementer(IFieldSerializer)
+class GeverRelationListFieldSerializer(RelationListFieldSerializer):
+
+    def __call__(self):
+        value = super(RelationListFieldSerializer, self).__call__()
+        return [item for item in value if item is not None]
 
 
 @adapter(long)

--- a/opengever/base/monkey/patches/__init__.py
+++ b/opengever/base/monkey/patches/__init__.py
@@ -28,6 +28,7 @@ from .readonly import PatchMembershipToolSetLoginTimes
 from .readonly import PatchPloneProtectOnUserLogsIn
 from .readonly import PatchPloneUserAllowed
 from .readonly import PatchPloneUserGetRolesInContext
+from .relation_fields import PatchRelationFieldEventHandlers
 from .resource_registries_url_regex import PatchResourceRegistriesURLRegex
 from .rolemanager import PatchOFSRoleManager
 from .scrub_bobo_exceptions import ScrubBoboExceptions
@@ -39,7 +40,6 @@ from .workflowtool import PatchWorkflowTool
 from opengever.debug import debug_modified_out_of_sync_env_var_is_set
 from opengever.debug.patches.modified_out_of_sync import PatchConnectionRegister
 from opengever.readonly import readonly_env_var_is_set
-
 
 PatchActionInfo()()
 PatchBaseOrderedViewletManagerExceptions()()
@@ -58,6 +58,8 @@ PatchDXContainerPastePermission()()
 PatchDXCreateContentInContainer()()
 PatchExceptionFormatter()()
 PatchExtendedPathIndex()()
+PatchFullHistory()()
+PatchGetJsonschemaForPortalType()()
 PatchInvokeFactory()()
 PatchMembershipToolCreateMemberarea()()
 PatchMembershipToolSetLoginTimes()()
@@ -65,6 +67,7 @@ PatchNamedfileNamedDataConverter()()
 PatchOFSRoleManager()()
 PatchPlone43RC1Upgrade()()
 PatchPloneProtectOnUserLogsIn()()
+PatchRelationFieldEventHandlers()()
 PatchResourceRegistriesURLRegex()()
 PatchSessionCookie()()
 PatchTransmogrifyDXSchemaUpdater()()
@@ -74,8 +77,6 @@ PatchZ2LogTimezone()()
 PatchZ3CFormChangedField()()
 PatchZ3CFormWidgetUpdate()()
 ScrubBoboExceptions()()
-PatchGetJsonschemaForPortalType()()
-PatchFullHistory()()
 
 # These three patches implement role and permission filtering during RO mode.
 # We only apply these conditionally when RO mode actually is active.

--- a/opengever/base/monkey/patches/relation_fields.py
+++ b/opengever/base/monkey/patches/relation_fields.py
@@ -1,0 +1,37 @@
+from opengever.base.monkey.patching import MonkeyPatch
+
+
+class PatchRelationFieldEventHandlers(MonkeyPatch):
+    """Monkeypatch for z3c.relation.event._potential_relations
+    """
+
+    def __call__(self):
+        from z3c.relationfield.interfaces import IRelation
+        from z3c.relationfield.interfaces import IRelationList
+        from zope.interface import providedBy
+        from zope.schema import getFields
+
+        def _potential_relations(obj):
+            """Copy of z3c.relation.event._potential_relations
+            """
+            for iface in providedBy(obj).flattened():
+                for name, field in getFields(iface).items():
+                    if IRelation.providedBy(field):
+                        try:
+                            relation = getattr(obj, name)
+                        except AttributeError:
+                            # can't find this relation on the object
+                            continue
+                        yield name, None, relation
+                    if IRelationList.providedBy(field):
+                        try:
+                            l = getattr(obj, name)
+                        except AttributeError:
+                            # can't find the relation list on this object
+                            continue
+                        if l is not None:
+                            for i, relation in enumerate(l):
+                                yield name, i, relation
+
+        from z3c.relationfield import event
+        self.patch_refs(event, '_potential_relations', _potential_relations)

--- a/opengever/core/upgrades/20210819081602_clean_up_relation_catalog/upgrade.py
+++ b/opengever/core/upgrades/20210819081602_clean_up_relation_catalog/upgrade.py
@@ -1,0 +1,19 @@
+from ftw.upgrade import UpgradeStep
+from zc.relation.interfaces import ICatalog
+from zope import component
+
+
+class CleanUpRelationCatalog(UpgradeStep):
+    """Clean up relation catalog.
+    """
+
+    deferrable = True
+
+    def __call__(self):
+        catalog = component.queryUtility(ICatalog)
+        for relation in catalog:
+            if relation.to_object is None:
+                if not relation.isBroken():
+                    relation.broken(None)
+            if relation.from_object is None:
+                catalog.unindex(relation)

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -301,7 +301,7 @@ class Document(Item, BaseDocumentMixin):
         relations = IRelatedDocuments(self).relatedItems
 
         if relations:
-            _related_items += [rel.to_object for rel in relations]
+            _related_items += [rel.to_object for rel in relations if not rel.isBroken()]
 
         if bidirectional:
             catalog = getUtility(ICatalog)

--- a/opengever/document/tests/test_behaviors.py
+++ b/opengever/document/tests/test_behaviors.py
@@ -39,6 +39,15 @@ class TestRelatedDocuments(IntegrationTestCase):
         self.assertTrue(related_docs[0].isBroken())
         self.assertIsNone(related_docs[0].to_object)
 
+    def test_related_items_does_not_include_broken_relations(self):
+        self.login(self.manager)
+        related_docs = self.subdocument.related_items()
+        self.assertEqual(self.document, related_docs[0])
+
+        api.content.delete(self.document)
+        related_docs = self.subdocument.related_items()
+        self.assertEqual(0, len(related_docs))
+
     def test_relations_get_removed_when_from_object_is_deleted(self):
         self.login(self.manager)
         catalog = component.queryUtility(ICatalog)

--- a/opengever/document/tests/test_document.py
+++ b/opengever/document/tests/test_document.py
@@ -139,7 +139,16 @@ class TestDocument(IntegrationTestCase):
         self.login(self.regular_user)
         self.assertEqual([], self.document.related_items())
         self.assertEqual([self.document], self.subdocument.related_items())
-        self.assertEqual([self.document, self.subdocument], self.subsubdocument.related_items())
+        self.assertEqual([self.document, self.subdocument],
+                         self.subsubdocument.related_items())
+
+        self.assertItemsEqual(
+            [self.proposal, self.subdocument, self.subsubdocument, self.task,
+             self.subtask, self.info_task, self.private_task, self.inbox_task],
+            self.document.related_items(bidirectional=True))
+        self.assertItemsEqual(
+            [self.subdocument, self.subsubdocument],
+            self.document.related_items(bidirectional=True, documents_only=True))
 
     def test_is_removed(self):
         self.login(self.regular_user)

--- a/opengever/dossier/browser/overview.py
+++ b/opengever/dossier/browser/overview.py
@@ -183,7 +183,8 @@ class DossierOverview(BoxesViewMixin, BrowserView, GeverTabMixin):
         ids = self.get_dossier_back_relations()
         if IDossier(self.context).relatedDossier:
             for rel in IDossier(self.context).relatedDossier:
-                ids.append(rel.to_id)
+                if not rel.isBroken():
+                    ids.append(rel.to_id)
 
         for iid in ids:
             obj = intids.queryObject(iid)


### PR DESCRIPTION
We fix the handling of relations when deleting an object. There were 2 main issues:
- The `z3c.relationfield` only handles fields stored on the object, while we store our relations in the annotations
- When the `to_object` of a relation is deleted, the relation remains in the catalog, but is marked as broken. We did not handle that case anywhere (API, overviews, etc).

I fixed the event handlers, so that relations get deleted from the catalog when the `from_object` is deleted. 
I also fixed the serializer, so that broken relations are not serialized to the frontend, so that we don't have to handle that case everywhere in the frontend (before they got serialized as `None`, so for a relation list `[None]`). 
I also added handling of broken relations for documents (and all derived types), as well as in the dossier overview, to cover the most likely cases. There are probably other places where we might still have failures, but this seems to never have been a problem. I did not want to invest more time, as this will only lead to errors in the classic ui, and as deletion is still something vera rare in Gever.

I did not add an API changelog entry for this.

For [CA-371] and [CA-2693]

Sentry: 
- https://sentry.4teamwork.ch/organizations/sentry/issues/76984
- https://sentry.4teamwork.ch/organizations/sentry/issues/77009

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed

[CA-371]: https://4teamwork.atlassian.net/browse/CA-371
[CA-2693]: https://4teamwork.atlassian.net/browse/CA-2693