### PR TITLE
Add responsible_org_unit field to repository folders.

### DIFF
--- a/changes/CA-1269.feature
+++ b/changes/CA-1269.feature
@@ -1,0 +1,1 @@
+Add responsible_org_unit field to repository folders. [njohner]

--- a/docs/schema-dumps/opengever.repository.repositoryfolder.schema.json
+++ b/docs/schema-dumps/opengever.repository.repositoryfolder.schema.json
@@ -202,6 +202,13 @@
             "description": "",
             "_zope_schema_type": "RelationList",
             "default": []
+        },
+        "responsible_org_unit": {
+            "type": "string",
+            "title": "Federf\u00fchrendes Amt",
+            "maxLength": 30,
+            "description": "",
+            "_zope_schema_type": "TextLine"
         }
     },
     "allOf": [
@@ -250,6 +257,7 @@
         "date_of_cassation",
         "date_of_submission",
         "reference_number_prefix",
-        "addable_dossier_templates"
+        "addable_dossier_templates",
+        "responsible_org_unit"
     ]
 }

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -84,6 +84,7 @@ REPOFOLDER_MISSING_VALUES = {
     'former_reference': None,
     'location': None,
     'referenced_activity': None,
+    'responsible_org_unit': None,
     'retention_period_annotation': None,
     'title_fr': None,
     'valid_from': None,

--- a/opengever/bundle/schemas/repofolders.schema.json
+++ b/opengever/bundle/schemas/repofolders.schema.json
@@ -290,6 +290,16 @@
                     "_zope_schema_type": "RelationList",
                     "default": []
                 },
+                "responsible_org_unit": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "title": "Federf\u00fchrendes Amt",
+                    "maxLength": 30,
+                    "description": "",
+                    "_zope_schema_type": "TextLine"
+                },
                 "review_state": {
                     "type": "string",
                     "enum": [
@@ -385,7 +395,8 @@
                 "date_of_cassation",
                 "date_of_submission",
                 "reference_number_prefix",
-                "addable_dossier_templates"
+                "addable_dossier_templates",
+                "responsible_org_unit"
             ]
         },
         "permission": {

--- a/opengever/core/profiles/default/types/opengever.repository.repositoryfolder.xml
+++ b/opengever/core/profiles/default/types/opengever.repository.repositoryfolder.xml
@@ -34,6 +34,7 @@
     <element value="opengever.tabbedview.interfaces.ITabbedViewEnabled" />
     <element value="plone.app.lockingbehavior.behaviors.ILocking" />
     <element value="opengever.dossier.dossiertemplate.behaviors.IRestrictAddableDossierTemplates" />
+    <element value="opengever.repository.behaviors.responsibleorg.IResponsibleOrgUnit" />
   </property>
 
   <!-- View information -->

--- a/opengever/core/upgrades/20210913180533_add_responsible_org_unit_field_to_repository_folders/types/opengever.repository.repositoryfolder.xml
+++ b/opengever/core/upgrades/20210913180533_add_responsible_org_unit_field_to_repository_folders/types/opengever.repository.repositoryfolder.xml
@@ -1,0 +1,8 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="opengever.repository.repositoryfolder" meta_type="Dexterity FTI" i18n:domain="opengever.core">
+
+    <!-- enabled behaviors -->
+    <property name="behaviors" purge="False">
+        <element value="opengever.repository.behaviors.responsibleorg.IResponsibleOrgUnit" />
+    </property>
+
+</object>

--- a/opengever/core/upgrades/20210913180533_add_responsible_org_unit_field_to_repository_folders/upgrade.py
+++ b/opengever/core/upgrades/20210913180533_add_responsible_org_unit_field_to_repository_folders/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddResponsibleOrgUnitFieldToRepositoryFolders(UpgradeStep):
+    """Add responsible org unit field to repository folders.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
This was a customisation for AI, but as we are trying to get rid of customisations and that it generally makes sense for multi-OrgUnit deployments to have the `responsible_org_unit` field on repository folders, we have decided to add this to `opengever.core` instead and remove AI's customization.

For [CA-1269]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-1269]: https://4teamwork.atlassian.net/browse/CA-1269