### PR TITLE
Add support for unicode userids in ogds-users and ogds-user-listing endpoints.

### DIFF
--- a/changes/CA-2751.bugfix
+++ b/changes/CA-2751.bugfix
@@ -1,0 +1,1 @@
+Add support for unicode userids in ogds-users and ogds-user-listing endpoints. [njohner]

--- a/opengever/api/ogdsuser.py
+++ b/opengever/api/ogdsuser.py
@@ -25,7 +25,7 @@ class OGDSUserGet(Service):
         return self
 
     def reply(self):
-        userid = self.read_params()
+        userid = self.read_params().decode('utf-8')
         service = ogds_service()
         user = service.fetch_user(userid)
         serializer = queryMultiAdapter((user, self.request), ISerializeToJson)

--- a/opengever/api/serializer.py
+++ b/opengever/api/serializer.py
@@ -451,7 +451,7 @@ class SerializeSQLModelToJsonSummaryBase(object):
 
     @property
     def get_url(self):
-        return '{}/{}/{}'.format(
+        return u'{}/{}/{}'.format(
             self.base_url,
             self.endpoint_name,
             getattr(self.context, self.id_attribute_name)

--- a/opengever/api/tests/test_ogdsuser.py
+++ b/opengever/api/tests/test_ogdsuser.py
@@ -5,6 +5,7 @@ from opengever.api.serializer import SerializeUserModelToJson
 from opengever.ogds.base.utils import get_current_org_unit
 from opengever.ogds.models.group import Group
 from opengever.ogds.models.tests.base import OGDSTestCase
+from opengever.ogds.models.user import User
 from opengever.testing import IntegrationTestCase
 from zExceptions import BadRequest
 
@@ -155,6 +156,24 @@ class TestOGDSUserGet(IntegrationTestCase):
             browser.open(self.portal,
                          view='@ogds-users/kathi.barfuss/foobar',
                          headers=self.api_headers)
+
+    @browsing
+    def test_handles_non_ascii_userids(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        ogds_user = User.query.get_by_userid(self.reader_user.id)
+        ogds_user.userid = u'l\xfccklicher.laser'
+
+        browser.open(u'http://nohost/plone/@ogds-users/l\xfccklicher.laser',
+                     headers=self.api_headers)
+
+        self.assertEqual(
+            u'http://nohost/plone/@ogds-users/l%C3%BCcklicher.laser',
+            browser.json['@id'])
+
+        self.assertEqual(
+            u'l\xfccklicher.laser',
+            browser.json['userid'])
 
 
 class TestAssignedGroupsMethod(OGDSTestCase):

--- a/opengever/api/tests/test_ogdsuserlisting.py
+++ b/opengever/api/tests/test_ogdsuserlisting.py
@@ -290,3 +290,33 @@ class TestOGDSUserListingGet(IntegrationTestCase):
             [u'Ziegler', u'User', u'Secretary', u'Schr\xf6dinger'],
             [each['lastname'] for each in browser.json['items'][:4]])
         self.assertEqual(19, browser.json['items_total'])
+
+    @browsing
+    def test_handles_non_ascii_userids(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        ogds_user = User.query.get_by_userid(self.reader_user.id)
+        ogds_user.userid = u'l\xfccklicher.laser'
+
+        browser.open(self.portal,
+                     view=u'@ogds-user-listing?search=L\xfcck',
+                     headers=self.api_headers)
+
+        self.assertEqual(1, len(browser.json['items']))
+        self.assertEqual([
+            {u'@id': u'http://nohost/plone/@ogds-users/l\xfccklicher.laser',
+             u'@type': u'virtual.ogds.user',
+             u'active': True,
+             u'department': None,
+             u'directorate': None,
+             u'email': u'lucklicher.laser@gever.local',
+             u'email2': None,
+             u'firstname': u'L\xfccklicher',
+             u'lastname': u'L\xe4ser',
+             u'phone_fax': None,
+             u'phone_mobile': None,
+             u'phone_office': None,
+             u'title': u'L\xe4ser L\xfccklicher',
+             u'userid': u'l\xfccklicher.laser'}],
+            browser.json['items'])
+        self.assertEqual(1, browser.json['items_total'])

--- a/opengever/ogds/models/tests/test_user.py
+++ b/opengever/ogds/models/tests/test_user.py
@@ -21,7 +21,7 @@ class TestUserModel(OGDSTestCase):
         self.assertEqual(users[-1].userid, 'admin')
 
     def test_repr(self):
-        self.assertEqual(str(User('a-user')), '<User a-user>')
+        self.assertEqual(str(User('a-user')), "<User 'a-user'>")
 
     def test_fullname_is_last_and_firstname(self):
         self.assertEqual('Smith John', self.john.fullname())
@@ -66,3 +66,15 @@ class TestUserModel(OGDSTestCase):
 
         for key, value in attrs.items():
             self.assertEqual(getattr(user, key), value)
+
+    def test_supports_non_ascii_firstname_and_lastname(self):
+        self.john.firstname = u'J\xf6hn'
+        self.john.lastname = u'Sm\xe4th'
+
+        self.assertEqual(u'Sm\xe4th J\xf6hn (john)', self.john.label())
+        self.assertEqual(u'Sm\xe4th J\xf6hn', self.john.fullname())
+
+    def test_supports_non_ascii_userid(self):
+        self.john.userid = u'J\xf6hn'
+        self.assertEqual(u'Smith John (J\xf6hn)', self.john.label())
+        self.assertEqual("<User u'J\\xf6hn'>", str(self.john))

--- a/opengever/ogds/models/user.py
+++ b/opengever/ogds/models/user.py
@@ -76,7 +76,7 @@ class User(Base):
         super(User, self).__init__(**kwargs)
 
     def __repr__(self):
-        return '<User %s>' % self.userid
+        return '<User %r>' % self.userid
 
     def __eq__(self, other):
         if isinstance(other, User):
@@ -93,7 +93,7 @@ class User(Base):
         if not with_principal:
             return self.fullname()
 
-        return "%s (%s)" % (self.fullname(), self.userid)
+        return u"%s (%s)" % (self.fullname(), self.userid)
 
     def fullname(self):
         """Return a visual representation of the UserPersona as String.
@@ -109,4 +109,4 @@ class User(Base):
         if not parts:
             parts.append(self.userid)
 
-        return ' '.join(parts)
+        return u' '.join(parts)


### PR DESCRIPTION
It seems IMAG has one user with a unicode userid. We fix the `ogds-users` and `ogds-user-listing` endpoints so that they support non-ascii userids.

For [CA-2751]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))

[CA-2751]: https://4teamwork.atlassian.net/browse/CA-2751