### PR TITLE
Fix ++widget++ traversal when form contains custom properties

### DIFF
--- a/changes/CA-2482.bugfix
+++ b/changes/CA-2482.bugfix
@@ -1,0 +1,1 @@
+Fix ++widget++ traversal when form contains custom properties. [lgraf]

--- a/opengever/propertysheets/widgets.py
+++ b/opengever/propertysheets/widgets.py
@@ -69,6 +69,14 @@ class PropertySheetWiget(Widget):
             self.widgets.append(widget)
 
     def update(self):
+        if '/++widget++' in self.request.URL:
+            # z3c.form ++widget++ traversal requests try to update the entire
+            # form (for example for autocomplete searches in the 'responsible'
+            # field). This causes issues because of the 'special' way the
+            # propertysheet widgets work, and we therefore prevent them from
+            # updating themselves.
+            return
+
         super(PropertySheetWiget, self).update()
         self.initialize_widgets()
 


### PR DESCRIPTION
The `++widget++` traversal for autocomplete searches in the `responsible` field cause the entire form to be updated. When the form contained custom properties widgets, these got updated as well. This caused issues when the custom property widgets did not contain valid values yet at this point.

We therefore skip updating custom properties widgets on `++widget++` traversal requests to avoid this.

I tried to write a test for this, but I was unable to create a test that actually *failed* first.

For [CA-2482](https://4teamwork.atlassian.net/browse/CA-2482)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

