### PR TITLE
Fix storing documents in bumblebee during copy/paste

### DIFF
--- a/changes/CA-3117.bugfix
+++ b/changes/CA-3117.bugfix
@@ -1,0 +1,1 @@
+Fix storing document in bumblebee during copy-paste. [njohner]


### PR DESCRIPTION
Copied documents need to get stored in bumblebee once all their parents have been renamed, as otherwise the url in the storing job will be outdated by the time the job gets processed. This only matters for documents with docproperties which will modify the file, i.e. the document's checksum will not already be stored in bumblebee.

For [CA-3117]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-3117]: https://4teamwork.atlassian.net/browse/CA-3117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ