### PR TITLE
Implement webactions with scope context.

### DIFF
--- a/changes/CA-2860.feature
+++ b/changes/CA-2860.feature
@@ -1,0 +1,1 @@
+Implement webactions with scope context. [tinagerber]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -12,6 +12,8 @@ Breaking Changes
 Other Changes
 ^^^^^^^^^^^^^
 
+- ``@webactions``: Support activation and deactivation of context webactions (see :ref:`docs <webactions>`).
+
 2021.20.0 (2021-10-06)
 ----------------------
 

--- a/docs/public/dev-manual/api/webactions.rst
+++ b/docs/public/dev-manual/api/webactions.rst
@@ -336,6 +336,82 @@ Löschen (DELETE)
     +------------------+------------------------------------------------------------------+
 
 
+
+Webaktion aktivieren (POST)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Webaktionen mit dem scope ``context`` müssen zuerst auf dem Objekt, auf dem sie angezeigt werden sollen, aktiviert werden.
+
+.. http:post:: /context/@webactions/(action_id)
+
+   Aktiviert die durch die ``action_id`` identifizierte Webaktion auf dem Kontext.
+
+   **Request**:
+
+   .. sourcecode:: http
+
+      POST /context/@webactions/0 HTTP/1.1
+      Accept: application/json
+
+
+   **Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 204 No Content
+      Content-Type: application/json
+
+.. table::
+
+    +------------------+------------------------------------------------------------------+
+    | Status Code      | Beschreibung                                                     |
+    +==================+==================================================================+
+    | 204 No Content   | WebAction erfolgreich aktiviert.                                 |
+    +------------------+------------------------------------------------------------------+
+    | 401 Unauthorized | Authentisierung oder Autorisierung fehlgeschlagen.               |
+    +------------------+------------------------------------------------------------------+
+    | 404 Not Found    | WebAction mit dieser ``action_id`` konnte nicht gefunden werden. |
+    +------------------+------------------------------------------------------------------+
+
+Webaktion deaktivieren (DELETE)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Aktivierte Webaktionen können auch wieder deaktiviert werden.
+
+.. http:delete:: /context/@webactions/(action_id)
+
+   Deaktiviert die durch die ``action_id`` identifizierte Webaktion auf dem Kontext.
+
+   **Request**:
+
+   .. sourcecode:: http
+
+      DELETE /context/@webactions/0 HTTP/1.1
+      Accept: application/json
+
+
+   **Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 204 No Content
+      Content-Type: application/json
+
+.. table::
+
+    +------------------+------------------------------------------------------------------+
+    | Status Code      | Beschreibung                                                     |
+    +==================+==================================================================+
+    | 204 No Content   | WebAction erfolgreich deaktiviert.                               |
+    +------------------+------------------------------------------------------------------+
+    | 400 Bad Request  | Webaction war nicht aktiviert.                                   |
+    +------------------+------------------------------------------------------------------+
+    | 401 Unauthorized | Authentisierung oder Autorisierung fehlgeschlagen.               |
+    +------------------+------------------------------------------------------------------+
+    | 404 Not Found    | WebAction mit dieser ``action_id`` konnte nicht gefunden werden. |
+    +------------------+------------------------------------------------------------------+
+
+
 .. _webactions-fields:
 
 Eigenschaften von Webaktionen
@@ -417,15 +493,15 @@ Scope
 Über das Feld ``scope`` kann gesteuert werden, bei welchen Objekten die
 Webaktion angeboten wird.
 
-+---------------+---------------------------------------------------------------------+
-| Wert          | Beschreibung                                                        |
-+===============+=====================================================================+
-| ``global``    | Die Webaktion wird grundsätzlich bei allen Objekten angeboten.      |
-+---------------+---------------------------------------------------------------------+
-| ``context``   | Noch nicht implementiert.                                           |
-+---------------+---------------------------------------------------------------------+
-| ``recursive`` | Noch nicht implementiert.                                           |
-+---------------+---------------------------------------------------------------------+
++---------------+------------------------------------------------------------------------------+
+| Wert          | Beschreibung                                                                 |
++===============+==============================================================================+
+| ``global``    | Die Webaktion wird grundsätzlich bei allen Objekten angeboten.               |
++---------------+------------------------------------------------------------------------------+
+| ``context``   | Die Webaktion wird nur bei Objekten angezeigt, bei denen sie aktiviert wurde |
++---------------+------------------------------------------------------------------------------+
+| ``recursive`` | Noch nicht implementiert.                                                    |
++---------------+------------------------------------------------------------------------------+
 
 
 .. _webactions-server-metadata:

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -601,6 +601,14 @@
       />
 
   <plone:service
+      method="POST"
+      name="@webactions"
+      for="plone.dexterity.interfaces.IDexterityContent"
+      factory=".webactions.ContextWebActionsPost"
+      permission="cmf.ModifyPortalContent"
+      />
+
+  <plone:service
       method="GET"
       name="@webactions"
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"
@@ -622,6 +630,14 @@
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"
       factory=".webactions.WebActionsDelete"
       permission="opengever.webactions.ManageOwnWebActions"
+      />
+
+  <plone:service
+      method="DELETE"
+      name="@webactions"
+      for="plone.dexterity.interfaces.IDexterityContent"
+      factory=".webactions.ContextWebActionsDelete"
+      permission="cmf.ModifyPortalContent"
       />
 
   <plone:service

--- a/opengever/base/configure.zcml
+++ b/opengever/base/configure.zcml
@@ -306,6 +306,12 @@
       />
 
   <subscriber
+      for="plone.dexterity.interfaces.IDexterityContent
+           OFS.interfaces.IObjectWillBeRemovedEvent"
+      handler=".handlers.remove_from_context_webactions"
+      />
+
+  <subscriber
       for="opengever.repository.interfaces.IRepositoryFolder
            zope.lifecycleevent.IObjectRemovedEvent"
       handler=".handlers.update_favorited_repositoryfolder"

--- a/opengever/webactions/schema.py
+++ b/opengever/webactions/schema.py
@@ -105,7 +105,7 @@ class IWebActionSchema(Interface):
         description=u'Where the webaction applies.',
         values=[
             'global',
-            # TODO: 'context' (needs more discussion)
+            'context',
             # TODO: 'recursive'
         ],
         required=True)

--- a/opengever/webactions/tests/test_webactions_provider.py
+++ b/opengever/webactions/tests/test_webactions_provider.py
@@ -7,6 +7,8 @@ from opengever.webactions.schema import ACTION_PERMISSIONS
 from opengever.webactions.storage import get_storage
 from zope.annotation.interfaces import IAnnotations
 from zope.component import getMultiAdapter
+from zope.component import getUtility
+from zope.intid.interfaces import IIntIds
 
 
 class TestWebActionBase(IntegrationTestCase):
@@ -123,6 +125,18 @@ class TestWebActionProvider(TestWebActionBase):
         storage._actions[2]["scope"] = "recursive"
 
         expected_data = {'actions-menu': [self.action2_data]}
+        self.assertDictEqual(expected_data, provider.get_webactions())
+
+    def test_webaction_provider_returns_action_with_scope_context_if_action_activated(self):
+        self.login(self.regular_user)
+        provider = getMultiAdapter((self.dossier, self.request), IWebActionsProvider)
+        storage = get_storage()
+        storage.update(0, {"scope": "context"})
+        storage.update(2, {"scope": "context"})
+        intid = getUtility(IIntIds).getId(self.dossier)
+        storage.add_context_intid(0, intid)
+
+        expected_data = {'actions-menu': [self.action1_data, self.action2_data]}
         self.assertDictEqual(expected_data, provider.get_webactions())
 
     def test_webaction_provider_respects_portal_type(self):


### PR DESCRIPTION
Until now, there were only global webactions. Now there are also webactions with the scope `context`. Such a webaction is only displayed on an object if it has been explicitly activated for this object.

For [CA-2860]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))

[CA-2860]: https://4teamwork.atlassian.net/browse/CA-2860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ