### PR TITLE
Update local roles when dossier protection is revoked.

### DIFF
--- a/changes/CA-2774.bugfix
+++ b/changes/CA-2774.bugfix
@@ -1,0 +1,1 @@
+Update local roles when dossier protection is revoked. [tinagerber]

--- a/opengever/dossier/behaviors/protect_dossier.py
+++ b/opengever/dossier/behaviors/protect_dossier.py
@@ -182,7 +182,7 @@ class DossierProtection(AnnotationsFactoryImpl):
         to the current dossier also if it not defined in the schema. This
         is to prevent locking out yourself.
         """
-        if not self.need_update(force_update):
+        if not self.is_update_allowed(force_update):
             return
 
         self.update_role_inheritance()
@@ -193,16 +193,14 @@ class DossierProtection(AnnotationsFactoryImpl):
 
         self.context.reindexObjectSecurity()
 
-    def need_update(self, force_update=False):
+    def is_update_allowed(self, force_update=False):
         """Only update the permissions if the current user has the
         protect dossier permission and a dossier manager is set.
         """
         if force_update:
             return True
-
-        return api.user.has_permission(
-            'opengever.dossier: Protect dossier', obj=self.context) and \
-            self.dossier_manager
+        return api.user.has_permission('opengever.dossier: Protect dossier', obj=self.context) and \
+            (self.dossier_manager or not self.is_dossier_protected())
 
     def update_role_inheritance(self):
         old_value = self.is_role_inheritance_blocked(self.context)


### PR DESCRIPTION
Since it is not possible to authorize users through the `reading` and `reading_and_writing` fields if no dossier manager is set, it is not necessary to check if a dossier manager is set when making a change, as this prevents dossier protection from being removed if all fields are cleared at the same time.

For [CA-2774]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-2774]: https://4teamwork.atlassian.net/browse/CA-2774