### PR TITLE
Transform default *value* to *token* in custom property schemas.

### DIFF
--- a/changes/CA-2482-2.bugfix
+++ b/changes/CA-2482-2.bugfix
@@ -1,0 +1,1 @@
+Transform default *value* to *token* in custom property schemas. [lgraf]

--- a/opengever/propertysheets/schema.py
+++ b/opengever/propertysheets/schema.py
@@ -22,6 +22,15 @@ def get_property_sheet_schema(schema_class):
     required = []
     for field in iter_fields(fieldsets):
         name = field.field.getName()
+
+        # Transform default *value* to *token*
+        default = getattr(field.field, 'default', None)
+        if default is not None:
+            vocab = getattr(field.field, 'vocabulary', None)
+            if vocab:
+                term = vocab.getTerm(field.field.default)
+                properties[name]['default'] = term.token
+
         # Determine required fields
         if field.field.required:
             required.append(name)

--- a/opengever/propertysheets/tests/test_schema.py
+++ b/opengever/propertysheets/tests/test_schema.py
@@ -108,6 +108,12 @@ class TestPropertySheetJSONSchema(FunctionalTestCase):
             },
         )
         definition.add_field(
+            "choice", u"choice_with_unicode", u"Choice with Unicode",
+            u"", True,
+            values=[u'Deutsch', u'Fran\xe7ais'],
+            default=u'Fran\xe7ais',
+        )
+        definition.add_field(
             "int", u"num", u"A number", u"Put a number.", True
         )
         definition.add_field(
@@ -134,6 +140,7 @@ class TestPropertySheetJSONSchema(FunctionalTestCase):
                        u'choice_with_default_factory',
                        u'choice_with_default_expression',
                        u'choice_with_default_from_member',
+                       u'choice_with_unicode',
                        u'num',
                        u'blabla',
                        u'bla',
@@ -256,6 +263,25 @@ class TestPropertySheetJSONSchema(FunctionalTestCase):
                     u'title': u'Choice with default from Member',
                     u'type': u'string',
                 },
+                u'choice_with_unicode': {
+                    u'choices': [
+                        [u'Deutsch', u'Deutsch'],
+                        [u'Fran\\xe7ais', u'Fran\xe7ais'],
+                    ],
+                    u'default': u'Fran\\xe7ais',
+                    u'description': u'',
+                    u'enum': [
+                        u'Deutsch',
+                        u'Fran\\xe7ais',
+                    ],
+                    u'enumNames': [
+                        u'Deutsch',
+                        u'Fran\xe7ais',
+                    ],
+                    u'factory': u'Choice',
+                    u'title': u'Choice with Unicode',
+                    u'type': u'string',
+                },
                 u'chooseone': {
                     u'choices': [
                         [u'bl\\xe4h', u'bl\xe4h'],
@@ -292,6 +318,7 @@ class TestPropertySheetJSONSchema(FunctionalTestCase):
                 u'choice_with_default_factory',
                 u'choice_with_default_expression',
                 u'choice_with_default_from_member',
+                u'choice_with_unicode',
                 u'num',
                 u'blabla',
                 u'bla',


### PR DESCRIPTION
Custom properties don't have support for controlling the vocabularies on `Choice` fields yet. Their vocabularies therefore get autogenerated. During that autogeneration, the `token` is always made 7-bit ASCII when it's derived from `values`.

For values that contain non-ASCII characters, this is achieved using `unicode_escape(value)`. That therefore leads to `token`s that are different from `values` (for these terms).

Because the REST API never should expose vocabulary _values_, the client is expected to pass the `token` in its requests. But that means any Field `default`s also need to be translated to the respective `token` before serializing the schema.

For [CA-2482](https://4teamwork.atlassian.net/browse/CA-2482)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- API change:
  - [ ] Documentation is updated (nothing to update)
  - [ ] API Changelog entry (deemed unnecessary - bugfix, not a breaking change)
  
