### PR TITLE
Fix resolving of multi adminunit tasks for approval.

### DIFF
--- a/opengever/api/complete_successor_task.py
+++ b/opengever/api/complete_successor_task.py
@@ -34,7 +34,7 @@ class CompleteSuccessorTaskPost(RemoteTaskBaseService):
     """
 
     required_params = ('transition', )
-    optional_params = ('documents', 'text')
+    optional_params = ('documents', 'text', 'approved_documents')
 
     @staticmethod
     def _resolve_doc_ref_to_intid(doc_ref):
@@ -66,6 +66,7 @@ class CompleteSuccessorTaskPost(RemoteTaskBaseService):
         transition = params['transition']
         docs_to_deliver = params.get('documents', [])
         response_text = params.get('text', u'')
+        approved_documents = params.get('approved_documents', [])
 
         # Map any supported document reference type to an IntId
         docs_to_deliver = map(self._resolve_doc_ref_to_intid, docs_to_deliver)
@@ -83,7 +84,8 @@ class CompleteSuccessorTaskPost(RemoteTaskBaseService):
         remote_response = complete_task_and_deliver_documents(
             successor_task, transition,
             docs_to_deliver=docs_to_deliver,
-            response_text=response_text)
+            response_text=response_text,
+            approved_documents=approved_documents)
 
         remote_response_body = remote_response.read()
         if remote_response_body.strip() != 'OK':

--- a/opengever/task/browser/complete_utils.py
+++ b/opengever/task/browser/complete_utils.py
@@ -29,9 +29,9 @@ import json
 # harm than good.
 
 
-def complete_task_and_deliver_documents(task, transition,
-                                        docs_to_deliver=None,
-                                        response_text=None):
+def complete_task_and_deliver_documents(
+        task, transition, docs_to_deliver=None, response_text=None,
+        approved_documents=None):
     """Delivers the selected documents to the predecesser task and
     complete the task:
 
@@ -42,10 +42,14 @@ def complete_task_and_deliver_documents(task, transition,
     """
     # Syncing the workflow change is done during document delivery
     # (see below) therefore we skip the workflow syncing.
+    transition_data = {'text': response_text}
+    if approved_documents:
+        transition_data['approved_documents'] = approved_documents
+
     util.change_task_workflow_state(task,
                                     transition,
                                     disable_sync=True,
-                                    text=response_text)
+                                    **transition_data)
 
     response_obj = IResponseContainer(task).list()[-1]
 


### PR DESCRIPTION
The approval of a document with a task is now also supported for the `@complete-successor-task` endpoint, which solves an issue when resolving a multi adminunit task for approval.

The endpoint does not sync or copy the approval to the predecessor site, but it handles a stores the approval on the successor site.

For [CA-2269]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] Changelog entry (not necessary - fix for an existing entry)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-2269]: https://4teamwork.atlassian.net/browse/CA-2269