### PR TITLE
Respect maximum dossier depth when moving a dossier.

### DIFF
--- a/changes/CA-1207.bugfix
+++ b/changes/CA-1207.bugfix
@@ -1,0 +1,1 @@
+Moving a dossier over the API now respects the maximum dossier depth. [njohner]

--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -185,13 +185,18 @@ class DossierContainer(Container):
         """Only checks if the maximum dossier depth allows another level
         of subdossiers but not for permissions.
         """
+        return self.is_dossier_structure_addable(additional_depth=1)
+
+    def is_dossier_structure_addable(self, additional_depth=1):
+        """Checks if the maximum dossier depth allows additional_depth levels
+        of subdossiers but not for permissions.
+        """
         max_depth = api.portal.get_registry_record(
             name='maximum_dossier_depth',
             interface=IDossierContainerTypes,
             default=100,
             )
-
-        return self._get_dossier_depth() <= max_depth
+        return self._get_dossier_depth() + additional_depth <= max_depth + 1
 
     def has_subdossiers(self):
         return len(self.get_subdossiers()) > 0
@@ -202,8 +207,7 @@ class DossierContainer(Container):
             sort_order='ascending',
             review_state=None,
             depth=-1,
-            unrestricted=False,
-        ):
+            unrestricted=False):
 
         dossier_path = '/'.join(self.getPhysicalPath())
 

--- a/opengever/dossier/configure.zcml
+++ b/opengever/dossier/configure.zcml
@@ -333,4 +333,6 @@
   <adapter factory=".participations.PloneParticipationData" />
   <adapter factory=".participations.SQLParticipationData" />
 
+  <adapter factory=".move_items.DossierMovabiliyChecker" />
+
 </configure>

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-03-23 14:26+0000\n"
+"POT-Creation-Date: 2021-09-10 06:35+0000\n"
 "PO-Revision-Date: 2017-05-23 04:53+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -57,11 +57,12 @@ msgstr "Benutzerdefinierte Felder"
 msgid "Description"
 msgstr "Beschreibung"
 
-#: ./opengever/dossier/resolve.py
+#: ./opengever/dossier/statusmessage_mixin.py
 msgid "Dossier has already been resolved."
 msgstr "Dieses Dossier wurde bereits abgeschlossen."
 
 #: ./opengever/dossier/resolve.py
+#: ./opengever/dossier/statusmessage_mixin.py
 msgid "Dossier is already being resolved"
 msgstr "Der Abschlussvorgang für dieses Dossier läuft bereits."
 
@@ -131,7 +132,7 @@ msgstr "Es existieren noch Teamräume, auf die Sie keinen Zugriff haben. Das Dos
 msgid "Not all linked workspaces are deactivated."
 msgstr "Nicht alle verlinkten Teamräume sind deaktiviert."
 
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "Not all required fields are filled."
 msgstr "Nicht alle benötigten Felder wurden ausgefüllt."
 
@@ -208,7 +209,7 @@ msgstr "Das Dossier wurde storniert."
 msgid "The Dossier has been resolved"
 msgstr "Das Dossier wurde erfolgreich abgeschlossen"
 
-#: ./opengever/dossier/resolve.py
+#: ./opengever/dossier/statusmessage_mixin.py
 msgid "The dossier ${dossier} has a invalid end_date"
 msgstr "Das Dossier ${dossier} hat ein ungültiges Enddatum."
 
@@ -216,7 +217,7 @@ msgstr "Das Dossier ${dossier} hat ein ungültiges Enddatum."
 msgid "The dossier contains active proposals."
 msgstr "Das Dossier enthält aktive Anträge."
 
-#: ./opengever/dossier/resolve.py
+#: ./opengever/dossier/statusmessage_mixin.py
 msgid "The dossier has been succesfully resolved."
 msgstr "Das Dossier wurde erfolgreich abgeschlossen."
 
@@ -224,11 +225,11 @@ msgstr "Das Dossier wurde erfolgreich abgeschlossen."
 msgid "The filing number has been given."
 msgstr "Die Ablagenummer wurde vergeben."
 
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "The given end date is not valid, it needs to be younger or                  equal than ${date} (the youngest contained object)."
 msgstr "Das Ende-Datum ist ungültig, es muss jünger oder gleich sein wie das Datum des jüngsten enthaltenen Dokuments (${date})."
 
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "The given value is not a valid Year."
 msgstr "Das angegeben Ablagejahr ist ungültig."
 
@@ -244,7 +245,7 @@ msgstr "Das Beginn-Datum muss vor dem Ende-Datum liegen."
 msgid "The start or end date is invalid"
 msgstr "Das Beginn- oder Ende-Datum ist ungültig."
 
-#: ./opengever/dossier/resolve.py
+#: ./opengever/dossier/statusmessage_mixin.py
 msgid "The subdossier has been succesfully resolved."
 msgstr "Das Subdossier wurde erfolgreich abgeschlossen."
 
@@ -256,7 +257,7 @@ msgstr "Dieses Subdossier kann nicht wieder aktiviert werden, da das Hauptdossie
 msgid "Updated with a newer generated version from dossier ${title}."
 msgstr "Mit einer neuen Version des Dossiers ${title} aktualisiert."
 
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "When the Action give filing number is selected,                         all fields are required."
 msgstr "Für die Vergabe der Ablagenummer, werden alle Felder benötigt."
 
@@ -366,7 +367,7 @@ msgid "error_NotInContentTypes ${failed_objects}"
 msgstr "Es wurden keine Objekte verschoben. Folgende Objekte dürfen nicht in den Zielordner eingefügt werden: ${failed_objects}"
 
 #. Default: "The enddate is required."
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "error_enddate"
 msgstr "Enddatum erforderlich"
 
@@ -403,7 +404,7 @@ msgid "fieldset_protect"
 msgstr "Schützen"
 
 #. Default: "Action"
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "filing_action"
 msgstr "Aktion"
 
@@ -434,14 +435,14 @@ msgid "filing_number"
 msgstr "Ablagenummer"
 
 #. Default: "filing prefix"
-#: ./opengever/dossier/archive.py
 #: ./opengever/dossier/behaviors/dossier.py
 #: ./opengever/dossier/browser/overview.py
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "filing_prefix"
 msgstr "Ablage Präfix"
 
 #. Default: "filing Year"
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "filing_year"
 msgstr "Ablage Jahr"
 
@@ -633,6 +634,7 @@ msgstr "Dossiervorlagen"
 
 #. Default: "Dossier type"
 #: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "label_dossier_type"
 msgstr "Dossiertyp"
 
@@ -652,9 +654,9 @@ msgid "label_email_address"
 msgstr "E-Mail"
 
 #. Default: "Closing Date"
-#: ./opengever/dossier/archive.py
 #: ./opengever/dossier/behaviors/dossier.py
 #: ./opengever/dossier/browser/report.py
+#: ./opengever/dossier/filing/form.py
 msgid "label_end"
 msgstr "Ende"
 
@@ -732,6 +734,11 @@ msgstr "Zuletzt Bearbeitet"
 #: ./opengever/dossier/widget.py
 msgid "label_no_reference_number"
 msgstr "Die Archivnummer wird erst beim Erstellen generiert."
+
+#. Default: "Dossier ${name} cannot be moved because it would exceed the maximum allowed dossier depth."
+#: ./opengever/dossier/move_items.py
+msgid "label_not_movable_since_exceeds_maximum_depth"
+msgstr "Das Dossier ${name} kann nicht verschoben werden, weil die maximal erlaubte Dossiertiefe überschritten würde."
 
 #. Default: "Document ${name} is inside a proposal and therefore not movable. Move the proposal instead"
 #: ./opengever/dossier/move_items.py
@@ -970,23 +977,23 @@ msgstr "Es sind nicht alle Aufgaben abgeschlossen"
 msgid "note_text_confirm_abord"
 msgstr "Sie haben nicht gespeicherte Änderungen, wollen Sie wirklich abbrechen?"
 
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "only resolve, set filing no later"
 msgstr "Nur abschliessen (keine Ablagenummer vergeben)"
 
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "resolve and set a new filing no"
 msgstr "Abschliessen und Ablagenummer neu vergeben"
 
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "resolve and set filing no"
 msgstr "Abschliessen und Ablagenummer vergeben"
 
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "resolve and take the existing filing no"
 msgstr "Abschliessen und die existierende Ablagenummer verwenden"
 
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "set a filing no"
 msgstr "Ablagenummer vergeben"
 

--- a/opengever/dossier/locales/en/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/en/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-03-23 14:26+0000\n"
+"POT-Creation-Date: 2021-09-10 06:35+0000\n"
 "PO-Revision-Date: 2017-05-23 04:53+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -67,12 +67,13 @@ msgid "Description"
 msgstr "Description"
 
 #. German translation: Dieses Dossier wurde bereits abgeschlossen.
-#: ./opengever/dossier/resolve.py
+#: ./opengever/dossier/statusmessage_mixin.py
 msgid "Dossier has already been resolved."
 msgstr "Dossier has already been resolved."
 
 #. German translation: Der Abschlussvorgang für dieses Dossier läuft bereits.
 #: ./opengever/dossier/resolve.py
+#: ./opengever/dossier/statusmessage_mixin.py
 msgid "Dossier is already being resolved"
 msgstr "Dossier is already being resolved"
 
@@ -158,7 +159,7 @@ msgid "Not all linked workspaces are deactivated."
 msgstr "Not all linked workspaces are deactivated."
 
 #. German translation: Nicht alle benötigten Felder wurden ausgefüllt.
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "Not all required fields are filled."
 msgstr "Some required fields are missing."
 
@@ -261,7 +262,7 @@ msgstr "Dossier has been resolved"
 
 #. German translation: Das Dossier ${dossier} hat ein ungültiges Enddatum.
 #. MARKER: used-in-api-response
-#: ./opengever/dossier/resolve.py
+#: ./opengever/dossier/statusmessage_mixin.py
 msgid "The dossier ${dossier} has a invalid end_date"
 msgstr "The dossier ${dossier} has a invalid end_date"
 
@@ -271,7 +272,7 @@ msgid "The dossier contains active proposals."
 msgstr "Dossier contains active proposals."
 
 #. German translation: Das Dossier wurde erfolgreich abgeschlossen.
-#: ./opengever/dossier/resolve.py
+#: ./opengever/dossier/statusmessage_mixin.py
 msgid "The dossier has been succesfully resolved."
 msgstr "Dossier has been resolved succesfully."
 
@@ -281,12 +282,12 @@ msgid "The filing number has been given."
 msgstr "Filing number issued."
 
 #. German translation: Das Ende-Datum ist ungültig, es muss jünger oder gleich sein wie das Datum des jüngsten enthaltenen Dokuments (${date}).
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "The given end date is not valid, it needs to be younger or                  equal than ${date} (the youngest contained object)."
 msgstr "The given end date is not valid. It needs to be more recent or equal to the most recent contained object's date (${date})."
 
 #. German translation: Das angegeben Ablagejahr ist ungültig.
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "The given value is not a valid Year."
 msgstr "The given filing year value is not valid."
 
@@ -306,7 +307,7 @@ msgid "The start or end date is invalid"
 msgstr "The start or end date is invalid"
 
 #. German translation: Das Subdossier wurde erfolgreich abgeschlossen.
-#: ./opengever/dossier/resolve.py
+#: ./opengever/dossier/statusmessage_mixin.py
 msgid "The subdossier has been succesfully resolved."
 msgstr "Subdossier has been resolved succesfully."
 
@@ -322,7 +323,7 @@ msgid "Updated with a newer generated version from dossier ${title}."
 msgstr "Updated with a fresh version generated from dossier ${title}."
 
 #. German translation: Für die Vergabe der Ablagenummer, werden alle Felder benötigt.
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "When the Action give filing number is selected,                         all fields are required."
 msgstr "All fields are required when issuing a filing number."
 
@@ -456,7 +457,7 @@ msgstr "No objects were moved. The following items are not allowed in the target
 
 #. German translation: Enddatum erforderlich
 #. Default: "The enddate is required."
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "error_enddate"
 msgstr "End date is required."
 
@@ -500,7 +501,7 @@ msgstr "Protect"
 
 #. German translation: Aktion
 #. Default: "Action"
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "filing_action"
 msgstr "Action"
 
@@ -538,15 +539,15 @@ msgstr "Filing number"
 
 #. German translation: Ablage Präfix
 #. Default: "filing prefix"
-#: ./opengever/dossier/archive.py
 #: ./opengever/dossier/behaviors/dossier.py
 #: ./opengever/dossier/browser/overview.py
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "filing_prefix"
 msgstr "Filing number prefix"
 
 #. German translation: Ablage Jahr
 #. Default: "filing Year"
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "filing_year"
 msgstr "Filing year"
 
@@ -777,6 +778,7 @@ msgstr "Dossier templates"
 
 #. Default: "Dossier type"
 #: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "label_dossier_type"
 msgstr "Dossier type"
 
@@ -800,9 +802,9 @@ msgstr "Email"
 
 #. German translation: Ende
 #. Default: "Closing Date"
-#: ./opengever/dossier/archive.py
 #: ./opengever/dossier/behaviors/dossier.py
 #: ./opengever/dossier/browser/report.py
+#: ./opengever/dossier/filing/form.py
 msgid "label_end"
 msgstr "End date"
 
@@ -895,6 +897,11 @@ msgstr "Modified"
 #: ./opengever/dossier/widget.py
 msgid "label_no_reference_number"
 msgstr "Reference number will be generated after creation."
+
+#. Default: "Dossier ${name} cannot be moved because it would exceed the maximum allowed dossier depth."
+#: ./opengever/dossier/move_items.py
+msgid "label_not_movable_since_exceeds_maximum_depth"
+msgstr "Dossier ${name} cannot be moved because it would exceed the maximum allowed dossier depth."
 
 #. German translation: Das Dokument «${name}» befindet sich in einem Antrag und ist nicht verschiebbar. Verschieben sie den Antrag.
 #. Default: "Document ${name} is inside a proposal and therefore not movable. Move the proposal instead"
@@ -1182,27 +1189,27 @@ msgid "note_text_confirm_abord"
 msgstr "You have unsaved changes. Do you really want to cancel?"
 
 #. German translation: Nur abschliessen (keine Ablagenummer vergeben)
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "only resolve, set filing no later"
 msgstr "Just resolve, don't issue a filing number yet"
 
 #. German translation: Abschliessen und Ablagenummer neu vergeben
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "resolve and set a new filing no"
 msgstr "Resolve and issue a new filing number"
 
 #. German translation: Abschliessen und Ablagenummer vergeben
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "resolve and set filing no"
 msgstr "Resolve and issue filing number"
 
 #. German translation: Abschliessen und die existierende Ablagenummer verwenden
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "resolve and take the existing filing no"
 msgstr "Resolve and reuse existing filing number"
 
 #. German translation: Ablagenummer vergeben
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "set a filing no"
 msgstr "Issue filing number"
 

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-23 14:26+0000\n"
+"POT-Creation-Date: 2021-09-10 06:35+0000\n"
 "PO-Revision-Date: 2017-12-03 11:16+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/fr/>\n"
@@ -56,11 +56,12 @@ msgstr "Champs personnalisés"
 msgid "Description"
 msgstr "Description"
 
-#: ./opengever/dossier/resolve.py
+#: ./opengever/dossier/statusmessage_mixin.py
 msgid "Dossier has already been resolved."
 msgstr "Ce dossier a déjà été clôturé."
 
 #: ./opengever/dossier/resolve.py
+#: ./opengever/dossier/statusmessage_mixin.py
 msgid "Dossier is already being resolved"
 msgstr "Le processus de clôture de ce dossier est déjà en cours."
 
@@ -130,7 +131,7 @@ msgstr "Vous ne pouvez pas clôturer le dossier, parce que vous n'avez opas acc�
 msgid "Not all linked workspaces are deactivated."
 msgstr "Tous les espaces de travail liés ne sont pas désactivés."
 
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "Not all required fields are filled."
 msgstr "Un ou plusieurs des champs requis n'ont pas été remplis."
 
@@ -206,7 +207,7 @@ msgstr "Le dossier a été annulé."
 msgid "The Dossier has been resolved"
 msgstr "Le dossier a été clôturé avec succès."
 
-#: ./opengever/dossier/resolve.py
+#: ./opengever/dossier/statusmessage_mixin.py
 msgid "The dossier ${dossier} has a invalid end_date"
 msgstr "La date de clôture du dossier ${dossier} n'est pas valable."
 
@@ -214,7 +215,7 @@ msgstr "La date de clôture du dossier ${dossier} n'est pas valable."
 msgid "The dossier contains active proposals."
 msgstr "Le dossier contient des requêtes actives."
 
-#: ./opengever/dossier/resolve.py
+#: ./opengever/dossier/statusmessage_mixin.py
 msgid "The dossier has been succesfully resolved."
 msgstr "Le dossier a été clôturé avec succès."
 
@@ -222,11 +223,11 @@ msgstr "Le dossier a été clôturé avec succès."
 msgid "The filing number has been given."
 msgstr "Le numéro d'inventaire a été attribué."
 
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "The given end date is not valid, it needs to be younger or                  equal than ${date} (the youngest contained object)."
 msgstr "La date de clôture n'est pas valable. Elle doit être plus récente ou égale à la date de l'objet le plus récent y contenu (${date})."
 
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "The given value is not a valid Year."
 msgstr "L'année d'archivage indiquée n'est pas valable."
 
@@ -242,7 +243,7 @@ msgstr "La date de début doit être plus récente que la date de clôture."
 msgid "The start or end date is invalid"
 msgstr "La date de début ou la date de clôture n'est pas valable."
 
-#: ./opengever/dossier/resolve.py
+#: ./opengever/dossier/statusmessage_mixin.py
 msgid "The subdossier has been succesfully resolved."
 msgstr "Le sous-dossier a été clôturé avec succès."
 
@@ -254,7 +255,7 @@ msgstr "Ce sous-dossier ne peut pas être réactivé, parce que le dossier princ
 msgid "Updated with a newer generated version from dossier ${title}."
 msgstr "Actualisé par une nouvelle version du dossier ${title}."
 
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "When the Action give filing number is selected,                         all fields are required."
 msgstr "Pour l'attribution du numéro d'inventaire, tous les champs sont obligatoires."
 
@@ -364,7 +365,7 @@ msgid "error_NotInContentTypes ${failed_objects}"
 msgstr "Aucun objet n'a été déplacé. Les objets suivants ne peuvent être insérés dans le classeur choisi: ${failed_objects}"
 
 #. Default: "The enddate is required."
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "error_enddate"
 msgstr "Date de clôture requise"
 
@@ -401,7 +402,7 @@ msgid "fieldset_protect"
 msgstr "Protéger"
 
 #. Default: "Action"
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "filing_action"
 msgstr "Action"
 
@@ -432,14 +433,14 @@ msgid "filing_number"
 msgstr "Numéro d'inventaire"
 
 #. Default: "filing prefix"
-#: ./opengever/dossier/archive.py
 #: ./opengever/dossier/behaviors/dossier.py
 #: ./opengever/dossier/browser/overview.py
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "filing_prefix"
 msgstr "Préfixe du lieu de dépôt"
 
 #. Default: "filing Year"
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "filing_year"
 msgstr "Année de dépôt"
 
@@ -631,6 +632,7 @@ msgstr "Modèles de dossier"
 
 #. Default: "Dossier type"
 #: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "label_dossier_type"
 msgstr "Type de dossier"
 
@@ -650,9 +652,9 @@ msgid "label_email_address"
 msgstr "E-mail"
 
 #. Default: "Closing Date"
-#: ./opengever/dossier/archive.py
 #: ./opengever/dossier/behaviors/dossier.py
 #: ./opengever/dossier/browser/report.py
+#: ./opengever/dossier/filing/form.py
 msgid "label_end"
 msgstr "Fin"
 
@@ -730,6 +732,11 @@ msgstr "Dernière modification"
 #: ./opengever/dossier/widget.py
 msgid "label_no_reference_number"
 msgstr "Le numéro de classement est seulement généré lors de la création du document."
+
+#. Default: "Dossier ${name} cannot be moved because it would exceed the maximum allowed dossier depth."
+#: ./opengever/dossier/move_items.py
+msgid "label_not_movable_since_exceeds_maximum_depth"
+msgstr "Le dossier ${name} ne peut pas être déplacé car celà enfreindrait la profondeur maximale de dossiers autorisée"
 
 #. Default: "Document ${name} is inside a proposal and therefore not movable. Move the proposal instead"
 #: ./opengever/dossier/move_items.py
@@ -968,23 +975,23 @@ msgstr "Pas toutes les tâches ont été clôturées."
 msgid "note_text_confirm_abord"
 msgstr "Vous avez des modifications non sauvegardées. Voulez-vous vraiment annuler?"
 
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "only resolve, set filing no later"
 msgstr "Clôturer seulement (numéro d'inventaire non attribué)"
 
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "resolve and set a new filing no"
 msgstr "Clôturer et attribuer un nouveau numéro d'inventaire"
 
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "resolve and set filing no"
 msgstr "Clôturer et attribuer un numéro d'inventaire"
 
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "resolve and take the existing filing no"
 msgstr "Clôturer et utiliser le numéro d'inventaire existant"
 
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "set a filing no"
 msgstr "Attribuer un numéro d'inventaire"
 

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-03-23 14:26+0000\n"
+"POT-Creation-Date: 2021-09-10 06:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -57,11 +57,12 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: ./opengever/dossier/resolve.py
+#: ./opengever/dossier/statusmessage_mixin.py
 msgid "Dossier has already been resolved."
 msgstr ""
 
 #: ./opengever/dossier/resolve.py
+#: ./opengever/dossier/statusmessage_mixin.py
 msgid "Dossier is already being resolved"
 msgstr ""
 
@@ -131,7 +132,7 @@ msgstr ""
 msgid "Not all linked workspaces are deactivated."
 msgstr ""
 
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "Not all required fields are filled."
 msgstr ""
 
@@ -207,7 +208,7 @@ msgstr ""
 msgid "The Dossier has been resolved"
 msgstr ""
 
-#: ./opengever/dossier/resolve.py
+#: ./opengever/dossier/statusmessage_mixin.py
 msgid "The dossier ${dossier} has a invalid end_date"
 msgstr ""
 
@@ -215,7 +216,7 @@ msgstr ""
 msgid "The dossier contains active proposals."
 msgstr ""
 
-#: ./opengever/dossier/resolve.py
+#: ./opengever/dossier/statusmessage_mixin.py
 msgid "The dossier has been succesfully resolved."
 msgstr ""
 
@@ -223,11 +224,11 @@ msgstr ""
 msgid "The filing number has been given."
 msgstr ""
 
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "The given end date is not valid, it needs to be younger or                  equal than ${date} (the youngest contained object)."
 msgstr ""
 
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "The given value is not a valid Year."
 msgstr ""
 
@@ -243,7 +244,7 @@ msgstr ""
 msgid "The start or end date is invalid"
 msgstr ""
 
-#: ./opengever/dossier/resolve.py
+#: ./opengever/dossier/statusmessage_mixin.py
 msgid "The subdossier has been succesfully resolved."
 msgstr ""
 
@@ -255,7 +256,7 @@ msgstr ""
 msgid "Updated with a newer generated version from dossier ${title}."
 msgstr ""
 
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "When the Action give filing number is selected,                         all fields are required."
 msgstr ""
 
@@ -365,7 +366,7 @@ msgid "error_NotInContentTypes ${failed_objects}"
 msgstr ""
 
 #. Default: "The enddate is required."
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "error_enddate"
 msgstr ""
 
@@ -402,7 +403,7 @@ msgid "fieldset_protect"
 msgstr ""
 
 #. Default: "Action"
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "filing_action"
 msgstr ""
 
@@ -433,14 +434,14 @@ msgid "filing_number"
 msgstr ""
 
 #. Default: "filing prefix"
-#: ./opengever/dossier/archive.py
 #: ./opengever/dossier/behaviors/dossier.py
 #: ./opengever/dossier/browser/overview.py
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "filing_prefix"
 msgstr ""
 
 #. Default: "filing Year"
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "filing_year"
 msgstr ""
 
@@ -630,6 +631,7 @@ msgstr ""
 
 #. Default: "Dossier type"
 #: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "label_dossier_type"
 msgstr ""
 
@@ -649,9 +651,9 @@ msgid "label_email_address"
 msgstr ""
 
 #. Default: "Closing Date"
-#: ./opengever/dossier/archive.py
 #: ./opengever/dossier/behaviors/dossier.py
 #: ./opengever/dossier/browser/report.py
+#: ./opengever/dossier/filing/form.py
 msgid "label_end"
 msgstr ""
 
@@ -728,6 +730,11 @@ msgstr ""
 #. Default: "Reference Number will be generated                 after content creation"
 #: ./opengever/dossier/widget.py
 msgid "label_no_reference_number"
+msgstr ""
+
+#. Default: "Dossier ${name} cannot be moved because it would exceed the maximum allowed dossier depth."
+#: ./opengever/dossier/move_items.py
+msgid "label_not_movable_since_exceeds_maximum_depth"
 msgstr ""
 
 #. Default: "Document ${name} is inside a proposal and therefore not movable. Move the proposal instead"
@@ -967,23 +974,23 @@ msgstr ""
 msgid "note_text_confirm_abord"
 msgstr ""
 
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "only resolve, set filing no later"
 msgstr ""
 
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "resolve and set a new filing no"
 msgstr ""
 
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "resolve and set filing no"
 msgstr ""
 
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "resolve and take the existing filing no"
 msgstr ""
 
-#: ./opengever/dossier/archive.py
+#: ./opengever/dossier/filing/form.py
 msgid "set a filing no"
 msgstr ""
 


### PR DESCRIPTION
Moving a dossier over the API did not validate the dossier depth. Also note that in the classic UI we only checked whether we can add a dossier in the target, we did not check whether the dossier we are adding itself contains subdossiers and if that would respect the dossier depth. This is now also fixed.

For [CA-1207]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed

[CA-1207]: https://4teamwork.atlassian.net/browse/CA-1207