### PR TITLE
Use UIDs as tokens in attachable_documents_vocabulary.

### DIFF
--- a/changes/CA-2358.other
+++ b/changes/CA-2358.other
@@ -1,0 +1,1 @@
+Use UIDs as tokens for documents when delegating a task. [njohner]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -8,6 +8,7 @@ API Changelog
 
 Breaking Changes
 ^^^^^^^^^^^^^^^^
+- task-transition-delegate now expects UIDs for the documents parameter.
 
 Other Changes
 ^^^^^^^^^^^^^

--- a/docs/public/dev-manual/api/tasks.rst
+++ b/docs/public/dev-manual/api/tasks.rst
@@ -279,6 +279,14 @@ Zusätzliche Metadaten:
 
        :Datentyp: ``Text``
 
+   .. py:attribute:: responsibles
+
+       :Datentyp: ``ChoiceList``
+       :Pflichtfeld: Ja :required:`(*)`
+
+   .. py:attribute:: documents
+
+       :Datentyp: ``Choice``
 
 Des weiteren stehen auch die Statuswechsel für sequentielle Aufgaben zur Verfügung:
 

--- a/opengever/api/tests/test_task.py
+++ b/opengever/api/tests/test_task.py
@@ -599,7 +599,7 @@ class TestTaskTransitions(IntegrationTestCase):
         self.assertEqual(200, browser.status_code)
         self.assertEqual(2, browser.json['items_total'])
         self.assertItemsEqual(
-            [str(intids.getId(el)) for el in [self.document, self.taskdocument]],
+            [el.UID() for el in [self.document, self.taskdocument]],
             [term['token'] for term in browser.json['items']])
 
 

--- a/opengever/task/browser/delegate/vocabulary.py
+++ b/opengever/task/browser/delegate/vocabulary.py
@@ -26,18 +26,20 @@ def attachable_documents_vocabulary(context):
         contentFilter={'portal_type': ['opengever.document.document',
                                        'ftw.mail.mail']}):
 
-        key = str(intids.getId(doc))
+        value = str(intids.getId(doc))
+        token = doc.UID()
         label = doc.Title()
-        terms.append(SimpleVocabulary.createTerm(key, key, label))
-        ids.append(key)
+        terms.append(SimpleVocabulary.createTerm(value, token, label))
+        ids.append(value)
 
     for relation in getattr(context, 'relatedItems', []):
-        key = str(relation.to_id)
+        value = str(relation.to_id)
+        token = relation.to_object.UID()
         # check if the task doesn't contain the related document allready
-        if key in ids:
+        if value in ids:
             continue
         label = relation.to_object.Title()
-        terms.append(SimpleVocabulary.createTerm(key, key, label))
+        terms.append(SimpleVocabulary.createTerm(value, token, label))
 
     return SimpleVocabulary(terms)
 

--- a/opengever/task/tests/test_delegate.py
+++ b/opengever/task/tests/test_delegate.py
@@ -107,5 +107,8 @@ class TestAttachableDocumentsVocabulary(IntegrationTestCase):
         terms = attachable_documents_vocabulary(self.task)
 
         self.assertItemsEqual(
+            [el.UID() for el in [self.document, self.taskdocument]],
+            [term.token for term in terms])
+        self.assertItemsEqual(
             [str(intids.getId(el)) for el in [self.document, self.taskdocument]],
             [term.value for term in terms])


### PR DESCRIPTION
Because the frontend does not know the`IntId`s of the documents it wants to link to the created subtasks when delegating a task, we modify the corresponding vocabulary to use `UID`s as tokens instead. We leave the values as `IntIds` as this is necessary to create the relations in the backend afterwards.

I guess this is a breaking change...

For [CA-2358]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [x] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed

[CA-2358]: https://4teamwork.atlassian.net/browse/CA-2358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ