### PR TITLE
Add additional field `text` to tasktemplatefolder.

### DIFF
--- a/opengever/tasktemplates/content/templatefoldersschema.py
+++ b/opengever/tasktemplates/content/templatefoldersschema.py
@@ -17,11 +17,17 @@ class ITaskTemplateFolderSchema(model.Schema):
     model.fieldset(
         u'common',
         label=_(u'fieldset_common', default=u'Common'),
-        fields=[u'sequence_type'])
+        fields=[u'sequence_type', 'text'])
 
     directives.order_after(sequence_type='IOpenGeverBase.description')
     sequence_type = schema.Choice(
         title=_(u'label_sequence_type', default='Type'),
         vocabulary=sequence_type_vocabulary,
         required=True,
+    )
+
+    directives.order_after(text='sequence_type')
+    text = schema.Text(
+        title=_(u"label_text", default=u"Text"),
+        required=False,
     )

--- a/opengever/tasktemplates/tasktemplatefolder.py
+++ b/opengever/tasktemplates/tasktemplatefolder.py
@@ -74,7 +74,7 @@ class TaskTemplateFolderTrigger(object):
 
     def create_main_task(self):
         title = self.main_task_overrides.get("title", self.context.title)
-        text = self.main_task_overrides.get("text")
+        text = self.main_task_overrides.get("text", self.context.text)
         deadline = self.main_task_overrides.get("deadline", self.get_main_task_deadline())
         data = dict(
             title=title,

--- a/opengever/tasktemplates/tests/test_trigger.py
+++ b/opengever/tasktemplates/tests/test_trigger.py
@@ -137,6 +137,7 @@ class TestTriggeringTaskTemplate(IntegrationTestCase):
 
         main_task = self.dossier.listFolderContents()[-1]
         self.assertEquals(u'Verfahren Neuanstellung', main_task.title)
+        self.assertEquals(u'Neuanstellungsprozess MA XY', main_task.text)
         self.assertEquals(self.regular_user.getId(), main_task.responsible)
         self.assertEquals(self.regular_user.getId(), main_task.issuer)
         self.assertEquals('direct-execution', main_task.task_type)

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -760,7 +760,8 @@ class OpengeverContentFixture(object):
             Builder('tasktemplatefolder')
             .titled(u'Verfahren Neuanstellung')
             .in_state('tasktemplatefolder-state-activ')
-            .having(sequence_type='parallel')
+            .having(sequence_type='parallel',
+                    text=u'Neuanstellungsprozess MA XY')
             .within(self.templates)
         ))
 


### PR DESCRIPTION
So it's possible for the template creator to also pre fill the main_tasks text field.

For [CA-3081]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- New translations
  - [x] All msg-strings are unicode


[CA-3081]: https://4teamwork.atlassian.net/browse/CA-3081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ