### PR TITLE
Add validation of the end date for meetings

### DIFF
--- a/changes/CA-3113.bugfix
+++ b/changes/CA-3113.bugfix
@@ -1,0 +1,1 @@
+Add validation of the end date for meetings. [tinagerber]

--- a/opengever/core/upgrades/20211028173917_fix_committee_meeting_end_date/upgrade.py
+++ b/opengever/core/upgrades/20211028173917_fix_committee_meeting_end_date/upgrade.py
@@ -1,0 +1,13 @@
+from opengever.core.upgrade import SchemaMigration
+from opengever.meeting.model.meeting import Meeting
+
+
+class FixCommitteeMeetingEndDate(SchemaMigration):
+    """Fix committee meeting end date.
+    """
+
+    def migrate(self):
+        meetings = self.session.query(Meeting).filter(
+            Meeting.end != None).filter(Meeting.start >= Meeting.end).all()  # noqa
+        for meeting in meetings:
+            meeting.end = None

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -37,6 +37,8 @@ from zope import schema
 from zope.component import getUtility
 from zope.globalrequest import getRequest
 from zope.i18n import translate
+from zope.interface import Invalid
+from zope.interface import invariant
 from zope.interface import provider
 from zope.schema.interfaces import IContextAwareDefaultFactory
 from zope.schema.interfaces import IVocabularyFactory
@@ -93,6 +95,13 @@ class IMeetingModel(model.Schema):
     end = UTCDatetime(
         title=_('label_end', default=u"End"),
         required=False)
+
+    @invariant
+    def validate_start_end(data):
+        if data.end is not None:
+            if data.start >= data.end:
+                raise Invalid(
+                    _(u'Start date must be before end date.'))
 
 
 ADD_MEETING_STEPS = (

--- a/opengever/meeting/browser/meetings/protocol.py
+++ b/opengever/meeting/browser/meetings/protocol.py
@@ -10,6 +10,8 @@ from plone.supermodel import model
 from Products.Five.browser import BrowserView
 from z3c.form.browser.checkbox import CheckBoxFieldWidget
 from zope import schema
+from zope.interface import Invalid
+from zope.interface import invariant
 
 
 class IMeetingMetadata(model.Schema):
@@ -65,6 +67,13 @@ class IMeetingMetadata(model.Schema):
     end = UTCDatetime(
         title=_('label_end', default=u"End"),
         required=False)
+
+    @invariant
+    def validate_start_end(data):
+        if data.end is not None:
+            if data.start >= data.end:
+                raise Invalid(
+                    _(u'Start date must be before end date.'))
 
 
 class DownloadProtocolJson(BrowserView):

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-08-29 18:45+0000\n"
+"POT-Creation-Date: 2021-10-28 15:10+0000\n"
 "PO-Revision-Date: 2017-10-23 18:40+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -210,6 +210,10 @@ msgstr "Speichern"
 #: ./opengever/meeting/browser/meetings/unscheduled_proposals.py
 msgid "Scheduled Successfully"
 msgstr "Erfolgreich traktandiert"
+
+#: ./opengever/meeting/browser/meetings/meeting.py
+msgid "Start date must be before end date."
+msgstr "Das Start-Datum muss vor dem Ende-Datum liegen."
 
 #: ./opengever/meeting/browser/meetings/meeting.py
 msgid "The meeting and its dossier were created successfully"

--- a/opengever/meeting/locales/en/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/en/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-08-29 18:45+0000\n"
+"POT-Creation-Date: 2021-10-28 15:10+0000\n"
 "PO-Revision-Date: 2017-10-23 18:40+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -257,6 +257,10 @@ msgstr "Save"
 #: ./opengever/meeting/browser/meetings/unscheduled_proposals.py
 msgid "Scheduled Successfully"
 msgstr "Scheduled Successfully"
+
+#: ./opengever/meeting/browser/meetings/meeting.py
+msgid "Start date must be before end date."
+msgstr "Start date must be before end date."
 
 #. German translation: Die Sitzung und das dazugehörige Sitzungsdossier wurden erfolgreich erstellt.
 #: ./opengever/meeting/browser/meetings/meeting.py

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-08-29 18:45+0000\n"
+"POT-Creation-Date: 2021-10-28 15:10+0000\n"
 "PO-Revision-Date: 2018-05-22 10:15+0000\n"
 "Last-Translator: Niklaus Johner <Niklaus.johner@4teamwork.ch>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-meeting/fr/>\n"
@@ -212,6 +212,10 @@ msgstr "Sauvegarder"
 #: ./opengever/meeting/browser/meetings/unscheduled_proposals.py
 msgid "Scheduled Successfully"
 msgstr "Joint à l'ordre du jour avec succès"
+
+#: ./opengever/meeting/browser/meetings/meeting.py
+msgid "Start date must be before end date."
+msgstr "La date de début doit être plus récente que la date de fin."
 
 #: ./opengever/meeting/browser/meetings/meeting.py
 msgid "The meeting and its dossier were created successfully"

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-08-29 18:45+0000\n"
+"POT-Creation-Date: 2021-10-28 15:10+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -208,6 +208,10 @@ msgstr ""
 
 #: ./opengever/meeting/browser/meetings/unscheduled_proposals.py
 msgid "Scheduled Successfully"
+msgstr ""
+
+#: ./opengever/meeting/browser/meetings/meeting.py
+msgid "Start date must be before end date."
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/meeting.py

--- a/opengever/meeting/tests/test_meeting.py
+++ b/opengever/meeting/tests/test_meeting.py
@@ -53,6 +53,20 @@ class TestMeeting(IntegrationTestCase):
         self.assertIsNotNone(meeting.modified)
 
     @browsing
+    def test_cannot_set_invalid_end_date(self, browser):
+        self.login(self.committee_responsible, browser)
+        browser.open(self.committee, view='add-meeting')
+        browser.fill({
+            'Title': u'M\xe4\xe4hting',
+            'Start': '01.01.2010 10:00',
+            'End': '01.01.2009 11:00',
+            'Location': 'Somewhere',
+        }).submit()
+
+        self.assertEqual('Start date must be before end date.',
+                         browser.css('div.error')[0].text)
+
+    @browsing
     def test_meeting_title_is_used_as_site_title_and_heading(self, browser):
         self.login(self.committee_responsible, browser)
         browser.open(self.meeting.absolute_url())

--- a/opengever/meeting/tests/test_meeting_edit.py
+++ b/opengever/meeting/tests/test_meeting_edit.py
@@ -102,6 +102,14 @@ class TestEditMeeting(IntegrationTestCase):
             self.assertEquals('edit-meeting', plone.view(browser2))
 
     @browsing
+    def test_cannot_set_invalid_end_date(self, browser):
+        self.login(self.committee_responsible, browser)
+        browser.open(self.meeting, view='edit-meeting')
+        browser.fill({'End': '13.10.1995 08:00'}).save()
+        self.assertEqual('Start date must be before end date.',
+                         browser.css('div.error')[0].text)
+
+    @browsing
     def test_edit_meeting_reports_write_conflicts(self, tab1):
         self.login(self.committee_responsible, tab1)
         with tab1.clone() as tab2:


### PR DESCRIPTION
Since the end date is validated in the meetings app, this repeatedly led to import errors. Therefore, the end date is now also validated in Gever.

The end date can now no longer be before the start date. For meetings that have an invalid end date set, the end date is set to None.

For [CA-3113]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-3113]: https://4teamwork.atlassian.net/browse/CA-3113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ