### PR TITLE
Use plone site title as WOPI BreadcrumbBrandName.

### DIFF
--- a/changes/CA-2850.bugfix
+++ b/changes/CA-2850.bugfix
@@ -1,0 +1,1 @@
+Use portal title as WOPI BreadcrumbBrandName. [phgross]

--- a/opengever/wopi/browser/wopi.py
+++ b/opengever/wopi/browser/wopi.py
@@ -160,7 +160,7 @@ class WOPIView(BrowserView):
             'UserCanWrite': True,
             'CloseUrl': self.obj.absolute_url(),
             'HostEditUrl': '{}/office_online_edit'.format(self.obj.absolute_url()),
-            'BreadcrumbBrandName': 'OneGov GEVER',
+            'BreadcrumbBrandName': api.portal.get().title,
             'BreadcrumbBrandUrl': self.portal_state.portal_url(),
             'BreadcrumbDocName': self.obj.Title(),
             'BreadcrumbFolderName': dossier.Title(),

--- a/opengever/wopi/tests/test_wopi.py
+++ b/opengever/wopi/tests/test_wopi.py
@@ -83,3 +83,7 @@ class TestWOPIView(IntegrationTestCase):
             self.check_file_info()[u'HostEditUrl'],
             u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-14/office_online_edit',
         )
+
+    def test_breadcrumbBrandName_is_portal_title(self):
+        self.assertIn(u'BreadcrumbBrandName', self.check_file_info())
+        self.assertEqual('Plone site', self.check_file_info()[u'BreadcrumbBrandName'])


### PR DESCRIPTION
This way we can make sure that even in teamraum deployments the label in the office online breadcrumb makes sense. In addition, the client title is also visible for MulitAdminUnit sites in this way.

The BreadcrumbBrandName is visible in office onlines Breadcrumb:
<img width="636" alt="Bildschirmfoto 2021-09-08 um 10 16 18" src="https://user-images.githubusercontent.com/485755/132481121-e58a94e1-3e5c-4ba4-888b-4a8e3d254294.png">


For [CA-2850]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-2850]: https://4teamwork.atlassian.net/browse/CA-2850