### PR TITLE
Fixed FixSharingPermissions upgradestep.

### DIFF
--- a/changes/CA-2352.bugfix
+++ b/changes/CA-2352.bugfix
@@ -1,0 +1,1 @@
+Avoid workflow update for all documents, in the FixSharingPermissions upgradestep. [phgross]

--- a/opengever/core/upgrades/20210806084458_fix_sharing_permissions/upgrade.py
+++ b/opengever/core/upgrades/20210806084458_fix_sharing_permissions/upgrade.py
@@ -1,17 +1,66 @@
+from ftw.upgrade import ProgressLogger
 from ftw.upgrade import UpgradeStep
+from ftw.upgrade.helpers import update_security_for
+from ftw.upgrade.utils import SavepointIterator
+from ftw.upgrade.utils import SizedGenerator
+from plone import api
+from zope.component.hooks import getSite
 
 
 class FixSharingPermissions(UpgradeStep):
     """Fix sharing permissions.
     """
 
+    deferrable = True
+
     def __call__(self):
+        self.catalog = api.portal.get_tool('portal_catalog')
         self.install_upgrade_profile()
         self.update_workflow_security(
-            ['opengever_inbox_document_workflow',
-             'opengever_private_document_workflow',
-             'opengever_tasktemplatefolder_workflow',
+            ['opengever_tasktemplatefolder_workflow',
              'opengever_inbox_workflow',
              'opengever_disposition_workflow',
              'opengever_proposal_workflow'],
             reindex_security=False)
+
+        # We can't use the update_workflow_security for inbox and private
+        # documents otherwise we would update also all regular documents
+        # therefore we fetch and updated them manually
+        inbox_path = self.get_inbox_path()
+        if inbox_path:
+            self.update_workflow_for_documents(inbox_path)
+
+        private_path = self.get_private_path()
+        if private_path:
+            self.update_workflow_for_documents(private_path)
+
+    def update_workflow_for_documents(self, path):
+        # Copied from ftw.upgrade.workflow.WorkflowSecurityUpdater
+        portal = getSite()
+        query = {'portal_type': 'opengever.document.document', 'path': path}
+        brains = tuple(self.catalog.unrestrictedSearchResults(query))
+        lookup = lambda brain: portal.unrestrictedTraverse(brain.getPath())
+        generator = SizedGenerator(
+            (lookup(brain) for brain in brains), len(brains))
+        objects = SavepointIterator.build(
+            ProgressLogger('Update object security', generator), 1000)
+
+        for obj in objects:
+            update_security_for(obj, reindex_security=False)
+
+    def get_inbox_path(self):
+        containers = self.catalog.unrestrictedSearchResults(
+            portal_type='opengever.inbox.container')
+        if len(containers):
+            return containers[0].getPath()
+
+        inboxes = self.catalog.unrestrictedSearchResults(
+            portal_type='opengever.inbox.inbox')
+        if len(inboxes):
+            return inboxes[0].getPath()
+
+    def get_private_path(self):
+        roots = self.catalog.unrestrictedSearchResults(
+            portal_type='opengever.private.root')
+        if len(roots):
+            return roots[0].getPath()


### PR DESCRIPTION
Avoid workflow update for all documents.

During the SG testrun I realized that the upgrade step `FixSharingPermissions`, which intends to update only the inbox and private documents, updates the workflow for all documents. Which would make the upgrade step unnecessarily longer. 

The reason is how the ftw.upgrades `WorkflowSecurityUpdater` works. It fetches the types for the given workflows (https://github.com/4teamwork/ftw.upgrade/blob/master/ftw/upgrade/workflow.py#L179) and queries all those types. Because we use a placeful workflow for inbox_documents and private_documents, the type `opengever.document.document` is queried and we update all documents.

I have therefore rewritten the upgrade step so that we update the inbox and private documents manually.

For [CA-2352]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-2352]: https://4teamwork.atlassian.net/browse/CA-2352