### PR TITLE
Allow checkin for collaborative checkout if it's not locked

### DIFF
--- a/changes/CA-2339.other
+++ b/changes/CA-2339.other
@@ -1,0 +1,1 @@
+- Allow check-in for collaborators if lock expired. [buchi]

--- a/changes/CA-2339a.feature
+++ b/changes/CA-2339a.feature
@@ -1,0 +1,1 @@
+- Include checkout collaborators and file modification time in document serialization. [buchi]

--- a/changes/CA-2339b.feature
+++ b/changes/CA-2339b.feature
@@ -1,0 +1,1 @@
+- Include checkout collaborators, file modification time, lock time and lock timeout in document status. [buchi]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -20,6 +20,7 @@ Other Changes
 - Propertysheets: ``multiple_choice`` fields are now supported.
 - Prevent changing ``file`` of ``opengever.document.document`` to a non-docx file if it is inside an ``opengever.meeting.proposal``.
 - Prevent setting ``file`` to ``null`` for ``opengever.document.document`` if it is inside an ``opengever.meeting.proposal``.
+- Include checkout collaborators and file modification time in document serialization.
 
 
 2021.17.0 (2021-08-30)

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -21,6 +21,7 @@ Other Changes
 - Prevent changing ``file`` of ``opengever.document.document`` to a non-docx file if it is inside an ``opengever.meeting.proposal``.
 - Prevent setting ``file`` to ``null`` for ``opengever.document.document`` if it is inside an ``opengever.meeting.proposal``.
 - Include checkout collaborators and file modification time in document serialization.
+- Include checkout collaborators, file modification time, lock time and lock timeout in document status.
 
 
 2021.17.0 (2021-08-30)

--- a/opengever/api/document.py
+++ b/opengever/api/document.py
@@ -62,6 +62,7 @@ class SerializeDocumentToJson(GeverSerializeToJson):
             'checked_out': checked_out_by,
             'checked_out_fullname': checked_out_by_fullname,
             'checkout_collaborators': list(obj.get_collaborators()),
+            'file_mtime': obj.get_file_mtime(),
             'is_collaborative_checkout': obj.is_collaborative_checkout(),
             'is_locked': obj.is_locked(),
             'containing_dossier': obj.containing_dossier_title(),

--- a/opengever/api/document.py
+++ b/opengever/api/document.py
@@ -61,6 +61,7 @@ class SerializeDocumentToJson(GeverSerializeToJson):
         additional_metadata = {
             'checked_out': checked_out_by,
             'checked_out_fullname': checked_out_by_fullname,
+            'checkout_collaborators': list(obj.get_collaborators()),
             'is_collaborative_checkout': obj.is_collaborative_checkout(),
             'is_locked': obj.is_locked(),
             'containing_dossier': obj.containing_dossier_title(),

--- a/opengever/api/tests/test_document.py
+++ b/opengever/api/tests/test_document.py
@@ -121,6 +121,7 @@ class TestDocumentSerializer(IntegrationTestCase):
 
         browser.open(self.subdocument, headers={'Accept': 'application/json'})
         self.assertTrue(browser.json['is_collaborative_checkout'])
+        self.assertEqual(browser.json['checkout_collaborators'], ['kathi.barfuss'])
 
     @browsing
     def test_respects_version_id_when_traversing_on_older_version(self, browser):

--- a/opengever/api/tests/test_document.py
+++ b/opengever/api/tests/test_document.py
@@ -124,6 +124,13 @@ class TestDocumentSerializer(IntegrationTestCase):
         self.assertEqual(browser.json['checkout_collaborators'], ['kathi.barfuss'])
 
     @browsing
+    def test_contains_file_modification_time(self, browser):
+        self.login(self.regular_user, browser)
+
+        browser.open(self.subdocument, headers={'Accept': 'application/json'})
+        self.assertTrue(isinstance(browser.json['file_mtime'], float))
+
+    @browsing
     def test_respects_version_id_when_traversing_on_older_version(self, browser):
         self.login(self.regular_user, browser)
 

--- a/opengever/api/tests/test_mail.py
+++ b/opengever/api/tests/test_mail.py
@@ -30,6 +30,7 @@ class TestGetMail(IntegrationTestCase):
         self.assertFalse(browser.json['is_shadow_document'])
         self.assertFalse(0, browser.json['current_version_id'])
         self.assertEqual([], browser.json['attachments'])
+        self.assertEqual(self.mail_eml.message._p_mtime, browser.json['file_mtime'])
 
     @browsing
     def test_contains_also_original_message(self, browser):

--- a/opengever/api/tests/test_mail.py
+++ b/opengever/api/tests/test_mail.py
@@ -28,7 +28,7 @@ class TestGetMail(IntegrationTestCase):
         self.assertIsNone(browser.json['containing_subdossier_url'])
         self.assertFalse(browser.json['trashed'])
         self.assertFalse(browser.json['is_shadow_document'])
-        self.assertFalse(0, browser.json['current_version_id'])
+        self.assertEqual(0, browser.json['current_version_id'])
         self.assertEqual([], browser.json['attachments'])
         self.assertEqual(self.mail_eml.message._p_mtime, browser.json['file_mtime'])
 

--- a/opengever/document/checkout/manager.py
+++ b/opengever/document/checkout/manager.py
@@ -265,6 +265,7 @@ class CheckinCheckoutManager(object):
 
         # remember that we canceled in
         self.annotations[CHECKIN_CHECKOUT_ANNOTATIONS_KEY] = None
+        self.annotations.pop(COLLABORATORS_ANNOTATIONS_KEY, None)
 
         # finally, reindex the object
         self.context.reindexObject(idxs=['checked_out'])

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -360,6 +360,11 @@ class Document(Item, BaseDocumentMixin):
                                   ICheckinCheckoutManager)
         return manager.is_collaborative_checkout()
 
+    def get_collaborators(self):
+        manager = getMultiAdapter((self, self.REQUEST),
+                                  ICheckinCheckoutManager)
+        return manager.get_collaborators()
+
     def is_office_online_editable(self):
         filename = self.get_filename()
         if filename is None:

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -470,6 +470,11 @@ class Document(Item, BaseDocumentMixin):
             return self.file.filename
         return None
 
+    def get_file_mtime(self):
+        if self.has_file():
+            return self.file._p_mtime
+        return None
+
     def get_download_view_name(self):
         return 'download'
 

--- a/opengever/document/tests/test_cancel.py
+++ b/opengever/document/tests/test_cancel.py
@@ -55,6 +55,23 @@ class TestCancelDocuments(FunctionalTestCase):
         self.assertEquals('Test data', doc.file.data)
         self.assertEquals(None, self.get_manager(doc).get_checked_out_by())
 
+    def test_cancel_clears_collaborators(self):
+        doc = create(Builder('document').within(self.dossier)
+                     .with_dummy_content())
+        manager = self.get_manager(doc)
+
+        manager.checkout(collaborative=True)
+        manager.add_collaborator('kathi.barfuss')
+        self.assertEqual(
+            ['test_user_1_', 'kathi.barfuss'],
+            manager.get_collaborators())
+        self.assertTrue(manager.is_collaborative_checkout())
+
+        manager.cancel()
+        self.assertEqual([], manager.get_collaborators())
+        self.assertFalse(manager.is_collaborative_checkout())
+        self.assertIsNone(manager.get_checked_out_by())
+
     @browsing
     def test_cancel_checkout_for_all_selected_documents(self, browser):
         doc1 = create(Builder('document').within(self.dossier).checked_out())

--- a/opengever/mail/mail.py
+++ b/opengever/mail/mail.py
@@ -347,6 +347,11 @@ class OGMail(Mail, BaseDocumentMixin):
             return self.get_file().filename
         return None
 
+    def get_file_mtime(self):
+        if self.has_file():
+            return self.get_file()._p_mtime
+        return None
+
     def get_download_view_name(self):
         if self.original_message:
             return '@@download/original_message'

--- a/opengever/mail/mail.py
+++ b/opengever/mail/mail.py
@@ -289,6 +289,11 @@ class OGMail(Mail, BaseDocumentMixin):
         """
         return False
 
+    def get_collaborators(self):
+        """Mail does not support checkin/checkout.
+        """
+        return []
+
     def is_checkout_and_edit_available(self):
         """Mail does not support checkin/checkout.
         """


### PR DESCRIPTION
Include additional infos in document serialization and status endpoint:
- file modification time
- checkout collaborators
- lock time and timeout

This info will be displayed in the document status bar.

Allow checkin of collaborative checkouts for all collaborators if the document is not locked (lock has expired).
Usually Office Online renews the lock regularly. It happens that Office Online does not unlock the document correctly, e.g. if the user closes the Office Online tab while not being connected to the internet. In this case the lock expires and the collaborators should be able to checkin the document.

For [CA-2339](https://4teamwork.atlassian.net/browse/CA-2339)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- API change:
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
- New functionality:
  - [x] for `document` also works for `mail`

