### PR TITLE
Fix changing bucket being iterated in size during relation catalog cleanup.

### DIFF
--- a/changes/CA-2485.bugfix
+++ b/changes/CA-2485.bugfix
@@ -1,0 +1,1 @@
+Fix changing bucket being iterated in size during relation catalog cleanup. [deiferni]

--- a/opengever/core/upgrades/20210819081602_clean_up_relation_catalog/upgrade.py
+++ b/opengever/core/upgrades/20210819081602_clean_up_relation_catalog/upgrade.py
@@ -11,9 +11,13 @@ class CleanUpRelationCatalog(UpgradeStep):
 
     def __call__(self):
         catalog = component.queryUtility(ICatalog)
+        to_unindex = []
         for relation in catalog:
             if relation.to_object is None:
                 if not relation.isBroken():
                     relation.broken(None)
             if relation.from_object is None:
-                catalog.unindex(relation)
+                to_unindex.append(relation)
+
+        for relation in to_unindex:
+            catalog.unindex(relation)


### PR DESCRIPTION
This upgrade iterated and modified the relation catalog at the same time. This will lead to a RuntimeError as the bucket being iteratedchanged size.

To prevent the issue we defer unindexing broken relations to afteriterating the relation catalog.

✅  &nbsp;tested and confirmed working on a test-run system.

For [CA-2485](https://4teamwork.atlassian.net/browse/CA-2485)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)