### PR TITLE
Continue temporary disable lock check in tus-replace

### DIFF
--- a/opengever/api/tests/test_tus.py
+++ b/opengever/api/tests/test_tus.py
@@ -160,7 +160,7 @@ class TestTUSUpload(IntegrationTestCase):
         self.assert_tus_replace_fails(self.document, browser)
 
     @skipIf(
-        datetime.now() < datetime(2021, 9, 11),
+        datetime.now() < datetime(2022, 9, 11),
         "Lock verification temporary disabled, because it's not yet supported "
         "by Office Connector",
     )
@@ -266,7 +266,7 @@ class TestTUSUpload(IntegrationTestCase):
             u'IDocument.default': {
                 u'notrequired': u'This is an actual value, not a default',
             },
-        } 
+        }
         self.assert_tus_replace_succeeds(self.document, browser)
         expected_defaults = {
             u'IDocument.default': {


### PR DESCRIPTION
Continue temporary disable lock check in tus-replace because office-connector still does not proivde this feature.

See https://github.com/4teamwork/opengever.core/pull/6636 for more information.
