### PR TITLE
Allow editing of a document with Office Online even if the document is not locked

### DIFF
--- a/changes/CA-2370.bugfix
+++ b/changes/CA-2370.bugfix
@@ -1,0 +1,1 @@
+Allow editing of a document with Office Online even if the document is not locked. [tinagerber]

--- a/opengever/document/fileactions.py
+++ b/opengever/document/fileactions.py
@@ -10,7 +10,6 @@ from opengever.officeconnector.helpers import is_officeconnector_attach_feature_
 from opengever.officeconnector.helpers import is_officeconnector_checkout_feature_enabled  # noqa
 from opengever.trash.trash import ITrasher
 from opengever.wopi import is_wopi_feature_enabled
-from opengever.wopi.lock import get_lock_token
 from opengever.workspace.interfaces import IDeleter
 from opengever.workspace.interfaces import IWorkspaceFolder
 from plone import api
@@ -271,12 +270,9 @@ class DocumentFileActions(BaseDocumentFileActions):
     def _can_edit_with_office_online(self):
         # Office Online allows collaborative editing
         # Thus a document is editable by Office Online if it's not checked out and not locked
-        # or if it's checked out by Office Online.
+        # or if it's collaboratively checked out.
         if self.context.checked_out_by():
-            if get_lock_token(self.context):
-                return True
-            else:
-                return False
+            return self.context.is_collaborative_checkout()
         if self.context.is_locked():
             return False
         return True

--- a/opengever/document/tests/test_fileactions.py
+++ b/opengever/document/tests/test_fileactions.py
@@ -99,8 +99,7 @@ class TestOfficeOnlineEditable(IntegrationTestCase):
         self.login(self.regular_user)
         manager = getMultiAdapter((self.document, self.request),
                                   ICheckinCheckoutManager)
-        manager.checkout()
-        create_lock(self.document, 'TOKEN')
+        manager.checkout(True)
         actions = getMultiAdapter((self.document, self.request), IFileActions)
         self.assertTrue(actions.is_office_online_edit_action_available())
 


### PR DESCRIPTION
Since the edit_office_online action used the lock token to determine if a document was checked out collaboratively, the action was no longer available when the lock was removed.

For [CA-2370]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-2370]: https://4teamwork.atlassian.net/browse/CA-2370