### PR TITLE
Make workspace invitation mail content customizable.

### DIFF
--- a/changes/CA-3038.feature
+++ b/changes/CA-3038.feature
@@ -1,0 +1,1 @@
+Make workspace invitation mail content customizable. [phgross]

--- a/opengever/core/upgrades/20211018134101_add_invitation_mail_content_setting/registry.xml
+++ b/opengever/core/upgrades/20211018134101_add_invitation_mail_content_setting/registry.xml
@@ -1,0 +1,5 @@
+<registry>
+
+  <record interface="opengever.workspace.interfaces.IWorkspaceSettings" field="custom_invitation_mail_content" />
+
+</registry>

--- a/opengever/core/upgrades/20211018134101_add_invitation_mail_content_setting/upgrade.py
+++ b/opengever/core/upgrades/20211018134101_add_invitation_mail_content_setting/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddInvitationMailContentSetting(UpgradeStep):
+    """Add invitation_mail_content setting.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/workspace/interfaces.py
+++ b/opengever/workspace/interfaces.py
@@ -36,6 +36,13 @@ class IWorkspaceSettings(Interface):
         required=False,
     )
 
+    custom_invitation_mail_content = schema.Text(
+        title=u'Invitation mail content',
+        description=u'Mail content for workspace invitation mails, dynamic '
+        'attributes `title`, `user`, `platform` and `accept_url` can be used',
+        required=True,
+    )
+
 
 class IWorkspaceMeetingSettings(Interface):
 


### PR DESCRIPTION
This PR adds an additional registry entry, to customize the invitation mail content. 

The setting is empty by default, therefore the default mail content (which also provides translations) is used. The customization flag does not support translations.

The mail content is customized only in exceptional cases, therefore the flag is not set in the policy generator.

For [CA-3038]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-3038]: https://4teamwork.atlassian.net/browse/CA-3038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ