### PR TITLE
Make testserver more sturdy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1120,11 +1120,13 @@ Once installed properly, the server can be started with ``bin/testserver``:
 
 .. code::
 
-   ./bin/testserver
+   ./bin/testserver -v
    Plone:  http://localhost:55001/plone
    XMLRPC: http://localhost:55002
    ...
    18:13:39 [ ready ] Started Zope 2 server
+
+Use the `-v` flag in order to make errors and exceptions appear on `stderr`.
 
 Next you need to tell the testserver that you will now run a test:
 

--- a/base-testserver.cfg
+++ b/base-testserver.cfg
@@ -11,7 +11,6 @@ recipe = zc.recipe.egg
 eggs =
     ${test:eggs}
     plone.app.robotframework
-scripts = robot-server=testserver
 initialization =
     import os
     # Enable conditional readonly patches during tests

--- a/bin/testserverctl
+++ b/bin/testserverctl
@@ -7,7 +7,7 @@ import xmlrpclib
 CTL_PORT = os.environ.get('TESTSERVER_CTL_PORT', '55002')
 
 parser = argparse.ArgumentParser()
-parser.add_argument('action', choices=['zodb_setup', 'zodb_teardown'])
+parser.add_argument('action', choices=['zodb_setup', 'zodb_teardown', 'isolate'])
 args = parser.parse_args()
 
 proxy = xmlrpclib.ServerProxy('http://localhost:{}'.format(CTL_PORT))

--- a/opengever/core/testserver.py
+++ b/opengever/core/testserver.py
@@ -11,6 +11,7 @@ from opengever.core.solr_testing import SolrReplicationAPIClient
 from opengever.core.solr_testing import SolrServer
 from opengever.core.testing import activate_bumblebee_feature
 from opengever.core.testing import OpengeverFixture
+from opengever.core.testserver_zope2server import ISOLATION_READINESS
 from opengever.testing.helpers import incrementing_intids
 from plone import api
 from plone.app.testing import applyProfile
@@ -63,6 +64,7 @@ class TestserverLayer(OpengeverFixture):
     defaultBases = (COMPONENT_REGISTRY_ISOLATION,)
 
     def setUpZope(self, app, configurationContext):
+        ISOLATION_READINESS.patch_publisher()
         solr = SolrServer.get_instance()
         solr.configure(SOLR_PORT, SOLR_CORE)
 

--- a/opengever/core/testserver_selftest.py
+++ b/opengever/core/testserver_selftest.py
@@ -140,7 +140,7 @@ class TestserverSelftest(object):
     def start_testserver(self):
         """Start the testserver in a subprocess controlled by a separate thread.
         """
-        args = ['bin/testserver']
+        args = ['bin/testserver', '-v']
         print ansi_blue('>', *args)
         self.testserver_process = subprocess.Popen(args, stdout=subprocess.PIPE)
 

--- a/opengever/core/testserver_zope2server.py
+++ b/opengever/core/testserver_zope2server.py
@@ -2,6 +2,7 @@ from plone.app.robotframework import server as robotframework_server
 from six.moves.xmlrpc_server import SimpleXMLRPCServer
 import argparse
 import logging
+import sys
 
 
 """To make e2e tests more robust during teardown/setup of the zodb, we have
@@ -115,6 +116,7 @@ def server():
         global HAS_VERBOSE_CONSOLE
         HAS_VERBOSE_CONSOLE = True
         loglevel = logging.ERROR - (args.verbose - 1) * 10
+        logging.getLogger().addHandler(logging.StreamHandler(sys.stderr))
     else:
         loglevel = logging.ERROR
     logging.basicConfig(level=loglevel)

--- a/opengever/core/testserver_zope2server.py
+++ b/opengever/core/testserver_zope2server.py
@@ -1,0 +1,132 @@
+from plone.app.robotframework import server as robotframework_server
+from six.moves.xmlrpc_server import SimpleXMLRPCServer
+import argparse
+import logging
+
+
+"""To make e2e tests more robust during teardown/setup of the zodb, we have
+to provide a way to do it in one single request. Unfortunately, the
+robotframwork does not provide such a method.
+
+Thus, we decided to override the Zope2Server from the robotframework to
+provide an 'isolate' method which tears-down the zodb if necessary and directly
+sets it up.
+
+We make this method available through the xmlrpc server.
+This allows us to teardown/setup the database in one single request.
+"""
+
+
+class Zope2Server(robotframework_server.Zope2Server):
+    is_zodb_setup = False
+
+    def isolate(self, *args, **kwargs):
+        if self.is_zodb_setup:
+            self.zodb_teardown(*args, **kwargs)
+
+        self.zodb_setup(*args, **kwargs)
+        self.is_zodb_setup = True
+
+
+def start(zope_layer_dotted_name):
+    """This is a copy of the plone.app.robotframework.server.start method.
+
+    We just register the additional 'isolate' method here.
+
+    Why not monkey-patching? Because the monkey patch is too late. It has no effect.
+    """
+    print(robotframework_server.WAIT("Starting Zope 2 server"))
+
+    zsl = Zope2Server()
+    zsl.start_zope_server(zope_layer_dotted_name)
+
+    print(robotframework_server.READY("Started Zope 2 server"))
+
+    listener = SimpleXMLRPCServer((robotframework_server.LISTENER_HOST,
+                                   robotframework_server.LISTENER_PORT),
+                                  logRequests=False)
+    listener.allow_none = True
+    listener.register_function(zsl.zodb_setup, 'zodb_setup')
+    listener.register_function(zsl.zodb_teardown, 'zodb_teardown')
+    listener.register_function(zsl.isolate, 'isolate')  # PATCH
+
+    robotframework_server.print_urls(zsl.zope_layer, listener)
+
+    try:
+        listener.serve_forever()
+    finally:
+        print()
+        print(robotframework_server.WAIT("Stopping Zope 2 server"))
+
+        zsl.stop_zope_server()
+
+        print(robotframework_server.READY("Zope 2 server stopped"))
+
+
+def server():
+    """This is a copy of the plone.app.robotframework.server.server method.
+
+    This method will be called in the 'bin/testserver' script and is the entry
+    point of the Z2 testserver.
+
+    This method directly calls the 'start' method, which we have customized.
+    We have to override this method to tell it, that it should use our customized
+    'start' method.
+
+    This also means, that we have to provide this method as a console-script in
+    'opengever.core.setup'
+
+    Same here, a monkey-patch is too late and does not work.
+    """
+    if robotframework_server.HAS_RELOAD:
+        parser = argparse.ArgumentParser()
+    else:
+        parser = argparse.ArgumentParser(
+            epilog='Note: require \'plone.app.robotframework\' with '
+                   '\'[reload]\'-extras to get the automatic code reloading '
+                   'support (powered by \'watchdog\').')
+    parser.add_argument('layer')
+    parser.add_argument('--debug-mode', '-d', dest='debug_mode',
+                        action='store_true')
+    VERBOSE_HELP = (
+        '-v information about test layers setup and tear down, '
+        '-vv add logging.WARNING messages, '
+        '-vvv add INFO messages, -vvvv add DEBUG messages.')
+    parser.add_argument('--verbose', '-v', action='count', help=VERBOSE_HELP)
+
+    if robotframework_server.HAS_RELOAD:
+        parser.add_argument('--reload-path', '-p', dest='reload_paths',
+                            action='append')
+        parser.add_argument('--reload-extensions', '-x', dest='extensions',
+                            nargs='*', help=(
+                                'file extensions to watch for changes'))
+        parser.add_argument('--preload-layer', '-l', dest='preload_layer')
+        parser.add_argument('--no-reload', '-n', dest='reload',
+                            action='store_false')
+    args = parser.parse_args()
+
+    # Set debug mode
+    if args.debug_mode is True:
+        global HAS_DEBUG_MODE
+        HAS_DEBUG_MODE = True
+
+    # Set console log level
+    if args.verbose:
+        global HAS_VERBOSE_CONSOLE
+        HAS_VERBOSE_CONSOLE = True
+        loglevel = logging.ERROR - (args.verbose - 1) * 10
+    else:
+        loglevel = logging.ERROR
+    logging.basicConfig(level=loglevel)
+
+    # Set reload when available
+    if not robotframework_server.HAS_RELOAD or args.reload is False:
+        try:
+            start(args.layer)
+        except KeyboardInterrupt:
+            pass
+    else:
+        robotframework_server.start_reload(
+            args.layer, args.reload_paths or ['src'],
+            args.preload_layer or 'plone.app.testing.PLONE_FIXTURE',
+            args.extensions)

--- a/opengever/core/testserver_zope2server.py
+++ b/opengever/core/testserver_zope2server.py
@@ -76,6 +76,10 @@ class IsolationReadiness(object):
                 stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr,
                 environ=os.environ, debug=0, request=None, response=None):
             try:
+                if not self._ready:
+                    print 'WARNING: unexpected request:', request.method, \
+                        request.base + request.get('PATH_TRANSLATED')
+                    print '         while testserver is in teardown/setup phase.'
                 self.await_ready_for_request()
             except Exception, exc:
                 # XXX this will not properly close the pending HTTP request.

--- a/opengever/core/testserver_zope2server.py
+++ b/opengever/core/testserver_zope2server.py
@@ -1,8 +1,12 @@
+from functools import wraps
 from plone.app.robotframework import server as robotframework_server
 from six.moves.xmlrpc_server import SimpleXMLRPCServer
+from ZPublisher import Publish
 import argparse
 import logging
+import os
 import sys
+import time
 
 
 """To make e2e tests more robust during teardown/setup of the zodb, we have
@@ -18,8 +22,77 @@ This allows us to teardown/setup the database in one single request.
 """
 
 
+class IsolationReadinessTimeout(Exception):
+
+    def __init__(self, timeout):
+        super(IsolationReadinessTimeout, self).__init__(
+            'Timeout awaiting isolation readiness (after {} seconds).'.format(timeout))
+
+
+class IsolationReadiness(object):
+    """This singleton object knows whether test setup / isolation is
+    finished and the testserver is ready to handle requests.
+    This is important, so that the testserver is sturdy enough for
+    randomly timed requests from the client.
+    """
+
+    def __init__(self):
+        self._ready = False
+
+    def teardown_started(self):
+        self._ready = False
+
+    def setup_finished(self):
+        self._ready = True
+
+    def await_ready(self, timeout_s=5):
+        interval_s = 0.1
+        for _ in range(int(timeout_s / interval_s)):
+            if self._ready:
+                return
+            time.sleep(interval_s)
+        raise IsolationReadinessTimeout(timeout_s)
+
+    def patch_publisher(self):
+        """We are patching the publisher in order to let HTTP requests wait
+        until the isolation / test setup has finished.
+        If requests are processed while tearing down / setting up, it may
+        corrupt the database connection, leaving the testserver in an
+        unrecoverable state.
+        """
+        original = Publish.publish_module_standard
+
+        @wraps(Publish.publish_module_standard)
+        def publish_module_standard(module_name,
+                                    stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr,
+                                    environ=os.environ, debug=0, request=None, response=None):
+            try:
+                self.await_ready()
+            except Exception, exc:
+                # XXX this will not properly close the pending HTTP request.
+                # I couldn't get that running. I don't think this is very important though,
+                # since it would have to be fixed anyway and the exception is visible in the log.
+                logging.exception(exc)
+                raise
+            else:
+                return original(module_name, stdin, stdout, stderr, environ, debug, request, response)
+
+        Publish.publish_module_standard = publish_module_standard
+
+
+ISOLATION_READINESS = IsolationReadiness()
+
+
 class Zope2Server(robotframework_server.Zope2Server):
     is_zodb_setup = False
+
+    def zodb_setup(self, *args, **kwargs):
+        robotframework_server.Zope2Server.zodb_setup(self, *args, **kwargs)
+        ISOLATION_READINESS.setup_finished()
+
+    def zodb_teardown(self, *args, **kwargs):
+        ISOLATION_READINESS.teardown_started()
+        robotframework_server.Zope2Server.zodb_teardown(self, *args, **kwargs)
 
     def isolate(self, *args, **kwargs):
         if self.is_zodb_setup:

--- a/setup.py
+++ b/setup.py
@@ -216,5 +216,6 @@ setup(name='opengever.core',
       create-policy = opengever.policytemplates.cli:main
       pyxbgen = opengever.disposition.ech0160.pyxbgen:main
       toggle-readonly = opengever.readonly.cli:main
+      testserver = opengever.core.testserver_zope2server:server
       """,
       )


### PR DESCRIPTION
**The goal is to make the testserver more sturdy, so that it does not break when doing unexpected things such as making HTTP requests while doing isolation (teardown/setup) between tests.**

- _⚠️ currently merging into #7182; rebase needed ⚠️_
- superseding #7189 
- part of: https://4teamwork.atlassian.net/browse/CA-749

 
## Why?

Until now, the testserver was built expecting that the client is well-behaved, does not make any HTTP requests while doing isolation and waits until the testserver is ready again. But fact is that our JavaScript-based frontend is not that well-behaved. It does not wait (long enough) until the setup is finished or may send requests after tear down is initialized.

## Problems

Making HTTP requests when the testserver is not ready can cause problems such as:
- `KeyError: 'test-stack-4'` (access to the component registry when we shouldn't
- Handling exceptions, causing the logging to access `time()` while we are recording a mocker and thus it does not return an `int`
- trying to access the database from a no longer valid database connection

These problems cause the testserver to break in an unrecoverable manner.


## What?

1. **`bin/testerverctl isolate`**
In addition to `bin/testerverctl zodb_setup` and `bin/testerverctl zodb_teardown` we now also have a `bin/testerverctl isolate` method, so that from a client perspective everything necessary is done at once and one transaction. This makes it a lot easier to control from the frontend.
(Thanks @elioschmutz for implementing that in #7189).

2. **Implement a "isolation readyness" concept**
The `IsolationReadyness` component knows whether the testserver has finished setting up and is ready. The component blocks incoming HTTP requests when the testserver is not ready for up to 5 seconds. The sole purpose is to protect the consistency of the testserver and make it more sturdy; the client is responsible for timing the setup and the requests correctly and may have to cope with strange results when requests are executed with the database state of another test case.
When a request gets a isolation timeout (5 seconds), the response will not be answered at all and will keep being pending (I couldn't get it working with a proper error response; but I think this should be the case very often).

3. **Logging**
Since we now have to copy/patch some parts of robotframework for customizations, the testserver now logs to `stderr` whenever a `-v` flag is used. Using more (e.g. `-vv`) increases the log level.

4. **Tests**
I've integrated a case in the selftest, which used to be enough for letting the testserver crash. This case works now, proving that the testserver got sturdier 😉 