### PR TITLE
Initialize custom properties with default values on non-interactive document creations

### DIFF
--- a/opengever/api/tus.py
+++ b/opengever/api/tus.py
@@ -1,3 +1,4 @@
+from opengever.base.interfaces import IDuringContentCreation
 from opengever.document import _
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.meeting.proposaltemplate import IProposalTemplate
@@ -7,7 +8,9 @@ from zExceptions import BadRequest
 from zExceptions import Forbidden
 from zope.component import getMultiAdapter
 from zope.i18n import translate
+from zope.interface import alsoProvides
 from zope.interface import implementer
+from zope.interface import noLongerProvides
 from zope.publisher.interfaces import IPublishTraverse
 import transaction
 
@@ -18,7 +21,9 @@ class GeverUploadPatch(UploadPatch):
 
     def reply(self):
         try:
+            alsoProvides(self.request, IDuringContentCreation)
             data = super(GeverUploadPatch, self).reply()
+            noLongerProvides(self.request, IDuringContentCreation)
         except ForbiddenByQuota as exc:
             transaction.abort()
             self.request.response.setStatus(507)

--- a/opengever/base/quickupload.py
+++ b/opengever/base/quickupload.py
@@ -7,8 +7,10 @@ from collective.quickupload.interfaces import IQuickUploadFileFactory
 from ftw.tabbedview.interfaces import ITabbedviewUploadable
 from opengever.base.command import CreateDocumentCommand
 from opengever.base.command import CreateEmailCommand
+from opengever.document.behaviors.customproperties import IDocumentCustomProperties
 from opengever.mail.mail import MESSAGE_SOURCE_DRAG_DROP_UPLOAD
 from opengever.mail.utils import is_rfc822_ish_mimetype
+from opengever.propertysheets.creation_defaults import initialize_customproperties_defaults
 from opengever.quota.exceptions import ForbiddenByQuota
 from opengever.virusscan.interfaces import IAVScannerSettings
 from opengever.virusscan.validator import validateStream
@@ -108,6 +110,9 @@ class OGQuickUploadCapableFileFactory(object):
             return {'error': translate(exc.message,
                                        context=self.context.REQUEST),
                     'success': None}
+
+        # Initialize custom properties with default values
+        initialize_customproperties_defaults(obj, IDocumentCustomProperties)
 
         result = {'success': obj}
         return result

--- a/opengever/mail/create.py
+++ b/opengever/mail/create.py
@@ -1,6 +1,8 @@
 from ftw.mail.create import CreateMailInContainer
 from opengever.base.command import CreateEmailCommand
+from opengever.document.behaviors.customproperties import IDocumentCustomProperties
 from opengever.mail.mail import MESSAGE_SOURCE_MAILIN
+from opengever.propertysheets.creation_defaults import initialize_customproperties_defaults
 import email
 
 
@@ -26,7 +28,13 @@ class OGCreateMailInContainer(CreateMailInContainer):
 
         command = CreateEmailCommand(self.context, filename, message,
                                      message_source=MESSAGE_SOURCE_MAILIN)
-        return command.execute()
+
+        obj = command.execute()
+
+        # Initialize custom properties with default values
+        initialize_customproperties_defaults(obj, IDocumentCustomProperties)
+
+        return obj
 
     def is_application_pkcs7_mime(self, message_raw):
         """Return if message is of application/pkcs7-mime media type.

--- a/opengever/mail/mail.py
+++ b/opengever/mail/mail.py
@@ -12,6 +12,7 @@ from opengever.base.model import create_session
 from opengever.base.model.favorite import Favorite
 from opengever.document.base import BaseDocumentMixin
 from opengever.document.behaviors import metadata as ogmetadata
+from opengever.document.behaviors.customproperties import IDocumentCustomProperties
 from opengever.document.behaviors.related_docs import IRelatedDocuments
 from opengever.dossier import _ as dossier_mf
 from opengever.mail import _
@@ -20,6 +21,7 @@ from opengever.mail.exceptions import InvalidAttachmentPosition
 from opengever.mail.interfaces import IExtractedFromMail
 from opengever.mail.utils import is_rfc822_ish_mimetype
 from opengever.ogds.models.user import User
+from opengever.propertysheets.creation_defaults import initialize_customproperties_defaults
 from opengever.virusscan.validator import validateUploadForFieldIfNecessary
 from plone import api
 from plone.app.dexterity.behaviors import metadata
@@ -261,6 +263,11 @@ class OGMail(Mail, BaseDocumentMixin):
 
             IRelatedDocuments(doc).relatedItems = [RelationValue(iid)]
             alsoProvides(doc, IExtractedFromMail)
+
+            # Initialize custom properties with default values
+            initialize_customproperties_defaults(
+                doc, IDocumentCustomProperties, reindex=False)
+
             doc.reindexObject()
 
         # mark attachment as extracted

--- a/opengever/propertysheets/creation_defaults.py
+++ b/opengever/propertysheets/creation_defaults.py
@@ -1,4 +1,17 @@
 from opengever.propertysheets.storage import PropertySheetSchemaStorage
+from zope.component import queryAdapter
+
+
+def initialize_customproperties_defaults(obj, behavior_iface):
+    behavior = queryAdapter(obj, behavior_iface)
+    if behavior:
+        custom_prop_defaults = get_customproperties_defaults(
+            behavior_iface['custom_properties'])
+
+        # Only attempt to set defaults if no actual custom properties exist yet
+        if not behavior.custom_properties:
+            behavior.custom_properties = custom_prop_defaults
+            obj.reindexObject()
 
 
 def get_customproperties_defaults(propsheet_field):

--- a/opengever/propertysheets/creation_defaults.py
+++ b/opengever/propertysheets/creation_defaults.py
@@ -2,7 +2,7 @@ from opengever.propertysheets.storage import PropertySheetSchemaStorage
 from zope.component import queryAdapter
 
 
-def initialize_customproperties_defaults(obj, behavior_iface):
+def initialize_customproperties_defaults(obj, behavior_iface, reindex=True):
     behavior = queryAdapter(obj, behavior_iface)
     if behavior:
         custom_prop_defaults = get_customproperties_defaults(
@@ -11,7 +11,8 @@ def initialize_customproperties_defaults(obj, behavior_iface):
         # Only attempt to set defaults if no actual custom properties exist yet
         if not behavior.custom_properties:
             behavior.custom_properties = custom_prop_defaults
-            obj.reindexObject()
+            if reindex:
+                obj.reindexObject()
 
 
 def get_customproperties_defaults(propsheet_field):

--- a/opengever/propertysheets/creation_defaults.py
+++ b/opengever/propertysheets/creation_defaults.py
@@ -1,3 +1,4 @@
+from copy import copy
 from opengever.propertysheets.storage import PropertySheetSchemaStorage
 from zope.component import queryAdapter
 
@@ -38,7 +39,11 @@ def get_customproperties_defaults(propsheet_field):
         if definition is not None:
             for (field_name, field) in definition.get_fields():
                 if field.default is not None:
-                    slot_values[field.__name__] = field.default
+                    # Make sure to dereference defaults that have possibly
+                    # been declared as a mutable kwarg
+                    default = copy(field.default)
+
+                    slot_values[field.__name__] = default
 
             if slot_values:
                 default_values_by_slot[slot_name] = slot_values

--- a/opengever/propertysheets/creation_defaults.py
+++ b/opengever/propertysheets/creation_defaults.py
@@ -1,0 +1,32 @@
+from opengever.propertysheets.storage import PropertySheetSchemaStorage
+
+
+def get_customproperties_defaults(propsheet_field):
+    """Returns defaults for all custom properties on a given PropertySheetField.
+
+    These are *creation* defaults, intended to be used during or immediately
+    after initial object creation. They therefore get determined on an unbound
+    field, because no context (the object to be created) exists yet.
+
+    Defaults are returned as a sparse representation in the PropertySheetField
+    internal format (a {slot_name: {field_name: field_value}} mapping).
+
+    For example:
+    {u'IDocument.default': {u'language': u'en'}}
+    """
+    default_values_by_slot = {}
+
+    storage = PropertySheetSchemaStorage()
+    for slot_name in propsheet_field.valid_assignment_slots_factory():
+        slot_values = {}
+        definition = storage.query(slot_name)
+
+        if definition is not None:
+            for (field_name, field) in definition.get_fields():
+                if field.default is not None:
+                    slot_values[field.__name__] = field.default
+
+            if slot_values:
+                default_values_by_slot[slot_name] = slot_values
+
+    return default_values_by_slot

--- a/opengever/propertysheets/tests/test_creation_defaults.py
+++ b/opengever/propertysheets/tests/test_creation_defaults.py
@@ -1,0 +1,163 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.document.behaviors.customproperties import IDocumentCustomProperties
+from opengever.dossier.behaviors.customproperties import IDossierCustomProperties
+from opengever.propertysheets.creation_defaults import get_customproperties_defaults
+from opengever.propertysheets.exportimport import dottedname
+from opengever.propertysheets.storage import PropertySheetSchemaStorage
+from opengever.testing import IntegrationTestCase
+from zope.interface import provider
+from zope.schema.interfaces import IContextAwareDefaultFactory
+
+
+@provider(IContextAwareDefaultFactory)
+def location_df(context):
+    return u'CH'
+
+
+class TestPropertySheetsCreationDefaultsForDocument(IntegrationTestCase):
+
+    def test_doesnt_produce_empty_slots_if_no_defaults(self):
+        self.login(self.regular_user)
+        PropertySheetSchemaStorage().clear()
+
+        create(
+            Builder('property_sheet_schema')
+            .named('schema1')
+            .assigned_to_slots(u'IDocument.default')
+            .with_field(
+                'text', u'nodefault', u'Field without default', u'',
+                required=False,
+            )
+        )
+
+        field = IDocumentCustomProperties['custom_properties']
+        defaults = get_customproperties_defaults(field)
+        self.assertEqual({}, defaults)
+
+    def test_determine_doc_defaults(self):
+        self.login(self.regular_user)
+        PropertySheetSchemaStorage().clear()
+
+        create(
+            Builder('property_sheet_schema')
+            .named('schema1')
+            .assigned_to_slots(u'IDocument.default')
+            .with_field(
+                'text', u'nodefault', u'Field without default', u'',
+                required=False,
+            )
+            .with_field(
+                'textline', u'notrequired', u'Optional field with default', u'',
+                required=False,
+                default=u'Not required, still has default'
+            )
+            .with_field(
+                'multiple_choice', u'languages', u'Languages', u'',
+                required=True, values=[u'de', u'fr', u'en'],
+                default={u'de', u'en'},
+            )
+            .with_field(
+                'choice', u'location', u'Location', u'',
+                values=[u'CH', u'DE', u'US'],
+                required=True,
+                default_factory=dottedname(location_df),
+            )
+            .with_field(
+                'textline', u'userid', u'User ID', u'',
+                required=True,
+                default_expression='member/getId',
+            )
+            .with_field(
+                'textline', u'email', u'E-Mail', u'',
+                required=True,
+                default_from_member={'property': 'email'},
+            )
+        )
+
+        field = IDocumentCustomProperties['custom_properties']
+        defaults = get_customproperties_defaults(field)
+        expected_defaults = {
+            'IDocument.default': {
+                'notrequired': u'Not required, still has default',
+                'languages': {u'de', u'en'},
+                'location': u'CH',
+                'userid': u'kathi.barfuss',
+                'email': u'foo@example.com',
+            }
+        }
+        self.assertEqual(expected_defaults, defaults)
+
+
+class TestPropertySheetsCreationDefaultsForDossier(IntegrationTestCase):
+
+    def test_doesnt_produce_empty_slots_if_no_defaults(self):
+        self.login(self.regular_user)
+        PropertySheetSchemaStorage().clear()
+
+        create(
+            Builder('property_sheet_schema')
+            .named('schema1')
+            .assigned_to_slots(u'IDossier.default')
+            .with_field(
+                'text', u'nodefault', u'Field without default', u'',
+                required=False,
+            )
+        )
+
+        field = IDossierCustomProperties['custom_properties']
+        defaults = get_customproperties_defaults(field)
+        self.assertEqual({}, defaults)
+
+    def test_determine_dossier_defaults(self):       
+        self.login(self.regular_user)
+        PropertySheetSchemaStorage().clear()
+
+        create(
+            Builder('property_sheet_schema')
+            .named('schema1')
+            .assigned_to_slots(u'IDossier.default')
+            .with_field(
+                'text', u'nodefault', u'Field without default', u'',
+                required=False,
+            )
+            .with_field(
+                'textline', u'notrequired', u'Optional field with default', u'',
+                required=False,
+                default=u'Not required, still has default'
+            )
+            .with_field(
+                'multiple_choice', u'languages', u'Languages', u'',
+                required=True, values=[u'de', u'fr', u'en'],
+                default={u'de', u'en'},
+            )
+            .with_field(
+                'choice', u'location', u'Location', u'',
+                values=[u'CH', u'DE', u'US'],
+                required=True,
+                default_factory=dottedname(location_df),
+            )
+            .with_field(
+                'textline', u'userid', u'User ID', u'',
+                required=True,
+                default_expression='member/getId',
+            )
+            .with_field(
+                'textline', u'email', u'E-Mail', u'',
+                required=True,
+                default_from_member={'property': 'email'},
+            )
+        )
+
+        field = IDossierCustomProperties['custom_properties']
+        defaults = get_customproperties_defaults(field)
+        expected_defaults = {
+            'IDossier.default': {
+                'notrequired': u'Not required, still has default',
+                'languages': {u'de', u'en'},
+                'location': u'CH',
+                'userid': u'kathi.barfuss',
+                'email': u'foo@example.com',
+            }
+        }
+        self.assertEqual(expected_defaults, defaults)


### PR DESCRIPTION
This initializes custom properties with default values for

- Documents and mails **uploaded with TUS**
- Documents and mails **uploaded via QuickUpload**
- Mails received via **inbound mail**
- Documents **extracted from mail attachments**

For [CA-2482](https://4teamwork.atlassian.net/browse/CA-2482)

## Checklist

- [ ] Changelog entry (*not necessary - fix for behavior that was introduced in the same release*)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- New functionality:
  - [x] for `document` also works for `mail`
  