### PR TITLE
Track nightly jobs and OGDS sync runs with timestamps 

### DIFF
--- a/changes/CA-1346-2.other
+++ b/changes/CA-1346-2.other
@@ -1,0 +1,1 @@
+OGDS sync: Add helper to determine if sync happened in last 24h. [lgraf]

--- a/changes/CA-1346.other
+++ b/changes/CA-1346.other
@@ -1,0 +1,1 @@
+NightlyJobRunner: Update a timestamp on PloneSite when executing jobs. [lgraf]

--- a/opengever/nightlyjobs/runner.py
+++ b/opengever/nightlyjobs/runner.py
@@ -54,6 +54,21 @@ def nightly_run_within_24h():
     return last_run + delta > datetime.now()
 
 
+def get_job_counts():
+    """Get the nightly job counts (by provider).
+
+    This function is used by the @@health-check view in og.maintenance.
+    Don't change it without testing that the health check still works!
+    """
+    logger = logging.getLogger('opengever.nightlyjobs')
+    providers = {name: provider for name, provider
+                 in getAdapters([api.portal.get(), getRequest(), logger],
+                                INightlyJobProvider)}
+
+    job_counts = {name: len(provider) for name, provider in providers.items()}
+    return job_counts
+
+
 class TimeWindowExceeded(Exception):
 
     message = "Time window exceeded. Window: {}-{}. "\

--- a/opengever/nightlyjobs/runner.py
+++ b/opengever/nightlyjobs/runner.py
@@ -24,9 +24,26 @@ def nightly_jobs_feature_enabled():
         'is_feature_enabled', interface=INightlyJobsSettings)
 
 
-def nightly_run_within_24h():
+def get_nightly_run_timestamp():
+    """Get the timestamp of the last nightly run as a datetime.
+
+    This function is used by the @@health-check view in og.maintenance.
+    Don't change it without testing that the health check still works!
+    """
     portal = api.portal.get()
     last_run = IAnnotations(portal).get('last_nightly_run')
+
+    if last_run:
+        return last_run
+
+
+def nightly_run_within_24h():
+    """Determine whether nightly jobs ran within the last 24h.
+
+    This function is used by the @@health-check view in og.maintenance.
+    Don't change it without testing that the health check still works!
+    """
+    last_run = get_nightly_run_timestamp()
 
     if not last_run:
         return False

--- a/opengever/nightlyjobs/runner.py
+++ b/opengever/nightlyjobs/runner.py
@@ -198,5 +198,5 @@ class NightlyJobRunner(object):
         return len(self.job_providers[provider_name])
 
     def get_executed_jobs_count(self, provider_name=None):
-        return (self.get_initial_jobs_count(provider_name) -
-                self.get_remaining_jobs_count(provider_name))
+        return (self.get_initial_jobs_count(provider_name)
+                - self.get_remaining_jobs_count(provider_name))

--- a/opengever/nightlyjobs/runner.py
+++ b/opengever/nightlyjobs/runner.py
@@ -31,7 +31,10 @@ def nightly_run_within_24h():
     if not last_run:
         return False
 
-    return last_run + timedelta(hours=24) > datetime.now()
+    # Timestamp update may only be committed at the very end.
+    # So add a margin of error of 4h (usual duration) + 1h
+    delta = timedelta(hours=24 + 4 + 1)
+    return last_run + delta > datetime.now()
 
 
 class TimeWindowExceeded(Exception):

--- a/opengever/nightlyjobs/tests/test_nightly_job_runner.py
+++ b/opengever/nightlyjobs/tests/test_nightly_job_runner.py
@@ -317,7 +317,11 @@ class TestNightlyJobRunner(IntegrationTestCase):
         ann['last_nightly_run'] = datetime.now() - timedelta(hours=23)
         self.assertTrue(nightly_run_within_24h())
 
-        ann['last_nightly_run'] = datetime.now() - timedelta(hours=25)
+        # Margin of error (24h + 4h + 1h)
+        ann['last_nightly_run'] = datetime.now() - timedelta(hours=28)
+        self.assertTrue(nightly_run_within_24h())
+
+        ann['last_nightly_run'] = datetime.now() - timedelta(hours=30)
         self.assertFalse(nightly_run_within_24h())
 
         ann['last_nightly_run'] = None

--- a/opengever/nightlyjobs/tests/test_nightly_job_runner.py
+++ b/opengever/nightlyjobs/tests/test_nightly_job_runner.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from ftw.testing.freezer import FreezedClock
 from opengever.base.interfaces import IOpengeverBaseLayer
 from opengever.nightlyjobs.interfaces import INightlyJobsSettings
+from opengever.nightlyjobs.runner import get_nightly_run_timestamp
 from opengever.nightlyjobs.runner import nightly_run_within_24h
 from opengever.nightlyjobs.runner import SystemLoadCritical
 from opengever.nightlyjobs.runner import TimeWindowExceeded
@@ -308,6 +309,17 @@ class TestNightlyJobRunner(IntegrationTestCase):
 
         timestamp = IAnnotations(self.portal).get('last_nightly_run')
         self.assertEqual(datetime(2019, 1, 1, 4, 0), timestamp)
+
+    def test_get_nightly_run_timestamp(self):
+        self.login(self.manager)
+
+        ann = IAnnotations(self.portal)
+
+        self.assertIsNone(get_nightly_run_timestamp())
+
+        ann['last_nightly_run'] = datetime(2021, 5, 17, 12, 45)
+        self.assertEqual(
+            datetime(2021, 5, 17, 12, 45), get_nightly_run_timestamp())
 
     def test_nightly_run_within_24h_helper(self):
         self.login(self.manager)

--- a/opengever/ogds/base/sync/import_stamp.py
+++ b/opengever/ogds/base/sync/import_stamp.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from datetime import timedelta
 from opengever.base.protect import unprotected_write
 from opengever.base.request import dispatch_request
 from opengever.base.request import tracebackify
@@ -13,6 +14,7 @@ from zope.annotation.interfaces import IAnnotations
 from zope.component import getUtility
 from zope.globalrequest import setRequest
 from zope.interface import implementer
+import dateutil
 import logging
 
 
@@ -20,6 +22,16 @@ logger = logging.getLogger('opengever.ogds.base')
 
 DICTSTORAGE_SYNC_KEY = 'last_ldap_synchronisation'
 REQUEST_SYNC_KEY = 'last_ldap_synchronisation'
+
+
+def ogds_sync_within_24h():
+    sync_stamp = getUtility(ISyncStamp).get_sync_stamp()
+
+    if not sync_stamp:
+        return False
+
+    sync_stamp = dateutil.parser.parse(sync_stamp)
+    return sync_stamp + timedelta(hours=24) > datetime.now()
 
 
 def update_sync_stamp(context):

--- a/opengever/ogds/base/sync/import_stamp.py
+++ b/opengever/ogds/base/sync/import_stamp.py
@@ -24,14 +24,30 @@ DICTSTORAGE_SYNC_KEY = 'last_ldap_synchronisation'
 REQUEST_SYNC_KEY = 'last_ldap_synchronisation'
 
 
-def ogds_sync_within_24h():
+def get_ogds_sync_stamp():
+    """Get the timestamp of the last OGDS sync as a datetime.
+
+    This function is used by the @@health-check view in og.maintenance.
+    Don't change it without testing that the health check still works!
+    """
     sync_stamp = getUtility(ISyncStamp).get_sync_stamp()
 
-    if not sync_stamp:
+    if sync_stamp:
+        return dateutil.parser.parse(sync_stamp)
+
+
+def ogds_sync_within_24h():
+    """Determine whether an OGDS sync happened within the last 24h.
+
+    This function is used by the @@health-check view in og.maintenance.
+    Don't change it without testing that the health check still works!
+    """
+    sync_stamp_dt = get_ogds_sync_stamp()
+
+    if not sync_stamp_dt:
         return False
 
-    sync_stamp = dateutil.parser.parse(sync_stamp)
-    return sync_stamp + timedelta(hours=24) > datetime.now()
+    return sync_stamp_dt + timedelta(hours=24) > datetime.now()
 
 
 def update_sync_stamp(context):

--- a/opengever/ogds/base/tests/test_ogds_updater.py
+++ b/opengever/ogds/base/tests/test_ogds_updater.py
@@ -5,6 +5,7 @@ from ftw.builder import create
 from opengever.ogds.base.interfaces import IOGDSSyncConfiguration
 from opengever.ogds.base.interfaces import IOGDSUpdater
 from opengever.ogds.base.interfaces import ISyncStamp
+from opengever.ogds.base.sync.import_stamp import get_ogds_sync_stamp
 from opengever.ogds.base.sync.import_stamp import ogds_sync_within_24h
 from opengever.ogds.base.tests.ldaphelpers import FakeLDAPPlugin
 from opengever.ogds.base.tests.ldaphelpers import FakeLDAPSearchUtility
@@ -322,6 +323,14 @@ class TestOGDSUpdater(FunctionalTestCase):
 
 
 class TestImportStamp(IntegrationTestCase):
+
+    def test_get_ogds_sync_stamp(self):
+        util = getUtility(ISyncStamp)
+
+        self.assertIsNone(get_ogds_sync_stamp())
+
+        util.set_sync_stamp(datetime(2021, 9, 11, 12, 45).isoformat())
+        self.assertEqual(datetime(2021, 9, 11, 12, 45), get_ogds_sync_stamp())
 
     def test_ogds_sync_within_24h_helper(self):
         util = getUtility(ISyncStamp)

--- a/opengever/ogds/base/tests/test_ogds_updater.py
+++ b/opengever/ogds/base/tests/test_ogds_updater.py
@@ -1,7 +1,11 @@
+from datetime import datetime
+from datetime import timedelta
 from ftw.builder import Builder
 from ftw.builder import create
 from opengever.ogds.base.interfaces import IOGDSSyncConfiguration
 from opengever.ogds.base.interfaces import IOGDSUpdater
+from opengever.ogds.base.interfaces import ISyncStamp
+from opengever.ogds.base.sync.import_stamp import ogds_sync_within_24h
 from opengever.ogds.base.tests.ldaphelpers import FakeLDAPPlugin
 from opengever.ogds.base.tests.ldaphelpers import FakeLDAPSearchUtility
 from opengever.ogds.base.tests.ldaphelpers import FakeLDAPUserFolder
@@ -9,7 +13,10 @@ from opengever.ogds.models.group import Group
 from opengever.ogds.models.service import ogds_service
 from opengever.ogds.models.user import User
 from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 from plone import api
+from zope.annotation import IAnnotations
+from zope.component import getUtility
 
 
 FAKE_LDAP_USERFOLDER = FakeLDAPUserFolder()
@@ -312,3 +319,21 @@ class TestOGDSUpdater(FunctionalTestCase):
 
         group = ogds_service().fetch_group('duplicate_group')
         self.assertEqual(group.is_local, True)
+
+
+class TestImportStamp(IntegrationTestCase):
+
+    def test_ogds_sync_within_24h_helper(self):
+        util = getUtility(ISyncStamp)
+
+        util.set_sync_stamp((datetime.now() - timedelta(hours=23)).isoformat())
+        self.assertTrue(ogds_sync_within_24h())
+
+        util.set_sync_stamp((datetime.now() - timedelta(hours=25)).isoformat())
+        self.assertFalse(ogds_sync_within_24h())
+
+        IAnnotations(self.portal)['sync_stamp'] = None
+        self.assertFalse(ogds_sync_within_24h())
+
+        IAnnotations(self.portal).pop('sync_stamp')
+        self.assertFalse(ogds_sync_within_24h())


### PR DESCRIPTION
- Track nightly job runs with a timestamp on the Plone site
- Such a timestamp already exists for OGDS sync
- Add helper functions that determine, based on those timestamps, whether these jobs have been executed in the last 24h:
  - `nightly_run_within_24h()`
  - `ogds_sync_within_24h()`
 
- Add helper functions provide the underlying information:
  - `get_ogds_sync_stamp()`
  - `get_nightly_run_timestamp()`
  - `get_job_counts()`

The nightly jobs timestamp will not so much track *success*, but any *attempt* to run the jobs (that could be successful). So it gets updated whenever the runner is invoked by the cron job and:
- we're not outside the time window
- nightly jobs are not disabled via registry
- system load at the start doesn't lead to an immediate abort


For [CA-1346](https://4teamwork.atlassian.net/browse/CA-1346)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
