### PR TITLE
Rename label for "Reference prefix" to "Repository number" (en, de, fr)

### DIFF
--- a/changes/CA-2767.other
+++ b/changes/CA-2767.other
@@ -1,0 +1,1 @@
+Rename label for "Reference prefix" to "Repository number" (en, de, fr) [lgraf]

--- a/docs/public/dev-manual/api/schemas/opengever.repository.repositoryfolder.inc
+++ b/docs/public/dev-manual/api/schemas/opengever.repository.repositoryfolder.inc
@@ -236,7 +236,7 @@
 
    .. py:attribute:: reference_number_prefix
 
-       :Feldname: :field-title:`Präfix des Aktenzeichens`
+       :Feldname: :field-title:`Ordnungspositionsnummer`
        :Datentyp: ``TextLine``
        
        :Default: <Höchste auf dieser Ebene vergebene Nummer + 1>

--- a/docs/schema-dumps/opengever.repository.repositoryfolder.schema.json
+++ b/docs/schema-dumps/opengever.repository.repositoryfolder.schema.json
@@ -191,7 +191,7 @@
         },
         "reference_number_prefix": {
             "type": "string",
-            "title": "Pr\u00e4fix des Aktenzeichens",
+            "title": "Ordnungspositionsnummer",
             "description": "",
             "_zope_schema_type": "TextLine",
             "default": "<H\u00f6chste auf dieser Ebene vergebene Nummer + 1>"

--- a/opengever/bundle/schemas/repofolders.schema.json
+++ b/opengever/bundle/schemas/repofolders.schema.json
@@ -275,7 +275,7 @@
                         "null",
                         "string"
                     ],
-                    "title": "Pr\u00e4fix des Aktenzeichens",
+                    "title": "Ordnungspositionsnummer",
                     "description": "",
                     "_zope_schema_type": "TextLine",
                     "default": "<H\u00f6chste auf dieser Ebene vergebene Nummer + 1>"

--- a/opengever/repository/behaviors/referenceprefix.py
+++ b/opengever/repository/behaviors/referenceprefix.py
@@ -40,10 +40,18 @@ class IReferenceNumberPrefix(model.Schema):
             ],
         )
 
+    # In technical contexts, this field / concept is still called
+    # "reference number prefix", even though that's incorrect. In any user
+    # facing context, it should be called "Repository number".
+    #
+    # This term only refers to the local component of a single
+    # RepositoryFolder. For the full dotted number and the complete reference
+    # number, different terms are used ("rubric" and "reference number",
+    # respectively).
     reference_number_prefix = schema.TextLine(
         title=_(
             u'label_reference_number_prefix',
-            default=u'Reference Prefix'),
+            default=u'Repository number'),
         required=False,
         defaultFactory=reference_number_prefix_default,
         )

--- a/opengever/repository/locales/de/LC_MESSAGES/opengever.repository.po
+++ b/opengever/repository/locales/de/LC_MESSAGES/opengever.repository.po
@@ -193,7 +193,7 @@ msgstr "Aktenzeichen Zusatz"
 #. Default: "Repository number"
 #: ./opengever/repository/behaviors/referenceprefix.py
 msgid "label_reference_number_prefix"
-msgstr "Präfix des Aktenzeichens"
+msgstr "Ordnungspositionsnummer"
 
 #. Default: "Referenced activity"
 #: ./opengever/repository/repositoryfolder.py

--- a/opengever/repository/locales/de/LC_MESSAGES/opengever.repository.po
+++ b/opengever/repository/locales/de/LC_MESSAGES/opengever.repository.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-05-28 13:17+0000\n"
+"POT-Creation-Date: 2021-08-23 08:54+0000\n"
 "PO-Revision-Date: 2014-11-25 11:31+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -190,7 +190,7 @@ msgstr "Anträge"
 msgid "label_reference_number_addendum"
 msgstr "Aktenzeichen Zusatz"
 
-#. Default: "Reference Prefix"
+#. Default: "Repository number"
 #: ./opengever/repository/behaviors/referenceprefix.py
 msgid "label_reference_number_prefix"
 msgstr "Präfix des Aktenzeichens"

--- a/opengever/repository/locales/en/LC_MESSAGES/opengever.repository.po
+++ b/opengever/repository/locales/en/LC_MESSAGES/opengever.repository.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-05-28 13:17+0000\n"
+"POT-Creation-Date: 2021-08-23 08:54+0000\n"
 "PO-Revision-Date: 2014-11-25 11:31+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -225,10 +225,10 @@ msgid "label_reference_number_addendum"
 msgstr "Reference number addendum"
 
 #. German translation: Präfix des Aktenzeichens
-#. Default: "Reference Prefix"
+#. Default: "Repository number"
 #: ./opengever/repository/behaviors/referenceprefix.py
 msgid "label_reference_number_prefix"
-msgstr "Reference number component"
+msgstr "Repository number"
 
 #. German translation: Leistung
 #. Default: "Referenced activity"

--- a/opengever/repository/locales/en/LC_MESSAGES/opengever.repository.po
+++ b/opengever/repository/locales/en/LC_MESSAGES/opengever.repository.po
@@ -224,7 +224,7 @@ msgstr "Proposals"
 msgid "label_reference_number_addendum"
 msgstr "Reference number addendum"
 
-#. German translation: Präfix des Aktenzeichens
+#. German translation: Ordnungspositionsnummer
 #. Default: "Repository number"
 #: ./opengever/repository/behaviors/referenceprefix.py
 msgid "label_reference_number_prefix"

--- a/opengever/repository/locales/fr/LC_MESSAGES/opengever.repository.po
+++ b/opengever/repository/locales/fr/LC_MESSAGES/opengever.repository.po
@@ -192,7 +192,7 @@ msgstr "Numéro de référence addendum"
 #. Default: "Repository number"
 #: ./opengever/repository/behaviors/referenceprefix.py
 msgid "label_reference_number_prefix"
-msgstr "Préfixe référence"
+msgstr "Numéro de classement"
 
 #. Default: "Referenced activity"
 #: ./opengever/repository/repositoryfolder.py

--- a/opengever/repository/locales/fr/LC_MESSAGES/opengever.repository.po
+++ b/opengever/repository/locales/fr/LC_MESSAGES/opengever.repository.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-05-28 13:17+0000\n"
+"POT-Creation-Date: 2021-08-23 08:54+0000\n"
 "PO-Revision-Date: 2017-12-03 11:31+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-repository/fr/>\n"
@@ -189,7 +189,7 @@ msgstr "Requêtes"
 msgid "label_reference_number_addendum"
 msgstr "Numéro de référence addendum"
 
-#. Default: "Reference Prefix"
+#. Default: "Repository number"
 #: ./opengever/repository/behaviors/referenceprefix.py
 msgid "label_reference_number_prefix"
 msgstr "Préfixe référence"

--- a/opengever/repository/locales/opengever.repository.pot
+++ b/opengever/repository/locales/opengever.repository.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-05-28 13:17+0000\n"
+"POT-Creation-Date: 2021-08-23 08:54+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -190,7 +190,7 @@ msgstr ""
 msgid "label_reference_number_addendum"
 msgstr ""
 
-#. Default: "Reference Prefix"
+#. Default: "Repository number"
 #: ./opengever/repository/behaviors/referenceprefix.py
 msgid "label_reference_number_prefix"
 msgstr ""

--- a/opengever/repository/tests/test_reference_behavior.py
+++ b/opengever/repository/tests/test_reference_behavior.py
@@ -23,7 +23,7 @@ class TestReferenceBehavior(IntegrationTestCase):
         self.login(self.administrator, browser)
         browser.open(self.branch_repofolder)
         factoriesmenu.add('Repository Folder')
-        self.assertEquals('2', browser.find('Reference number component').value)
+        self.assertEquals('2', browser.find('Repository number').value)
 
     @browsing
     def test_using_already_used_prefix_is_not_possible(self, browser):
@@ -33,11 +33,11 @@ class TestReferenceBehavior(IntegrationTestCase):
         browser.fill({
             'Title (German)': u'Test repository',
             'Title (English)': u'Test repository',
-            'Reference number component': '1',
+            'Repository number': '1',
         }).save()
 
         self.assertEquals(
-            {'Reference number component': [
+            {'Repository number': [
                 'A repository folder with the same reference number already exists on the same level.']},
             z3cform.erroneous_fields(browser.forms['form']))
 
@@ -53,7 +53,7 @@ class TestReferenceBehavior(IntegrationTestCase):
         browser.fill({
             'Title (German)': u'Test repository',
             'Title (English)': u'Test repository',
-            'Reference number component': '26',
+            'Repository number': '26',
         }).save()
         statusmessages.assert_no_error_messages()
 
@@ -68,7 +68,7 @@ class TestReferenceBehavior(IntegrationTestCase):
         browser.fill({
             'Title (German)': u'Test repository',
             'Title (English)': u'Test repository',
-            'Reference number component': 'a1x10',
+            'Repository number': 'a1x10',
         }).save()
         statusmessages.assert_no_error_messages()
 

--- a/opengever/repository/tests/test_subscribers.py
+++ b/opengever/repository/tests/test_subscribers.py
@@ -13,7 +13,7 @@ class TestReferencePrefixUpdating(IntegrationTestCase):
         self.assertEquals('Client1 1.1', obj2brain(self.leaf_repofolder).reference)
 
         browser.open(self.leaf_repofolder, view='edit')
-        browser.fill({'Reference number component': u'7'}).save()
+        browser.fill({'Repository number': u'7'}).save()
         self.assertEquals('Client1 1.7', obj2brain(self.leaf_repofolder).reference)
 
     @browsing
@@ -26,5 +26,5 @@ class TestReferencePrefixUpdating(IntegrationTestCase):
         self.assertEquals('Client1 1.1 / 1', obj2brain(self.dossier).reference)
 
         browser.open(self.leaf_repofolder, view='edit')
-        browser.fill({'Reference number component': u'7'}).save()
+        browser.fill({'Repository number': u'7'}).save()
         self.assertEquals('Client1 1.7 / 1', obj2brain(self.dossier).reference)


### PR DESCRIPTION
This renames the label for the `reference_number_prefix` field (previously labelled `Reference prefix`) to 

- `Repository number` (English)
- `Ordnungspositionsnummer` (German)
- `Numéro de classement` (French)

The internal name of the field in technical contexts (code base, API, ...) is left untouched.

Since the frontend fetches the field labels from the schema, this will result in the field label changing in **user facing** contexts, like the add view for a new repository folder:

![Screenshot 2021-08-23 at 13 21 57](https://user-images.githubusercontent.com/405124/130439298-e7c4eabb-3864-44b5-b595-1b2bb83caa31.png)
 
For [CA-2767](https://4teamwork.atlassian.net/browse/CA-2767)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- API change:
  - [x] Documentation is updated _(schema dumps)_

