### PR TITLE
Add help text for the new tasktemplatefolders `text` field.

### DIFF
--- a/opengever/tasktemplates/content/templatefoldersschema.py
+++ b/opengever/tasktemplates/content/templatefoldersschema.py
@@ -29,5 +29,7 @@ class ITaskTemplateFolderSchema(model.Schema):
     directives.order_after(text='sequence_type')
     text = schema.Text(
         title=_(u"label_text", default=u"Text"),
+        description=_('help_tasktemplatefolder_text',
+                      default=u'Prefills the comment field of the main task'),
         required=False,
     )

--- a/opengever/tasktemplates/locales/de/LC_MESSAGES/opengever.tasktemplates.po
+++ b/opengever/tasktemplates/locales/de/LC_MESSAGES/opengever.tasktemplates.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-01-29 14:29+0000\n"
+"POT-Creation-Date: 2021-10-28 09:03+0000\n"
 "PO-Revision-Date: 2012-02-23 14:39+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -77,6 +77,11 @@ msgstr "Wählen Sie den Mandanten des Auftragnehmers aus oder wählen Sie \"Inte
 #: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "help_task_type"
 msgstr "Wählen Sie den Typ der Aufgabe aus."
+
+#. Default: "Prefills the comment field of the main task"
+#: ./opengever/tasktemplates/content/templatefoldersschema.py
+msgid "help_tasktemplatefolder_text"
+msgstr "Wird beim Auslösen des Standardablaufs als Beschreibung der Hauptaufgabe verwendet"
 
 #: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "help_text"
@@ -192,6 +197,7 @@ msgstr "Aufgabenvorlage"
 
 #. Default: "Text"
 #: ./opengever/tasktemplates/content/tasktemplate.py
+#: ./opengever/tasktemplates/content/templatefoldersschema.py
 msgid "label_text"
 msgstr "Kommentar"
 

--- a/opengever/tasktemplates/locales/en/LC_MESSAGES/opengever.tasktemplates.po
+++ b/opengever/tasktemplates/locales/en/LC_MESSAGES/opengever.tasktemplates.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-01-29 14:29+0000\n"
+"POT-Creation-Date: 2021-10-28 09:03+0000\n"
 "PO-Revision-Date: 2012-02-23 14:39+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -93,6 +93,11 @@ msgstr "Choose the responsible user's organization / department or select 'Inter
 #: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "help_task_type"
 msgstr "Choose the task type."
+
+#. Default: "Prefills the comment field of the main task"
+#: ./opengever/tasktemplates/content/templatefoldersschema.py
+msgid "help_tasktemplatefolder_text"
+msgstr "Used as a description of the main task when the tasktemplate folder is triggered"
 
 #. German translation: Geben Sie eine detaillierte Arbeitsanweisung oder einen Kommentar ein.
 #: ./opengever/tasktemplates/content/tasktemplate.py
@@ -234,6 +239,7 @@ msgstr "Task template"
 #. German translation: Kommentar
 #. Default: "Text"
 #: ./opengever/tasktemplates/content/tasktemplate.py
+#: ./opengever/tasktemplates/content/templatefoldersschema.py
 msgid "label_text"
 msgstr "Text"
 

--- a/opengever/tasktemplates/locales/fr/LC_MESSAGES/opengever.tasktemplates.po
+++ b/opengever/tasktemplates/locales/fr/LC_MESSAGES/opengever.tasktemplates.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-29 14:29+0000\n"
+"POT-Creation-Date: 2021-10-28 09:03+0000\n"
 "PO-Revision-Date: 2017-12-03 11:48+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-tasktemplates/fr/>\n"
@@ -79,6 +79,11 @@ msgstr "Choix du client du mandataire ou choisissez \"utilisateur interactif\"."
 #: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "help_task_type"
 msgstr "Choisir le type de tâche."
+
+#. Default: "Prefills the comment field of the main task"
+#: ./opengever/tasktemplates/content/templatefoldersschema.py
+msgid "help_tasktemplatefolder_text"
+msgstr "Utilisé comme description de la tâche principale lorsque le déroulement standard est enclenchée"
 
 #: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "help_text"
@@ -194,6 +199,7 @@ msgstr "Modèle de tâches"
 
 #. Default: "Text"
 #: ./opengever/tasktemplates/content/tasktemplate.py
+#: ./opengever/tasktemplates/content/templatefoldersschema.py
 msgid "label_text"
 msgstr "commentaire"
 

--- a/opengever/tasktemplates/locales/opengever.tasktemplates.pot
+++ b/opengever/tasktemplates/locales/opengever.tasktemplates.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-29 14:29+0000\n"
+"POT-Creation-Date: 2021-10-28 09:03+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -79,6 +79,11 @@ msgstr ""
 
 #: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "help_task_type"
+msgstr ""
+
+#. Default: "Prefills the comment field of the main task"
+#: ./opengever/tasktemplates/content/templatefoldersschema.py
+msgid "help_tasktemplatefolder_text"
 msgstr ""
 
 #: ./opengever/tasktemplates/content/tasktemplate.py
@@ -195,6 +200,7 @@ msgstr ""
 
 #. Default: "Text"
 #: ./opengever/tasktemplates/content/tasktemplate.py
+#: ./opengever/tasktemplates/content/templatefoldersschema.py
 msgid "label_text"
 msgstr ""
 


### PR DESCRIPTION
This helps for the understanding of the new field. follow up of #7220 

For [CA-3081]

## Checklist
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- New translations
  - [x] All msg-strings are unicode


[CA-3081]: https://4teamwork.atlassian.net/browse/CA-3081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ