### PR TITLE
Strip outlooks AD information in mails document_author extraction.

### DIFF
--- a/changes/CA-2773.bugfix
+++ b/changes/CA-2773.bugfix
@@ -1,0 +1,1 @@
+Strip outlooks AD information in mails document_author extraction. [phgross]

--- a/opengever/mail/tests/__init__.py
+++ b/opengever/mail/tests/__init__.py
@@ -2,3 +2,4 @@ from pkg_resources import resource_string
 
 
 MAIL_DATA = resource_string('opengever.mail.tests', 'mail.txt')
+MAIL_DATA_WITH_AD_FROM_HEADER = resource_string('opengever.mail.tests', 'mail_with_ad_from.txt')

--- a/opengever/mail/tests/mail_with_ad_from.txt
+++ b/opengever/mail/tests/mail_with_ad_from.txt
@@ -1,0 +1,21 @@
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf8"
+Content-Transfer-Encoding: base64
+To: =?utf-8?q?Peter_M=C3=B6rgeli?= <to@example.org>
+From: Muster Helen </o=XYHS/ou=Exchange Group Administrative
+ (FYDIBOHF23SPDLT)/cn=Recipients/cn=a8a0720d71eb4c349aeeff7dd1d91967-HMUSTER>
+Subject: =?utf-8?q?Die_B=C3=BCrgschaft?=
+Date: Thu, 01 Jan 1999 01:00:00 +0100
+Message-Id: <1>
+X-Mailer: Zope/SecureMailHost
+
+RGllIELDvHJnc2NoYWZ0CkZyaWVkcmljaCBTY2hpbGxlcgoKWnUgRGlvbnlzLCBkZW0gVHlyYW5u
+ZW4sIHNjaGxpY2gKRGFtb24sIGRlbiBEb2xjaCBpbSBHZXdhbmRlOgpJaG4gc2NobHVnZW4gZGll
+IEjDpHNjaGVyIGluIEJhbmRlLArCu1dhcyB3b2xsdGVzdCBkdSBtaXQgZGVtIERvbGNoZT8gc3By
+aWNoIcKrCkVudGdlZ25ldCBpaG0gZmluc3RlciBkZXIgV8O8dGVyaWNoLgrCu0RpZSBTdGFkdCB2
+b20gVHlyYW5uZW4gYmVmcmVpZW4hwqsKwrtEYXMgc29sbHN0IGR1IGFtIEtyZXV6ZSBiZXJldWVu
+LsKrCgrCu0ljaCBiaW7Cqywgc3ByaWNodCBqZW5lciwgwrt6dSBzdGVyYmVuIGJlcmVpdApVbmQg
+Yml0dGUgbmljaHQgdW0gbWVpbiBMZWJlbjoKRG9jaCB3aWxsc3QgZHUgR25hZGUgbWlyIGdlYmVu
+LApJY2ggZmxlaGUgZGljaCB1bSBkcmVpIFRhZ2UgWmVpdCwKQmlzIGljaCBkaWUgU2Nod2VzdGVy
+IGRlbSBHYXR0ZW4gZ2VmcmVpdDsKSWNoIGxhc3NlIGRlbiBGcmV1bmQgZGlyIGFscyBCw7xyZ2Vu
+LApJaG4gbWFnc3QgZHUsIGVudHJpbm4nIGljaCwgZXJ3w7xyZ2VuLsKrCg==

--- a/opengever/mail/tests/test_mail_metadata.py
+++ b/opengever/mail/tests/test_mail_metadata.py
@@ -9,6 +9,7 @@ from opengever.mail.mail import extract_email
 from opengever.mail.mail import get_author_by_email
 from opengever.mail.mail import MESSAGE_SOURCE_DRAG_DROP_UPLOAD
 from opengever.mail.tests import MAIL_DATA
+from opengever.mail.tests import MAIL_DATA_WITH_AD_FROM_HEADER
 from opengever.mail.tests.utils import get_header_date
 from opengever.testing import FunctionalTestCase
 from opengever.testing import IntegrationTestCase
@@ -101,6 +102,13 @@ class TestMailMetadataWithBuilder(FunctionalTestCase):
         self.assertEquals(
             get_author_by_email(mail),
             mail.document_author)
+
+    def test_strips_AD_information_FROM_data_if_user_does_not_exist(self):
+        mail = create(Builder("mail")
+                      .with_message(MAIL_DATA_WITH_AD_FROM_HEADER))
+
+        self.assertEquals(u'Muster Helen', get_author_by_email(mail))
+        self.assertEquals(u'Muster Helen', mail.document_author)
 
     def test_mail_catalog_metadata(self):
         mail = self.create_mail()
@@ -272,4 +280,4 @@ class TestEmailRegex(TestCase):
 
     def test_no_match(self):
         header_from = 'example.org'
-        self.assertEquals('example.org', extract_email(header_from))
+        self.assertEquals(None, extract_email(header_from))


### PR DESCRIPTION
The ad information inside `<` `>` leads to very long and confusing document_authors, so we strip them, if it's not an email.

For [CA-2773]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-2773]: https://4teamwork.atlassian.net/browse/CA-2773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ