### PR TITLE
Allow activating and deactivating web actions that are not owned by the user

### DIFF
--- a/opengever/api/tests/test_webactions.py
+++ b/opengever/api/tests/test_webactions.py
@@ -635,6 +635,7 @@ class TestContextWebActionsPost(IntegrationTestCase):
         self.login(self.webaction_manager, browser=browser)
         create(Builder('webaction').having(title=u'My webaction', scope='context'))
 
+        self.login(self.regular_user, browser=browser)
         browser.open(self.dossier, view='/@webactions/0', method='POST', headers=self.api_headers)
         self.assertEqual(204, browser.status_code)
 
@@ -691,6 +692,7 @@ class TestContextWebActionsDelete(IntegrationTestCase):
         create(Builder('webaction').having(title=u'My webaction', scope='context'))
         create(Builder('webaction').having(title=u'Second webaction', scope='context'))
 
+        self.login(self.regular_user, browser=browser)
         browser.open(self.dossier, view='/@webactions/0', method='POST', headers=self.api_headers)
         browser.open(self.dossier, view='/@webactions/1', method='POST', headers=self.api_headers)
 

--- a/opengever/api/webactions.py
+++ b/opengever/api/webactions.py
@@ -250,6 +250,11 @@ class ContextWebActionsPost(WebActionLocator):
         self.request.response.setStatus(204)
         return _no_content_marker
 
+    def _check_ownership(self, action):
+        # Must be overridden because users can activate a web action
+        # even if they are not the owner.
+        return
+
 
 class ContextWebActionsDelete(WebActionLocator):
 
@@ -265,6 +270,11 @@ class ContextWebActionsDelete(WebActionLocator):
 
         self.request.response.setStatus(204)
         return _no_content_marker
+
+    def _check_ownership(self, action):
+        # Must be overridden because users can deactivate a web action
+        # even if they are not the owner.
+        return
 
 
 def serialize_webaction(action):


### PR DESCRIPTION
Follow up for #7210 

`_check_ownership` must be overridden, otherwise an Unauthorized will be thrown if a user other than the owner tries to activate or deactivate the webaction.

For [CA-2860]

[CA-2860]: https://4teamwork.atlassian.net/browse/CA-2860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ