### PR TITLE
Add application/msonenote to OC editable types.

### DIFF
--- a/changes/CA-2674.other
+++ b/changes/CA-2674.other
@@ -1,0 +1,1 @@
+Add application/msonenote to OC editable types. [njohner]

--- a/opengever/officeconnector/mimetypes.py
+++ b/opengever/officeconnector/mimetypes.py
@@ -44,6 +44,7 @@ EDITABLE_TYPES = [
     'application/vnd.openxmlformats-officedocument.spreadsheetml.template',
     # MS OneNote
     'application/onenote',
+    'application/msonenote',
     # MS Powerpoint
     'application/vnd.ms-powerpoint.addin.macroEnabled.12',
     'application/vnd.ms-powerpoint.presentation.macroEnabled.12',


### PR DESCRIPTION
Sometimes the mimetype of onenote documents is `application/msonenote` instead of `application/onenote`. This should be Editable by OC.

Note that I've added it manually for Fribourg in the `IOfficeConnectorSettings.officeconnector_editable_types_extra`.

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-2674]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-2674]: https://4teamwork.atlassian.net/browse/CA-2674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ