### PR TITLE
Skip duplicate users with different capitalization during LDAP-OGDS sync

### DIFF
--- a/changes/CA-2947.bugfix
+++ b/changes/CA-2947.bugfix
@@ -1,0 +1,1 @@
+Skip duplicate users with different capitalization during ogds sync. [phgross]

--- a/opengever/ogds/base/sync/ogds_updater.py
+++ b/opengever/ogds/base/sync/ogds_updater.py
@@ -532,10 +532,19 @@ class OGDSUpdater(object):
         """
         ldap_keys = set(ldap_objects.keys())
         ogds_keys = set(ogds_objects.keys())
+        lower_ogds_keys = set([userid.lower() for userid in ogds_keys])
         ogds_active_keys = set(
             [key for key, value in ogds_objects.items() if value.get('active')])
 
         added = ldap_keys - ogds_keys
+        # Skip duplicate users with different capitalization
+        added_ignore_capitalization = set([
+            userid for userid in added
+            if userid.lower() not in lower_ogds_keys])
+
+        for skipped in added - added_ignore_capitalization:
+            logger.info('Skip duplicate user {}'.format(skipped))
+
         deleted = ogds_active_keys - ldap_keys
         existing = ldap_keys & ogds_keys
         modified = {}
@@ -545,7 +554,7 @@ class OGDSUpdater(object):
                 attributes = dict(diff).keys()
                 modified[key] = attributes
 
-        added_mappings = [ldap_objects[a] for a in added]
+        added_mappings = [ldap_objects[a] for a in added_ignore_capitalization]
         deleted_mappings = [{pk: d, 'active': False} for d in deleted]
         modified_mappings = []
         for key, modified_attrs in modified.items():


### PR DESCRIPTION
We have again and again the case that the notation of the userid is changed in the AD/LDAP, this leads then to a `StaleDataError` during the OGDS synchronisation. Therefore such "duplicated" users are now ignored and skipped.

We already did the similar fix in the old implementation of the OGDS sync (see #1054)

Fixes [CA-2947]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-2947]: https://4teamwork.atlassian.net/browse/CA-2947