### PR TITLE
Fix handling of unicode actor ids

### DIFF
--- a/changes/CA-3001.bugfix
+++ b/changes/CA-3001.bugfix
@@ -1,0 +1,1 @@
+Fix handling of unicode actor ids. [buchi]

--- a/opengever/api/actors.py
+++ b/opengever/api/actors.py
@@ -20,7 +20,7 @@ def serialize_actor_id_to_json_summary(actor_id):
     We therefore should only return data that we can compute without retrieving
     the actual actor object.
     """
-    url = '{}/@actors/{}'.format(api.portal.get().absolute_url(), actor_id)
+    url = u'{}/@actors/{}'.format(api.portal.get().absolute_url(), actor_id)
     return {'@id': url,
             'identifier': actor_id}
 

--- a/opengever/api/tests/test_actors.py
+++ b/opengever/api/tests/test_actors.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from ftw.testbrowser import browsing
 from opengever.testing import IntegrationTestCase
 from opengever.api.actors import serialize_actor_id_to_json_summary
@@ -15,6 +16,12 @@ class TestActorSummarySerialization(IntegrationTestCase):
             {'@id': self.actors_url + "/some_id",
              'identifier': 'some_id'},
             serialize_actor_id_to_json_summary('some_id'))
+
+    def test_serialize_unicode_actor_id_to_json_summary(self):
+        self.assertDictEqual(
+            {'@id': self.actors_url + u"/Utilisateurs authentifiés",
+             'identifier': u'Utilisateurs authentifiés'},
+            serialize_actor_id_to_json_summary(u'Utilisateurs authentifiés'))
 
 
 class TestActorsGet(IntegrationTestCase):


### PR DESCRIPTION
`serialize_actor_id_to_json_summary()` is also called from the sharing endpoint.  From there, actor ids can have non-ascii characters.

https://sentry.4teamwork.ch/organizations/sentry/issues/78180

For [CA-3001]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-3001]: https://4teamwork.atlassian.net/browse/CA-3001