### PR TITLE
Support multiple choice custom fields.

### DIFF
--- a/changes/CA-1957.feature
+++ b/changes/CA-1957.feature
@@ -1,0 +1,1 @@
+Add new customfield type multiple_choice.

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -13,6 +13,7 @@ Other Changes
 ^^^^^^^^^^^^^
 
 - Add new endpoint ``@reactivate-local-group`` (see :ref:`docs <reactivate-local-group>`)
+- Propertysheets: ``multiple_choice`` fields are now supported.
 
 
 2021.17.0 (2021-08-30)

--- a/docs/public/dev-manual/api/propertysheets.rst
+++ b/docs/public/dev-manual/api/propertysheets.rst
@@ -72,6 +72,7 @@ Einzelne Felder werden in folgendem Format erwartet:
 
   - ``bool``
   - ``choice``
+  - ``multiple_choice``
   - ``int``
   - ``text``
   - ``textline``

--- a/opengever/api/tests/test_listing_custom_fields.py
+++ b/opengever/api/tests/test_listing_custom_fields.py
@@ -32,6 +32,11 @@ class TestListingCustomFieldsGet(IntegrationTestCase):
                             u"title": u"Choose",
                             u"type": u"string"
                         },
+                        u'choosemulti_custom_field_strings': {
+                            u'name': u'choosemulti_custom_field_strings',
+                            u'title': u'Choose multi',
+                            u'type': u'array'
+                        },
                         u"f1_custom_field_string": {
                             u"name": u"f1_custom_field_string",
                             u"title": u"Field 1",

--- a/opengever/document/indexers.py
+++ b/opengever/document/indexers.py
@@ -210,11 +210,13 @@ def metadata(obj):
         field = getFields(IDocumentCustomProperties).get('custom_properties')
         active_slot = field.get_active_assignment_slot(obj)
         for slot in [active_slot, field.default_slot]:
-            metadata.extend([
-                ensure_str(value) for value
-                in custom_properties.get(slot, {}).values()
-                if not isinstance(value, bool)
-            ])
+            for value in custom_properties.get(slot, {}).values():
+                if isinstance(value, bool):
+                    continue
+                elif isinstance(value, list):
+                    metadata.extend([ensure_str(item) for item in value])
+                else:
+                    metadata.append(ensure_str(value))
 
     return ' '.join(metadata)
 

--- a/opengever/document/tests/test_indexers.py
+++ b/opengever/document/tests/test_indexers.py
@@ -258,6 +258,8 @@ class TestDocumentIndexers(FunctionalTestCase):
             .assigned_to_slots(u"IDocumentMetadata.document_type.question")
             .with_field("bool", u"yesorno", u"Yes or no", u"", True)
             .with_field("choice", u"choose", u"Choose", u"", True, values=choices)
+            .with_field("multiple_choice", u"choosemulti",
+                        u"Choose Multi", u"", True, values=choices)
             .with_field("int", u"num", u"Number", u"", True)
             .with_field("text", u"text", u"Some lines of text", u"", True)
             .with_field("textline", u"textline", u"A line of text", u"", True)
@@ -267,6 +269,7 @@ class TestDocumentIndexers(FunctionalTestCase):
             "IDocumentMetadata.document_type.question": {
                 "yesorno": False,
                 "choose": u"gr\xfcn",
+                "choosemulti": ["rot", "blau"],
                 "num": 122333,
                 "text": u"K\xe4fer\nJ\xe4ger",
                 "textline": u"Kr\xe4he",
@@ -278,6 +281,8 @@ class TestDocumentIndexers(FunctionalTestCase):
         self.assertIn(u"K\xe4fer", indexed_value)
         self.assertIn(u"J\xe4ger", indexed_value)
         self.assertIn(u"Kr\xe4he", indexed_value)
+        self.assertIn(u"rot", indexed_value)
+        self.assertIn(u"blau", indexed_value)
 
 
 class SolrDocumentIndexer(SolrIntegrationTestCase):

--- a/opengever/dossier/indexers.py
+++ b/opengever/dossier/indexers.py
@@ -239,11 +239,13 @@ class SearchableTextExtender(object):
             field = getFields(IDossierCustomProperties).get('custom_properties')
             active_slot = field.get_active_assignment_slot(self.context)
             for slot in [active_slot, field.default_slot]:
-                searchable.extend([
-                    ensure_str(value) for value
-                    in custom_properties.get(slot, {}).values()
-                    if not isinstance(value, bool)
-                ])
+                for value in custom_properties.get(slot, {}).values():
+                    if isinstance(value, bool):
+                        continue
+                    elif isinstance(value, list):
+                        searchable.extend([ensure_str(item) for item in value])
+                    else:
+                        searchable.append(ensure_str(value))
 
         return ' '.join(searchable)
 

--- a/opengever/dossier/tests/test_indexer.py
+++ b/opengever/dossier/tests/test_indexer.py
@@ -215,6 +215,8 @@ class TestDossierIndexers(SolrIntegrationTestCase):
             .assigned_to_slots(u"IDossier.dossier_type.businesscase")
             .with_field("bool", u"yesorno", u"Yes or no", u"", True)
             .with_field("choice", u"choose", u"Choose", u"", True, values=choices)
+            .with_field("multiple_choice", u"choosemulti",
+                        u"Choose Multi", u"", True, values=choices)
             .with_field("int", u"num", u"Number", u"", True)
             .with_field("text", u"text", u"Some lines of text", u"", True)
             .with_field("textline", u"textline", u"A line of text", u"", True)
@@ -224,6 +226,7 @@ class TestDossierIndexers(SolrIntegrationTestCase):
             "IDossier.dossier_type.businesscase": {
                 "yesorno": False,
                 "choose": u"gr\xfcn",
+                "choosemulti": ["rot", "blau"],
                 "num": 122333,
                 "text": u"K\xe4fer\nJ\xe4ger",
                 "textline": u"Kr\xe4he",
@@ -238,6 +241,8 @@ class TestDossierIndexers(SolrIntegrationTestCase):
         self.assertIn(u"K\xe4fer", indexed_value)
         self.assertIn(u"J\xe4ger", indexed_value)
         self.assertIn(u"Kr\xe4he", indexed_value)
+        self.assertIn(u"rot", indexed_value)
+        self.assertIn(u"blau", indexed_value)
 
     def test_dossiertemplate_searchable_text_contains_keywords(self):
         self.login(self.regular_user)

--- a/opengever/propertysheets/definition.py
+++ b/opengever/propertysheets/definition.py
@@ -13,6 +13,7 @@ from plone.schemaeditor.utils import IEditableSchema
 from plone.supermodel import loadString
 from plone.supermodel import model
 from plone.supermodel import serializeSchema
+from zope import schema
 from zope.component import getUtility
 from zope.component import queryMultiAdapter
 from zope.globalrequest import getRequest
@@ -88,6 +89,7 @@ class PropertySheetSchemaDefinition(object):
     FACTORIES = {
         'bool': fields.BoolFactory,
         'choice': fields.ChoiceFactory,
+        'multiple_choice': fields.MultiChoiceFactory,
         'int': fields.IntFactory,
         'text': fields.TextFactory,
         'textline': fields.TextLineFactory,
@@ -183,15 +185,17 @@ class PropertySheetSchemaDefinition(object):
             "required": required,
         }
 
-        if field_type == 'choice':
+        if field_type in ['choice', 'multiple_choice']:
             if not values:
                 raise InvalidFieldTypeDefinition(
-                    "For 'choice' fields types values are required."
+                    "For 'choice' or 'multiple_choice' fields types "
+                    "values are required."
                 )
 
             if not all(isinstance(choice, basestring) for choice in values):
                 raise InvalidFieldTypeDefinition(
-                    "For 'choice' field types values must be string."
+                    "For 'choice' or 'multiple_choice' fields types "
+                    "values must be string."
                 )
 
             # Using `unicode_escape` encoding for tokens is a requirement of
@@ -203,12 +207,19 @@ class PropertySheetSchemaDefinition(object):
                 )
                 for item in values
             ]
-            properties['vocabulary'] = SimpleVocabulary(terms)
-            # The field factory injects an empty list as values argument if it
-            # is not set. This will lead to a conflict with the vocabylary we
-            # provide here. We prevent this error by actively setting the
-            # values argument to None.
-            properties['values'] = None
+
+            vocabulary = SimpleVocabulary(terms)
+            if field_type == 'multiple_choice':
+                properties['value_type'] = Choice(
+                    values=None, vocabulary=SimpleVocabulary(terms))
+            else:
+                properties['vocabulary'] = vocabulary
+                # The field factory injects an empty list as values argument if it
+                # is not set. This will lead to a conflict with the vocabylary we
+                # provide here. We prevent this error by actively setting the
+                # values argument to None.
+                properties['values'] = None
+
         elif values:
             raise InvalidFieldTypeDefinition(
                 "The argument 'values' is only valid for 'choice' fields."

--- a/opengever/propertysheets/definition.py
+++ b/opengever/propertysheets/definition.py
@@ -22,6 +22,7 @@ from zope.schema import Choice
 from zope.schema import getFieldNamesInOrder
 from zope.schema import getFieldsInOrder
 from zope.schema import Int
+from zope.schema import Set
 from zope.schema import TextLine
 from zope.schema import ValidationError
 from zope.schema.interfaces import IVocabularyFactory
@@ -43,6 +44,8 @@ class SolrDynamicField(object):
         Choice: 'string',
         Int: 'int',
         TextLine: 'string',
+        # We currently only support multiple_choice for string values
+        Set: 'strings'
     }
     DYNAMIC_FIELD_IDENT = '_custom_field_'
 

--- a/opengever/propertysheets/serializer.py
+++ b/opengever/propertysheets/serializer.py
@@ -61,7 +61,8 @@ class PropertySheetFieldSerializer(DefaultFieldSerializer):
                         # value in storage and drop the field from serialization
                         del data[name]
 
-                elif IChoice.providedBy(field.value_type):
+                elif hasattr(field, 'value_type') and IChoice.providedBy(
+                        field.value_type):
                     field_values = data[name]
                     tokenized_values = []
                     for field_value in field_values:

--- a/opengever/propertysheets/tests/test_document_custom_properties.py
+++ b/opengever/propertysheets/tests/test_document_custom_properties.py
@@ -19,6 +19,8 @@ class TestDocumentCustomPropertiesPatch(IntegrationTestCase):
             .assigned_to_slots(u"IDocumentMetadata.document_type.question")
             .with_field("bool", u"yesorno", u"Yes or no", u"", True)
             .with_field("choice", u"choose", u"Choose", u"", True, values=choices)
+            .with_field("multiple_choice", u"choosemulti",
+                        u"Choose Multi", u"", True, values=choices)
             .with_field("int", u"num", u"Number", u"", True)
             .with_field("text", u"text", u"Some lines of text", u"", True)
             .with_field("textline", u"textline", u"A line of text", u"", True)
@@ -31,6 +33,7 @@ class TestDocumentCustomPropertiesPatch(IntegrationTestCase):
                 "IDocumentMetadata.document_type.question": {
                     "yesorno": False,
                     "choose": u"zw\xf6i".encode("unicode_escape"),
+                    "choosemulti": ["one", "three"],
                     "num": 123,
                     "text": u"bl\xe4\nblub",
                     "textline": u"bl\xe4",
@@ -47,6 +50,7 @@ class TestDocumentCustomPropertiesPatch(IntegrationTestCase):
             "IDocumentMetadata.document_type.question": {
                 "yesorno": False,
                 "choose": u"zw\xf6i",
+                "choosemulti": ["three", "one"],
                 "num": 123,
                 "text": u"bl\xe4\nblub",
                 "textline": u"bl\xe4",

--- a/opengever/propertysheets/tests/test_dossier_custom_properties.py
+++ b/opengever/propertysheets/tests/test_dossier_custom_properties.py
@@ -18,6 +18,8 @@ class TestDossierCustomPropertiesPatch(IntegrationTestCase):
             .named("schema1")
             .assigned_to_slots(u"IDossier.dossier_type.businesscase")
             .with_field("choice", u"choose", u"Choose", u"", True, values=choices)
+            .with_field("multiple_choice", u"choosemulti",
+                        u"Choose Multi", u"", True, values=choices)
             .with_field("textline", u"textline", u"A line of text", u"", True)
         )
         self.dossier.dossier_type = u"businesscase"
@@ -27,6 +29,7 @@ class TestDossierCustomPropertiesPatch(IntegrationTestCase):
             "custom_properties": {
                 "IDossier.dossier_type.businesscase": {
                     "choose": u"zw\xf6i".encode("unicode_escape"),
+                    "choosemulti": ["one", "three"],
                     "textline": u"bl\xe4",
                 },
             }
@@ -37,6 +40,7 @@ class TestDossierCustomPropertiesPatch(IntegrationTestCase):
         expected_properties = {
             "IDossier.dossier_type.businesscase": {
                 "choose": u"zw\xf6i",
+                "choosemulti": ["three", "one"],
                 "textline": u"bl\xe4",
             },
         }

--- a/opengever/propertysheets/tests/test_mail_custom_properties.py
+++ b/opengever/propertysheets/tests/test_mail_custom_properties.py
@@ -19,6 +19,8 @@ class TestMailCustomPropertiesPatch(IntegrationTestCase):
             .assigned_to_slots(u"IDocumentMetadata.document_type.question")
             .with_field("bool", u"yesorno", u"Yes or no", u"", True)
             .with_field("choice", u"choose", u"Choose", u"", True, values=choices)
+            .with_field("multiple_choice", u"choosemulti",
+                        u"Choose Multi", u"", True, values=choices)
             .with_field("int", u"num", u"Number", u"", True)
             .with_field("text", u"text", u"Some lines of text", u"", True)
             .with_field("textline", u"textline", u"A line of text", u"", True)
@@ -31,6 +33,7 @@ class TestMailCustomPropertiesPatch(IntegrationTestCase):
                 "IDocumentMetadata.document_type.question": {
                     "yesorno": False,
                     "choose": "two",
+                    "choosemulti": ["three", "one"],
                     "num": 123,
                     "text": u"bl\xe4\nblub",
                     "textline": u"bl\xe4",

--- a/opengever/propertysheets/tests/test_schema_definition_post.py
+++ b/opengever/propertysheets/tests/test_schema_definition_post.py
@@ -125,6 +125,12 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
                     "values": [u"\xf6ins", u"zwei"]
                 },
                 {
+                    "name": "colors",
+                    "field_type": u"multiple_choice",
+                    "title": u"Select one or more",
+                    "values": [u"gr\xfcn", "blau", "weiss"]
+                },
+                {
                     "name": "nummer",
                     "field_type": u"int",
                     "title": u"zahl"
@@ -155,7 +161,7 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
         definition = storage.get("meinschema")
 
         self.assertEqual(
-            ["yn", "wahl", "nummer", "text", "zeiletext"],
+            ["yn", "wahl", "colors", "nummer", "text", "zeiletext"],
             definition.get_fieldnames()
         )
 

--- a/opengever/propertysheets/tests/test_serializer.py
+++ b/opengever/propertysheets/tests/test_serializer.py
@@ -55,6 +55,38 @@ class TestPropertySheetFieldSerializer(IntegrationTestCase):
             self.serializer(),
         )
 
+    def test_serializes_multiple_choice_fields_as_a_list_of_token_title_object(self):
+        self.login(self.regular_user)
+
+        choices = [u"one", u"two", u"dr\xfc\xfc"]
+        create(
+            Builder("property_sheet_schema")
+            .named("schema1")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field(
+                "multiple_choice", u"multichoose", u"Multi Choose", u"", True, values=choices
+            )
+        )
+        self.document.document_type = u"question"
+        IDocumentCustomProperties(self.document).custom_properties = {
+            "IDocumentMetadata.document_type.question": {
+                "multichoose": [u"dr\xfc\xfc", u"one"],
+            }
+        }
+
+        self.assertEqual(
+            {
+                "IDocumentMetadata.document_type.question": {
+                    "multichoose": [
+                        {"title": u"dr\xfc\xfc",
+                         "token": u"dr\xfc\xfc".encode("unicode_escape")},
+                        {"title": u"one", "token": u"one"}
+                    ]
+                }
+            },
+            self.serializer(),
+        )
+
     def test_skips_invalid_vocabulary_values_during_serialization(self):
         self.login(self.regular_user)
 

--- a/opengever/propertysheets/tests/test_solr.py
+++ b/opengever/propertysheets/tests/test_solr.py
@@ -42,6 +42,7 @@ class TestCustomPropertiesIndexHandler(SolrIntegrationTestCase):
             "IDocumentMetadata.document_type.regulations": {
                 "yesorno": False,
                 "choose": u"gr\xfcn",
+                "choosemulti": ["two", "three"],
                 "num": 122333,
                 "text": u"K\xe4fer\nJ\xe4ger",
                 "textline": u"Kr\xe4he",
@@ -55,6 +56,8 @@ class TestCustomPropertiesIndexHandler(SolrIntegrationTestCase):
             solr_doc.get(u'yesorno_custom_field_boolean'), False)
         self.assertEqual(
             solr_doc.get(u'choose_custom_field_string'), u"gr\xfcn")
+        self.assertEqual(
+            solr_doc.get(u'choosemulti_custom_field_strings'), ["three", "two"])
         self.assertEqual(
             solr_doc.get(u'num_custom_field_int'), 122333)
         self.assertNotIn(u'text_custom_field_string', solr_doc)

--- a/opengever/propertysheets/tests/test_widget.py
+++ b/opengever/propertysheets/tests/test_widget.py
@@ -25,6 +25,8 @@ class TestPropertySheetWidget(IntegrationTestCase):
             .with_field(
                 "choice", u"choose", u"Choose", u"", True, values=choices
             )
+            .with_field("multiple_choice", u"choosemulti",
+                        u"Choose Multi", u"", True, values=choices)
             .with_field("int", u"num", u"Number", u"", True)
             .with_field("text", u"text", u"Some lines of text", u"", True)
             .with_field("textline", u"textline", u"A line of text", u"", True)
@@ -44,6 +46,7 @@ class TestPropertySheetWidget(IntegrationTestCase):
                 u"Custom properties",  # the composite field label
                 u"Yes or no",
                 u"Choose",
+                u"Choose Multi",
                 u"Number",
                 u"Some lines of text",
                 u"A line of text",
@@ -55,6 +58,7 @@ class TestPropertySheetWidget(IntegrationTestCase):
             {
                 "Yes or no": True,
                 "Choose": u"zw\xf6i",
+                "Choose Multi": ["one", "three"],
                 "Number": "3",
                 "Some lines of text": "Foo\nbar",
                 "A line of text": u"b\xe4\xe4",
@@ -69,6 +73,7 @@ class TestPropertySheetWidget(IntegrationTestCase):
                     "num": 3,
                     "yesorno": True,
                     "choose": u"zw\xf6i",
+                    "choosemulti": ["three", "one"],
                     "textline": u"b\xe4\xe4",
                 }
             },

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -503,6 +503,8 @@ class OpengeverContentFixture(object):
             .with_field("bool", u"yesorno", u"Yes or no", u"", True)
             .with_field("choice", u"choose", u"Choose", u"", True,
                         values=["one", "two", "three"])
+            .with_field("multiple_choice", u"choosemulti", u"Choose multi", u"", True,
+                        values=["one", "two", "three"])
             .with_field("int", u"num", u"Number", u"", True)
             .with_field("text", u"text", u"Some lines of text", u"", True)
             .with_field("textline", u"textline", u"A line of text", u"", True)

--- a/solr-conf/managed-schema
+++ b/solr-conf/managed-schema
@@ -188,6 +188,7 @@
     <dynamicField name="*_custom_field_string" type="string" indexed="true" stored="false"/>
     <dynamicField name="*_custom_field_int" type="pint" indexed="true" stored="false"/>
     <dynamicField name="*_custom_field_boolean" type="boolean" indexed="true" stored="false"/>
+    <dynamicField name="*_custom_field_strings" type="string" indexed="true" stored="false" multiValued="true"/>
 
     <dynamicField name="ignored_*" type="ignored"/>
 


### PR DESCRIPTION
Adds new customfield type `multiple_choice`, which allows to select multiple values from a list of strings.

For [CA-1957]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))


[CA-1957]: https://4teamwork.atlassian.net/browse/CA-1957