### PR TITLE
Fix testserver

### DIFF
--- a/opengever/core/testserver_zope2server.py
+++ b/opengever/core/testserver_zope2server.py
@@ -103,7 +103,7 @@ class IsolationReadiness(object):
         for _ in range(int(timeout_seconds / interval_seconds)):
             yield
             time.sleep(interval_seconds)
-        raise IsolationReadiness('Timeout after {} seconds'.format(timeout_seconds))
+        raise IsolationReadinessTimeout('Timeout after {} seconds'.format(timeout_seconds))
 
 
 ISOLATION_READINESS = IsolationReadiness()

--- a/opengever/core/testserver_zope2server.py
+++ b/opengever/core/testserver_zope2server.py
@@ -103,8 +103,7 @@ class IsolationReadiness(object):
         for _ in range(int(timeout_seconds / interval_seconds)):
             yield
             time.sleep(interval_seconds)
-        raise IsolationReadiness(': '.join(filter(None, (
-            'Timeout after {} seconds'.format(timeout_seconds)))))
+        raise IsolationReadiness('Timeout after {} seconds'.format(timeout_seconds))
 
 
 ISOLATION_READINESS = IsolationReadiness()


### PR DESCRIPTION
This fixes a minor issue discovered by @jone and me while trying to find out why the E2E tests in RIS were no longer working when testing against the latest `master` of `opengever.core` (9e90421705221866cae63ae4b03a526b0961f662).