### PR TITLE
Do not create DocumenVersionCreatedActivity when cancelling checkout.

### DIFF
--- a/changes/CA-3000.bugfix
+++ b/changes/CA-3000.bugfix
@@ -1,0 +1,1 @@
+Do not create DocumenVersionCreatedActivity when cancelling checkout. [njohner]

--- a/opengever/document/configure.zcml
+++ b/opengever/document/configure.zcml
@@ -236,7 +236,7 @@
   <subscriber
       for="opengever.document.document.IDocumentSchema
            opengever.document.interfaces.IObjectRevertedToVersion"
-      handler=".handlers.document_version_created"
+      handler=".handlers.document_reverted_to_version"
       />
 
   <subscriber

--- a/opengever/document/handlers.py
+++ b/opengever/document/handlers.py
@@ -112,6 +112,11 @@ def _update_favorites_icon_class(context):
         favorite.icon_class = get_css_class(context, for_user=favorite.userid)
 
 
+def document_reverted_to_version(context, event):
+    if event.create_version:
+        document_version_created(context, event)
+
+
 def document_version_created(context, event):
     DocumenVersionCreatedActivity(context, getRequest()).record()
 

--- a/opengever/document/tests/test_activities.py
+++ b/opengever/document/tests/test_activities.py
@@ -5,6 +5,7 @@ from opengever.activity.model import Notification
 from opengever.activity.roles import WATCHER_ROLE
 from opengever.document.activities import DocumentWatcherAddedActivity
 from opengever.document.interfaces import ICheckinCheckoutManager
+from opengever.document.versioner import Versioner
 from opengever.testing import IntegrationTestCase
 from zope.component import getMultiAdapter
 import json
@@ -93,6 +94,22 @@ class TestDocumentChangedActivities(IntegrationTestCase):
         self.assertEqual([u'New document version created by B\xe4rfuss K\xe4thi (kathi.barfuss)',
                           u'New document version created by B\xe4rfuss K\xe4thi (kathi.barfuss)'],
                          [activity.summary for activity in activities])
+
+    @browsing
+    def test_no_document_version_created_activity_when_cancelling_checkout(self, browser):
+        self.login(self.regular_user, browser)
+
+        versioner = Versioner(self.document)
+        versioner.create_initial_version()
+
+        self.assertEqual(0, Activity.query.count())
+        manager = getMultiAdapter(
+            (self.document, self.request),
+            ICheckinCheckoutManager)
+        manager.checkout()
+        manager.cancel()
+
+        self.assertEqual(0, Activity.query.count())
 
     @browsing
     def test_change_document_title_notifies_watcher(self, browser):


### PR DESCRIPTION
The `IObjectRevertedToVersion` event gets notified in the [revert_to_version method](https://github.com/4teamwork/opengever.core/blob/master/opengever/document/checkout/manager.py#L365-L366), which is also called when [cancelling a checkout](https://github.com/4teamwork/opengever.core/blob/master/opengever/document/checkout/manager.py#L263-L264). This led to an `DocumenVersionCreatedActivity` being created although no new version of the document was actually created.

For [CA-3000]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-3000]: https://4teamwork.atlassian.net/browse/CA-3000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ