### PR TITLE
Make performance improvements for API endpoints using SQLHypermediaBatch.

### DIFF
--- a/changes/CA-2852.bugfix
+++ b/changes/CA-2852.bugfix
@@ -1,0 +1,1 @@
+Improve performance for SQL API endpoints, which uses the SQLHypermediaBatch. [phgross]

--- a/opengever/api/tests/test_globalindex.py
+++ b/opengever/api/tests/test_globalindex.py
@@ -83,6 +83,16 @@ class TestGlobalIndexGet(IntegrationTestCase):
              u'next': u'http://nohost/plone/@globalindex?b_start=3&b_size=3'},
             browser.json['batching'])
 
+        browser.open(self.portal, view='@globalindex?b_start=6&b_size=3',
+                     headers=self.api_headers)
+        self.assertEqual(
+            {u'@id': u'http://nohost/plone/@globalindex?b_start=6&b_size=3',
+             u'first': u'http://nohost/plone/@globalindex?b_start=0&b_size=3',
+             u'last': u'http://nohost/plone/@globalindex?b_start=12&b_size=3',
+             u'prev': u'http://nohost/plone/@globalindex?b_start=3&b_size=3',
+             u'next': u'http://nohost/plone/@globalindex?b_start=9&b_size=3'},
+            browser.json['batching'])
+
     @browsing
     def test_respect_sort_parameter(self, browser):
         self.login(self.regular_user, browser=browser)


### PR DESCRIPTION
The current implementation of SQLHyperMediaBatch passed in the SQLAlchemy query in to the Batch mechanism, this lead to several unnecessary SQL queries and performance Issue on deployments with a large amount of tasks (`@globalindex` endpoint).

I switched the implementation of the `SQLHyperMedia`, so that the query is only called when initializing the HyperMediaBatch and make sure that the query.count() is also only called once.

On local measurements with 50K tasks, the @globalindex endpoint could be reduced from approx. 5s to approx. 500ms.


For [CA-2852]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)



[CA-2852]: https://4teamwork.atlassian.net/browse/CA-2852