### PR TITLE
Prevent transferring working copies in remote task.

### DIFF
--- a/changes/CA-2156-2.bugfix
+++ b/changes/CA-2156-2.bugfix
@@ -1,0 +1,1 @@
+Prevent transferring checked out documents when completing successor tasks. [deiferni]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -22,6 +22,7 @@ Other Changes
 - Prevent setting ``file`` to ``null`` for ``opengever.document.document`` if it is inside an ``opengever.meeting.proposal``.
 - Include checkout collaborators and file modification time in document serialization.
 - Include checkout collaborators, file modification time, lock time and lock timeout in document status.
+- ``@complete-successor-task``: Prevent transferring checked out documents when completing successor tasks.
 
 
 2021.17.0 (2021-08-30)

--- a/opengever/api/complete_successor_task.py
+++ b/opengever/api/complete_successor_task.py
@@ -3,6 +3,7 @@ from opengever.base.oguid import Oguid
 from opengever.globalindex.model.task import Task
 from opengever.task.browser.complete_utils import complete_task_and_deliver_documents
 from opengever.task.exceptions import TaskRemoteRequestError
+from opengever.task.validators import get_checked_out_documents
 from plone import api
 from plone.protect.interfaces import IDisableCSRFProtection
 from Products.CMFDiffTool.utils import safe_utf8
@@ -70,6 +71,10 @@ class CompleteSuccessorTaskPost(RemoteTaskBaseService):
 
         # Map any supported document reference type to an IntId
         docs_to_deliver = map(self._resolve_doc_ref_to_intid, docs_to_deliver)
+
+        invalid = get_checked_out_documents(docs_to_deliver)
+        if invalid:
+            raise BadRequest('Some documents are checked out.')
 
         # Validate that this is actually a successor task
         successor_task = self.context

--- a/opengever/api/tests/test_complete_successor_task.py
+++ b/opengever/api/tests/test_complete_successor_task.py
@@ -7,11 +7,13 @@ from opengever.api.complete_successor_task import CompleteSuccessorTaskPost
 from opengever.base.oguid import Oguid
 from opengever.base.response import IResponseContainer
 from opengever.document.approvals import IApprovalList
+from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.task.browser.accept.utils import accept_task_with_successor
 from opengever.testing import IntegrationTestCase
 from plone import api
 from plone.uuid.interfaces import IUUID
 from zExceptions import BadRequest
+from zope.component import getMultiAdapter
 from zope.component import getUtility
 from zope.intid import IIntIds
 import json
@@ -103,6 +105,51 @@ class TestCompleteSuccessorTaskPost(IntegrationTestCase):
             {u'type': u'BadRequest',
              u'message': u'@complete-successor-task only supports successor '
                          u'tasks. This task has no predecessor.'},
+            browser.json)
+
+    @browsing
+    def test_prevents_checked_out_documents(self, browser):
+        self.login(self.regular_user, browser)
+
+        # Test setup - create predecessor and accepted successor task pair
+        predecessor, successor = self.prepare_accepted_task_pair()
+
+        # Add a document in successor that is supposed to be delivered back
+        produced_doc = create(Builder('document')
+                              .within(successor)
+                              .titled(u'Statement in response to inquiry')
+                              .attach_file_containing(
+                                  'Statement text',
+                                  u'statement.docx'))
+
+        self.login(self.dossier_responsible, browser)
+        manager = getMultiAdapter((produced_doc, self.request),
+                                  ICheckinCheckoutManager)
+        manager.checkout()
+
+        self.login(self.regular_user, browser)
+        # Need to trick the transition controller into thinking its a remote
+        # request so that it allows the resolve transition on the predecessor
+        with patch('opengever.task.browser.transitioncontroller.'
+                   'RequestChecker.is_remote',
+                   new_callable=PropertyMock) as mock_is_remote:
+            mock_is_remote.return_value = True
+
+            request_body = json.dumps({
+                'transition': 'task-transition-in-progress-resolved',
+                'text': 'I finished this task.',
+                'documents': ["/".join(produced_doc.getPhysicalPath())]
+            })
+            with browser.expect_http_error(code=400):
+                browser.open(
+                    successor.absolute_url() + '/@complete-successor-task',
+                    method='POST',
+                    data=request_body,
+                    headers=self.api_headers)
+
+        self.assertEqual(
+            {u'type': u'BadRequest',
+             u'message': u'Some documents are checked out.'},
             browser.json)
 
     @browsing

--- a/opengever/task/validators.py
+++ b/opengever/task/validators.py
@@ -1,11 +1,27 @@
+from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.task import _
 from plone.app.uuid.utils import uuidToCatalogBrain
 from plone.uuid.interfaces import IUUID
 from z3c.form import validator
-from zope.app.intid.interfaces import IIntIds
-from zope.component import getUtility
-from zope.interface import Invalid
 from z3c.relationfield.interfaces import IRelationList
+from zope.app.intid.interfaces import IIntIds
+from zope.component import getMultiAdapter
+from zope.component import getUtility
+from zope.globalrequest import getRequest
+from zope.interface import Invalid
+
+
+def get_checked_out_documents(intids):
+    checked_out = []
+    intid_utility = getUtility(IIntIds)
+    request = getRequest()
+    for intid in intids:
+        doc = intid_utility.getObject(intid)
+        manager = getMultiAdapter((doc, request),
+                                  ICheckinCheckoutManager)
+        if manager.get_checked_out_by():
+            checked_out.append(doc)
+    return checked_out
 
 
 class NoCheckedoutDocsValidator(validator.SimpleFieldValidator):


### PR DESCRIPTION
Prevent transferring documents checked out by different users when completing successor tasks in `@complete-successor-task`. This makes the behavior consistent with validation in the classic UI where such documents are not allowed.

![Screenshot 2021-09-08 at 14 56 33](https://user-images.githubusercontent.com/736583/132513350-89deaab5-17bd-42eb-a82b-b81a0a389be8.png)

Error handling is unfortunately very basic for the new UI but we have other issues that block having something better right now.

For [CA-2156](https://4teamwork.atlassian.net/browse/CA-2156)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
