### PR TITLE
Prevent non-docx and empty files in a PATCH request to a proposal document.

### DIFF
--- a/changes/CA-2156-1.bugfix
+++ b/changes/CA-2156-1.bugfix
@@ -1,0 +1,1 @@
+Prevent non-docx and empty files in a PATCH request to a proposal document. [deiferni]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -14,6 +14,8 @@ Other Changes
 
 - Add new endpoint ``@reactivate-local-group`` (see :ref:`docs <reactivate-local-group>`)
 - Propertysheets: ``multiple_choice`` fields are now supported.
+- Prevent changing ``file`` of ``opengever.document.document`` to a non-docx file if it is inside an ``opengever.meeting.proposal``.
+- Prevent setting ``file`` to ``null`` for ``opengever.document.document`` if it is inside an ``opengever.meeting.proposal``.
 
 
 2021.17.0 (2021-08-30)

--- a/opengever/api/document.py
+++ b/opengever/api/document.py
@@ -147,6 +147,16 @@ class DocumentPatch(ContentPatch):
             return
 
         value = data['file']
+        if not value:
+            return {
+                "error": {
+                    "type": "Forbidden",
+                    "message": "It's not possible to have no file in proposal "
+                               "documents."
+
+                }
+            }
+
         content_type = value.get('content-type')
         filename = value.get('filename')
 

--- a/opengever/api/document.py
+++ b/opengever/api/document.py
@@ -21,6 +21,10 @@ from zope.component import adapter
 from zope.component import getMultiAdapter
 from zope.interface import implementer
 from zope.interface import Interface
+import os.path
+
+
+MIME_DOCX = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
 
 
 @implementer(ISerializeToJson)
@@ -107,20 +111,64 @@ class SerializeDocumentToJson(GeverSerializeToJson):
 class DocumentPatch(ContentPatch):
 
     def reply(self):
+        data = json_body(self.request)
 
-        # Only allow updating a documents file if the document is checked-out
-        # by the current user.
+        error = self._validate_checked_out(data) or self._validate_proposal_document(data)
+        if error:
+            self.request.response.setStatus(403)
+            return error
+
+        return super(DocumentPatch, self).reply()
+
+    def _validate_checked_out(self, data):
+        """Only allow updating a documents file if the document is checked-out
+        by the current user.
+        """
+        if 'file' not in data:
+            return
+
         manager = getMultiAdapter((self.context, self.request),
                                   ICheckinCheckoutManager)
         if not manager.is_checked_out_by_current_user():
-            data = json_body(self.request)
-            if 'file' in data:
-                self.request.response.setStatus(403)
-                return dict(error=dict(
-                    type='Forbidden',
-                    message='Document not checked-out by current user.'))
+            return {
+                "error": {
+                    "type": "Forbidden",
+                    "message": "Document not checked-out by current user."
+                }
+            }
 
-        return super(DocumentPatch, self).reply()
+    def _validate_proposal_document(self, data):
+        """Prevent a proposals document being replaced by non-docx file.
+        """
+        if not self.context.is_inside_a_proposal():
+            return
+
+        if 'file' not in data:
+            return
+
+        value = data['file']
+        content_type = value.get('content-type')
+        filename = value.get('filename')
+
+        if content_type and content_type != MIME_DOCX:
+            return {
+                "error": {
+                    "type": "Forbidden",
+                    "message": "Mime type must be {} for "
+                               "proposal documents.".format(MIME_DOCX)
+
+                }
+            }
+
+        if not os.path.splitext(filename)[1].lower() == '.docx':
+            return {
+                "error": {
+                    "type": "Forbidden",
+                    "message": "File extension must be .docx for "
+                               "proposal documents."
+
+                }
+            }
 
 
 @implementer(IExpandableElement)

--- a/opengever/api/tests/test_document.py
+++ b/opengever/api/tests/test_document.py
@@ -313,9 +313,6 @@ class TestDocumentDelete(IntegrationTestCase):
 
 class TestDocumentPatch(IntegrationTestCase):
 
-    def setUp(self):
-        super(TestDocumentPatch, self).setUp()
-
     @browsing
     def test_document_patch_forbidden_if_not_checked_out(self, browser):
         self.login(self.regular_user, browser)


### PR DESCRIPTION
Bring API validation in line with classic ui validation for proposal documents. We fix the following two potential issues:
- Prevent users from replacing a proposal document with a non-docx document.
- Prevent users from removing the file from a proposal document.

_This still leaves a potential loophole as we don't inspect file data. This is consistent with behavior in the classical UI and also i'm not sure if want to do so and can do so reliably._

For [CA-2156](https://4teamwork.atlassian.net/browse/CA-2156)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- API change:
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))