### PR TITLE
Add upgrade to fix mail authors with newlines.

### DIFF
--- a/opengever/core/upgrades/20210908103657_remove_newlines_from_mail_document_authors/upgrade.py
+++ b/opengever/core/upgrades/20210908103657_remove_newlines_from_mail_document_authors/upgrade.py
@@ -1,0 +1,27 @@
+from ftw.upgrade import UpgradeStep
+from Products.CMFPlone.utils import safe_unicode
+
+
+class RemoveNewlinesFromMailDocumentAuthors(UpgradeStep):
+    """Remove newlines from mail document authors."""
+
+    deferrable = True
+
+    def __call__(self):
+        for mail in self.objects(
+            {"object_provides": "opengever.mail.mail.IOGMailMarker"},
+            "Remove newlines from mail document authors.",
+        ):
+            self.remove_newlines(mail)
+
+    def remove_newlines(self, mail):
+        author = mail.document_author
+        if not author:
+            return
+
+        stripped = safe_unicode(author).replace(u"\n", u"").replace(u"\r", u"")
+        if stripped == author:
+            return
+
+        mail.document_author = stripped
+        mail.reindexObject(idxs=["sortable_author", "document_author"])


### PR DESCRIPTION
Follow up for https://github.com/4teamwork/opengever.core/pull/7158 to add an upgrade that also fixes affected content in production. In contrary to my initial assumptions this seems to have happened occasionally and we prefer to have correct data in production 😉 .

- The upgrade applies the same replacements as is done by input sanitation in https://github.com/4teamwork/opengever.core/blob/73a17fb6fd9838a758f97622d96d8665269fbd38/opengever/mail/mail.py#L420
- Would also convert any non-unicode `document_authors` should they exist

For [CA-2152](https://4teamwork.atlassian.net/browse/CA-2152)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] ~~Changelog entry~~
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)