### PR TITLE
Filter non-documentish types for IRelatedDocuments.relatedItems backrefs

### DIFF
--- a/changes/CA-2936.bugfix
+++ b/changes/CA-2936.bugfix
@@ -1,0 +1,1 @@
+Filter non-documentish types for document-to-document relations. [lgraf]

--- a/opengever/api/document.py
+++ b/opengever/api/document.py
@@ -50,7 +50,8 @@ class SerializeDocumentToJson(GeverSerializeToJson):
         result[u'file_extension'] = self.context.get_file_extension()
 
         extend_with_backreferences(
-            result, self.context, self.request, 'relatedItems')
+            result, self.context, self.request, 'relatedItems',
+            documents_only=True)
 
         checked_out_by = obj.checked_out_by()
         checked_out_by_fullname = display_name(checked_out_by) if checked_out_by else None

--- a/opengever/api/serializer.py
+++ b/opengever/api/serializer.py
@@ -107,7 +107,8 @@ def extend_with_groupurl(result, context, request):
         api.portal.get().absolute_url(), context.groupid)
 
 
-def extend_with_backreferences(result, context, request, reference_attribute_name):
+def extend_with_backreferences(result, context, request, reference_attribute_name,
+                               documents_only=False):
     """Extend the given result dict with an additional key
     `back_references_{reference_attribute_name}` for example
     `back_references_relatedDossiers` and a list of backreferences.
@@ -118,6 +119,13 @@ def extend_with_backreferences(result, context, request, reference_attribute_nam
     relations = catalog.findRelations(
         {'to_id': intids.getId(aq_inner(context)),
          'from_attribute': reference_attribute_name})
+
+    # Filter non-documentish types for document-to-document relations
+    if documents_only:
+        relations = filter(
+            lambda rel: IBaseDocument.providedBy(rel.from_object),
+            relations)
+
     summaries = [
         getMultiAdapter((relation.from_object, request), ISerializeToJsonSummary)()
         for relation in relations]

--- a/opengever/api/tests/test_document.py
+++ b/opengever/api/tests/test_document.py
@@ -193,7 +193,7 @@ class TestDocumentSerializer(IntegrationTestCase):
         self.assertEqual(expected_links, browser.json['teamraum_connect_links'])
 
     @browsing
-    def test_contains_dossier_backreferences(self, browser):
+    def test_contains_document_backreferences(self, browser):
         self.login(self.regular_user, browser=browser)
 
         browser.open(self.subdocument, method="GET", headers=self.api_headers)

--- a/opengever/api/tests/test_document.py
+++ b/opengever/api/tests/test_document.py
@@ -212,6 +212,18 @@ class TestDocumentSerializer(IntegrationTestCase):
         self.assertEqual([], browser.json['back_references_relatedItems'])
 
     @browsing
+    def test_filters_anything_but_documents_from_backreferences(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(self.document, method="GET", headers=self.api_headers)
+        self.assertEqual([
+            (u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/dossier-2/document-22',
+             u'opengever.document.document'),
+            (u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/dossier-2/dossier-4/document-23',
+             u'opengever.document.document')],
+            [(ref['@id'], ref['@type']) for ref in browser.json['back_references_relatedItems']])
+
+    @browsing
     def test_approvals_expansion(self, browser):
         self.login(self.regular_user, browser=browser)
 


### PR DESCRIPTION
This change makes sure that **on documents**, non-documentish types are also filtered from the `back_references_...` property returned by the REST API, similarly to what already is [being done in the classic UI with `related_items(documents_only=True)`](https://github.com/4teamwork/opengever.core/blob/f7d69a99f17fcf38f94de2cd7f3a8c6c972142f8/opengever/document/browser/overview.py#L269-L282).

For [CA-2936](https://4teamwork.atlassian.net/browse/CA-2936)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- New functionality:
  - [x] for `document` also works for `mail`
