### PR TITLE
Sanitize extracted document_author from mails.

### DIFF
--- a/changes/CA-2152.bugfix
+++ b/changes/CA-2152.bugfix
@@ -1,0 +1,1 @@
+Sanitize document_author after extracting from mail header. [deiferni]

--- a/opengever/mail/mail.py
+++ b/opengever/mail/mail.py
@@ -31,6 +31,7 @@ from plone.supermodel import model
 from plone.supermodel.interfaces import FIELDSETS_KEY
 from plone.supermodel.model import Fieldset
 from plone.uuid.interfaces import IUUID
+from Products.CMFPlone.utils import safe_unicode
 from sqlalchemy import func
 from z3c.form.interfaces import DISPLAY_MODE
 from z3c.relationfield.relation import RelationValue
@@ -407,15 +408,16 @@ def extract_email(header_from):
 
 def get_author_by_email(mail):
     header_from = utils.get_header(mail.msg, 'From')
-    email = extract_email(header_from)
 
+    email = safe_unicode(extract_email(header_from)).strip()
     session = create_session()
     principal = session.query(User).filter(
         func.lower(User.email) == email).first()
+    if principal:
+        return u'{0} {1}'.format(principal.lastname, principal.firstname)
 
-    if principal is None:
-        return header_from.decode('utf-8')
-    return u'{0} {1}'.format(principal.lastname, principal.firstname)
+    author = safe_unicode(header_from).strip()
+    return author.replace(u'\n', u'').replace(u'\r', u'')
 
 
 def initialize_metadata(mail, event):


### PR DESCRIPTION
When extracting `document_author` from mails and setting it on D&Duploaded mails we did bypass input validation of the form fields. We change how the from header is handled by adding manual sanitation of
extracted values. The field is relatively permissive and only disallows newlines and carriage returns. We also strip the value before attempting to lookup an actor so that we could also handle leading/trailing whitespace should it make its way into the header somehow.

For [CA-2152](https://4teamwork.atlassian.net/browse/CA-2152)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
