### PR TITLE
Include document version in Office Connector metadata

### DIFF
--- a/changes/CA-2971.other
+++ b/changes/CA-2971.other
@@ -1,0 +1,1 @@
+Include document version in Office Connector metadata. [buchi]

--- a/opengever/docugate/tests/test_service.py
+++ b/opengever/docugate/tests/test_service.py
@@ -39,6 +39,7 @@ class TestOfficeConnectorDocugatePayload(IntegrationTestCase):
                 u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/'
                 u'vertrage-und-vereinbarungen/dossier-1/document-41',
                 u'uuid': u'createshadowdocument000000000001',
+                u'version': None,
             }]
         )
 

--- a/opengever/officeconnector/service.py
+++ b/opengever/officeconnector/service.py
@@ -146,6 +146,7 @@ class OfficeConnectorPayload(Service):
                         'document-url': document.absolute_url(),
                         'document': document,
                         'uuid': uuid,
+                        'version': document.get_current_version_id(),
                         }
                     )
 

--- a/opengever/officeconnector/tests/test_api_dossier_attach.py
+++ b/opengever/officeconnector/tests/test_api_dossier_attach.py
@@ -50,6 +50,7 @@ class TestOfficeconnectorDossierAPIWithAttach(OCIntegrationTestCase):
             u'filename': u'Vertraegsentwurf.docx',
             u'title': u'Vertr\xe4gsentwurf',
             u'uuid': u'createtreatydossiers000000000002',
+            u'version': None,
             }]
         payloads = self.fetch_document_attach_payloads(browser, raw_token, token)
         self.assertEquals(200, browser.status_code)
@@ -97,6 +98,7 @@ class TestOfficeconnectorDossierAPIWithAttach(OCIntegrationTestCase):
             u'filename': u'Uebersicht der Inaktiven Vertraege von 2016.xlsx',
             u'title': u'\xdcbersicht der Inaktiven Vertr\xe4ge von 2016',
             u'uuid': u'createinactivedossier00000000002',
+            u'version': None,
             }]
         payloads = self.fetch_document_attach_payloads(browser, raw_token, token)
         self.assertEquals(200, browser.status_code)
@@ -144,6 +146,7 @@ class TestOfficeconnectorDossierAPIWithAttach(OCIntegrationTestCase):
             u'filename': u'Uebersicht der Vertraege vor 2000.doc',
             u'title': u'\xdcbersicht der Vertr\xe4ge vor 2000',
             u'uuid': u'createexpireddossier000000000002',
+            u'version': None,
             }]
         payloads = self.fetch_document_attach_payloads(browser, raw_token, token)
         self.assertEquals(200, browser.status_code)
@@ -200,6 +203,7 @@ class TestOfficeconnectorDossierAPIWithAttach(OCIntegrationTestCase):
                 u'filename': u'Vertraegsentwurf.docx',
                 u'title': u'Vertr\xe4gsentwurf',
                 u'uuid': u'createtreatydossiers000000000002',
+                u'version': None,
                 },
             {
                 u'bcc': u'1014013300@example.org',
@@ -211,6 +215,7 @@ class TestOfficeconnectorDossierAPIWithAttach(OCIntegrationTestCase):
                 u'filename': u'Feedback zum Vertragsentwurf.docx',
                 u'title': u'Feedback zum Vertragsentwurf',
                 u'uuid': u'createtasks000000000000000000003',
+                u'version': None,
                 },
             ]
         payloads = self.fetch_document_attach_payloads(browser, raw_token, token)
@@ -263,6 +268,7 @@ class TestOfficeconnectorDossierAPIWithAttach(OCIntegrationTestCase):
                 u'filename': u'Vertraegsentwurf.docx',
                 u'title': u'Vertr\xe4gsentwurf',
                 u'uuid': u'createtreatydossiers000000000002',
+                u'version': None,
                 },
             {
                 u'content-type': u'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
@@ -273,6 +279,7 @@ class TestOfficeconnectorDossierAPIWithAttach(OCIntegrationTestCase):
                 u'filename': u'Feedback zum Vertragsentwurf.docx',
                 u'title': u'Feedback zum Vertragsentwurf',
                 u'uuid': u'createtasks000000000000000000003',
+                u'version': None,
                 },
             ]
         payloads = self.fetch_document_attach_payloads(browser, raw_token, token)
@@ -325,6 +332,7 @@ class TestOfficeconnectorDossierAPIWithAttach(OCIntegrationTestCase):
                 u'filename': u'Vertraegsentwurf.docx',
                 u'title': u'Vertr\xe4gsentwurf',
                 u'uuid': u'createtreatydossiers000000000002',
+                u'version': None,
                 },
             {
                 u'content-type': u'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
@@ -335,6 +343,7 @@ class TestOfficeconnectorDossierAPIWithAttach(OCIntegrationTestCase):
                 u'filename': u'Feedback zum Vertragsentwurf.docx',
                 u'title': u'Feedback zum Vertragsentwurf',
                 u'uuid': u'createtasks000000000000000000003',
+                u'version': None,
                 },
             ]
         payloads = self.fetch_document_attach_payloads(browser, raw_token, token)

--- a/opengever/officeconnector/tests/test_api_dossier_checkout.py
+++ b/opengever/officeconnector/tests/test_api_dossier_checkout.py
@@ -193,6 +193,7 @@ class TestOfficeconnectorDossierAPIWithCheckout(OCIntegrationTestCase):
             u'unlock': u'@unlock',
             u'upload': u'@tus-replace',
             u'uuid': u'createtreatydossiers000000000002',
+            u'version': None,
             }]
         payloads = self.fetch_document_checkout_payloads(browser, raw_token, token)
         self.assertEqual(200, browser.status_code)
@@ -258,6 +259,7 @@ class TestOfficeconnectorDossierAPIWithCheckout(OCIntegrationTestCase):
             u'unlock': u'@unlock',
             u'upload': u'@tus-replace',
             u'uuid': u'createtreatydossiers000000000002',
+            u'version': None,
         }]
         payloads = self.fetch_document_checkout_payloads(browser, raw_token, token)
         self.assertEqual(200, browser.status_code)

--- a/opengever/officeconnector/tests/test_api_dossier_oneoffixx.py
+++ b/opengever/officeconnector/tests/test_api_dossier_oneoffixx.py
@@ -44,6 +44,7 @@ class TestOfficeconnectorDossierAPIWithOneOffixx(OCIntegrationTestCase):
             u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-41',
             u'filename': None,
             u'uuid': u'createshadowdocument000000000001',
+            u'version': None,
             }]
 
         payloads = self.fetch_document_oneoffixx_payloads(browser, raw_token, token)
@@ -95,6 +96,7 @@ class TestOfficeconnectorDossierAPIWithOneOffixx(OCIntegrationTestCase):
             u'unlock': u'@unlock',
             u'upload': u'@tus-replace',
             u'uuid': u'createshadowdocument000000000001',
+            u'version': None,
         }]
         # XXX - As the last document we touched was XML and we touched XML
         # namespacing after that, we'll need to reset the browser to circumvent

--- a/opengever/officeconnector/tests/test_api_forwarding_attach.py
+++ b/opengever/officeconnector/tests/test_api_forwarding_attach.py
@@ -53,6 +53,7 @@ class TestOfficeconnectorForwardingAPIWithAttach(OCIntegrationTestCase):
             u'filename': u'Dokument im Eingangskoerbliweiterleitung.txt',
             u'title': u'Dokument im Eingangsk\xf6rbliweiterleitung',
             u'uuid': u'createinboxfa0000000000000000004',
+            u'version': None,
             }]
         payloads = self.fetch_document_attach_payloads(browser, raw_token, token)
         self.assertEquals(200, browser.status_code)

--- a/opengever/officeconnector/tests/test_api_mail_attach.py
+++ b/opengever/officeconnector/tests/test_api_mail_attach.py
@@ -41,6 +41,7 @@ class TestOfficeconnectorMailAPIWithAttach(OCIntegrationTestCase):
             u"filename": u"Die Buergschaft.eml",
             u"title": u"Die B\xfcrgschaft",
             u"uuid": u"createemails00000000000000000001",
+            u'version': 0,
         }]
         payloads = self.fetch_document_attach_payloads(browser, raw_token, token)
         self.assertEqual(200, browser.status_code)
@@ -80,6 +81,7 @@ class TestOfficeconnectorMailAPIWithAttach(OCIntegrationTestCase):
             u"filename": u"No Subject.msg",
             u"title": u"[No Subject]",
             u"uuid": u"createemails00000000000000000002",
+            u'version': 0,
         }]
         payloads = self.fetch_document_attach_payloads(browser, raw_token, token)
         self.assertEqual(200, browser.status_code)
@@ -128,6 +130,7 @@ class TestOfficeconnectorMailAPIWithAttach(OCIntegrationTestCase):
                 u"filename": u"Die Buergschaft.eml",
                 u"title": u"Die B\xfcrgschaft",
                 u"uuid": u"createemails00000000000000000001",
+                u'version': 0,
             },
             {
                 u"bcc": u"1014013300@example.org",
@@ -139,6 +142,7 @@ class TestOfficeconnectorMailAPIWithAttach(OCIntegrationTestCase):
                 u"filename": u"No Subject.msg",
                 u"title": u"[No Subject]",
                 u"uuid": u"createemails00000000000000000002",
+                u'version': 0,
             },
         ]
 

--- a/opengever/officeconnector/tests/test_api_task_checkout.py
+++ b/opengever/officeconnector/tests/test_api_task_checkout.py
@@ -66,6 +66,7 @@ class TestOfficeconnectorTaskAPIWithCheckoutWithRESTAPI(OCIntegrationTestCase):
             u'unlock': u'@unlock',
             u'upload': u'@tus-replace',
             u'uuid': u'createtreatydossiers000000000002',
+            u'version': None,
         }]
         payloads = self.fetch_document_checkout_payloads(browser, raw_token, token)
         self.assertEqual(200, browser.status_code)

--- a/opengever/officeconnector/tests/test_zopemaster.py
+++ b/opengever/officeconnector/tests/test_zopemaster.py
@@ -44,6 +44,7 @@ class TestOfficeconnectorAsZopemasterDossierAPIWithAttach(OCIntegrationTestCase)
             u'filename': u'Vertraegsentwurf.docx',
             u'title': u'Vertr\xe4gsentwurf',
             u'uuid': u'createtreatydossiers000000000002',
+            u'version': None,
             }]
         payloads = self.fetch_document_attach_payloads(browser, raw_token, token)
         self.assertEquals(200, browser.status_code)
@@ -91,6 +92,7 @@ class TestOfficeconnectorAsZopemasterDossierAPIWithCheckout(OCIntegrationTestCas
             u'unlock': u'@unlock',
             u'upload': u'@tus-replace',
             u'uuid': u'createtreatydossiers000000000002',
+            u'version': None,
             }]
         payloads = self.fetch_document_checkout_payloads(browser, raw_token, token)
         self.assertEquals(200, browser.status_code)


### PR DESCRIPTION
In Office Connector we want to notify the user if his checked out local copy of a document is older than the current version on the server. For this we need to get the current version.

This situation can occur if the document is not checked-in by Office Connector because of a problem and then manually checked-in by the user.  If meanwhile another user creates a new version and the first user wants to continue working on the current version, OC still uses his local copy.

For [CA-2971]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-2971]: https://4teamwork.atlassian.net/browse/CA-2971