### PR TITLE
Allow to include subtasks in task reports

### DIFF
--- a/changes/CA-2844.feature
+++ b/changes/CA-2844.feature
@@ -1,0 +1,1 @@
+Allow to include subtasks in task reports. [tinagerber]

--- a/opengever/globalindex/browser/report.py
+++ b/opengever/globalindex/browser/report.py
@@ -55,6 +55,8 @@ class TaskReporter(BaseReporterView):
             {'id': 'completed', 'title': _('label_completed'),
              'number_format': DATE_NUMBER_FORMAT},
             {'id': 'containing_dossier', 'title': _('label_dossier')},
+            {'id': 'get_main_task_title', 'callable': True,
+             'title': _('label_main_task', default=u'Main task')},
             {'id': 'issuer', 'title': _('label_issuer'),
              'transform': readable_author},
             {'id': 'issuing_org_unit_label',

--- a/opengever/globalindex/locales/de/LC_MESSAGES/opengever.globalindex.po
+++ b/opengever/globalindex/locales/de/LC_MESSAGES/opengever.globalindex.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-05-26 14:29+0000\n"
+"POT-Creation-Date: 2021-10-26 06:53+0000\n"
 "PO-Revision-Date: 2016-07-22 15:25+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-globalindex/de/>\n"
@@ -53,6 +53,11 @@ msgstr "Auftraggeber"
 #: ./opengever/globalindex/browser/report.py
 msgid "label_issuing_org_unit"
 msgstr "Auftraggeber Mandant"
+
+#. Default: "Main task"
+#: ./opengever/globalindex/browser/report.py
+msgid "label_main_task"
+msgstr "Hauptaufgabe"
 
 #: ./opengever/globalindex/browser/report.py
 msgid "label_responsible"

--- a/opengever/globalindex/locales/en/LC_MESSAGES/opengever.globalindex.po
+++ b/opengever/globalindex/locales/en/LC_MESSAGES/opengever.globalindex.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-05-26 14:29+0000\n"
+"POT-Creation-Date: 2021-10-26 06:53+0000\n"
 "PO-Revision-Date: 2016-07-22 15:25+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-globalindex/de/>\n"
@@ -62,6 +62,11 @@ msgstr "Issuer"
 #: ./opengever/globalindex/browser/report.py
 msgid "label_issuing_org_unit"
 msgstr "Issuing organization"
+
+#. Default: "Main task"
+#: ./opengever/globalindex/browser/report.py
+msgid "label_main_task"
+msgstr "Main task"
 
 #. German translation: Auftragnehmer
 #: ./opengever/globalindex/browser/report.py

--- a/opengever/globalindex/locales/fr/LC_MESSAGES/opengever.globalindex.po
+++ b/opengever/globalindex/locales/fr/LC_MESSAGES/opengever.globalindex.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-05-26 14:29+0000\n"
+"POT-Creation-Date: 2021-10-26 06:53+0000\n"
 "PO-Revision-Date: 2017-12-03 09:48+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-globalindex/fr/>\n"
@@ -53,6 +53,11 @@ msgstr "Mandant"
 #: ./opengever/globalindex/browser/report.py
 msgid "label_issuing_org_unit"
 msgstr "Donneur d'ordre / mandant"
+
+#. Default: "Main task"
+#: ./opengever/globalindex/browser/report.py
+msgid "label_main_task"
+msgstr "Tâche principale"
 
 #: ./opengever/globalindex/browser/report.py
 msgid "label_responsible"

--- a/opengever/globalindex/locales/opengever.globalindex.pot
+++ b/opengever/globalindex/locales/opengever.globalindex.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-05-26 14:29+0000\n"
+"POT-Creation-Date: 2021-10-26 06:53+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -53,6 +53,11 @@ msgstr ""
 
 #: ./opengever/globalindex/browser/report.py
 msgid "label_issuing_org_unit"
+msgstr ""
+
+#. Default: "Main task"
+#: ./opengever/globalindex/browser/report.py
+msgid "label_main_task"
 msgstr ""
 
 #: ./opengever/globalindex/browser/report.py

--- a/opengever/globalindex/model/task.py
+++ b/opengever/globalindex/model/task.py
@@ -29,6 +29,7 @@ from sqlalchemy import ForeignKey
 from sqlalchemy import func
 from sqlalchemy import Index
 from sqlalchemy import Integer
+from sqlalchemy import literal
 from sqlalchemy import or_
 from sqlalchemy import String
 from sqlalchemy import UniqueConstraint
@@ -505,6 +506,20 @@ class Task(Base):
         """containing subdossier title encoded as utf-8 to mirror the behavior
         of opengever.task.task.Task"""
         return self.containing_subdossier.encode('utf-8')
+
+    def get_main_task(self):
+        if not self.is_subtask:
+            return None
+
+        query = Task.query.restrict().filter(
+            literal(self.physical_path).contains(Task.physical_path))
+        query = query.order_by(func.length(Task.physical_path))
+        return query.first()
+
+    def get_main_task_title(self):
+        main_task = self.get_main_task()
+        if main_task:
+            return main_task.title
 
 
 class TaskQuery(BaseQuery):

--- a/opengever/globalindex/tests/test_reporter.py
+++ b/opengever/globalindex/tests/test_reporter.py
@@ -17,7 +17,8 @@ class TestTaskReporter(IntegrationTestCase):
         browser.open(view='task_report',
                      data={'view_name': 'mytasks',
                            'task_ids': [self.task.get_sql_object().task_id,
-                                        self.meeting_task.get_sql_object().task_id]})
+                                        self.meeting_task.get_sql_object().task_id,
+                                        self.subtask.get_sql_object().task_id]})
 
         with NamedTemporaryFile(delete=False, suffix='.xlsx') as tmpfile:
             tmpfile.write(browser.contents)
@@ -28,7 +29,7 @@ class TestTaskReporter(IntegrationTestCase):
         self.assertSequenceEqual(
             [u'Title', u'State',
              u'Deadline', u'Completed on',
-             u'Dossier', u'Issuer',
+             u'Dossier', u'Main task', u'Issuer',
              u'Issuing organization', u'Responsible',
              u'Task type', 'Tenant', u'Sequence number',
              u'Description'],
@@ -38,7 +39,7 @@ class TestTaskReporter(IntegrationTestCase):
         self.assertSequenceEqual(
             [self.task.title,  u'In progress',
              datetime(2016, 11, 1, 0, 0), None,
-             self.dossier.title, u'Ziegler Robert (robert.ziegler)',
+             self.dossier.title, None, u'Ziegler Robert (robert.ziegler)',
              u'Finanz\xe4mt', u'B\xe4rfuss K\xe4thi (kathi.barfuss)',
              u'For your review', u'plone', 1, u'A description'],
             [cell.value for cell in list(workbook.active.rows)[1]])
@@ -47,10 +48,19 @@ class TestTaskReporter(IntegrationTestCase):
         self.assertSequenceEqual(
             [self.meeting_task.title, u'In progress',
              datetime(2016, 11, 1, 0, 0), None,
-             self.meeting_dossier.title, u'Ziegler Robert (robert.ziegler)',
+             self.meeting_dossier.title, None, u'Ziegler Robert (robert.ziegler)',
              u'Finanz\xe4mt', u'Ziegler Robert (robert.ziegler)',
              u'For your review', u'plone', 9, None],
             [cell.value for cell in list(workbook.active.rows)[2]])
+
+        # self.subtask
+        self.assertSequenceEqual(
+            [self.subtask.title,  u'Resolved',
+             datetime(2016, 11, 1, 0, 0), None,
+             self.dossier.title, self.task.title, u'Ziegler Robert (robert.ziegler)',
+             u'Finanz\xe4mt', u'B\xe4rfuss K\xe4thi (kathi.barfuss)',
+             u'For your review', u'plone', 2, None],
+            [cell.value for cell in list(workbook.active.rows)[3]])
 
     @browsing
     def test_respects_column_tabbedview_settings_if_exists(self, browser):
@@ -114,7 +124,7 @@ class TestTaskReporter(IntegrationTestCase):
         self.assertSequenceEqual(
             [self.task.title,  u'In progress',
              datetime(2016, 11, 1, 0, 0), None,
-             self.dossier.title, u'Ziegler Robert (robert.ziegler)',
+             self.dossier.title, None, u'Ziegler Robert (robert.ziegler)',
              u'Finanz\xe4mt', u'B\xe4rfuss K\xe4thi (kathi.barfuss)',
              u'For your review', u'plone', 1, None],
             [cell.value for cell in task_cells])
@@ -124,7 +134,7 @@ class TestTaskReporter(IntegrationTestCase):
         self.assertSequenceEqual(
             [self.meeting_task.title, u'In progress',
              datetime(2016, 11, 1, 0, 0), None,
-             self.meeting_dossier.title, u'Ziegler Robert (robert.ziegler)',
+             self.meeting_dossier.title, None, u'Ziegler Robert (robert.ziegler)',
              u'Finanz\xe4mt', u'Ziegler Robert (robert.ziegler)',
              u'For your review', u'plone', 9, None],
             [cell.value for cell in list(workbook.active.rows)[2]])

--- a/opengever/latex/tasklisting.py
+++ b/opengever/latex/tasklisting.py
@@ -75,6 +75,8 @@ class TaskListingLaTeXView(MakoLaTeXView):
 
         dossier_title = item.containing_dossier or ''
 
+        main_task_title = item.get_main_task_title() or ''
+
         reference = unicode(
             getattr(item, 'reference',
                     getattr(item, 'reference_number', ''))).encode('utf-8')
@@ -87,6 +89,7 @@ class TaskListingLaTeXView(MakoLaTeXView):
             title,
             task_type,
             dossier_title,
+            main_task_title,
             reference,
             issuer,
             responsible_label,

--- a/opengever/latex/templates/tasklisting.tex
+++ b/opengever/latex/templates/tasklisting.tex
@@ -5,8 +5,8 @@
 \noindent
 
 \setlength\extrarowheight{1pt}
-\tablehead{\bfseries Mandant&\bfseries Nr.&\bfseries Aufgabentitel&\bfseries Aufgabentyp&\bfseries Dossiertitel&\bfseries Aktenzeichen&\bfseries Auftraggeber&\bfseries Auftragnehmer&\bfseries Zu erledigen bis&\bfseries Status\\ \hline}
-\begin{supertabular*}{\textwidth}{llp{40mm}p{17mm}p{40mm}lp{25mm}p{25mm}ll}
+\tablehead{\bfseries Mandant&\bfseries Nr.&\bfseries Aufgabentitel&\bfseries Aufgabentyp&\bfseries Dossiertitel&\bfseries Hauptaufgabe&\bfseries Aktenzeichen&\bfseries Auftraggeber&\bfseries Auftragnehmer&\bfseries Zu erledigen bis&\bfseries Status\\ \hline}
+\begin{supertabular*}{\textwidth}{llp{40mm}p{17mm}p{30mm}p{25mm}lp{25mm}p{25mm}ll}
 \shrinkheight{20mm}
 
 % for row in rows:

--- a/opengever/latex/tests/test_listing.py
+++ b/opengever/latex/tests/test_listing.py
@@ -2,11 +2,17 @@ from datetime import date
 from DateTime import DateTime
 from ftw.builder import Builder
 from ftw.builder import create
+from ftw.pdfgenerator.builder import Builder as PDFBuilder
+from ftw.pdfgenerator.interfaces import ILaTeXView
+from ftw.pdfgenerator.utils import provide_request_layer
 from ftw.testbrowser import browsing
 from lxml.cssselect import CSSSelector
 from opengever.base.interfaces import IReferenceNumberSettings
+from opengever.latex.layouts.default import DefaultLayout
 from opengever.latex.listing import ILaTexListing
+from opengever.latex.tasklisting import ITaskListingLayer
 from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 from opengever.testing import obj2brain
 from plone.registry.interfaces import IRegistry
 from zope.component import getMultiAdapter
@@ -285,6 +291,31 @@ class TestTaskListings(BaseLatexListingTest):
         task_id = self.task.get_sql_object().id
         browser.login().open(data={'pdf-tasks-listing:method': 1,
                                    'task_ids:list': task_id})
+
+
+class TestTaskListingLaTeXView(IntegrationTestCase):
+
+    def test_task_listing_latex_view_shows_main_task(self):
+        self.login(self.regular_user)
+        subsubtask = create(Builder('task')
+                            .titled(u'My Subsubtask')
+                            .having(issuer=self.dossier_responsible.id,
+                                    responsible=self.regular_user.id,
+                                    responsible_client='fa',
+                                    task_type='information')
+                            .within(self.subtask))
+        provide_request_layer(self.request, ITaskListingLayer)
+        self.request.form['tasks'] = [
+            self.task.absolute_url(), self.subtask.absolute_url(), subsubtask]
+
+        layout = DefaultLayout(self.dossier, self.request, PDFBuilder())
+        view = getMultiAdapter((self.dossier, self.request, layout), ILaTeXView)
+
+        subtask_row = view.get_row_for_item(self.subtask.get_sql_object())
+        subsubtask_row = view.get_row_for_item(subsubtask.get_sql_object())
+        self.assertIn(self.task.Title(), subtask_row)
+        self.assertIn(self.task.Title(), subsubtask_row)
+        self.assertNotIn(self.subtask.Title(), subsubtask_row)
 
 
 class TestJournalListings(BaseLatexListingTest):


### PR DESCRIPTION
This PR introduces a new parameter `include_subtasks` to include subtasks in task reports. The parameter is only used in the new frontend, because in the listings of the classic frontend, unlike the listings of the new frontend, subtasks are displayed.

I decided to sort the subtasks by path so that subsubtasks appear below the correct subtask. This has the consequence that for sequential tasks the order is not necessarily correct. But since determining the correct order for sequential tasks would require retrieving the Plone task, I chose not to include this.

For [CA-2844]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-2844]: https://4teamwork.atlassian.net/browse/CA-2844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ