### PR TITLE
Propertysheets: Add allow_unmapped parameter to default_from_member options.

### DIFF
--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -3,7 +3,7 @@
 API Changelog
 =============
 
-2021.19.0 (unreleased)
+2021.18.1 (unreleased)
 ----------------------
 
 Breaking Changes
@@ -11,6 +11,8 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- ``@propertysheets``: Add ``allow_unmapped`` to ``default_from_member`` options.
+
 
 2021.18.0 (2021-09-10)
 ----------------------

--- a/docs/public/dev-manual/api/propertysheets.rst
+++ b/docs/public/dev-manual/api/propertysheets.rst
@@ -240,6 +240,14 @@ Optional unterstützt ``default_from_member`` auch die Angabe eines Mappings,
 und eines Fallback-Wertes der Verwendet wird wenn das Property nicht gefunden
 werden kann, oder einen Wert zurückgibt der Falsy ist.
 
+Wenn ein Mapping verwendet wird, kann über den Parameter ``allow_unmapped``
+gesteuert werden, ob Rückgabewerte erlaubt sind, die nicht im Mapping vorkommen:
+
+- ``allow_unmapped = False (default)``: Werte, die nicht im Mapping vorkommen, sind nicht erlaubt. Für solche Werte wird stattdessen das ``fallback`` verwendet.
+
+- ``allow_unmapped = True``: Werte, die nicht im Mapping vorkommen, werden 1:1 als default zurückgegeben.
+
+
 **Beispiel**:
 
 .. sourcecode:: json

--- a/opengever/propertysheets/default_from_member.py
+++ b/opengever/propertysheets/default_from_member.py
@@ -35,6 +35,7 @@ def member_property_default_factory(default_from_member_options):
     property_name = default_from_member_options['property']
     mapping = default_from_member_options.get('mapping', {})
     fallback = default_from_member_options.get('fallback')
+    allow_unmapped = default_from_member_options.get('allow_unmapped', False)
 
     member = api.user.get_current()
 
@@ -55,6 +56,9 @@ def member_property_default_factory(default_from_member_options):
 
         if result in mapping:
             result = mapping[result]
+        else:
+            if mapping and not allow_unmapped:
+                result = fallback
 
     except Exception as exc:
         logger.warn(
@@ -64,5 +68,5 @@ def member_property_default_factory(default_from_member_options):
     if isinstance(result, str):
         # Most text-like zope.schema fields require unicode
         result = safe_unicode(result)
-    
+
     return result

--- a/opengever/propertysheets/tests/test_default_from_member.py
+++ b/opengever/propertysheets/tests/test_default_from_member.py
@@ -1,5 +1,6 @@
 from opengever.propertysheets.default_from_member import member_property_default_factory
 from opengever.testing import IntegrationTestCase
+from plone import api
 import json
 
 
@@ -72,3 +73,38 @@ class TestDefaultFromMemberDefaultFactory(IntegrationTestCase):
                     'fallback': u'<No description>'
                     }
                 )))
+
+    def test_uses_fallback_for_unmapped_value_by_default(self):
+        self.login(self.regular_user)
+
+        member = api.user.get_current()
+        member.setProperties({'email': 'notmapped@example.org'})
+
+        self.assertEqual(
+            u'FALLBACK',
+            member_property_default_factory(
+                json.dumps({
+                    'property': 'email',
+                    'fallback': u'FALLBACK',
+                    'mapping': {
+                        u'foo@example.com': u'FOO@EXAMPLE.COM',
+                    }
+                })))
+
+    def test_honours_allow_unmapped(self):
+        self.login(self.regular_user)
+
+        member = api.user.get_current()
+        member.setProperties({'email': 'notmapped@example.org'})
+
+        self.assertEqual(
+            u'notmapped@example.org',
+            member_property_default_factory(
+                json.dumps({
+                    'property': 'email',
+                    'fallback': u'FALLBACK',
+                    'allow_unmapped': True,
+                    'mapping': {
+                        u'foo@example.com': u'FOO@EXAMPLE.COM',
+                    }
+                })))


### PR DESCRIPTION
This adds a new parameter `allow_unmapped` (default: `False`) to the `default_from_member` options for propertysheet definitions.

This will therefore change the default behavior of `default_from_member`: Unless `allow_unmapped` is set to `True`, unmapped values are not returned as defaults, but the `fallback` is used instead.

With `allow_unmapped == True`, unmapped values are returned 1:1.

The reason for this is to add an additional level of robustness, where unexpected (i.e. unmapped) values don't result in invalid defaults being produced.

For [CA-2288](https://4teamwork.atlassian.net/browse/CA-2288)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry
  - If breaking:
    - [ ] api-change label added _(deemed unnecessary, this API is currently internal and hasn't been used yet)_
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed