### PR TITLE
Testserver: provide connection test action for testserverctl.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1222,6 +1222,14 @@ Whenever the application needs to support a new version of GEVER, a developer re
 of the testserver, so that compatibility with the new version can be proven.
 
 
+Connectiontest
+~~~~~~~~~~~~~~
+
+The connection from the ``testserverctl`` to the XMLRPC-Server can be tested with ``bin/testserverctl connectiontest``.
+This will result in a "Connection refused" error as long as the testserver is starting and will do nothing when the server is ready for the first ``isolate`` or ``zodb_setup``.
+This can be used as docker healthcheck.
+
+
 Testing Inbound Mail
 --------------------
 

--- a/bin/testserverctl
+++ b/bin/testserverctl
@@ -7,7 +7,7 @@ import xmlrpclib
 CTL_PORT = os.environ.get('TESTSERVER_CTL_PORT', '55002')
 
 parser = argparse.ArgumentParser()
-parser.add_argument('action', choices=['zodb_setup', 'zodb_teardown', 'isolate'])
+parser.add_argument('action', choices=['zodb_setup', 'zodb_teardown', 'isolate', 'connectiontest'])
 args = parser.parse_args()
 
 proxy = xmlrpclib.ServerProxy('http://localhost:{}'.format(CTL_PORT))

--- a/opengever/core/testserver_zope2server.py
+++ b/opengever/core/testserver_zope2server.py
@@ -149,6 +149,7 @@ def start(zope_layer_dotted_name):
     listener.register_function(zsl.zodb_setup, 'zodb_setup')
     listener.register_function(zsl.zodb_teardown, 'zodb_teardown')
     listener.register_function(zsl.isolate, 'isolate')  # PATCH
+    listener.register_function(lambda: None, 'connectiontest')
 
     robotframework_server.print_urls(zsl.zope_layer, listener)
 


### PR DESCRIPTION
## Motivation

We want to be able to provide the testserver as docker container. It is best practice to use health checks so that other containers can wait until the dependant container is ready.

## Change 

This change adds a ``connectiontest`` action to the ``bin/testserverctl`` script. It can be used as docker / docker-compose healthcheck. It fails with an exit code until the testserver is up and ready.

/cc @bierik 