### PR TITLE
Propertysheets: Avoid 'RequiredMissing' for empty multiple_choice fie…

### DIFF
--- a/changes/CA-2482-3.bugfix
+++ b/changes/CA-2482-3.bugfix
@@ -1,0 +1,1 @@
+Propertysheets: Avoid 'RequiredMissing' for empty multiple_choice fields [lgraf]

--- a/opengever/propertysheets/deserializer.py
+++ b/opengever/propertysheets/deserializer.py
@@ -7,6 +7,7 @@ from zope.component import adapter
 from zope.component import getMultiAdapter
 from zope.interface import implementer
 from zope.publisher.interfaces.browser import IBrowserRequest
+from zope.schema import Set
 
 
 @implementer(IFieldDeserializer)
@@ -44,6 +45,14 @@ class PropertySheetFieldDeserializer(DefaultFieldDeserializer):
                 deserializer = getMultiAdapter(
                     (field, self.context, self.request), IFieldDeserializer
                 )
+
+                # If an API client specifies None as the field value
+                # for a multiple_choice field, the CollectionFieldDeserializer
+                # will turn it into [None] which will cause RequiredMissing.
+                # We therefore replace it with an empty list.
+                if isinstance(field, Set) and field_value is None:
+                    field_value = []
+
                 data[name] = deserializer(field_value)
 
         return value

--- a/opengever/propertysheets/tests/test_deserializer.py
+++ b/opengever/propertysheets/tests/test_deserializer.py
@@ -72,3 +72,33 @@ class TestPropertySheetFieldDeserializer(IntegrationTestCase):
             },
             deserialized_data,
         )
+
+    def test_deserializes_empty_multiple_choice(self):
+        self.login(self.regular_user)
+
+        choices = ["one", "two", "five"]
+        create(
+            Builder("property_sheet_schema")
+            .named("schema1")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field(
+                "multiple_choice", u"choose", u"Choose", u"", False, values=choices
+            )
+        )
+
+        deserialized_data = self.deserializer(
+            {
+                "IDocumentMetadata.document_type.question": {
+                    "choose": None
+                }
+            }
+        )
+        self.assertEqual(
+            {
+                "IDocumentMetadata.document_type.question": {
+                    "choose": set([]),
+                },
+            },
+            deserialized_data,
+        )
+


### PR DESCRIPTION
If an API client specifies `None` as the field value for a `multiple_choice` field, the `CollectionFieldDeserializer` will turn it into `[None]`, which will cause a `RequiredMissing` error.

We therefore replace `None` with an empty list in the propertysheets deserializer.

This for example happens on `dev` for the `fachbereich` field: Since 4teamwork/gever-ui#1926, the frontend now sends

```
  "custom_properties": {
    "IDossier.default": {
      "fachbereich": null,
      "id_fachapplikation": null
    }
  }
```

instead of just `"custom_properties": {}` _(and it can't easily distinguish between multi-valued and single-valued fields, and "no default" vs. "default of `None`")._

For [CA-2482](https://4teamwork.atlassian.net/browse/CA-2482) (already closed, small follow-up bugfix)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
