### PR TITLE
Add @reactivate-local-group endpoint.

### DIFF
--- a/changes/CA-2777.feature
+++ b/changes/CA-2777.feature
@@ -1,0 +1,1 @@
+Add @reactivate-local-group endpoint. [tinagerber]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -12,6 +12,8 @@ Breaking Changes
 Other Changes
 ^^^^^^^^^^^^^
 
+- Add new endpoint ``@reactivate-local-group`` (see :ref:`docs <reactivate-local-group>`)
+
 
 2021.17.0 (2021-08-30)
 ----------------------

--- a/docs/public/dev-manual/api/users.rst
+++ b/docs/public/dev-manual/api/users.rst
@@ -339,3 +339,30 @@ Gruppen erstellen, modifizieren und löschen kann über den ``@groups`` Endpoint
 - Er steht auch für Administratoren zur Verfügung.
 - Er wurde eingeschränkt um nur die Administration von gewissen Rollen zu erlauben: ``workspace_guest``, ``workspace_member`` und ``workspace_admin``.
 - Gruppennamen darf nicht länger als 255 Zeichen lang sein
+
+.. _reactivate-local-group:
+
+Lokale Gruppen reaktivieren
+---------------------------
+
+Mit dem ``@reactivate-local-group`` Endpoint kann eine lokale, inaktive Gruppe wieder aktiviert werden. Der Endpoint steht auf Stufe PloneSite zur Verfügung.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+      POST /@reactivate-local-group HTTP/1.1
+      Accept: application/json
+
+      {
+        "groupname": "test-group"
+      }
+
+
+**Beispiel-Response**:
+
+
+   .. sourcecode:: http
+
+      HTTP/1.1 204 No content
+      Content-Type: application/json

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -1352,6 +1352,15 @@
       />
 
   <plone:service
+      method="POST"
+      name="@reactivate-local-group"
+      for="Products.CMFCore.interfaces.ISiteRoot"
+      factory=".reactivate_local_group.ReactivateLocalGroupPost"
+      permission="opengever.api.ManageGroups"
+      layer="opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
+  <plone:service
       method="GET"
       name="@participations"
       for="opengever.dossier.behaviors.participation.IParticipationAwareMarker"

--- a/opengever/api/reactivate_local_group.py
+++ b/opengever/api/reactivate_local_group.py
@@ -1,0 +1,50 @@
+from opengever.base.security import elevated_privileges
+from opengever.base.utils import check_group_plugin_configuration
+from opengever.ogds.models.group import Group
+from plone.protect.interfaces import IDisableCSRFProtection
+from plone.restapi.deserializer import json_body
+from plone.restapi.services import Service
+from Products.CMFCore.utils import getToolByName
+from zExceptions import BadRequest
+from zope.interface import alsoProvides
+
+
+class ReactivateLocalGroupPost(Service):
+
+    def check_preconditions(self, groupname):
+        check_group_plugin_configuration(self.context)
+
+        if not groupname:
+            raise BadRequest("Property 'groupname' is required.")
+
+        self.ogds_group = Group.query.get(groupname)
+        if not self.ogds_group:
+            raise BadRequest('Group {} does not exist in OGDS.'.format(groupname))
+
+        if self.ogds_group.active:
+            raise BadRequest('Can only reactivate inactive groups.')
+        if not self.ogds_group.is_local:
+            raise BadRequest('Can only reactivate local groups.')
+
+    def reply(self):
+        data = json_body(self.request)
+
+        groupname = data.get("groupname", None)
+        self.check_preconditions(groupname)
+
+        # Disable CSRF protection
+        alsoProvides(self.request, IDisableCSRFProtection)
+
+        gtool = getToolByName(self.context, "portal_groups")
+        success = gtool.addGroup(groupname)
+        if not success:
+            raise BadRequest("Error occurred, could not add group {}.".format(groupname))
+
+        # Add members
+        group = gtool.getGroupById(groupname)
+        for user in self.ogds_group.users:
+            with elevated_privileges():
+                group.addMember(user.userid)
+
+        self.ogds_group.active = True
+        return self.reply_no_content()

--- a/opengever/api/tests/test_reactivate_local_group.py
+++ b/opengever/api/tests/test_reactivate_local_group.py
@@ -1,0 +1,147 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.ogds.models.service import ogds_service
+from opengever.testing import IntegrationTestCase
+from Products.CMFCore.utils import getToolByName
+import json
+
+
+class TestReactivateLocalGroupPost(IntegrationTestCase):
+
+    @browsing
+    def test_reactivate_local_group(self, browser):
+        self.groupid = u'test_group'
+        group_users = [ogds_service().find_user(user.getId())
+                       for user in [self.workspace_member, self.workspace_guest]]
+        ogds_group = create(Builder('ogds_group').having(groupid=self.groupid, active=False,
+                                                         is_local=True, users=group_users))
+        payload = {
+            u'groupname': self.groupid,
+        }
+
+        self.login(self.administrator, browser)
+
+        browser.open(
+            self.portal,
+            view='@reactivate-local-group',
+            data=json.dumps(payload),
+            method='POST',
+            headers=self.api_headers)
+
+        self.assertEqual(204, browser.status_code)
+        self.assertTrue(ogds_group.active)
+        plone_group = getToolByName(self.portal, "portal_groups").getGroupById(self.groupid)
+        self.assertIsNotNone(plone_group)
+        self.assertEqual({self.workspace_member.getId(), self.workspace_guest.getId()},
+                         set(plone_group.getGroupMemberIds()))
+
+    @browsing
+    def test_group_reactivation_is_allowed_for_administrators(self, browser):
+        self.groupid = u'test_group'
+        create(Builder('ogds_group').having(groupid=self.groupid, active=False, is_local=True))
+
+        self.login(self.workspace_owner, browser)
+        portal_groups = getToolByName(self.portal, "portal_groups")
+        self.assertIsNone(portal_groups.getGroupById(self.groupid))
+
+        payload = {
+            u'groupname': self.groupid,
+        }
+
+        with browser.expect_unauthorized():
+            browser.open(
+                self.portal,
+                view='@reactivate-local-group',
+                data=json.dumps(payload),
+                method='POST',
+                headers=self.api_headers)
+
+        self.assertIsNone(portal_groups.getGroupById(self.groupid))
+
+        self.login(self.administrator, browser)
+        browser.open(
+            self.portal,
+            view='@reactivate-local-group',
+            data=json.dumps(payload),
+            method='POST',
+            headers=self.api_headers)
+
+        self.assertEqual(204, browser.status_code)
+
+    @browsing
+    def test_cannot_reactivate_active_group(self, browser):
+        self.login(self.administrator, browser)
+
+        payload = {
+            u'groupname': u'committee_rpk_group',
+        }
+
+        with browser.expect_http_error(400):
+            browser.open(
+                self.portal,
+                view='@reactivate-local-group',
+                data=json.dumps(payload),
+                method='POST',
+                headers=self.api_headers)
+
+        self.assertEqual(
+            browser.json[u'message'], u'Can only reactivate inactive groups.')
+        self.assertEqual(browser.json[u'type'], u'BadRequest')
+
+    @browsing
+    def test_can_not_reactivate_global_group(self, browser):
+        self.groupid = u'test_group'
+        create(Builder('ogds_group').having(groupid=self.groupid, active=False, is_local=False))
+        self.login(self.administrator, browser)
+
+        payload = {
+            u'groupname': self.groupid,
+        }
+
+        with browser.expect_http_error(400):
+            browser.open(
+                self.portal,
+                view='@reactivate-local-group',
+                data=json.dumps(payload),
+                method='POST',
+                headers=self.api_headers)
+
+        self.assertEqual(
+            browser.json[u'message'], u'Can only reactivate local groups.')
+        self.assertEqual(browser.json[u'type'], u'BadRequest')
+
+    @browsing
+    def test_group_reactivation_fails_if_groupname_is_missing(self, browser):
+        self.login(self.administrator, browser)
+
+        with browser.expect_http_error(400):
+            browser.open(
+                self.portal,
+                view='@reactivate-local-group',
+                method='POST',
+                headers=self.api_headers)
+
+        self.assertEqual(
+            browser.json[u'message'], "Property 'groupname' is required.")
+        self.assertEqual(browser.json[u'type'], u'BadRequest')
+
+    @browsing
+    def test_group_reactivation_fails_if_groupname_is_invalid(self, browser):
+        self.login(self.manager, browser)
+
+        payload = {
+            u'groupname': u'invalid',
+        }
+        with browser.expect_http_error(400):
+            browser.open(
+                self.portal,
+                view='@reactivate-local-group',
+                data=json.dumps(payload),
+                method='POST',
+                headers=self.api_headers)
+
+        self.assertEqual(
+            browser.json[u'message'],
+            u'Group invalid does not exist in OGDS.')
+        self.assertEqual(browser.json[u'type'], u'BadRequest')


### PR DESCRIPTION
Until now, local groups can only be deactivated, but not reactivated. With the endpoint @reactivate-local-group they can now also be reactivated.

For [CA-2777]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))

[CA-2777]: https://4teamwork.atlassian.net/browse/CA-2777