### PR TITLE
Fix accepting remote forwarding in new dossier without response text.

### DIFF
--- a/changes/CA-3011.bugfix
+++ b/changes/CA-3011.bugfix
@@ -1,0 +1,1 @@
+Fix accepting remote forwarding in new dossier without response text. [njohner]

--- a/opengever/api/tests/test_accept_remote_forwarding.py
+++ b/opengever/api/tests/test_accept_remote_forwarding.py
@@ -242,8 +242,7 @@ class TestAcceptRemoteForwardingPost(IntegrationTestCase):
             u'title': doc_in_successor_forwarding.title}],
             response['items'])
 
-    @browsing
-    def test_accept_remote_forwarding_creates_task_in_dossier(self, browser):
+    def _accept_remote_forwarding_creates_task_in_dossier(self, browser, response):
         self.login(self.secretariat_user, browser)
 
         forwarding = create(Builder('forwarding')
@@ -276,7 +275,7 @@ class TestAcceptRemoteForwardingPost(IntegrationTestCase):
             request_body = json.dumps({
                 'dossier_oguid': Oguid.for_object(self.dossier).id,
                 'forwarding_oguid': u'plone:%s' % sql_forwarding.int_id,
-                'text': u'I hereby accept this forwarding.',
+                'text': response,
             })
 
             browser.open(local_url, method='POST', data=request_body, headers=self.api_headers)
@@ -339,3 +338,13 @@ class TestAcceptRemoteForwardingPost(IntegrationTestCase):
             response['items'])
 
         self.assertEqual(self.dossier.absolute_url(), response['parent']['@id'])
+
+    @browsing
+    def test_accept_remote_forwarding_with_response_creates_task_in_dossier(self, browser):
+        self._accept_remote_forwarding_creates_task_in_dossier(
+            browser, response=u'I hereby accept this forwarding.')
+
+    @browsing
+    def test_accept_remote_forwarding_without_response_creates_task_in_dossier(self, browser):
+        self._accept_remote_forwarding_creates_task_in_dossier(
+            browser, response=None)

--- a/opengever/task/browser/accept/utils.py
+++ b/opengever/task/browser/accept/utils.py
@@ -100,7 +100,7 @@ def accept_forwarding_with_successor(
     transaction.savepoint()
     # Close the predessecor forwarding
 
-    response_text = response_text or ''
+    response_text = response_text or u''
     request_data = {'response_text': response_text.encode('utf-8'),
                     'successor_oguid': successor_tc.get_oguid(),
                     'transition': 'forwarding-transition-accept'}


### PR DESCRIPTION
Accepting a remote forwarding in a new dossier without a response was broken both for the new and the classic UI. This happened with https://github.com/4teamwork/opengever.core/pull/7091/commits/674e6a27cafa2567e3083e216ed9d355c8c331ad. Testing is difficult and incomplete for remote tasks and forwarding, but I've added a test that would have caught this bug.

For [CA-3011]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-3011]: https://4teamwork.atlassian.net/browse/CA-3011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ