### PR TITLE
Fix UnicodeEncodeError in ogds sync.

### DIFF
--- a/changes/CA-3125.bugfix
+++ b/changes/CA-3125.bugfix
@@ -1,0 +1,1 @@
+Fix UnicodeEncodeError in ogds sync. [tinagerber]

--- a/opengever/ogds/base/sync/ogds_updater.py
+++ b/opengever/ogds/base/sync/ogds_updater.py
@@ -516,7 +516,7 @@ class OGDSUpdater(object):
                 continue
             title = groups_plugin.getGroupInfo(groupid).get('title')
             if title is not None:
-                title = title.decode('utf8')
+                title = safe_unicode(title)
             groups[groupid] = {
                 'groupid': groupid.decode('utf8'),
                 'title': title,

--- a/opengever/ogds/base/tests/test_ogds_updater.py
+++ b/opengever/ogds/base/tests/test_ogds_updater.py
@@ -271,6 +271,14 @@ class TestOGDSUpdater(FunctionalTestCase):
         group = ogds_service().fetch_group('my_local_group')
         self.assertEqual(group.title, 'my_local_group')
 
+    def test_import_local_groups_can_handle_non_ascii_characters_in_title(self):
+        self.portal.portal_groups.addGroup('a_local_group', title=u'H\u79d2')
+        updater = IOGDSUpdater(self.portal)
+        updater.import_local_groups()
+
+        group = ogds_service().fetch_group('a_local_group')
+        self.assertEqual(group.title, u'H\u79d2')
+
     def test_deactivates_local_groups(self):
         create(Builder('ogds_group')
                .id('my_local_group').having(is_local=True, active=True))


### PR DESCRIPTION
Some deployments had errors in OGDS sync because they have group titles that contain non-ascii chars.

For [CA-3125]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-3125]: https://4teamwork.atlassian.net/browse/CA-3125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ