### PR TITLE
Add permission to protect lifecycle and classification fields.

### DIFF
--- a/changes/CA-2771.feature
+++ b/changes/CA-2771.feature
@@ -1,0 +1,1 @@
+Add permission to protect lifecycle and classification fields. [tinagerber]

--- a/opengever/base/behaviors/classification.py
+++ b/opengever/base/behaviors/classification.py
@@ -6,6 +6,7 @@ from opengever.base.utils import language_cache_key
 from plone import api
 from plone.app.dexterity.behaviors import metadata
 from plone.app.workflow.interfaces import ILocalrolesModifiedEvent
+from plone.autoform import directives as form
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.memoize import ram
 from plone.supermodel import model
@@ -67,6 +68,7 @@ class IClassification(model.Schema):
         ],
     )
 
+    form.write_permission(classification='opengever.base.EditLifecycleAndClassification')
     classification = schema.Choice(
         title=_(u'label_classification', default=u'Classification'),
         description=_(u'help_classification', default=u''),
@@ -74,6 +76,7 @@ class IClassification(model.Schema):
         required=True,
     )
 
+    form.write_permission(privacy_layer='opengever.base.EditLifecycleAndClassification')
     privacy_layer = schema.Choice(
         title=_(u'label_privacy_layer', default=u'Privacy layer'),
         description=_(u'help_privacy_layer', default=u''),

--- a/opengever/base/behaviors/lifecycle.py
+++ b/opengever/base/behaviors/lifecycle.py
@@ -42,7 +42,7 @@ class ILifeCycle(model.Schema):
             u'date_of_submission', ],
     )
 
-    # dexterity.write_permission(retention_period='cmf.ManagePortal')
+    form.write_permission(retention_period='opengever.base.EditLifecycleAndClassification')
     retention_period = schema.Choice(
         title=_(u'label_retention_period', u'Retention period (years)'),
         description=_(u'help_retention_period', default=u''),
@@ -50,14 +50,14 @@ class ILifeCycle(model.Schema):
         required=True,
     )
 
-    # dexterity.write_permission(retention_period_annotation='cmf.ManagePortal')
+    form.write_permission(retention_period_annotation='opengever.base.EditLifecycleAndClassification')
     retention_period_annotation = schema.Text(
         title=_(u'label_retention_period_annotation',
                 default=u'retentionPeriodAnnotation'),
         required=False
     )
 
-    # dexterity.write_permission(archival_value='cmf.ManagePortal')
+    form.write_permission(archival_value='opengever.base.EditLifecycleAndClassification')
     archival_value = schema.Choice(
         title=_(u'label_archival_value', default=u'Archival value'),
         description=_(u'help_archival_value', default=u'Archival value code'),
@@ -65,14 +65,14 @@ class ILifeCycle(model.Schema):
         required=True,
     )
 
-    # dexterity.write_permission(archival_value_annotation='cmf.ManagePortal')
+    form.write_permission(archival_value_annotation='opengever.base.EditLifecycleAndClassification')
     archival_value_annotation = schema.Text(
         title=_(u'label_archival_value_annotation',
                 default=u'archivalValueAnnotation'),
         required=False
     )
 
-    # dexterity.write_permission(custody_period='cmf.ManagePortal')
+    form.write_permission(custody_period='opengever.base.EditLifecycleAndClassification')
     custody_period = schema.Choice(
         title=_(u'label_custody_period', default=u'Custody period (years)'),
         description=_(u'help_custody_period', default=u''),

--- a/opengever/base/behaviors/utils.py
+++ b/opengever/base/behaviors/utils.py
@@ -42,3 +42,9 @@ def hide_fields_from_behavior(form, fieldnames):
         for fieldname in fieldnames:
             if fieldname in group.fields:
                 group.fields[fieldname].mode = HIDDEN_MODE
+
+
+def omit_classification_group(form):
+    for group in form.groups:
+        if group.__name__ == u'classification':
+            form.groups.remove(group)

--- a/opengever/base/behaviors/utils.py
+++ b/opengever/base/behaviors/utils.py
@@ -8,9 +8,9 @@ import re
 # TODO: Move to a more suitable place
 def split_string_by_numbers(x):
     x = str(x)
-    r = re.compile('(\d+)')
-    l = r.split(x)
-    return [int(y) if y.isdigit() else y for y in l]
+    r = re.compile(r'(\d+)')
+    left = r.split(x)
+    return [int(y) if y.isdigit() else y for y in left]
 
 
 def set_attachment_content_disposition(request, filename, file=None):

--- a/opengever/base/monkey/patches/readonly.py
+++ b/opengever/base/monkey/patches/readonly.py
@@ -251,6 +251,7 @@ WRITE_PERMISSIONS = [
     'Remove GEVER content',
     'Delete objects',
     'Copy or Move',
+    'Edit lifecycle and classification',
 
     'Set own properties',
 ]

--- a/opengever/base/permissions.zcml
+++ b/opengever/base/permissions.zcml
@@ -8,4 +8,6 @@
 
   <permission id="opengever.base.EditDateOfCassation" title="Edit date of cassation" />
 
+  <permission id="opengever.base.EditLifecycleAndClassification" title="Edit lifecycle and classification" />
+
 </configure>

--- a/opengever/core/lawgiver.zcml
+++ b/opengever/core/lawgiver.zcml
@@ -215,6 +215,7 @@
                    ATContentTypes: Add Large Plone Folder,
                    ATContentTypes: Add Link,
                    ATContentTypes: Add News Item,
+                   Edit lifecycle and classification,
                    ftw.usermigration: Migrate users,
                    opengever.api: Manage Groups,
                    opengever.api: Manage Role Assignment Reports,

--- a/opengever/core/profiles/default/rolemap.xml
+++ b/opengever/core/profiles/default/rolemap.xml
@@ -42,6 +42,15 @@
       <role name="Manager" />
     </permission>
 
+    <permission name="Edit lifecycle and classification" acquire="True">
+      <role name="Manager" />
+      <role name="Contributor" />
+      <role name="Editor" />
+      <role name="Administrator" />
+      <role name="WorkspaceAdmin" />
+      <role name="WorkspaceMember" />
+    </permission>
+
     <permission name="ftw.keywordwidget: Add new term" acquire="False">
       <role name="Manager" />
       <role name="Site Administrator" />

--- a/opengever/core/upgrades/20210920163320_add_permission_to_edit_classification_and_lifecycle_fields/rolemap.xml
+++ b/opengever/core/upgrades/20210920163320_add_permission_to_edit_classification_and_lifecycle_fields/rolemap.xml
@@ -1,0 +1,12 @@
+<rolemap>
+  <permissions>
+    <permission name="Edit lifecycle and classification" acquire="True">
+      <role name="Manager" />
+      <role name="Contributor" />
+      <role name="Editor" />
+      <role name="Administrator" />
+      <role name="WorkspaceAdmin" />
+      <role name="WorkspaceMember" />
+    </permission>
+  </permissions>
+</rolemap>

--- a/opengever/core/upgrades/20210920163320_add_permission_to_edit_classification_and_lifecycle_fields/upgrade.py
+++ b/opengever/core/upgrades/20210920163320_add_permission_to_edit_classification_and_lifecycle_fields/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddPermissionToEditClassifiacationAndLifecycleFields(UpgradeStep):
+    """Add permission to edit classification and lifecycle fields.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/dossier/browser/forms.py
+++ b/opengever/dossier/browser/forms.py
@@ -1,6 +1,7 @@
 from Acquisition import aq_inner, aq_parent
 from ftw.keywordwidget.widget import KeywordWidget
 from opengever.base.behaviors.utils import hide_fields_from_behavior
+from opengever.base.behaviors.utils import omit_classification_group
 from opengever.base.vocabulary import wrap_vocabulary
 from opengever.dossier import _
 from opengever.dossier.behaviors.dossier import IDossier
@@ -26,6 +27,7 @@ from z3c.form.field import Fields
 from z3c.form.form import Form
 from zExceptions import Unauthorized
 from zope.component import getUtility
+from zope.security import checkPermission
 import base64
 
 
@@ -98,8 +100,13 @@ class DossierAddForm(add.DefaultAddForm):
 
     def updateFields(self):
         super(DossierAddForm, self).updateFields()
-        fields = ['IClassification.public_trial',
-                  'IClassification.public_trial_statement']
+
+        if checkPermission('opengever.base.EditLifecycleAndClassification', self.context):
+            fields = ['IClassification.public_trial',
+                      'IClassification.public_trial_statement']
+        else:
+            omit_classification_group(self)
+            fields = []
 
         if not has_active_dossier_types(self.context):
             fields.append('IDossier.dossier_type')
@@ -147,8 +154,12 @@ class DossierEditForm(edit.DefaultEditForm):
                 group.fields['IDossier.reference_number'].widgetFactory = referenceNumberWidgetFactory
                 group.fields['IDossier.reference_number'].mode = 'display'
 
-        fields = ['IClassification.public_trial',
-                  'IClassification.public_trial_statement']
+        if checkPermission('opengever.base.EditLifecycleAndClassification', self.context):
+            fields = ['IClassification.public_trial',
+                      'IClassification.public_trial_statement']
+        else:
+            omit_classification_group(self)
+            fields = []
 
         if not has_active_dossier_types(self.context):
             fields.append('IDossier.dossier_type')

--- a/opengever/dossier/dossiertemplate/form.py
+++ b/opengever/dossier/dossiertemplate/form.py
@@ -252,13 +252,12 @@ class AddDossierFromTemplateWizardStep(WizzardWrappedAddForm):
                 """Update the widget-values of the dossier add-form
                 with the values of the selected dossiertemplate values.
                 """
+                self.is_available()
                 super(WrappedForm, self).update()
 
                 if not getSecurityManager().getUser().getId():
                     # this happens during ++widget++ traversal
                     return
-
-                self.is_available()
 
                 template_obj = get_saved_template_obj(self.context)
 

--- a/opengever/repository/browser/repositoryfolder_forms.py
+++ b/opengever/repository/browser/repositoryfolder_forms.py
@@ -1,4 +1,5 @@
 from opengever.base.behaviors.utils import hide_fields_from_behavior
+from opengever.base.behaviors.utils import omit_classification_group
 from opengever.base.browser.translated_title import TranslatedTitleAddForm
 from opengever.base.browser.translated_title import TranslatedTitleEditForm
 from opengever.dossier.behaviors.dossier import IDossierMarker
@@ -9,6 +10,7 @@ from plone.dexterity.interfaces import IDexterityFTI
 from Products.CMFCore.interfaces import IFolderish
 from zope.component import adapter
 from zope.publisher.interfaces.browser import IDefaultBrowserLayer
+from zope.security import checkPermission
 
 
 class AddForm(TranslatedTitleAddForm):
@@ -34,9 +36,12 @@ class AddForm(TranslatedTitleAddForm):
 
     def updateFields(self):
         super(AddForm, self).updateFields()
-        hide_fields_from_behavior(self,
-                                  ['IClassification.public_trial',
-                                   'IClassification.public_trial_statement'])
+        if checkPermission('opengever.base.EditLifecycleAndClassification', self.context):
+            hide_fields_from_behavior(self,
+                                      ['IClassification.public_trial',
+                                       'IClassification.public_trial_statement'])
+        else:
+            omit_classification_group(self)
 
 
 @adapter(IFolderish, IDefaultBrowserLayer, IDexterityFTI)
@@ -48,6 +53,9 @@ class EditForm(TranslatedTitleEditForm):
 
     def updateFields(self):
         super(EditForm, self).updateFields()
-        hide_fields_from_behavior(self,
-                                  ['IClassification.public_trial',
-                                   'IClassification.public_trial_statement'])
+        if checkPermission('opengever.base.EditLifecycleAndClassification', self.context):
+            hide_fields_from_behavior(self,
+                                      ['IClassification.public_trial',
+                                       'IClassification.public_trial_statement'])
+        else:
+            omit_classification_group(self)


### PR DESCRIPTION
This is necessary so that we can restrict who can edit these fields for St. Gallen. https://github.com/4teamwork/opengever.sg/pull/501

For [CA-2771]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-2771]: https://4teamwork.atlassian.net/browse/CA-2771