### PR TITLE
Remove immediate_view for proposals

### DIFF
--- a/changes/CA-2904.bugfix
+++ b/changes/CA-2904.bugfix
@@ -1,0 +1,1 @@
+Remove immediate_view for proposals, fixes protocol approval proposal creation. [phgross]

--- a/opengever/core/profiles/default/types/opengever.meeting.proposal.xml
+++ b/opengever/core/profiles/default/types/opengever.meeting.proposal.xml
@@ -30,7 +30,7 @@
 
   <!-- View information -->
   <property name="default_view">tabbed_view</property>
-  <property name="immediate_view">tabbed_view</property>
+  <property name="immediate_view" />
   <property name="default_view_fallback">False</property>
   <property name="view_methods">
     <element value="view" />

--- a/opengever/core/profiles/default/types/opengever.meeting.submittedproposal.xml
+++ b/opengever/core/profiles/default/types/opengever.meeting.submittedproposal.xml
@@ -29,7 +29,7 @@
 
   <!-- View information -->
   <property name="default_view">tabbed_view</property>
-  <property name="immediate_view">tabbed_view</property>
+  <property name="immediate_view" />
   <property name="default_view_fallback">False</property>
   <property name="view_methods">
     <element value="view" />

--- a/opengever/core/upgrades/20210917151047_remove_immediate_view_for_proposals/types/opengever.meeting.proposal.xml
+++ b/opengever/core/upgrades/20210917151047_remove_immediate_view_for_proposals/types/opengever.meeting.proposal.xml
@@ -1,0 +1,5 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="opengever.meeting.proposal" meta_type="Dexterity FTI" i18n:domain="opengever.core">
+
+  <property name="immediate_view"></property>
+
+</object>

--- a/opengever/core/upgrades/20210917151047_remove_immediate_view_for_proposals/types/opengever.meeting.submittedproposal.xml
+++ b/opengever/core/upgrades/20210917151047_remove_immediate_view_for_proposals/types/opengever.meeting.submittedproposal.xml
@@ -1,0 +1,5 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="opengever.meeting.submittedproposal" meta_type="Dexterity FTI" i18n:domain="opengever.core">
+
+  <property name="immediate_view"></property>
+
+</object>

--- a/opengever/core/upgrades/20210917151047_remove_immediate_view_for_proposals/upgrade.py
+++ b/opengever/core/upgrades/20210917151047_remove_immediate_view_for_proposals/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class RemoveImmediateViewForProposals(UpgradeStep):
+    """Remove immediate view for proposals.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
Fixes protocol approval proposal creation, when the new UI is enabled and after proposal creation it redirects to the new UI.

The regular URL of a proposal, works also for the new UI, but the `tabbed_view` addition does not. The change has no impact for the old UI.


Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-2904]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-2904]: https://4teamwork.atlassian.net/browse/CA-2904