### PR TITLE
Update sortable_reference and SearchableText for all childs when reference_prefix has changed.

### DIFF
--- a/changes/CA-3042.bugfix
+++ b/changes/CA-3042.bugfix
@@ -1,1 +1,1 @@
-Also update sortable_reference index when reference_prefix has changed. [phgross]
+Also update sortable_reference and SearchableText when reference_prefix has changed. [phgross]

--- a/opengever/repository/subscribers.py
+++ b/opengever/repository/subscribers.py
@@ -1,3 +1,4 @@
+from opengever.document.behaviors import IBaseDocument
 from opengever.repository.interfaces import IDuringRepositoryDeletion
 from plone import api
 from plone.app.workflow.interfaces import ILocalrolesModifiedEvent
@@ -32,7 +33,14 @@ def update_reference_prefixes(obj, event):
         children = catalog.unrestrictedSearchResults(
             path='/'.join(obj.getPhysicalPath()))
         for child in children:
-            child.getObject().reindexObject(idxs=['reference', 'sortable_reference'])
+            obj = child.getObject()
+            idxs = ['reference', 'sortable_reference']
+            if IBaseDocument.providedBy(obj):
+                idxs.append('metadata')
+            else:
+                idxs.append('SearchableText')
+
+            obj.reindexObject(idxs=idxs)
 
 
 def check_delete_preconditions(repository, event):

--- a/opengever/repository/tests/test_subscribers.py
+++ b/opengever/repository/tests/test_subscribers.py
@@ -39,3 +39,21 @@ class TestReferencePrefixUpdating(SolrIntegrationTestCase):
         self.assertEquals('Client1 1.7 / 1', obj2brain(self.dossier).reference)
         self.assertEquals(u'client00000001 00000001.00000007 / 00000001',
                           solr_data_for(self.dossier, 'sortable_reference'))
+
+    @browsing
+    def test_reference_number_in_searchableText_gets_updated(self, browser):
+        self.login(self.administrator, browser)
+
+        self.assertIn('Client1 1.1 / 1',
+                      solr_data_for(self.dossier, 'SearchableText'))
+        self.assertIn('Client1 1.1 / 1 / 14',
+                      solr_data_for(self.document, 'metadata'))
+
+        browser.open(self.leaf_repofolder, view='edit')
+        browser.fill({'Repository number': u'7'}).save()
+        self.commit_solr()
+
+        self.assertIn('Client1 1.7 / 1',
+                      solr_data_for(self.dossier, 'SearchableText'))
+        self.assertIn('Client1 1.7 / 1 / 14',
+                      solr_data_for(self.document, 'metadata'))


### PR DESCRIPTION
Currently only the `reference` index has been updated, but the recently introduced `sortable_reference` index was not updated yet. This PR fixes that. 

Besides that I realized that the reference number is also part of the SearchableText respectively Metadata index, therefore we also need to reindex those if a reference_prefix is changed.

For [CA-3042]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)



[CA-3042]: https://4teamwork.atlassian.net/browse/CA-3042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ