### PR TITLE
Add support for nightly maintenance jobs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1434,3 +1434,25 @@ Example configuration:
 .. _testing fixtures: https://github.com/4teamwork/opengever.core/blob/master/opengever/testing/fixtures.py
 .. _COMPONENT_REGISTRY_ISOLATION: https://github.com/4teamwork/ftw.testing#component-registry-isolation-layer
 .. _Sablon: https://github.com/4teamwork/sablon
+
+
+Nightly Jobs
+------------
+
+Gever offers a whole infrastructure to execute certain jobs overnight, to avoid excessive load of the instances during working hours. Nightly jobs are executed via a cronjob calling the ``NightlyJobRunner``, which will try to execute all jobs provided by the registered nightly job providers (named multiadapters of INightlyJobProvider).
+
+Reindexing operations as nightly maintenance jobs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+We offer a high level API to create nightly maintenance jobs for reindexing operations,
+which can be used in upgrade steps:
+
+.. code:: python
+
+    query = {'object_provides': IDexterityContent.__identifier__}
+    with NightlyIndexer(idxs=["sortable_reference"],
+                        index_in_solr_only=True) as indexer:
+        for obj in self.objects(query, 'Index sortable_reference in Solr'):
+            indexer.add_by_obj(obj)
+
+This will register the corresponding jobs to the ``NightlyMaintenanceJobsProvider``.

--- a/opengever/base/nightly_role_assignment_reports.py
+++ b/opengever/base/nightly_role_assignment_reports.py
@@ -3,26 +3,17 @@ from opengever.base.role_assignments import ASSIGNMENT_VIA_SHARING
 from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.base.storage import STATE_IN_PROGRESS
 from opengever.base.storage import STATE_READY
-from opengever.nightlyjobs.interfaces import INightlyJobProvider
+from opengever.nightlyjobs.provider import NightlyJobProviderBase
 from plone import api
-from Products.CMFPlone.interfaces import IPloneSiteRoot
-from zope.component import adapter
 from zope.component.hooks import getSite
 from zope.component.hooks import setSite
-from zope.interface import implementer
-from zope.publisher.interfaces.browser import IBrowserRequest
 import gc
-import logging
 
 
-@implementer(INightlyJobProvider)
-@adapter(IPloneSiteRoot, IBrowserRequest, logging.Logger)
-class NightlyRoleAssignmentReports(object):
+class NightlyRoleAssignmentReports(NightlyJobProviderBase):
 
     def __init__(self, context, request, logger):
-        self.context = context
-        self.request = request
-        self.logger = logger
+        super(NightlyRoleAssignmentReports, self).__init__(context, request, logger)
 
         self.storage = IRoleAssignmentReportsStorage(self.context)
         self.catalog = api.portal.get_tool('portal_catalog')

--- a/opengever/core/tests/test_upgrade.py
+++ b/opengever/core/tests/test_upgrade.py
@@ -168,3 +168,11 @@ class TestNightlyIndexer(SolrIntegrationTestCase):
             self.subdossier, "Title", ["new", "subdossier", "title"])
         self.assert_catalog_data(
             self.empty_dossier, "Title", ["new", "empty", "dossier", "title"])
+
+    def test_trying_to_reindex_searchable_text_in_solr_raises(self):
+        with self.assertRaises(ValueError) as exc:
+            NightlyIndexer(idxs=["Title", "SearchableText"],
+                           index_in_solr_only=True)
+        self.assertEqual(
+            'Reindexing SearchableText in solr only is not supported',
+            exc.exception.message)

--- a/opengever/core/tests/test_upgrade.py
+++ b/opengever/core/tests/test_upgrade.py
@@ -1,5 +1,10 @@
 from alembic.migration import MigrationContext
 from opengever.core.upgrade import IdempotentOperations
+from opengever.core.upgrade import NightlyIndexer
+from opengever.nightlyjobs.runner import NightlyJobRunner
+from opengever.testing import index_data_for
+from opengever.testing import solr_data_for
+from opengever.testing import SolrIntegrationTestCase
 from sqlalchemy import Column
 from sqlalchemy import create_engine
 from sqlalchemy import Integer
@@ -8,6 +13,8 @@ from sqlalchemy import String
 from sqlalchemy import Table
 from sqlalchemy.engine.reflection import Inspector
 from unittest import TestCase
+from zope.component import getUtility
+from zope.intid.interfaces import IIntIds
 
 
 class TestIdempotentOperations(TestCase):
@@ -73,3 +80,91 @@ class TestIdempotentOperations(TestCase):
         self.op.create_table('xuq', Column('foo', Integer, primary_key=True))
         self.refresh_metadata()
         self.assertEqual(['thingy', 'xuq'], self.metadata.tables.keys())
+
+
+class TestNightlyIndexer(SolrIntegrationTestCase):
+
+    features = ('nightly-jobs', )
+
+    def run_nightly_jobs(self):
+        runner = NightlyJobRunner(force_execution=True)
+        runner.execute_pending_jobs()
+        self.commit_solr()
+
+    def assert_catalog_data(self, obj, idx, value):
+        catalog_data = index_data_for(obj)
+        self.assertEqual(value, catalog_data.get(idx))
+
+    def assert_solr_data(self, obj, idx, value):
+        solr_data = solr_data_for(obj)
+        self.assertEqual(value, solr_data.get(idx))
+
+    def assert_solr_and_catalog_data(self, obj, idx, value):
+        self.assert_solr_data(obj, idx, value)
+        self.assert_catalog_data(obj, idx, value)
+
+    def test_nightly_indexer_indexes_only_passed_indexes(self):
+        intids = getUtility(IIntIds)
+        self.login(self.manager)
+        old_creator = self.dossier.Creator()
+        new_creator = "New creator"
+        self.dossier.creators = (new_creator,)
+
+        self.assert_solr_and_catalog_data(self.dossier, "Creator", old_creator)
+
+        with NightlyIndexer(idxs=["Title"]) as indexer:
+            indexer.add_by_intid(intids.getId(self.dossier))
+
+        self.run_nightly_jobs()
+        self.assert_solr_and_catalog_data(self.dossier, "Creator", old_creator)
+
+        with NightlyIndexer(idxs=["Title", "Creator"]) as indexer:
+            indexer.add_by_intid(intids.getId(self.dossier))
+
+        self.run_nightly_jobs()
+        self.assert_solr_and_catalog_data(self.dossier, "Creator", new_creator)
+
+    def test_nightly_solr_only_indexer(self):
+        intids = getUtility(IIntIds)
+        self.login(self.manager)
+        old_creator = self.dossier.Creator()
+        new_creator = "New creator"
+        self.dossier.creators = (new_creator,)
+
+        with NightlyIndexer(idxs=["Title"], index_in_solr_only=True) as indexer:
+            indexer.add_by_intid(intids.getId(self.dossier))
+
+        self.run_nightly_jobs()
+        self.assert_solr_and_catalog_data(self.dossier, "Creator", old_creator)
+
+        with NightlyIndexer(idxs=["Title", "Creator"], index_in_solr_only=True) as indexer:
+            indexer.add_by_intid(intids.getId(self.dossier))
+
+        self.run_nightly_jobs()
+        self.assert_solr_data(self.dossier, "Creator", new_creator)
+        self.assert_catalog_data(self.dossier, "Creator", old_creator)
+
+    def test_nightly_indexer_handles_multiple_jobs(self):
+        intids = getUtility(IIntIds)
+        self.login(self.manager)
+        self.dossier.title = "New dossier title"
+        self.empty_dossier.title = "New empty dossier title"
+        self.subdossier.title = "New subdossier title"
+
+        with NightlyIndexer(idxs=["Title"]) as indexer:
+            indexer.add_by_intid(intids.getId(self.dossier))
+            indexer.add_by_intid(intids.getId(self.subdossier))
+
+        with NightlyIndexer(idxs=["Title"]) as indexer:
+            indexer.add_by_intid(intids.getId(self.empty_dossier))
+
+        self.run_nightly_jobs()
+        self.assert_solr_data(self.dossier, "Title", "New dossier title")
+        self.assert_solr_data(self.subdossier, "Title", "New subdossier title")
+        self.assert_solr_data(self.empty_dossier, "Title", "New empty dossier title")
+        self.assert_catalog_data(
+            self.dossier, "Title", ["new", "dossier", "title"])
+        self.assert_catalog_data(
+            self.subdossier, "Title", ["new", "subdossier", "title"])
+        self.assert_catalog_data(
+            self.empty_dossier, "Title", ["new", "empty", "dossier", "title"])

--- a/opengever/core/upgrade.py
+++ b/opengever/core/upgrade.py
@@ -499,6 +499,7 @@ class GeverUpgradeStepRecorder(UpgradeStepRecorder):
 class NightlyIndexer(object):
 
     def __init__(self, idxs, index_in_solr_only=False):
+        self.check_preconditions(idxs, index_in_solr_only)
         self.queue_manager = MaintenanceQueuesManager(api.portal.get())
         if index_in_solr_only:
             function_name = self.index_in_solr.__name__
@@ -515,6 +516,11 @@ class NightlyIndexer(object):
     def __enter__(self):
         key, self.queue = self.queue_manager.add_queue(self.job_type, IITreeSet)
         return self
+
+    def check_preconditions(self, idxs, index_in_solr_only):
+        if index_in_solr_only and 'SearchableText' in idxs:
+            raise ValueError(
+                "Reindexing SearchableText in solr only is not supported")
 
     @staticmethod
     def index_in_catalog(intid, idxs):

--- a/opengever/core/upgrade.py
+++ b/opengever/core/upgrade.py
@@ -522,6 +522,7 @@ class NightlyIndexer(object):
         else:
             function = index_in_catalog
         self.job_type = MaintenanceJobType(function, idxs=tuple(idxs))
+        self.intids = getUtility(IIntIds)
 
     def __enter__(self):
         key, self.queue = self.queue_manager.add_queue(self.job_type, IITreeSet)
@@ -529,6 +530,9 @@ class NightlyIndexer(object):
 
     def add_by_intid(self, intid):
         self.queue_manager.add_job(MaintenanceJob(self.job_type, intid))
+
+    def add_by_obj(self, obj):
+        self.add_by_intid(self.intids.getId(obj))
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         if len(self.queue) == 0:

--- a/opengever/core/upgrades/20210205084521_add_sortable_reference_number_index/upgrade.py
+++ b/opengever/core/upgrades/20210205084521_add_sortable_reference_number_index/upgrade.py
@@ -1,9 +1,6 @@
-from ftw.solr.interfaces import ISolrConnectionManager
-from ftw.solr.interfaces import ISolrIndexHandler
 from ftw.upgrade import UpgradeStep
 from plone.dexterity.interfaces import IDexterityContent
-from zope.component import getMultiAdapter
-from zope.component import getUtility
+from opengever.core.upgrade import NightlyIndexer
 
 
 class AddSortableReferenceNumberIndex(UpgradeStep):
@@ -16,14 +13,8 @@ class AddSortableReferenceNumberIndex(UpgradeStep):
         self.index_sortable_reference_number()
 
     def index_sortable_reference_number(self):
-        manager = getUtility(ISolrConnectionManager)
-        solr_connection = manager.connection
-
         query = {'object_provides': IDexterityContent.__identifier__}
-        for index, obj in enumerate(
-                self.objects(query, 'Index sortable_reference in Solr'), 1):
-            handler = getMultiAdapter((obj, manager), ISolrIndexHandler)
-            handler.add(['sortable_reference'])
-            if index % 1000 == 0:
-                solr_connection.commit()
-        manager.connection.commit(soft_commit=False, extract_after_commit=False)
+        with NightlyIndexer(idxs=["sortable_reference"],
+                            index_in_solr_only=True) as indexer:
+            for obj in self.objects(query, 'Index sortable_reference in Solr'):
+                indexer.add_by_obj(obj)

--- a/opengever/disposition/nightly_jobs.py
+++ b/opengever/disposition/nightly_jobs.py
@@ -1,24 +1,15 @@
 from opengever.disposition.delivery import DeliveryScheduler
 from opengever.disposition.interfaces import IDisposition
-from opengever.nightlyjobs.interfaces import INightlyJobProvider
+from opengever.nightlyjobs.provider import NightlyJobProviderBase
 from plone import api
-from Products.CMFPlone.interfaces import IPloneSiteRoot
-from zope.component import adapter
-from zope.interface import implementer
-from zope.publisher.interfaces.browser import IBrowserRequest
-import logging
 
 
-@implementer(INightlyJobProvider)
-@adapter(IPloneSiteRoot, IBrowserRequest, logging.Logger)
-class NightlySIPDelivery(object):
+class NightlySIPDelivery(NightlyJobProviderBase):
     """Nightly job provider that delivers SIP packages scheduled for delivery.
     """
 
     def __init__(self, context, request, logger):
-        self.context = context
-        self.request = request
-        self.logger = logger
+        super(NightlySIPDelivery, self).__init__(context, request, logger)
 
         self.catalog = api.portal.get_tool('portal_catalog')
 

--- a/opengever/dossier/nightly_after_resolve_job.py
+++ b/opengever/dossier/nightly_after_resolve_job.py
@@ -1,13 +1,7 @@
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.resolve import AfterResolveJobs
-from opengever.nightlyjobs.interfaces import INightlyJobProvider
+from opengever.nightlyjobs.provider import NightlyJobProviderBase
 from plone import api
-from Products.CMFPlone.interfaces import IPloneSiteRoot
-from zope.component import adapter
-from zope.interface import implementer
-from zope.publisher.interfaces.browser import IBrowserRequest
-import logging
-
 
 MAX_CONVERSION_REQUESTS_PER_NIGHT = 10000
 
@@ -15,14 +9,10 @@ MAX_CONVERSION_REQUESTS_PER_NIGHT = 10000
 sent_conversion_requests = 0
 
 
-@implementer(INightlyJobProvider)
-@adapter(IPloneSiteRoot, IBrowserRequest, logging.Logger)
-class ExecuteNightlyAfterResolveJobs(object):
+class ExecuteNightlyAfterResolveJobs(NightlyJobProviderBase):
 
     def __init__(self, context, request, logger):
-        self.context = context
-        self.request = request
-        self.logger = logger
+        super(ExecuteNightlyAfterResolveJobs, self).__init__(context, request, logger)
 
         self.catalog = api.portal.get_tool('portal_catalog')
 

--- a/opengever/nightlyjobs/configure.zcml
+++ b/opengever/nightlyjobs/configure.zcml
@@ -1,0 +1,8 @@
+<configure xmlns="http://namespaces.zope.org/zope">
+
+  <adapter
+      factory=".maintenance_jobs.NightlyMaintenanceJobsProvider"
+      name="maintenance-jobs"
+      />
+
+</configure>

--- a/opengever/nightlyjobs/interfaces.py
+++ b/opengever/nightlyjobs/interfaces.py
@@ -57,6 +57,12 @@ class INightlyJobProvider(Interface):
         load constraints.
         """
 
+    def maybe_commit(job):
+        """This method is called after each job has been executed for the given
+        provider. The provider is in charge of deciding whether and how to
+        commit.
+        """
+
     def __iter__():
         """Returns an iterator of jobs.
 

--- a/opengever/nightlyjobs/maintenance_jobs.py
+++ b/opengever/nightlyjobs/maintenance_jobs.py
@@ -1,0 +1,216 @@
+"""
+This module provides a very flexible way to perform maintenance tasks overnight.
+A MaintenanceJob allows to execute any function with any number of arguments.
+Such MaintenanceJobs will get added to queues using the MaintenanceQueuesManager
+and run overnight by the NightlyMaintenanceJobsProvider. MaintenanceJobs are
+grouped by MaintenanceJobType in the queues (one queue per type) for efficiency.
+"""
+
+from opengever.nightlyjobs.interfaces import INightlyJobProvider
+from persistent.dict import PersistentDict
+from Products.CMFPlone.interfaces import IPloneSiteRoot
+from zope.annotation import IAnnotations
+from zope.component import adapter
+from zope.interface import implementer
+from zope.publisher.interfaces.browser import IBrowserRequest
+import importlib
+import logging
+
+
+NIGHTLY_MAINTENANCE_JOB_QUEUES_KEY = 'NIGHTLY_MAINTENANCE_JOB_QUEUES'
+
+
+class QueueAlreadyExistsWithDifferentType(Exception):
+    """Raised when trying to add a queue with a key that already exists but
+    a different type."""
+
+
+class QueueIsMissing(Exception):
+    """Raised when trying to add a job to a queue which does not exist"""
+
+
+class JobIsMissing(Exception):
+    """Raised when trying to remove a job not found in the queue"""
+
+
+class FunctionNotFound(Exception):
+    """Raised when the function of a maintenance job cannot be found"""
+
+
+class MaintenanceJobType(object):
+    """A maintenance job type is composed of a function and a set of arguments
+    (fixed_arguments).
+
+    An instance of MaintenanceJobType is fully determined by its
+    job_type_identifier which contains the fixed_arguments and the information
+    needed to import the function.
+
+    The class contains a constructor from_identifier allowing to reconstruct a
+    MaintenanceJobType from a job_type_identifier.
+    """
+
+    def __init__(self, function, **fixed_arguments):
+        self.function = function
+        self.fixed_arguments = fixed_arguments
+
+    def __eq__(self, other):
+        return (self.function == other.function and
+                self.fixed_arguments == other.fixed_arguments)
+
+    @property
+    def module_dotted_name(self):
+        return self.function.__module__
+
+    @property
+    def function_name(self):
+        return self.function.__name__
+
+    @property
+    def job_type_identifier(self):
+        return (self.function_name,
+                self.module_dotted_name,
+                tuple(sorted(self.fixed_arguments.items())))
+
+    @classmethod
+    def from_identifier(cls, job_type_identifier):
+        function_name, module_dotted_name, fixed_args_tuple = job_type_identifier
+        module = importlib.import_module(module_dotted_name)
+        function = getattr(module, function_name)
+        if function is None:
+            raise FunctionNotFound()
+        fixed_arguments = dict(fixed_args_tuple)
+        return cls(function, **fixed_arguments)
+
+
+class MaintenanceJob(object):
+    """A maintenance job is composed of a job_type (MaintenanceJobType) and
+    a variable_argument, so that MaintenanceJobs of the same type only differ
+    by their variable_argument. This allows for more efficient storage when
+    adding many MaintenanceJobs with the same job_type, as the job_type needs
+    to be saved only once and an associated queue can simply store the value of
+    the variable_argument for each MaintenanceJob (see MaintenanceQueuesManager)
+    """
+    def __init__(self, job_type, variable_argument):
+        self.job_type = job_type
+        self.variable_argument = variable_argument
+
+    def __repr__(self):
+        return u'{}({}, {})'.format(
+            self.function.__name__,
+            self.variable_argument,
+            ", ".join(["{}={}".format(name, value) for name, value in
+                       self.fixed_arguments.items()]))
+
+    def __eq__(self, other):
+        return (self.job_type == other.job_type and
+                self.variable_argument == other.variable_argument)
+
+    @property
+    def function(self):
+        return self.job_type.function
+
+    @property
+    def fixed_arguments(self):
+        return self.job_type.fixed_arguments
+
+    def execute(self):
+        return self.function(self.variable_argument, **self.fixed_arguments)
+
+
+class MaintenanceQueuesManager(object):
+    """Queues for MaintenanceJobs are stored in the annotations on the plone
+    site root. We make one queue per job type, corresponding to a function and
+    a set of fixed arguments, so that only the variable argument of the job
+    needs to be stored in the actual queue (e.g. the object's IntId).
+
+    A queue should be a TreeSet, for example an IITreeSet to store IntIds.
+    """
+    def __init__(self, context):
+        self.context = context
+
+    def add_queue(self, job_type, queue_type):
+        ann = IAnnotations(self.context)
+        if NIGHTLY_MAINTENANCE_JOB_QUEUES_KEY not in ann:
+            ann[NIGHTLY_MAINTENANCE_JOB_QUEUES_KEY] = PersistentDict()
+
+        queue_key = self.queue_key_for_job_type(job_type)
+        queues = self.get_queues()
+        if queue_key in queues:
+            if not isinstance(queues[queue_key], queue_type):
+                raise QueueAlreadyExistsWithDifferentType
+        else:
+            queues[queue_key] = queue_type()
+        return queue_key, queues[queue_key]
+
+    def remove_queue(self, job_type):
+        self.get_queues().pop(self.queue_key_for_job_type(job_type))
+
+    def get_queues(self):
+        ann = IAnnotations(self.context)
+        queues = ann.get(NIGHTLY_MAINTENANCE_JOB_QUEUES_KEY, {})
+        return queues
+
+    def queue_key_for_job_type(self, job_type):
+        return job_type.job_type_identifier
+
+    def get_queue(self, job_type):
+        key = self.queue_key_for_job_type(job_type)
+        queue = self.get_queues().get(key)
+        if queue is None:
+            raise QueueIsMissing()
+        return queue
+
+    def add_job(self, job):
+        queue = self.get_queue(job.job_type)
+        queue.add(job.variable_argument)
+
+    def remove_job(self, job, remove_queue_if_empty=True):
+        queue = self.get_queue(job.job_type)
+        if job.variable_argument not in queue:
+            raise JobIsMissing()
+        queue.remove(job.variable_argument)
+        if remove_queue_if_empty and len(queue) == 0:
+            self.remove_queue(job.job_type)
+
+    @property
+    def jobs(self):
+        queues = self.get_queues()
+        for queue_key, queue in queues.items():
+            job_type = MaintenanceJobType.from_identifier(queue_key)
+
+            # Avoid list size changing during iteration
+            job_arguments = list(queue)
+
+            for variable_argument in job_arguments:
+                yield MaintenanceJob(job_type, variable_argument)
+
+    def get_jobs_count(self):
+        return sum(len(queue) for queue in self.get_queues().values())
+
+
+@implementer(INightlyJobProvider)
+@adapter(IPloneSiteRoot, IBrowserRequest, logging.Logger)
+class NightlyMaintenanceJobsProvider(object):
+    """This provider is used to run MaintenanceJobs over night which have
+    previously been added in a queue using the MaintenanceQueuesManager.
+    """
+
+    def __init__(self, context, request, logger):
+        self.context = context
+        self.request = request
+        self.logger = logger
+        self.queues_manager = MaintenanceQueuesManager(context)
+
+    def __iter__(self):
+        return self.queues_manager.jobs
+
+    def __len__(self):
+        return self.queues_manager.get_jobs_count()
+
+    def run_job(self, job, interrupt_if_necessary):
+        """Run the job.
+        """
+        self.logger.info('Executing maintenance job: %r' % job)
+
+        job.execute()
+        self.queues_manager.remove_job(job)

--- a/opengever/nightlyjobs/maintenance_jobs.py
+++ b/opengever/nightlyjobs/maintenance_jobs.py
@@ -37,6 +37,10 @@ class FunctionNotFound(Exception):
     """Raised when the function of a maintenance job cannot be found"""
 
 
+class UnhashableArguments(Exception):
+    """Raised when the fixed_arguments are not hashable"""
+
+
 class MaintenanceJobType(object):
     """A maintenance job type is composed of a function and a set of arguments
     (fixed_arguments).
@@ -52,10 +56,16 @@ class MaintenanceJobType(object):
     def __init__(self, function_dotted_name, **fixed_arguments):
         self.function_dotted_name = function_dotted_name
         self.fixed_arguments = fixed_arguments
+
         try:
             self.function = resolve(self.function_dotted_name)
         except ImportError:
             raise FunctionNotFound()
+
+        try:
+            hash(self.job_type_identifier)
+        except TypeError:
+            raise UnhashableArguments()
 
     def __eq__(self, other):
         return (self.function_dotted_name == other.function_dotted_name and

--- a/opengever/nightlyjobs/maintenance_jobs.py
+++ b/opengever/nightlyjobs/maintenance_jobs.py
@@ -8,16 +8,10 @@ grouped by MaintenanceJobType in the queues (one queue per type) for efficiency.
 
 from BTrees.IIBTree import IITreeSet
 from BTrees.OOBTree import OOTreeSet
-from opengever.nightlyjobs.interfaces import INightlyJobProvider
+from opengever.nightlyjobs.provider import NightlyJobProviderBase
 from persistent.dict import PersistentDict
-from Products.CMFPlone.interfaces import IPloneSiteRoot
 from zope.annotation import IAnnotations
-from zope.component import adapter
 from zope.dottedname.resolve import resolve
-from zope.interface import implementer
-from zope.publisher.interfaces.browser import IBrowserRequest
-import logging
-
 
 NIGHTLY_MAINTENANCE_JOB_QUEUES_KEY = 'NIGHTLY_MAINTENANCE_JOB_QUEUES'
 
@@ -208,17 +202,13 @@ class MaintenanceQueuesManager(object):
         return sum(len(queue) for queue in self.get_queues().values())
 
 
-@implementer(INightlyJobProvider)
-@adapter(IPloneSiteRoot, IBrowserRequest, logging.Logger)
-class NightlyMaintenanceJobsProvider(object):
+class NightlyMaintenanceJobsProvider(NightlyJobProviderBase):
     """This provider is used to run MaintenanceJobs over night which have
     previously been added in a queue using the MaintenanceQueuesManager.
     """
 
     def __init__(self, context, request, logger):
-        self.context = context
-        self.request = request
-        self.logger = logger
+        super(NightlyMaintenanceJobsProvider, self).__init__(context, request, logger)
         self.queues_manager = MaintenanceQueuesManager(context)
 
     def __iter__(self):

--- a/opengever/nightlyjobs/maintenance_jobs.py
+++ b/opengever/nightlyjobs/maintenance_jobs.py
@@ -57,6 +57,13 @@ class MaintenanceJobType(object):
         return (self.function == other.function and
                 self.fixed_arguments == other.fixed_arguments)
 
+    def __repr__(self):
+        return u'{}({}, {})'.format(
+            self.__class__.__name__,
+            self.function.__name__,
+            ", ".join(["{}={}".format(name, value) for name, value in
+                       self.fixed_arguments.items()]))
+
     @property
     def module_dotted_name(self):
         return self.function.__module__

--- a/opengever/nightlyjobs/provider.py
+++ b/opengever/nightlyjobs/provider.py
@@ -1,0 +1,16 @@
+from opengever.nightlyjobs.interfaces import INightlyJobProvider
+from Products.CMFPlone.interfaces import IPloneSiteRoot
+from zope.component import adapter
+from zope.interface import implementer
+from zope.publisher.interfaces.browser import IBrowserRequest
+import logging
+
+
+@implementer(INightlyJobProvider)
+@adapter(IPloneSiteRoot, IBrowserRequest, logging.Logger)
+class NightlyJobProviderBase(object):
+
+    def __init__(self, context, request, logger):
+        self.context = context
+        self.request = request
+        self.logger = logger

--- a/opengever/nightlyjobs/provider.py
+++ b/opengever/nightlyjobs/provider.py
@@ -4,6 +4,7 @@ from zope.component import adapter
 from zope.interface import implementer
 from zope.publisher.interfaces.browser import IBrowserRequest
 import logging
+import transaction
 
 
 @implementer(INightlyJobProvider)
@@ -14,3 +15,6 @@ class NightlyJobProviderBase(object):
         self.context = context
         self.request = request
         self.logger = logger
+
+    def maybe_commit(self, job):
+        transaction.commit()

--- a/opengever/nightlyjobs/runner.py
+++ b/opengever/nightlyjobs/runner.py
@@ -114,7 +114,8 @@ class NightlyJobRunner(object):
                     message = self.format_early_abort_message(exc)
                     self.log_to_sentry(message)
                     return exc
-                transaction.commit()
+
+                provider.maybe_commit(job)
 
                 # If we set up our own task queue, process its jobs.
                 # This must happen after the transaction has been committed.

--- a/opengever/nightlyjobs/tests/test_maintenance_jobs.py
+++ b/opengever/nightlyjobs/tests/test_maintenance_jobs.py
@@ -97,6 +97,11 @@ class TestMaintenanceQueuesManager(IntegrationTestCase):
         self.assertEqual(self.queue_manager.get_queues(),
                          {self.job_type.job_type_identifier: queue})
 
+    def test_adding_invalid_queue_raises(self):
+        with self.assertRaises(AssertionError) as exc:
+            self.queue_manager.add_queue(self.job_type, list)
+        self.assertEqual("Invalid queue type", exc.exception.message)
+
     def test_adding_already_existing_queue_is_ignored(self):
         self.queue_manager.add_queue(self.job_type, IITreeSet)
         job = MaintenanceJob(self.job_type, 1)

--- a/opengever/nightlyjobs/tests/test_maintenance_jobs.py
+++ b/opengever/nightlyjobs/tests/test_maintenance_jobs.py
@@ -1,0 +1,194 @@
+from BTrees.IIBTree import IITreeSet
+from BTrees.OOBTree import OOTreeSet
+from opengever.nightlyjobs.maintenance_jobs import MaintenanceJob
+from opengever.nightlyjobs.maintenance_jobs import MaintenanceJobType
+from opengever.nightlyjobs.maintenance_jobs import MaintenanceQueuesManager
+from opengever.nightlyjobs.maintenance_jobs import NightlyMaintenanceJobsProvider
+from opengever.nightlyjobs.maintenance_jobs import QueueAlreadyExistsWithDifferentType
+from opengever.testing import IntegrationTestCase
+from plone import api
+from unittest import TestCase
+from zope.annotation import IAnnotations
+import logging
+
+
+def return_args(variable_argument, **kwargs):
+    output = {"variable_argument": variable_argument}
+    output.update(kwargs)
+    return output
+
+
+def write_args_to_portal(variable_argument, **kwargs):
+    output = {"variable_argument": variable_argument}
+    output.update(kwargs)
+    portal = api.portal.get()
+    annotations = IAnnotations(portal)
+    if 'jobs_run' not in annotations:
+        annotations['jobs_run'] = []
+    annotations['jobs_run'].append(output)
+
+
+class TestNightlyMaintenanceJobTypes(TestCase):
+
+    def test_job_type_identifier(self):
+        job_type = MaintenanceJobType(return_args, foo=1, bar="bar")
+        self.assertEqual(
+            ('return_args',
+             'opengever.nightlyjobs.tests.test_maintenance_jobs',
+             (('bar', 'bar'), ('foo', 1))),
+            job_type.job_type_identifier)
+
+    def test_can_recreate_job_type_from_identifier(self):
+        original = MaintenanceJobType(return_args, foo=1, bar="bar")
+        recreated = MaintenanceJobType.from_identifier(
+            original.job_type_identifier)
+        self.assertEqual(original, recreated)
+
+
+class TestNightlyMaintenanceJobs(TestCase):
+
+    def setUp(self):
+        super(TestNightlyMaintenanceJobs, self).setUp()
+        self.job_type = MaintenanceJobType(return_args, foo=1, bar="bar")
+
+    def test_job_representation(self):
+        job = MaintenanceJob(self.job_type, 123)
+        self.assertEqual('return_args(123, foo=1, bar=bar)',
+                         str(job))
+
+    def test_execute_job(self):
+        job = MaintenanceJob(self.job_type, 123)
+        result = job.execute()
+        self.assertEqual(
+            result, {"variable_argument": 123, "foo": 1, "bar": "bar"})
+        self.assertEqual(
+            result, return_args(123, foo=1, bar="bar"))
+
+
+class TestMaintenanceQueuesManager(IntegrationTestCase):
+
+    def setUp(self):
+        super(TestMaintenanceQueuesManager, self).setUp()
+        self.queue_manager = MaintenanceQueuesManager(api.portal.get())
+        self.job_type = MaintenanceJobType(return_args, foo=1, bar="bar")
+
+    def test_queue_key_is_job_type_identifier(self):
+        self.assertEqual(self.queue_manager.queue_key_for_job_type(self.job_type),
+                         self.job_type.job_type_identifier)
+
+    def test_adding_queue(self):
+        self.assertFalse(self.queue_manager.get_queues())
+        key, queue = self.queue_manager.add_queue(self.job_type, IITreeSet)
+        self.assertIn(self.job_type.job_type_identifier,
+                      self.queue_manager.get_queues())
+        self.assertEqual(self.queue_manager.get_queues(),
+                         {self.job_type.job_type_identifier: queue})
+
+    def test_adding_already_existing_queue_is_ignored(self):
+        self.queue_manager.add_queue(self.job_type, IITreeSet)
+        job = MaintenanceJob(self.job_type, 1)
+        self.queue_manager.add_job(job)
+        self.assertEqual(1, len(self.queue_manager.get_queues()))
+        self.assertEqual(1, self.queue_manager.get_jobs_count())
+
+        self.queue_manager.add_queue(self.job_type, IITreeSet)
+        self.assertEqual(1, len(self.queue_manager.get_queues()))
+        self.assertEqual(1, self.queue_manager.get_jobs_count())
+
+    def test_adding_queue_with_same_key_but_different_type_raises(self):
+        self.queue_manager.add_queue(self.job_type, IITreeSet)
+        with self.assertRaises(QueueAlreadyExistsWithDifferentType):
+            self.queue_manager.add_queue(self.job_type, OOTreeSet)
+
+    def test_only_variable_job_argument_is_stored_in_queue(self):
+        self.queue_manager.add_queue(self.job_type, IITreeSet)
+        job = MaintenanceJob(self.job_type, 123)
+        self.queue_manager.add_job(job)
+        queue = self.queue_manager.get_queue(self.job_type)
+        self.assertEqual([123], list(queue))
+
+    def test_returns_jobs_from_all_queues(self):
+        job1 = MaintenanceJob(self.job_type, 1)
+        job2 = MaintenanceJob(self.job_type, 2)
+        self.queue_manager.add_queue(self.job_type, IITreeSet)
+        self.queue_manager.add_job(job1)
+        self.queue_manager.add_job(job2)
+
+        job_type2 = MaintenanceJobType(return_args, foo=2, bar="bar")
+        job3 = MaintenanceJob(job_type2, 1)
+        self.queue_manager.add_queue(job_type2, IITreeSet)
+        self.queue_manager.add_job(job3)
+
+        jobs = list(self.queue_manager.jobs)
+        self.assertEqual(3, len(jobs))
+        self.assertIn(job1, jobs)
+        self.assertIn(job2, jobs)
+        self.assertIn(job3, jobs)
+
+    def test_dupplicate_job_is_not_added(self):
+        job = MaintenanceJob(self.job_type, 123)
+        self.queue_manager.add_queue(self.job_type, IITreeSet)
+        self.queue_manager.add_job(job)
+        self.assertEqual(1, self.queue_manager.get_jobs_count())
+
+        self.queue_manager.add_job(job)
+        self.assertEqual(1, self.queue_manager.get_jobs_count())
+
+    def test_removing_last_job_from_queue_removes_queue(self):
+        job = MaintenanceJob(self.job_type, 123)
+        self.queue_manager.add_queue(self.job_type, IITreeSet)
+        self.queue_manager.add_job(job)
+
+        self.assertIn(self.job_type.job_type_identifier,
+                      self.queue_manager.get_queues())
+
+        self.queue_manager.remove_job(job)
+        self.assertNotIn(self.job_type.job_type_identifier,
+                         self.queue_manager.get_queues())
+
+
+class TestNightlyMaintenanceJobsProvider(IntegrationTestCase):
+
+    features = ('nightly-jobs', )
+    maxDiff = None
+
+    def execute_nightly_jobs(self):
+        nightly_logger = logging.getLogger('opengever.nightlyjobs')
+
+        nightly_job_provider = NightlyMaintenanceJobsProvider(
+            self.portal, self.request, nightly_logger)
+
+        jobs = list(nightly_job_provider)
+
+        for job in jobs:
+            nightly_job_provider.run_job(job, None)
+
+    def test_runs_maintenance_jobs_and_clears_queues(self):
+        self.queue_manager = MaintenanceQueuesManager(api.portal.get())
+        annotations = IAnnotations(api.portal.get())
+
+        job_type1 = MaintenanceJobType(write_args_to_portal, foo=1, bar="bar")
+        job_type2 = MaintenanceJobType(write_args_to_portal, foo=2, bar="bar")
+
+        job1 = MaintenanceJob(job_type1, 1)
+        job2 = MaintenanceJob(job_type1, 2)
+        self.queue_manager.add_queue(job_type1, IITreeSet)
+        self.queue_manager.add_job(job1)
+        self.queue_manager.add_job(job2)
+
+        job3 = MaintenanceJob(job_type2, 1)
+        self.queue_manager.add_queue(job_type2, IITreeSet)
+        self.queue_manager.add_job(job3)
+
+        self.assertEqual(2, len(list(self.queue_manager.get_queues())))
+        self.assertEqual(3, len(list(self.queue_manager.jobs)))
+        self.assertNotIn('jobs_run', annotations)
+
+        self.execute_nightly_jobs()
+        self.assertEqual(0, len(list(self.queue_manager.jobs)))
+        self.assertEqual(0, len(list(self.queue_manager.get_queues())))
+        self.assertIn('jobs_run', annotations)
+        self.assertEqual([{'variable_argument': 1, 'bar': 'bar', 'foo': 1},
+                          {'variable_argument': 2, 'bar': 'bar', 'foo': 1},
+                          {'variable_argument': 1, 'bar': 'bar', 'foo': 2}],
+                         annotations['jobs_run'])

--- a/opengever/nightlyjobs/tests/test_maintenance_jobs.py
+++ b/opengever/nightlyjobs/tests/test_maintenance_jobs.py
@@ -38,6 +38,12 @@ class TestNightlyMaintenanceJobTypes(TestCase):
              (('bar', 'bar'), ('foo', 1))),
             job_type.job_type_identifier)
 
+    def test_job_type_representation(self):
+        job_type = MaintenanceJobType(return_args, foo=1, bar="bar")
+        self.assertEqual(
+            str(job_type),
+            'MaintenanceJobType(return_args, foo=1, bar=bar)')
+
     def test_can_recreate_job_type_from_identifier(self):
         original = MaintenanceJobType(return_args, foo=1, bar="bar")
         recreated = MaintenanceJobType.from_identifier(

--- a/opengever/nightlyjobs/tests/test_maintenance_jobs.py
+++ b/opengever/nightlyjobs/tests/test_maintenance_jobs.py
@@ -1,11 +1,12 @@
 from BTrees.IIBTree import IITreeSet
 from BTrees.OOBTree import OOTreeSet
+from opengever.nightlyjobs.maintenance_jobs import FunctionNotFound
 from opengever.nightlyjobs.maintenance_jobs import MaintenanceJob
 from opengever.nightlyjobs.maintenance_jobs import MaintenanceJobType
 from opengever.nightlyjobs.maintenance_jobs import MaintenanceQueuesManager
 from opengever.nightlyjobs.maintenance_jobs import NightlyMaintenanceJobsProvider
 from opengever.nightlyjobs.maintenance_jobs import QueueAlreadyExistsWithDifferentType
-from opengever.nightlyjobs.maintenance_jobs import FunctionNotFound
+from opengever.nightlyjobs.maintenance_jobs import UnhashableArguments
 from opengever.testing import IntegrationTestCase
 from plone import api
 from unittest import TestCase
@@ -49,6 +50,10 @@ class TestNightlyMaintenanceJobTypes(TestCase):
     def test_raises_if_function_dotted_name_cannot_be_resolved(self):
         with self.assertRaises(FunctionNotFound):
             MaintenanceJobType("unresolvable.function.name", foo=1)
+
+    def test_raises_if_arguments_are_not_hashable(self):
+        with self.assertRaises(UnhashableArguments):
+            MaintenanceJobType(return_args_dotted_name, foo=[1])
 
 
 class TestNightlyMaintenanceJobs(TestCase):

--- a/opengever/nightlyjobs/tests/test_maintenance_jobs.py
+++ b/opengever/nightlyjobs/tests/test_maintenance_jobs.py
@@ -94,8 +94,9 @@ class TestMaintenanceQueuesManager(IntegrationTestCase):
         key, queue = self.queue_manager.add_queue(self.job_type, IITreeSet)
         self.assertIn(self.job_type.job_type_identifier,
                       self.queue_manager.get_queues())
-        self.assertEqual(self.queue_manager.get_queues(),
-                         {self.job_type.job_type_identifier: queue})
+        self.assertEqual(
+            self.queue_manager.get_queues(),
+            {self.job_type.job_type_identifier: queue})
 
     def test_adding_invalid_queue_raises(self):
         with self.assertRaises(AssertionError) as exc:
@@ -123,7 +124,7 @@ class TestMaintenanceQueuesManager(IntegrationTestCase):
         job = MaintenanceJob(self.job_type, 123)
         self.queue_manager.add_job(job)
         queue = self.queue_manager.get_queue(self.job_type)
-        self.assertEqual([123], list(queue))
+        self.assertEqual([123], list(queue['queue']))
 
     def test_returns_jobs_from_all_queues(self):
         job1 = MaintenanceJob(self.job_type, 1)
@@ -152,18 +153,6 @@ class TestMaintenanceQueuesManager(IntegrationTestCase):
 
         self.queue_manager.add_job(job)
         self.assertEqual(1, self.queue_manager.get_jobs_count())
-
-    def test_removing_last_job_from_queue_removes_queue(self):
-        job = MaintenanceJob(self.job_type, 123)
-        self.queue_manager.add_queue(self.job_type, IITreeSet)
-        self.queue_manager.add_job(job)
-
-        self.assertIn(self.job_type.job_type_identifier,
-                      self.queue_manager.get_queues())
-
-        self.queue_manager.remove_job(job)
-        self.assertNotIn(self.job_type.job_type_identifier,
-                         self.queue_manager.get_queues())
 
 
 class TestNightlyMaintenanceJobsProvider(IntegrationTestCase):
@@ -194,6 +183,7 @@ class TestNightlyMaintenanceJobsProvider(IntegrationTestCase):
 
         for job in jobs:
             nightly_job_provider.run_job(job, None)
+            nightly_job_provider.maybe_commit(job)
 
     def test_runs_maintenance_jobs_and_clears_queues(self):
         self.queue_manager = MaintenanceQueuesManager(api.portal.get())

--- a/opengever/nightlyjobs/tests/test_nightly_job_provider.py
+++ b/opengever/nightlyjobs/tests/test_nightly_job_provider.py
@@ -64,6 +64,9 @@ class DocumentTitleModifierJobProvider(object):
         obj = uuidToObject(job['uid'])
         obj.title = u'Modified {}'.format(obj.title)
 
+    def maybe_commit(self, job):
+        pass
+
 
 class TestNightlyJobProviderClasses(IntegrationTestCase):
 


### PR DESCRIPTION
With this PR we add a new nightly job provider for maintenance jobs. The implementation is meant to keep as much flexibility as possible, allowing to basically run any function in a nightly maintenance job. I also tried to make the queues efficient, using BTrees and only storing the strict minimum in the queues.

I also added a helper context manager that allows to easily use the nightly maintenance jobs for upgrades reindexing objects in the catalog or in solr.

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-2366]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-2366]: https://4teamwork.atlassian.net/browse/CA-2366