### PR TITLE
Ignore collective.usernamelogger in testserver time freezer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1120,11 +1120,13 @@ Once installed properly, the server can be started with ``bin/testserver``:
 
 .. code::
 
-   ./bin/testserver
+   ./bin/testserver -v
    Plone:  http://localhost:55001/plone
    XMLRPC: http://localhost:55002
    ...
    18:13:39 [ ready ] Started Zope 2 server
+
+Use the `-v` flag in order to make errors and exceptions appear on `stderr`.
 
 Next you need to tell the testserver that you will now run a test:
 

--- a/base-testserver.cfg
+++ b/base-testserver.cfg
@@ -11,7 +11,6 @@ recipe = zc.recipe.egg
 eggs =
     ${test:eggs}
     plone.app.robotframework
-scripts = robot-server=testserver
 initialization =
     import os
     # Enable conditional readonly patches during tests

--- a/bin/testserverctl
+++ b/bin/testserverctl
@@ -7,7 +7,7 @@ import xmlrpclib
 CTL_PORT = os.environ.get('TESTSERVER_CTL_PORT', '55002')
 
 parser = argparse.ArgumentParser()
-parser.add_argument('action', choices=['zodb_setup', 'zodb_teardown'])
+parser.add_argument('action', choices=['zodb_setup', 'zodb_teardown', 'isolate'])
 args = parser.parse_args()
 
 proxy = xmlrpclib.ServerProxy('http://localhost:{}'.format(CTL_PORT))

--- a/changes/CA-2907.other
+++ b/changes/CA-2907.other
@@ -1,0 +1,1 @@
+Implement e2e testserver ogds isolation. [elioschmutz]

--- a/opengever/core/configure.zcml
+++ b/opengever/core/configure.zcml
@@ -3,6 +3,7 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     xmlns:profilehook="http://namespaces.zope.org/profilehook"
     xmlns:upgrade-step="http://namespaces.zope.org/ftw.upgrade"
+    xmlns:monkey="http://namespaces.plone.org/monkey"
     xmlns:i18n="http://namespaces.zope.org/i18n"
     i18n_domain="opengever.core">
 
@@ -37,5 +38,13 @@
       />
 
   <i18n:registerTranslations directory="locales" />
+
+  <include package="collective.monkeypatcher" file="meta.zcml" />
+
+  <monkey:patch
+     class="ZServer.medusa.http_server.http_request"
+     original="log_date_string"
+     replacement=".testserver.log_date_string"
+     docstringWarning="false" />
 
 </configure>

--- a/opengever/core/testserver.py
+++ b/opengever/core/testserver.py
@@ -30,6 +30,9 @@ SOLR_PORT = os.environ.get('SOLR_PORT', '55003')
 SOLR_CORE = os.environ.get('SOLR_CORE', 'testserver')
 REUSE_RUNNING_SOLR = os.environ.get('TESTSERVER_REUSE_RUNNING_SOLR', None)
 
+def log_date_string(*arg, **kwargs):
+     return ''
+
 
 class SQLiteBackup(object):
     backup_data = ''

--- a/opengever/core/testserver.py
+++ b/opengever/core/testserver.py
@@ -11,6 +11,7 @@ from opengever.core.solr_testing import SolrReplicationAPIClient
 from opengever.core.solr_testing import SolrServer
 from opengever.core.testing import activate_bumblebee_feature
 from opengever.core.testing import OpengeverFixture
+from opengever.core.testserver_zope2server import ISOLATION_READYNESS
 from opengever.testing.helpers import incrementing_intids
 from plone import api
 from plone.app.testing import applyProfile
@@ -58,6 +59,7 @@ class TestserverLayer(OpengeverFixture):
     defaultBases = (COMPONENT_REGISTRY_ISOLATION,)
 
     def setUpZope(self, app, configurationContext):
+        ISOLATION_READYNESS.patch_publisher()
         solr = SolrServer.get_instance()
         solr.configure(SOLR_PORT, SOLR_CORE)
 

--- a/opengever/core/testserver.py
+++ b/opengever/core/testserver.py
@@ -6,6 +6,7 @@ from ftw.testing import staticuid
 from ftw.testing.layer import COMPONENT_REGISTRY_ISOLATION
 from opengever.base.interfaces import ISearchSettings
 from opengever.base.model import create_session
+from opengever.core import sqlite_testing
 from opengever.core.solr_testing import SolrReplicationAPIClient
 from opengever.core.solr_testing import SolrServer
 from opengever.core.testing import activate_bumblebee_feature
@@ -27,6 +28,30 @@ import transaction
 SOLR_PORT = os.environ.get('SOLR_PORT', '55003')
 SOLR_CORE = os.environ.get('SOLR_CORE', 'testserver')
 REUSE_RUNNING_SOLR = os.environ.get('TESTSERVER_REUSE_RUNNING_SOLR', None)
+
+
+class SQLiteBackup(object):
+    backup_data = ''
+
+    def isolate(self):
+        if self.backup_data:
+            self.restore()
+        else:
+            self.backup()
+
+    def backup(self):
+        for line in create_session().bind.raw_connection().connection.iterdump():
+            if 'CREATE TABLE' in line or \
+               'opengever_upgrade_version' in line or \
+               'CREATE INDEX' in line:
+                continue
+            self.backup_data += line
+
+    def restore(self):
+        sqlite_testing.truncate_tables()
+        create_session().bind.raw_connection().connection.executescript(self.backup_data)
+
+sqlite_backup = SQLiteBackup()
 
 
 class TestserverLayer(OpengeverFixture):
@@ -152,6 +177,8 @@ class TestServerFunctionalTesting(FunctionalTesting):
         super(TestServerFunctionalTesting, self).testSetUp()
         self.context_manager = self.isolation()
         self.context_manager.__enter__()
+
+        sqlite_backup.isolate()
         transaction.commit()
 
     def testTearDown(self):

--- a/opengever/core/testserver_selftest.py
+++ b/opengever/core/testserver_selftest.py
@@ -140,7 +140,7 @@ class TestserverSelftest(object):
     def start_testserver(self):
         """Start the testserver in a subprocess controlled by a separate thread.
         """
-        args = ['bin/testserver']
+        args = ['bin/testserver', '-v']
         print ansi_blue('>', *args)
         self.testserver_process = subprocess.Popen(args, stdout=subprocess.PIPE)
 

--- a/opengever/core/testserver_zope2server.py
+++ b/opengever/core/testserver_zope2server.py
@@ -2,6 +2,7 @@ from plone.app.robotframework import server as robotframework_server
 from six.moves.xmlrpc_server import SimpleXMLRPCServer
 import argparse
 import logging
+import sys
 
 
 """To make e2e tests more robus when teardown/setup the zodb, we have
@@ -115,6 +116,7 @@ def server():
         global HAS_VERBOSE_CONSOLE
         HAS_VERBOSE_CONSOLE = True
         loglevel = logging.ERROR - (args.verbose - 1) * 10
+        logging.getLogger().addHandler(logging.StreamHandler(sys.stderr))
     else:
         loglevel = logging.ERROR
     logging.basicConfig(level=loglevel)

--- a/opengever/core/testserver_zope2server.py
+++ b/opengever/core/testserver_zope2server.py
@@ -1,0 +1,132 @@
+from plone.app.robotframework import server as robotframework_server
+from six.moves.xmlrpc_server import SimpleXMLRPCServer
+import argparse
+import logging
+
+
+"""To make e2e tests more robus when teardown/setup the zodb, we have
+to provide a way to do it in one single request. Unfortunately, the
+robotframwork does not provide such a method.
+
+Thus, we decided to override the Zope2Server from the robotframework to
+provide an 'isolate' method which tears-down the zodb if necessary and directly
+sets it up.
+
+We make this method available through the xmlrpc server.
+This allows us to teardown/setup the database in one single request.
+"""
+
+
+class Zope2Server(robotframework_server.Zope2Server):
+    is_zodb_setup = False
+
+    def isolate(self, *args, **kwargs):
+        if self.is_zodb_setup:
+            self.zodb_teardown(*args, **kwargs)
+
+        self.zodb_setup(*args, **kwargs)
+        self.is_zodb_setup = True
+
+
+def start(zope_layer_dotted_name):
+    """This is a copy of the plone.app.robotframework.server.start method.
+
+    We just register the additional 'isolate' method here.
+
+    Why not monkey-patching? Because the monkey patch is too late. It has no effect.
+    """
+    print(robotframework_server.WAIT("Starting Zope 2 server"))
+
+    zsl = Zope2Server()
+    zsl.start_zope_server(zope_layer_dotted_name)
+
+    print(robotframework_server.READY("Started Zope 2 server"))
+
+    listener = SimpleXMLRPCServer((robotframework_server.LISTENER_HOST,
+                                   robotframework_server.LISTENER_PORT),
+                                  logRequests=False)
+    listener.allow_none = True
+    listener.register_function(zsl.zodb_setup, 'zodb_setup')
+    listener.register_function(zsl.zodb_teardown, 'zodb_teardown')
+    listener.register_function(zsl.isolate, 'isolate')  # PATCH
+
+    robotframework_server.print_urls(zsl.zope_layer, listener)
+
+    try:
+        listener.serve_forever()
+    finally:
+        print()
+        print(robotframework_server.WAIT("Stopping Zope 2 server"))
+
+        zsl.stop_zope_server()
+
+        print(robotframework_server.READY("Zope 2 server stopped"))
+
+
+def server():
+    """This is a copy of the plone.app.robotframework.server.server method.
+
+    This method will be called in the 'bin/testserver' script and is the entry
+    point of the Z2 testserver.
+
+    This method directly calls the 'start' method, which we have customized.
+    We have to override this method to tell it, that it should use our customized
+    'start' method.
+
+    This also means, that we have to provide this method as a console-script in
+    'opengever.core.setup'
+
+    Same here, a monkey-patch is too late and does not work.
+    """
+    if robotframework_server.HAS_RELOAD:
+        parser = argparse.ArgumentParser()
+    else:
+        parser = argparse.ArgumentParser(
+            epilog='Note: require \'plone.app.robotframework\' with '
+                   '\'[reload]\'-extras to get the automatic code reloading '
+                   'support (powered by \'watchdog\').')
+    parser.add_argument('layer')
+    parser.add_argument('--debug-mode', '-d', dest='debug_mode',
+                        action='store_true')
+    VERBOSE_HELP = (
+        '-v information about test layers setup and tear down, '
+        '-vv add logging.WARNING messages, '
+        '-vvv add INFO messages, -vvvv add DEBUG messages.')
+    parser.add_argument('--verbose', '-v', action='count', help=VERBOSE_HELP)
+
+    if robotframework_server.HAS_RELOAD:
+        parser.add_argument('--reload-path', '-p', dest='reload_paths',
+                            action='append')
+        parser.add_argument('--reload-extensions', '-x', dest='extensions',
+                            nargs='*', help=(
+                                'file extensions to watch for changes'))
+        parser.add_argument('--preload-layer', '-l', dest='preload_layer')
+        parser.add_argument('--no-reload', '-n', dest='reload',
+                            action='store_false')
+    args = parser.parse_args()
+
+    # Set debug mode
+    if args.debug_mode is True:
+        global HAS_DEBUG_MODE
+        HAS_DEBUG_MODE = True
+
+    # Set console log level
+    if args.verbose:
+        global HAS_VERBOSE_CONSOLE
+        HAS_VERBOSE_CONSOLE = True
+        loglevel = logging.ERROR - (args.verbose - 1) * 10
+    else:
+        loglevel = logging.ERROR
+    logging.basicConfig(level=loglevel)
+
+    # Set reload when available
+    if not robotframework_server.HAS_RELOAD or args.reload is False:
+        try:
+            start(args.layer)
+        except KeyboardInterrupt:
+            pass
+    else:
+        robotframework_server.start_reload(
+            args.layer, args.reload_paths or ['src'],
+            args.preload_layer or 'plone.app.testing.PLONE_FIXTURE',
+            args.extensions)

--- a/setup.py
+++ b/setup.py
@@ -216,5 +216,6 @@ setup(name='opengever.core',
       create-policy = opengever.policytemplates.cli:main
       pyxbgen = opengever.disposition.ech0160.pyxbgen:main
       toggle-readonly = opengever.readonly.cli:main
+      testserver = opengever.core.testserver_zope2server:server
       """,
       )


### PR DESCRIPTION
🚧 POC 🚧 

Fixes: `TypeError: a float is required` => https://ci.4teamwork.ch/builds/453037/tasks/812449
