### PR TITLE
Make pass_documents flag also work for multi adminunit tasks.

### DIFF
--- a/opengever/api/complete_successor_task.py
+++ b/opengever/api/complete_successor_task.py
@@ -35,7 +35,8 @@ class CompleteSuccessorTaskPost(RemoteTaskBaseService):
     """
 
     required_params = ('transition', )
-    optional_params = ('documents', 'text', 'approved_documents')
+    optional_params = ('documents', 'text', 'approved_documents',
+                       'pass_documents_to_next_task')
 
     @staticmethod
     def _resolve_doc_ref_to_intid(doc_ref):
@@ -68,6 +69,7 @@ class CompleteSuccessorTaskPost(RemoteTaskBaseService):
         docs_to_deliver = params.get('documents', [])
         response_text = params.get('text', u'')
         approved_documents = params.get('approved_documents', [])
+        pass_documents_to_next_task = params.get('pass_documents_to_next_task', False)
 
         # Map any supported document reference type to an IntId
         docs_to_deliver = map(self._resolve_doc_ref_to_intid, docs_to_deliver)
@@ -90,7 +92,8 @@ class CompleteSuccessorTaskPost(RemoteTaskBaseService):
             successor_task, transition,
             docs_to_deliver=docs_to_deliver,
             response_text=response_text,
-            approved_documents=approved_documents)
+            approved_documents=approved_documents,
+            pass_documents_to_next_task=pass_documents_to_next_task)
 
         remote_response_body = remote_response.read()
         if remote_response_body.strip() != 'OK':

--- a/opengever/api/task.py
+++ b/opengever/api/task.py
@@ -45,6 +45,7 @@ class SerializeTaskToJson(GeverSerializeFolderToJson):
 
         model = self.context.get_sql_object()
         result[u'is_remote_task'] = model.is_remote_task
+        result[u'has_remote_predecessor'] = model.has_remote_predecessor
         result[u'responsible_admin_unit_url'] = model.get_assigned_org_unit().admin_unit.public_url
         return result
 

--- a/opengever/api/task.py
+++ b/opengever/api/task.py
@@ -46,6 +46,7 @@ class SerializeTaskToJson(GeverSerializeFolderToJson):
         model = self.context.get_sql_object()
         result[u'is_remote_task'] = model.is_remote_task
         result[u'has_remote_predecessor'] = model.has_remote_predecessor
+        result[u'has_sequential_successor'] = model.has_sequential_successor
         result[u'responsible_admin_unit_url'] = model.get_assigned_org_unit().admin_unit.public_url
         return result
 

--- a/opengever/api/tests/test_task.py
+++ b/opengever/api/tests/test_task.py
@@ -259,6 +259,13 @@ class TestTaskSerialization(SolrIntegrationTestCase):
         self.assertIn('responsible_admin_unit_url', browser.json)
         self.assertEqual('http://nohost/plone', browser.json['responsible_admin_unit_url'])
 
+    @browsing
+    def test_contains_has_remote_predecessor(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.task, method="GET", headers=self.api_headers)
+        self.assertIn('has_remote_predecessor', browser.json)
+        self.assertFalse(browser.json['has_remote_predecessor'])
+
 
 class TestTaskCommentSync(FunctionalTestCase):
 

--- a/opengever/api/tests/test_task.py
+++ b/opengever/api/tests/test_task.py
@@ -266,6 +266,19 @@ class TestTaskSerialization(SolrIntegrationTestCase):
         self.assertIn('has_remote_predecessor', browser.json)
         self.assertFalse(browser.json['has_remote_predecessor'])
 
+    @browsing
+    def test_contains_has_sequential_successor(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(self.seq_subtask_2, method="GET", headers=self.api_headers)
+        self.assertTrue(browser.json['has_sequential_successor'])
+
+        browser.open(self.seq_subtask_3, method="GET", headers=self.api_headers)
+        self.assertFalse(browser.json['has_sequential_successor'])
+
+        browser.open(self.task, method="GET", headers=self.api_headers)
+        self.assertFalse(browser.json['has_sequential_successor'])
+
 
 class TestTaskCommentSync(FunctionalTestCase):
 

--- a/opengever/globalindex/model/task.py
+++ b/opengever/globalindex/model/task.py
@@ -361,6 +361,20 @@ class Task(Base):
             return self.predecessor.admin_unit_id != self.admin_unit_id
         return False
 
+    @property
+    def has_sequential_successor(self):
+        if self.tasktemplate_successor:
+            return True
+
+        # This is the case if `self` is a cross-admin-unit copy of a task
+        # in a sequential chain.
+        # The next sequential task in the chain on the *other* side then is
+        # self.predecessor.tasktemplate_successor
+        elif self.predecessor and self.predecessor.tasktemplate_successor:
+            return True
+
+        return False
+
     def get_previous_task(self):
         """If the task is part of a sequence it returns previous task of the
         sequence otherwise None."""

--- a/opengever/globalindex/model/task.py
+++ b/opengever/globalindex/model/task.py
@@ -355,6 +355,12 @@ class Task(Base):
         """
         return self.get_assigned_org_unit().admin_unit != self.get_admin_unit()
 
+    @property
+    def has_remote_predecessor(self):
+        if self.predecessor:
+            return self.predecessor.admin_unit_id != self.admin_unit_id
+        return False
+
     def get_previous_task(self):
         """If the task is part of a sequence it returns previous task of the
         sequence otherwise None."""

--- a/opengever/globalindex/tests/test_sql_task.py
+++ b/opengever/globalindex/tests/test_sql_task.py
@@ -153,6 +153,21 @@ class TestGlobalindexTask(TestCase):
 
         self.assertTrue(task_with_pred.is_successor)
 
+    def test_has_remote_predecessor(self):
+        predecessor = create(Builder('globalindex_task')
+                             .having(int_id=1, admin_unit_id='fd'))
+        successor = create(Builder('globalindex_task')
+                           .having(int_id=2, admin_unit_id='rk'))
+        successor.predecessor = predecessor
+        self.assertTrue(successor.has_remote_predecessor)
+
+        forwarding = create(Builder('globalindex_task')
+                            .having(int_id=3, admin_unit_id='fd'))
+        task_successor = create(Builder('globalindex_task')
+                                .having(int_id=4, admin_unit_id='fd'))
+        task_successor.predecessor = forwarding
+        self.assertFalse(task_successor.has_remote_predecessor)
+
     def test_unique_id(self):
         create(
             Builder('globalindex_task')

--- a/opengever/globalindex/tests/test_sql_task.py
+++ b/opengever/globalindex/tests/test_sql_task.py
@@ -168,6 +168,21 @@ class TestGlobalindexTask(TestCase):
         task_successor.predecessor = forwarding
         self.assertFalse(task_successor.has_remote_predecessor)
 
+    def test_has_sequential_successor(self):
+        task1 = create(Builder('globalindex_task').having(int_id=1))
+        task2 = create(Builder('globalindex_task').having(int_id=2))
+        task3 = create(Builder('globalindex_task').having(int_id=3))
+
+        task1.tasktemplate_successor = task2
+        task2.tasktemplate_successor = task3
+
+        self.assertTrue(task1.has_sequential_successor)
+        self.assertTrue(task2.has_sequential_successor)
+        self.assertFalse(task3.has_sequential_successor)
+
+        task = create(Builder('globalindex_task').having(int_id=4))
+        self.assertFalse(task.has_sequential_successor)
+
     def test_unique_id(self):
         create(
             Builder('globalindex_task')

--- a/opengever/task/browser/complete.py
+++ b/opengever/task/browser/complete.py
@@ -249,7 +249,8 @@ class CompleteSuccessorTaskReceiveDelivery(BrowserView):
         # syncing, so no workflow syncing is necessary.
         util.change_task_workflow_state(
             self.context, data['transition'], text=data['text'],
-            disable_sync=True, added_objects=documents)
+            disable_sync=True, added_objects=documents,
+            pass_documents_to_next_task=data.get('pass_documents_to_next_task', False))
 
         return ok_response()
 

--- a/opengever/task/browser/complete_utils.py
+++ b/opengever/task/browser/complete_utils.py
@@ -31,7 +31,7 @@ import json
 
 def complete_task_and_deliver_documents(
         task, transition, docs_to_deliver=None, response_text=None,
-        approved_documents=None):
+        approved_documents=None, pass_documents_to_next_task=None):
     """Delivers the selected documents to the predecesser task and
     complete the task:
 
@@ -45,6 +45,9 @@ def complete_task_and_deliver_documents(
     transition_data = {'text': response_text}
     if approved_documents:
         transition_data['approved_documents'] = approved_documents
+
+    if pass_documents_to_next_task:
+        transition_data['pass_documents_to_next_task'] = pass_documents_to_next_task
 
     util.change_task_workflow_state(task,
                                     transition,
@@ -63,7 +66,8 @@ def complete_task_and_deliver_documents(
 
     data = {'documents': [],
             'text': response_text,
-            'transition': transition}
+            'transition': transition,
+            'pass_documents_to_next_task': pass_documents_to_next_task}
 
     related_ids = []
     if getattr(task, 'relatedItems'):


### PR DESCRIPTION
The recently introduced flag `pass_documents_to_next_task` had only worked for tasks inside an adminunit. This PR extends the functionality to also work if one part of a sequential task process is cross adminunit.

Besides that I added the helpers `has_sequential_successor` and `has_remote_predecessor` two the task serialization, to help display the correct transition fields in the gever-ui.

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-1978]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ]  Changelog entry (CL entry already done with the previous PR)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-1978]: https://4teamwork.atlassian.net/browse/CA-1978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ