### PR TITLE
Redirect to workspace if the invitation link refers to an already accepted invitation

### DIFF
--- a/changes/CA-1130.other
+++ b/changes/CA-1130.other
@@ -1,0 +1,1 @@
+Redirect to workspace if the invitation link refers to an already accepted invitation. [tinagerber]


### PR DESCRIPTION
Until now, an error was thrown when an invitation link was opened that referred to an already accepted invitation.
Now you will be redirected directly to the workspace the invitation was for or, if the user is not logged in, to the login form.

For [CA-1130]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-1130]: https://4teamwork.atlassian.net/browse/CA-1130