### PR TITLE
Add new object-button action `protect_dossier`

### DIFF
--- a/changes/CA-2401.other
+++ b/changes/CA-2401.other
@@ -1,0 +1,1 @@
+Add new object-button action `protect_dossier`. [elioschmutz]

--- a/opengever/api/tests/test_actions.py
+++ b/opengever/api/tests/test_actions.py
@@ -1543,6 +1543,38 @@ class TestObjectButtonsGetForTemplates(ObjectButtonsTestBase):
         )
 
 
+class TestObjectButtonsGetForDossiers(ObjectButtonsTestBase):
+
+    @browsing
+    def test_available_object_button_actions_for_dossier(self, browser):
+        self.login(self.dossier_responsible, browser)
+        expected_object_buttons = [
+            {u'icon': u'', u'id': u'zipexport', u'title': u'Export as Zip'},
+            {u'icon': u'', u'id': u'properties', u'title': u'Properties'},
+            {u'icon': u'', u'id': u'pdf_dossierdetails', u'title': u'Print details (PDF)'},
+            {u'icon': u'', u'id': u'export_pdf', u'title': u'Cover page (PDF)'}
+        ]
+        self.assertListEqual(
+            expected_object_buttons,
+            self.get_object_buttons(browser, self.dossier),
+        )
+
+    @browsing
+    def test_available_object_button_actions_for_dossier_as_dossier_manager(self, browser):
+        self.login(self.dossier_manager, browser)
+        expected_object_buttons = [
+            {u'icon': u'', u'id': u'zipexport', u'title': u'Export as Zip'},
+            {u'icon': u'', u'id': u'properties', u'title': u'Properties'},
+            {u'icon': u'', u'id': u'protect_dossier', u'title': u'Protect dossier'},
+            {u'icon': u'', u'id': u'pdf_dossierdetails', u'title': u'Print details (PDF)'},
+            {u'icon': u'', u'id': u'export_pdf', u'title': u'Cover page (PDF)'}
+        ]
+        self.assertListEqual(
+            expected_object_buttons,
+            self.get_object_buttons(browser, self.dossier),
+        )
+
+
 class TestObjectButtonsGetForDossierTemplateDocuments(ObjectButtonsTestBase):
 
     @browsing

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -819,6 +819,19 @@
       <property name="visible">True</property>
     </object>
 
+    <object name="protect_dossier" meta_type="CMF Action" i18n:domain="plone">
+      <property name="title" i18n:translate="">Protect dossier</property>
+      <property name="description">Gever-UI action</property>
+      <property name="icon_expr" />
+      <property name="available_expr">
+        python:context.restrictedTraverse('@@plone_interface_info').provides('opengever.dossier.behaviors.protect_dossier.IProtectDossierMarker')
+      </property>
+      <property name="permissions">
+        <element value="opengever.dossier: Protect dossier" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
     <object name="prefix_manager" meta_type="CMF Action" i18n:domain="opengever.core">
       <property name="title" i18n:translate="">Prefix Manager</property>
       <property name="description" i18n:translate="">Unlock unused repository prefixes.</property>

--- a/opengever/core/upgrades/20210819233605_add_protect_dossier_action/actions.xml
+++ b/opengever/core/upgrades/20210819233605_add_protect_dossier_action/actions.xml
@@ -1,0 +1,20 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="portal_actions" meta_type="Plone Actions Tool">
+
+  <object name="object_buttons" meta_type="CMF Action Category">
+
+    <object name="protect_dossier" meta_type="CMF Action" i18n:domain="plone">
+      <property name="title" i18n:translate="">Protect dossier</property>
+      <property name="description">Gever-UI action</property>
+      <property name="icon_expr" />
+      <property name="available_expr">
+        python:context.restrictedTraverse('@@plone_interface_info').provides('opengever.dossier.behaviors.protect_dossier.IProtectDossierMarker')
+      </property>
+      <property name="permissions">
+        <element value="opengever.dossier: Protect dossier" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
+  </object>
+
+</object>

--- a/opengever/core/upgrades/20210819233605_add_protect_dossier_action/upgrade.py
+++ b/opengever/core/upgrades/20210819233605_add_protect_dossier_action/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddProtectDossierAction(UpgradeStep):
+    """Add protect dossier action.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/dossier/tests/test_dossier_workflow.py
+++ b/opengever/dossier/tests/test_dossier_workflow.py
@@ -25,7 +25,7 @@ class TestDossierWorkflow(IntegrationTestCase):
     def test_offer_transition_is_hidden_in_action_menu(self, browser):
         self.login(self.manager, browser)
         browser.visit(self.expired_dossier)
-        expected = ['Cover page (PDF)', 'Export as Zip',
+        expected = ['Cover page (PDF)', 'Export as Zip', 'Protect dossier',
                     'Print details (PDF)', 'Properties', 'Sharing',
                     'Policy...']
         self.assertItemsEqual(expected, self.get_action_menu_content())
@@ -35,7 +35,7 @@ class TestDossierWorkflow(IntegrationTestCase):
         self.login(self.dossier_manager, browser)
         browser.visit(self.dossier)
         expected = ['Cover page (PDF)', 'Export as Zip', 'Print details (PDF)',
-                    'Properties', 'Deactivate']
+                    'Properties', 'Deactivate', 'Protect dossier']
         self.assertItemsEqual(expected, self.get_action_menu_content())
 
     @browsing
@@ -43,6 +43,6 @@ class TestDossierWorkflow(IntegrationTestCase):
         self.login(self.manager, browser)
         browser.visit(self.dossier)
         expected = ['Cover page (PDF)', 'Export as Zip', 'Print details (PDF)',
-                    'Properties', 'Sharing', 'Deactivate',
+                    'Properties', 'Sharing', 'Deactivate', 'Protect dossier',
                     'Resolve', 'Policy...']
         self.assertItemsEqual(expected, self.get_action_menu_content())


### PR DESCRIPTION
This PR adds a new object-button action `protect_dosser` which is required for the new UI to decide if the current user is allowed to protect the dossier.

For [CA-2401]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-2401]: https://4teamwork.atlassian.net/browse/CA-2401