### PR TITLE
Extend the testing fixture with a custom prop having a default value.

### DIFF
--- a/opengever/api/tests/test_listing_custom_fields.py
+++ b/opengever/api/tests/test_listing_custom_fields.py
@@ -65,7 +65,12 @@ class TestListingCustomFieldsGet(IntegrationTestCase):
                             u"name": u"additional_title_custom_field_string",
                             u"title": u"Additional dossier title",
                             u"type": u"string"
-                        }
+                        },
+                        u'location_custom_field_string': {
+                            u'name': u'location_custom_field_string',
+                            u'title': u'Location',
+                            u'type': u'string'
+                        },
                     }
                 }
             },

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -521,6 +521,8 @@ class OpengeverContentFixture(object):
             .assigned_to_slots(u"IDossier.default")
             .with_field("textline", u"additional_title",
                         u"Additional dossier title", u"", False)
+            .with_field("textline", u"location", u"Location", u"", False,
+                        default=u"B\xfcren an der Aare")
         )
 
     @staticuid()


### PR DESCRIPTION
This PR extends the testing fixture with a custom prop having a default value.

For [CA-2482]

[CA-2482]: https://4teamwork.atlassian.net/browse/CA-2482