### PR TITLE
Implement sqlite isolation for e2e tests.

### DIFF
--- a/changes/CA-2907.other
+++ b/changes/CA-2907.other
@@ -1,0 +1,1 @@
+Implement e2e testserver ogds isolation. [elioschmutz]

--- a/opengever/core/testserver.py
+++ b/opengever/core/testserver.py
@@ -6,6 +6,7 @@ from ftw.testing import staticuid
 from ftw.testing.layer import COMPONENT_REGISTRY_ISOLATION
 from opengever.base.interfaces import ISearchSettings
 from opengever.base.model import create_session
+from opengever.core import sqlite_testing
 from opengever.core.solr_testing import SolrReplicationAPIClient
 from opengever.core.solr_testing import SolrServer
 from opengever.core.testing import activate_bumblebee_feature
@@ -27,6 +28,35 @@ import transaction
 SOLR_PORT = os.environ.get('SOLR_PORT', '55003')
 SOLR_CORE = os.environ.get('SOLR_CORE', 'testserver')
 REUSE_RUNNING_SOLR = os.environ.get('TESTSERVER_REUSE_RUNNING_SOLR', None)
+
+
+class SQLiteBackup(object):
+    backup_data = ''
+
+    def isolate(self):
+        if self.backup_data:
+            self.restore()
+        else:
+            self.backup()
+
+    def backup(self):
+        for line in create_session().bind.raw_connection().connection.iterdump():
+            # We only want to store sql statements of the
+            # DML (Data Manipulation Language). Thus, we skip all other statements.
+            #
+            # When we restore the data in the restore-function, we'll empty all
+            # tables and feed it with the backedup data.
+            if 'CREATE TABLE' in line or \
+               'opengever_upgrade_version' in line or \
+               'CREATE INDEX' in line:
+                continue
+            self.backup_data += line
+
+    def restore(self):
+        sqlite_testing.truncate_tables()
+        create_session().bind.raw_connection().connection.executescript(self.backup_data)
+
+sqlite_backup = SQLiteBackup()
 
 
 class TestserverLayer(OpengeverFixture):
@@ -152,6 +182,8 @@ class TestServerFunctionalTesting(FunctionalTesting):
         super(TestServerFunctionalTesting, self).testSetUp()
         self.context_manager = self.isolation()
         self.context_manager.__enter__()
+
+        sqlite_backup.isolate()
         transaction.commit()
 
     def testTearDown(self):


### PR DESCRIPTION
Isolation for the sqlite in e2e tests:

Related frontend PR: https://github.com/4teamwork/gever-ui/pull/1948

## before

https://user-images.githubusercontent.com/557005/133816226-d5adde95-084f-4b82-a0a5-4eb182cfa447.mov


## after
https://user-images.githubusercontent.com/557005/133815502-3e2cb4bd-2182-4d49-93ea-8f71bc178965.mov


