### PR TITLE
Truncate filenames when updating favorites.

### DIFF
--- a/changes/CA-960.bugfix
+++ b/changes/CA-960.bugfix
@@ -1,0 +1,1 @@
+Truncate too long filenames when updating favorites. [deiferni]

--- a/opengever/base/tests/test_favorite.py
+++ b/opengever/base/tests/test_favorite.py
@@ -11,7 +11,32 @@ from opengever.trash.trash import ITrasher
 from plone import api
 from plone.namedfile.file import NamedBlobFile
 from sqlalchemy.exc import IntegrityError
+from unittest import TestCase
 import json
+
+
+class TestFavoriteTruncateFilename(TestCase):
+
+    def test_truncate_filename_none(self):
+        self.assertIsNone(Favorite.truncate_filename(None))
+
+    def test_truncate_filename_empty(self):
+        self.assertEqual(u'', Favorite.truncate_filename(u''))
+
+    def test_truncate_short_filename(self):
+        self.assertEqual(u'foo.txt', Favorite.truncate_filename(u'foo.txt'))
+
+    def test_truncate_long_filename_preserves_short_extensions(self):
+        expected = '{}.foo'.format(101 * 'x')
+        self.assertEqual(
+            expected, Favorite.truncate_filename('{}.foo'.format(200 * 'x'))
+        )
+
+    def test_truncate_long_filename_truncates_long_extensions(self):
+        expected = 'foo.{}'.format(101 * 'x')
+        self.assertEqual(
+            expected, Favorite.truncate_filename('foo.{}'.format(200 * 'x'))
+        )
 
 
 class TestFavoriteModel(IntegrationTestCase):


### PR DESCRIPTION
As the filename column has a length limit we must enforce it by truncating too long data. This adds another layer of sanitation to the already existing id normalizer. The normalizer seems to be a bit lenient when it comes to file extensions potentially allowing very long file extensions. We add strict sanitation for such cases to prevent errors while writing to the database.

For [CA-960](https://4teamwork.atlassian.net/browse/CA-960)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
