### PR TITLE
Make indexing of approval status more error-tolerant

### DIFF
--- a/opengever/document/approvals.py
+++ b/opengever/document/approvals.py
@@ -1,3 +1,4 @@
+from AccessControl.unauthorized import Unauthorized
 from collections import defaultdict
 from datetime import datetime
 from opengever.document.behaviors import IBaseDocument
@@ -149,8 +150,15 @@ class ApprovalList(object):
            at least one user (but the current one hasn't).
         - `None` otherwise (no approvals at all)
         """
-        current_version_id = Versioner(self.context).get_current_version_id(
-            missing_as_zero=True)
+
+        try:
+            current_version_id = Versioner(self.context).get_current_version_id(
+                missing_as_zero=True)
+        except Unauthorized:
+            # In some cases the current user is not allowed to access the history
+            # metadata of the original object, in this case we remove all approvals
+            return None
+
         approvals = self.get_grouped_by_version_id()
 
         current_version_approvals = approvals.get(current_version_id)


### PR DESCRIPTION
for cases in which the user does not yet have access to the document versions (HistoryMetadata) - often happens during content creation. We handle the same problem also in the `cleanup_document_approvals` subscribers.

Fixes [CA-2798]

## Checklist

- [ ] Changelog entry (_not necessary fixes an issue introduced in the current release_)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-2798]: https://4teamwork.atlassian.net/browse/CA-2798