### PR TITLE
Fix actors endpoint for the SystemActor.

### DIFF
--- a/changes/CA-2925.bugfix
+++ b/changes/CA-2925.bugfix
@@ -1,0 +1,1 @@
+Fix actors endpoint for the SystemActor. [phgross]

--- a/opengever/api/tests/test_actors.py
+++ b/opengever/api/tests/test_actors.py
@@ -270,6 +270,30 @@ class TestActorsGet(IntegrationTestCase):
         )
 
     @browsing
+    def test_actors_response_for_system_actor(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        actor_id = '__system__'
+        url = "{}/{}".format(self.actors_url, actor_id)
+        browser.open(url, headers=self.api_headers)
+        self.assertEqual(200, browser.status_code)
+
+        self.assertDictEqual(
+            {
+                u'@id': url,
+                u'@type': u'virtual.ogds.actor',
+                u'active': False,
+                u'actor_type': u'system',
+                u'identifier': actor_id,
+                u'portrait_url': None,
+                u'label': u'',
+                u'representatives': [],
+                u'represents': None,
+            },
+            browser.json
+        )
+
+    @browsing
     def test_raises_bad_request_when_actor_is_missing(self, browser):
         self.login(self.regular_user, browser=browser)
         with browser.expect_http_error(400):

--- a/opengever/ogds/base/actor.py
+++ b/opengever/ogds/base/actor.py
@@ -225,6 +225,10 @@ class SystemActor(object):
     def get_link(self, with_icon=False):
         return u''
 
+    @property
+    def is_active(self):
+        return False
+
     def represents(self):
         return None
 


### PR DESCRIPTION
The `is_active` property was missing for the SystemActor. Fixes https://sentry.4teamwork.ch/organizations/sentry/issues/77235.

For [CA-2925]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-2925]: https://4teamwork.atlassian.net/browse/CA-2925