### PR TITLE
Remove value restriction for the custody_period field.

### DIFF
--- a/changes/CA-2757.other
+++ b/changes/CA-2757.other
@@ -1,0 +1,1 @@
+Remove value restriction for the custody_period field. [tinagerber]

--- a/opengever/base/behaviors/configure.zcml
+++ b/opengever/base/behaviors/configure.zcml
@@ -57,8 +57,7 @@
       />
 
   <utility
-      component=".lifecycle.custody_period_vf"
-      provides="zope.schema.interfaces.IVocabularyFactory"
+      factory=".lifecycle.CustodyPeriodVocabulary"
       name="lifecycle_custody_period_vocabulary"
       />
 

--- a/opengever/base/behaviors/lifecycle.py
+++ b/opengever/base/behaviors/lifecycle.py
@@ -156,24 +156,18 @@ ILifeCycle['retention_period'].defaultFactory = retention_period_default
 # ---------- CUSTODY PERIOD -----------
 # Vocabulary
 
-def _get_custody_period_choices():
-    registry = getUtility(IRegistry)
-    proxy = registry.forInterface(IBaseCustodyPeriods)
-    choices = []
-    nums = getattr(proxy, 'custody_periods')
 
-    for num in nums:
-        num = int(num)
-        choices.append((num, num))
+@implementer(IVocabularyFactory)
+class CustodyPeriodVocabulary(object):
 
-    return choices
+    def __call__(self, context):
+        terms = []
+        custody_periods = getUtility(IRegistry).forInterface(IBaseCustodyPeriods).custody_periods
+        for custody_period in custody_periods:
+            custody_period = int(custody_period)
+            terms.append(SimpleTerm(custody_period, title=_(custody_period)))
 
-
-custody_period_vf = RestrictedVocabularyFactory(
-    ILifeCycle['custody_period'],
-    _get_custody_period_choices,
-    message_factory=_,
-    restricted=True)
+        return SimpleVocabulary(terms)
 
 
 @provider(IContextAwareDefaultFactory)


### PR DESCRIPTION
The value restriction on the custody_period field is no longer desired.

The PR replaces the RestrictedVocabulary with a SimpleVocabulary, with this changes also the value_propagation for no longer valid values is redundant.


Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-2757]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-2757]: https://4teamwork.atlassian.net/browse/CA-2757