### PR TITLE
Fix actor represents URL for teams

### DIFF
--- a/changes/CA-2896.bugfix
+++ b/changes/CA-2896.bugfix
@@ -1,0 +1,1 @@
+Fix actor represents URL for teams. [buchi]

--- a/opengever/api/tests/test_actors.py
+++ b/opengever/api/tests/test_actors.py
@@ -52,7 +52,7 @@ class TestActorsGet(IntegrationTestCase):
                     },
                 ],
                 u'represents': {
-                    u'@id': u'http://nohost/plone/@teams/team:1',
+                    u'@id': u'http://nohost/plone/@teams/1',
                 },
             },
             browser.json,
@@ -351,7 +351,7 @@ class TestActorsGetListPOST(IntegrationTestCase):
                         },
                     ],
                     u'represents': {
-                        u'@id': u'http://nohost/plone/@teams/team:1',
+                        u'@id': u'http://nohost/plone/@teams/1',
                     },
                 },
                 {
@@ -408,7 +408,7 @@ class TestActorsGetListPOST(IntegrationTestCase):
                         },
                     ],
                     u'represents': {
-                        u'@id': u'http://nohost/plone/@teams/team:1',
+                        u'@id': u'http://nohost/plone/@teams/1',
                     },
                 },
                 {

--- a/opengever/ogds/base/actor.py
+++ b/opengever/ogds/base/actor.py
@@ -325,7 +325,7 @@ class TeamActor(Actor):
 
     def represents_url(self):
         return '{}/@teams/{}'.format(
-            api.portal.getSite().absolute_url(), self.identifier)
+            api.portal.getSite().absolute_url(), self.team.team_id)
 
     def get_portrait_url(self):
         return None


### PR DESCRIPTION
The `@teams` endpoint expects the team id in the URL and not the actor identifier which includes a `team:` prefix.

For [CA-2896](https://4teamwork.atlassian.net/browse/CA-2896)


## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

