### PR TITLE
Expose `is_protected` in the dossier serializer.

### DIFF
--- a/changes/CA-2401_2.other
+++ b/changes/CA-2401_2.other
@@ -1,0 +1,1 @@
+Expose `is_protected` in the dossier serializer. [elioschmutz]

--- a/opengever/api/dossier.py
+++ b/opengever/api/dossier.py
@@ -5,6 +5,8 @@ from opengever.api.serializer import GeverSerializeFolderToJson
 from opengever.base.interfaces import IOpengeverBaseLayer
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.behaviors.dossier import IDossierMarker
+from opengever.dossier.behaviors.protect_dossier import IProtectDossier
+from opengever.dossier.behaviors.protect_dossier import IProtectDossierMarker
 from opengever.dossier.utils import get_main_dossier
 from plone.restapi.interfaces import IExpandableElement
 from plone.restapi.interfaces import ISerializeToJson
@@ -33,6 +35,8 @@ class SerializeDossierToJson(GeverSerializeFolderToJson):
             self.context)
         result[u'blocked_local_roles'] = bool(
             getattr(self.context.aq_inner, '__ac_local_roles_block__', False))
+        result[u'is_protected'] = IProtectDossier(self.context).is_dossier_protected() \
+            if IProtectDossierMarker.providedBy(self.context) else False
 
         extend_with_backreferences(
             result, self.context, self.request, 'relatedDossier')

--- a/opengever/api/tests/test_dossier.py
+++ b/opengever/api/tests/test_dossier.py
@@ -29,6 +29,12 @@ class TestDossierSerializer(IntegrationTestCase):
         self.assertIn("blocked_local_roles", browser.json)
 
     @browsing
+    def test_dossier_serializer_contains_is_protected(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.dossier, method="GET", headers=self.api_headers)
+        self.assertIn("is_protected", browser.json)
+
+    @browsing
     def test_undeterminable_subdossier_within_items(self, browser):
         self.login(self.regular_user, browser=browser)
         browser.open(self.dossier, method="GET", headers=self.api_headers)


### PR DESCRIPTION
This PR exposes the `is_protected` in the dossier serializer which is required for the new UI.

For [CA-2401]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-2401]: https://4teamwork.atlassian.net/browse/CA-2401