### PR TITLE
Extend API error representation

### DIFF
--- a/changes/CA-408.other
+++ b/changes/CA-408.other
@@ -1,0 +1,1 @@
+Extend API error representation. [phgross]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -8,6 +8,7 @@ API Changelog
 
 Breaking Changes
 ^^^^^^^^^^^^^^^^
+- Some error messages have been renamed, but the format how an error is returned stays the same, only the response now usually contains a translated error message and may contain additional metadata.
 - Toggling a Workspace Todos review state from active to completed and back can be done thorugh the newly introduced `@toggle` endpiont for todos. [elioschmutz]
 - Workspace Todos do no longer provide a completed-field. Completing a todo is now done through a workflow transition. [elioschmutz]
 - The ``completed`` field in the ``@listing`` is now longer supported, use the ``is_completed`` field instead.

--- a/opengever/api/__init__.py
+++ b/opengever/api/__init__.py
@@ -1,0 +1,4 @@
+from zope.i18nmessageid import MessageFactory
+
+
+_ = MessageFactory('opengever.api')

--- a/opengever/api/cancelcheckout.py
+++ b/opengever/api/cancelcheckout.py
@@ -1,8 +1,9 @@
+from opengever.api import _
 from opengever.document.interfaces import ICheckinCheckoutManager
 from plone.restapi.services import Service
+from zExceptions import Forbidden
 from zope.component import getMultiAdapter
 from zope.interface import alsoProvides
-
 import plone.protect.interfaces
 
 
@@ -14,11 +15,8 @@ class CancelCheckout(Service):
                                   ICheckinCheckoutManager)
 
         if not manager.is_cancel_allowed():
-            self.request.response.setStatus(403)
-            return {'error': {
-                'type': 'Forbidden',
-                'message': 'Cancel checkout is not allowed.',
-            }}
+            raise Forbidden(_('msg_cancel_checkout_disallowed',
+                              default=u'Cancel checkout is not allowed.'))
 
         # Disable CSRF protection
         if 'IDisableCSRFProtection' in dir(plone.protect.interfaces):

--- a/opengever/api/checkin.py
+++ b/opengever/api/checkin.py
@@ -1,9 +1,10 @@
+from opengever.api import _
 from opengever.document.interfaces import ICheckinCheckoutManager
 from plone.restapi.deserializer import json_body
 from plone.restapi.services import Service
+from zExceptions import Forbidden
 from zope.component import getMultiAdapter
 from zope.interface import alsoProvides
-
 import plone.protect.interfaces
 
 
@@ -15,11 +16,8 @@ class Checkin(Service):
                                   ICheckinCheckoutManager)
 
         if not manager.is_checkin_allowed():
-            self.request.response.setStatus(403)
-            return {'error': {
-                'type': 'Forbidden',
-                'message': 'Checkin is not allowed.',
-            }}
+            raise Forbidden(_('msg_checkin_disallowed',
+                              default=u'Checkin is not allowed.'))
 
         # Disable CSRF protection
         if 'IDisableCSRFProtection' in dir(plone.protect.interfaces):

--- a/opengever/api/checkout.py
+++ b/opengever/api/checkout.py
@@ -1,8 +1,9 @@
+from opengever.api import _
 from opengever.document.interfaces import ICheckinCheckoutManager
 from plone.restapi.services import Service
+from zExceptions import Forbidden
 from zope.component import getMultiAdapter
 from zope.interface import alsoProvides
-
 import plone.protect.interfaces
 
 
@@ -14,11 +15,8 @@ class Checkout(Service):
                                   ICheckinCheckoutManager)
 
         if not manager.is_checkout_allowed():
-            self.request.response.setStatus(403)
-            return {'error': {
-                'type': 'Forbidden',
-                'message': 'Checkout is not allowed.',
-            }}
+            raise Forbidden(_('msg_checkout_disallowed',
+                              default=u'Checkout is not allowed.'))
 
         # Disable CSRF protection
         if 'IDisableCSRFProtection' in dir(plone.protect.interfaces):

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -5,6 +5,8 @@
     xmlns:i18n="http://namespaces.zope.org/i18n"
     i18n_domain="opengever.api">
 
+  <i18n:registerTranslations directory="locales" />
+
   <include file="permissions.zcml" />
 
   <include package="plone.rest" file="meta.zcml" />

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -37,6 +37,8 @@
   <adapter factory=".serializer.SerializeOrgUnitModelToJsonSummary" />
   <adapter factory=".serializer.GeverRelationListFieldSerializer" />
 
+  <adapter factory=".deserializer.GeverDeserializeFromJson" />
+
   <adapter factory=".actors.SerializeActorToJson" />
   <adapter factory=".repositoryfolder.DeserializeRepositoryFolderFromJson" />
   <adapter factory=".repositoryfolder.SerializeRepositoryFolderToJson" />

--- a/opengever/api/deserializer.py
+++ b/opengever/api/deserializer.py
@@ -1,0 +1,72 @@
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+from opengever.base.default_values import set_default_values
+from opengever.base.interfaces import IOpengeverBaseLayer
+from plone.dexterity.interfaces import IDexterityContent
+from plone.restapi.deserializer import json_body
+from plone.restapi.deserializer.dxcontent import DeserializeFromJson
+from plone.restapi.interfaces import IDeserializeFromJson
+from z3c.form.interfaces import IManagerValidator
+from zExceptions import BadRequest
+from zope.component import adapter
+from zope.component import queryMultiAdapter
+from zope.event import notify
+from zope.interface import implementer
+from zope.lifecycleevent import Attributes
+from zope.lifecycleevent import ObjectModifiedEvent
+
+
+@implementer(IDeserializeFromJson)
+@adapter(IDexterityContent, IOpengeverBaseLayer)
+class GeverDeserializeFromJson(DeserializeFromJson):
+    """Customization of the default deserializer, to return the message
+    factory object instead of the error message string, if a validation error
+    occurs.
+    It also makes sure to prefill values that were not set with default or
+    missing values.
+    """
+
+    def __call__(self, validate_all=False, data=None, create=False):
+
+        if data is None:
+            data = json_body(self.request)
+
+        # set default values
+        if create:
+            container = aq_parent(aq_inner(self.context))
+            set_default_values(self.context, container, data)
+
+        schema_data, errors = self.get_schema_data(data, validate_all)
+
+        # Validate schemata
+        for schema, field_data in schema_data.items():
+            validator = queryMultiAdapter(
+                (self.context, self.request, None, schema, None), IManagerValidator
+            )
+            for error in validator.validate(field_data):
+                errors.append({"error": error, "message": error.message})
+
+        if errors:
+            # Drop Python specific error classes in order to be able to better handle
+            # errors on front-end
+            for error in errors:
+                error["error"] = "ValidationError"
+
+            raise BadRequest(errors)
+
+        # We'll set the layout after the validation and even if there
+        # are no other changes.
+        if "layout" in data:
+            layout = data["layout"]
+            self.context.setLayout(layout)
+
+        # OrderingMixin
+        self.handle_ordering(data)
+
+        if self.modified and not create:
+            descriptions = []
+            for interface, names in self.modified.items():
+                descriptions.append(Attributes(interface, *names))
+            notify(ObjectModifiedEvent(self.context, *descriptions))
+
+        return self.context

--- a/opengever/api/errors.py
+++ b/opengever/api/errors.py
@@ -11,11 +11,23 @@ class GeverErrorHandling(ErrorHandling):
 
     def render_exception(self, exception):
         result = super(GeverErrorHandling, self).render_exception(exception)
+        message = exception.message
 
         # Validation errors
-        if isinstance(exception.message, list):
+        if isinstance(message, list):
+            # Special handling for invitations etc.
+            if len(message) and isinstance(message[0], tuple):
+                return result
+
+            # Handle TUS error
+            elif len(message) and not message[0].get('field'):
+                result['additional_metadata'] = {}
+                result['translated_message'] = translate(
+                    message[0].get('message'), context=self.request)
+                return result
+
             fields = []
-            for error in exception.message:
+            for error in message:
                 fields.append({
                     'field': error['field'],
                     'type': str(error['error']).decode('utf-8'),
@@ -28,9 +40,9 @@ class GeverErrorHandling(ErrorHandling):
                 _('msg_inputs_not_valid', default=u'Inputs not valid'),
                 context=self.request)
 
-        elif isinstance(exception.message, Message):
+        elif isinstance(message, Message):
             result['additional_metadata'] = {}
             result['translated_message'] = translate(
-                exception.message, context=self.request)
+                message, context=self.request)
 
         return result

--- a/opengever/api/errors.py
+++ b/opengever/api/errors.py
@@ -1,0 +1,36 @@
+from opengever.base import _
+from plone.rest.errors import ErrorHandling
+from plone.rest.interfaces import IAPIRequest
+from zope.component import adapter
+from zope.i18n import translate
+from zope.i18nmessageid.message import Message
+
+
+@adapter(Exception, IAPIRequest)
+class GeverErrorHandling(ErrorHandling):
+
+    def render_exception(self, exception):
+        result = super(GeverErrorHandling, self).render_exception(exception)
+
+        # Validation errors
+        if isinstance(exception.message, list):
+            fields = []
+            for error in exception.message:
+                fields.append({
+                    'field': error['field'],
+                    'type': str(error['error']).decode('utf-8'),
+                    'translated_message': translate(
+                        error['message'], context=self.request)
+                })
+
+            result['additional_metadata'] = {'fields': fields}
+            result['translated_message'] = translate(
+                _('msg_inputs_not_valid', default=u'Inputs not valid'),
+                context=self.request)
+
+        elif isinstance(exception.message, Message):
+            result['additional_metadata'] = {}
+            result['translated_message'] = translate(
+                exception.message, context=self.request)
+
+        return result

--- a/opengever/api/locales/de/LC_MESSAGES/opengever.api.po
+++ b/opengever/api/locales/de/LC_MESSAGES/opengever.api.po
@@ -1,6 +1,3 @@
-# --- PLEASE EDIT THE LINES BELOW CORRECTLY ---
-# SOME DESCRIPTIVE TITLE.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
@@ -15,109 +12,109 @@ msgstr ""
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
-"Domain: opengever.api\n"
+"Domain: DOMAIN\n"
 
 #. Default: "Copy of ${title}"
 #: ./opengever/api/copy_.py
 msgid "copy_of"
-msgstr ""
+msgstr "Kopie von ${title}"
 
 #. Default: "It's not possible to have non-.docx documents as proposal documents."
 #: ./opengever/api/tus.py
 msgid "error_proposal_document_type"
-msgstr ""
+msgstr "Es ist nicht möglich, Dokumente, die nicht im Format docx vorliegen, als Antragsdokumente zu verwenden."
 
 #. Default: "Already trashed"
 #: ./opengever/api/trash.py
 msgid "msg_already_trashed"
-msgstr ""
+msgstr "Bereits in den Papierkorb verschoben"
 
 #. Default: "Cancel checkout is not allowed."
 #: ./opengever/api/cancelcheckout.py
 msgid "msg_cancel_checkout_disallowed"
-msgstr ""
+msgstr "Wiederrufen ist nicht erlaubt."
 
 #. Default: "Checkin is not allowed."
 #: ./opengever/api/checkin.py
 msgid "msg_checkin_disallowed"
-msgstr ""
+msgstr "Einchecken ist nicht erlaubt."
 
 #. Default: "Checkout is not allowed."
 #: ./opengever/api/checkout.py
 msgid "msg_checkout_disallowed"
-msgstr ""
+msgstr "Auschecken ist nicht erlaubt."
 
 #. Default: "File extension must be .docx for proposal documents."
 #: ./opengever/api/document.py
 msgid "msg_docx_file_extension_for_proposal"
-msgstr ""
+msgstr "Die Dateiendung für ein Antragsdokument muss .docx sein."
 
 #. Default: "Mime type must be ${docx_mimetype} for proposal documents."
 #: ./opengever/api/document.py
 msgid "msg_docx_mime_type_for_proposal"
-msgstr ""
+msgstr "Der Mimetype eines Antragsdokument muss ${docx_mimetype} sein."
 
 #. Default: "Empty filename not supported"
 #: ./opengever/api/upload_structure.py
 msgid "msg_filename_required"
-msgstr ""
+msgstr "Der Dateiname muss zwingend definiert werden"
 
 #. Default: "Inputs not valid"
 #: ./opengever/api/errors.py
 msgid "msg_inputs_not_valid"
-msgstr ""
+msgstr "Eingaben sind ungültig"
 
 #. Default: "Maximum dossier depth exceeded"
 #: ./opengever/api/upload_structure.py
 msgid "msg_max_dossier_depth_exceeded"
-msgstr ""
+msgstr "Die maximal erlaubte Dossiertiefe wird überschritten."
 
 #. Default: "It's not possible to have no file in proposal documents."
 #: ./opengever/api/document.py
 msgid "msg_needs_file_in_proposal_document"
-msgstr ""
+msgstr "Eine Datei ist zwingend erforderlich für ein Antragsdokument."
 
 #. Default: "Document not checked-out by current user."
 #: ./opengever/api/document.py
 msgid "msg_not_checked_out_by_current_user"
-msgstr ""
+msgstr "Das Dokument ist nicht durch denn aktuellen Benutzer ausgecheckt."
 
 #. Default: "Object is not trashable"
 #: ./opengever/api/trash.py
 msgid "msg_obj_not_trashable"
-msgstr ""
+msgstr "Das Objekt kann nicht in den Papierkorb verschoben werden."
 
 #. Default: "Property 'files' is required"
 #: ./opengever/api/upload_structure.py
 msgid "msg_prop_file_required"
-msgstr ""
+msgstr "Die Eigenschaft 'files' ist zwingend erforderlich"
 
 #. Default: "The reference_number ${number} is already in use."
 #: ./opengever/api/repositoryfolder.py
 msgid "msg_reference_already_in_use"
-msgstr ""
+msgstr "Das Aktenzeichen ${number} wird bereits verwendet."
 
 #. Default: "Resource is locked."
 #: ./opengever/api/update.py
 msgid "msg_resource_locked"
-msgstr ""
+msgstr "Dieses Objekt ist gesperrt."
 
 #. Default: "Some of the objects cannot be added here"
 #: ./opengever/api/upload_structure.py
 msgid "msg_some_objects_not_addable"
-msgstr ""
+msgstr "Ein Upload an dieser Position ist nicht erlaubt."
 
 #. Default: "Cannot trash a checked-out document"
 #: ./opengever/api/trash.py
 msgid "msg_trash_checked_out_doc"
-msgstr ""
+msgstr "Ein ausgechecktes Dokument kann nicht in den Papierkorb verschoben werden"
 
 #. Default: "Cannot trash a document that has been returned as excerpt"
 #: ./opengever/api/trash.py
 msgid "msg_trash_doc_returned_as_excerpt"
-msgstr ""
+msgstr "Protokollauszüge können nicht in den Papierkorb verschoben werden"
 
 #. Default: "Cannot trash a locked document"
 #: ./opengever/api/trash.py
 msgid "msg_trash_locked_doc"
-msgstr ""
+msgstr "Ein gesperrtes Dokument kann nicht in den Papierkorb verschoben werden"

--- a/opengever/api/locales/en/LC_MESSAGES/opengever.api.po
+++ b/opengever/api/locales/en/LC_MESSAGES/opengever.api.po
@@ -1,6 +1,3 @@
-# --- PLEASE EDIT THE LINES BELOW CORRECTLY ---
-# SOME DESCRIPTIVE TITLE.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
@@ -15,109 +12,109 @@ msgstr ""
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
-"Domain: opengever.api\n"
+"Domain: DOMAIN\n"
 
 #. Default: "Copy of ${title}"
 #: ./opengever/api/copy_.py
 msgid "copy_of"
-msgstr ""
+msgstr "Copy of ${title}"
 
 #. Default: "It's not possible to have non-.docx documents as proposal documents."
 #: ./opengever/api/tus.py
 msgid "error_proposal_document_type"
-msgstr ""
+msgstr "Only docx documents are allowed as proposal documents."
 
 #. Default: "Already trashed"
 #: ./opengever/api/trash.py
 msgid "msg_already_trashed"
-msgstr ""
+msgstr "Already trashed"
 
 #. Default: "Cancel checkout is not allowed."
 #: ./opengever/api/cancelcheckout.py
 msgid "msg_cancel_checkout_disallowed"
-msgstr ""
+msgstr "Cancel checkout is not allowed."
 
 #. Default: "Checkin is not allowed."
 #: ./opengever/api/checkin.py
 msgid "msg_checkin_disallowed"
-msgstr ""
+msgstr "Checkin is not allowed."
 
 #. Default: "Checkout is not allowed."
 #: ./opengever/api/checkout.py
 msgid "msg_checkout_disallowed"
-msgstr ""
+msgstr "Checkout is not allowed."
 
 #. Default: "File extension must be .docx for proposal documents."
 #: ./opengever/api/document.py
 msgid "msg_docx_file_extension_for_proposal"
-msgstr ""
+msgstr "File extension must be .docx for proposal documents."
 
 #. Default: "Mime type must be ${docx_mimetype} for proposal documents."
 #: ./opengever/api/document.py
 msgid "msg_docx_mime_type_for_proposal"
-msgstr ""
+msgstr "Mime type must be ${docx_mimetype} for proposal documents."
 
 #. Default: "Empty filename not supported"
 #: ./opengever/api/upload_structure.py
 msgid "msg_filename_required"
-msgstr ""
+msgstr "Empty filename not supported"
 
 #. Default: "Inputs not valid"
 #: ./opengever/api/errors.py
 msgid "msg_inputs_not_valid"
-msgstr ""
+msgstr "Inputs not valid"
 
 #. Default: "Maximum dossier depth exceeded"
 #: ./opengever/api/upload_structure.py
 msgid "msg_max_dossier_depth_exceeded"
-msgstr ""
+msgstr "Maximum dossier depth exceeded"
 
 #. Default: "It's not possible to have no file in proposal documents."
 #: ./opengever/api/document.py
 msgid "msg_needs_file_in_proposal_document"
-msgstr ""
+msgstr "Proposal documents require a file."
 
 #. Default: "Document not checked-out by current user."
 #: ./opengever/api/document.py
 msgid "msg_not_checked_out_by_current_user"
-msgstr ""
+msgstr "Document not checked-out by current user."
 
 #. Default: "Object is not trashable"
 #: ./opengever/api/trash.py
 msgid "msg_obj_not_trashable"
-msgstr ""
+msgstr "Object is not trashable"
 
 #. Default: "Property 'files' is required"
 #: ./opengever/api/upload_structure.py
 msgid "msg_prop_file_required"
-msgstr ""
+msgstr "Property 'files' is required"
 
 #. Default: "The reference_number ${number} is already in use."
 #: ./opengever/api/repositoryfolder.py
 msgid "msg_reference_already_in_use"
-msgstr ""
+msgstr "The reference_number ${number} is already in use."
 
 #. Default: "Resource is locked."
 #: ./opengever/api/update.py
 msgid "msg_resource_locked"
-msgstr ""
+msgstr "Resource is locked."
 
 #. Default: "Some of the objects cannot be added here"
 #: ./opengever/api/upload_structure.py
 msgid "msg_some_objects_not_addable"
-msgstr ""
+msgstr "Some of the objects cannot be added here"
 
 #. Default: "Cannot trash a checked-out document"
 #: ./opengever/api/trash.py
 msgid "msg_trash_checked_out_doc"
-msgstr ""
+msgstr "Cannot trash a checked-out document"
 
 #. Default: "Cannot trash a document that has been returned as excerpt"
 #: ./opengever/api/trash.py
 msgid "msg_trash_doc_returned_as_excerpt"
-msgstr ""
+msgstr "Cannot trash a document that has been returned as excerpt"
 
 #. Default: "Cannot trash a locked document"
 #: ./opengever/api/trash.py
 msgid "msg_trash_locked_doc"
-msgstr ""
+msgstr "Cannot trash a locked document"

--- a/opengever/api/locales/fr/LC_MESSAGES/opengever.api.po
+++ b/opengever/api/locales/fr/LC_MESSAGES/opengever.api.po
@@ -1,6 +1,3 @@
-# --- PLEASE EDIT THE LINES BELOW CORRECTLY ---
-# SOME DESCRIPTIVE TITLE.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
@@ -15,7 +12,7 @@ msgstr ""
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
-"Domain: opengever.api\n"
+"Domain: DOMAIN\n"
 
 #. Default: "Copy of ${title}"
 #: ./opengever/api/copy_.py

--- a/opengever/api/locales/opengever.api.pot
+++ b/opengever/api/locales/opengever.api.pot
@@ -1,0 +1,33 @@
+# --- PLEASE EDIT THE LINES BELOW CORRECTLY ---
+# SOME DESCRIPTIVE TITLE.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2021-11-04 10:22+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"Language-Code: en\n"
+"Language-Name: English\n"
+"Preferred-Encodings: utf-8 latin1\n"
+"Domain: opengever.api\n"
+
+#. Default: "Copy of ${title}"
+#: ./opengever/api/copy_.py
+msgid "copy_of"
+msgstr ""
+
+#. Default: "It's not possible to have non-.docx documents as proposal documents."
+#: ./opengever/api/tus.py
+msgid "error_proposal_document_type"
+msgstr ""
+
+#. Default: "Inputs not valid"
+#: ./opengever/api/errors.py
+msgid "msg_inputs_not_valid"
+msgstr ""

--- a/opengever/api/mail.py
+++ b/opengever/api/mail.py
@@ -1,4 +1,5 @@
 from ftw.mail.mail import IMail
+from opengever.api.deserializer import GeverDeserializeFromJson
 from opengever.api.document import SerializeDocumentToJson
 from opengever.base.transforms.msg2mime import Msg2MimeTransform
 from opengever.mail.exceptions import AlreadyExtractedError
@@ -9,7 +10,6 @@ from plone.app.uuid.utils import uuidToURL
 from plone.namedfile.file import NamedBlobFile
 from plone.protect.interfaces import IDisableCSRFProtection
 from plone.restapi.deserializer import json_body
-from plone.restapi.deserializer.dxcontent import DeserializeFromJson
 from plone.restapi.interfaces import IDeserializeFromJson
 from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.services import Service
@@ -23,7 +23,7 @@ from zope.interface import Interface
 # field.
 @implementer(IDeserializeFromJson)
 @adapter(IMail, Interface)
-class DeserializeMailFromJson(DeserializeFromJson):
+class DeserializeMailFromJson(GeverDeserializeFromJson):
 
     def __call__(self, validate_all=False, data=None, create=False):
         if data is None:

--- a/opengever/api/overrides.zcml
+++ b/opengever/api/overrides.zcml
@@ -1,0 +1,14 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser"
+    xmlns:i18n="http://namespaces.zope.org/i18n"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
+    i18n_domain="opengever.api">
+
+  <adapter
+      factory=".errors.GeverErrorHandling"
+      name="index.html"
+      provides="zope.interface.Interface"
+      />
+
+</configure>

--- a/opengever/api/repositoryfolder.py
+++ b/opengever/api/repositoryfolder.py
@@ -1,5 +1,6 @@
 from Acquisition import aq_inner
 from Acquisition import aq_parent
+from opengever.api import _
 from opengever.api.serializer import GeverSerializeFolderToJson
 from opengever.base.interfaces import IReferenceNumber
 from opengever.base.interfaces import IReferenceNumberPrefix as PrefixAdapter
@@ -41,7 +42,9 @@ class DeserializeRepositoryFolderFromJson(DeserializeFromJson):
             is_valid = PrefixAdapter(parent).is_valid_number(number,
                                                              self.context)
         if not is_valid:
-            msg = "The reference_number {} is already in use.".format(number)
+            msg = _(u'msg_reference_already_in_use',
+                    default=u'The reference_number ${number} is already in use.',
+                    mapping={'number': number})
             error = {
                 "message": msg,
                 "field": "reference_number",

--- a/opengever/api/repositoryfolder.py
+++ b/opengever/api/repositoryfolder.py
@@ -1,6 +1,7 @@
 from Acquisition import aq_inner
 from Acquisition import aq_parent
 from opengever.api import _
+from opengever.api.deserializer import GeverDeserializeFromJson
 from opengever.api.serializer import GeverSerializeFolderToJson
 from opengever.base.interfaces import IReferenceNumber
 from opengever.base.interfaces import IReferenceNumberPrefix as PrefixAdapter
@@ -8,7 +9,6 @@ from opengever.repository.deleter import RepositoryDeleter
 from opengever.repository.interfaces import IRepositoryFolder
 from plone import api
 from plone.restapi.deserializer import json_body
-from plone.restapi.deserializer.dxcontent import DeserializeFromJson
 from plone.restapi.interfaces import IDeserializeFromJson
 from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.services import Service
@@ -21,7 +21,7 @@ from zope.interface import Interface
 
 @implementer(IDeserializeFromJson)
 @adapter(IRepositoryFolder, Interface)
-class DeserializeRepositoryFolderFromJson(DeserializeFromJson):
+class DeserializeRepositoryFolderFromJson(GeverDeserializeFromJson):
 
     def __call__(self, validate_all=False, data=None, create=False):
         if data is None:

--- a/opengever/api/task.py
+++ b/opengever/api/task.py
@@ -1,5 +1,6 @@
 from opengever.api.actors import serialize_actor_id_to_json_summary
 from opengever.api.add import FolderPost
+from opengever.api.deserializer import GeverDeserializeFromJson
 from opengever.api.globalindex import translate_review_state
 from opengever.api.response import ResponsePost
 from opengever.api.response import SerializeResponseToJson
@@ -18,7 +19,6 @@ from opengever.task.task_response import ITaskResponse
 from opengever.tasktemplates.interfaces import IFromParallelTasktemplate
 from opengever.tasktemplates.interfaces import IFromSequentialTasktemplate
 from plone.restapi.deserializer import json_body
-from plone.restapi.deserializer.dxcontent import DeserializeFromJson
 from plone.restapi.interfaces import IDeserializeFromJson
 from plone.restapi.interfaces import IExpandableElement
 from plone.restapi.interfaces import ISerializeToJson
@@ -114,7 +114,7 @@ def deserialize_responsible(data):
 
 @implementer(IDeserializeFromJson)
 @adapter(ITask, Interface)
-class TaskDeserializeFromJson(DeserializeFromJson):
+class TaskDeserializeFromJson(GeverDeserializeFromJson):
     """A task specific deserializer which allows to pass in the
     responsible_client and responsible value in a combined string.
     In the same way as it is exposed by the APIs querysoure endpoint.

--- a/opengever/api/tests/test_checkout.py
+++ b/opengever/api/tests/test_checkout.py
@@ -28,7 +28,13 @@ class TestCheckoutAPI(IntegrationTestCase):
         with browser.expect_http_error(code=403, reason='Forbidden'):
             browser.open(self.document.absolute_url() + '/@checkout',
                          method='POST', headers={'Accept': 'application/json'})
-        self.assertIn('Checkout is not allowed', browser.contents)
+
+        self.assertEqual(
+            {u'type': u'Forbidden',
+             u'additional_metadata': {},
+             u'translated_message': u'Checkout is not allowed.',
+             u'message': u'msg_checkout_disallowed'},
+            browser.json)
 
     @browsing
     def test_checkin_document(self, browser):

--- a/opengever/api/tests/test_document.py
+++ b/opengever/api/tests/test_document.py
@@ -270,10 +270,10 @@ class TestDocumentPost(IntegrationTestCase):
             browser.open(self.dossier, data=json.dumps(data), method='POST',
                          headers=self.api_headers)
 
-        self.assertEqual(
-            u"[{'message': 'It is not possible to add E-mails as document, use portal_type ftw.mail.mail"
-            " instead.', 'error': 'ValidationError'}]",
-            browser.json['message'])
+        self.assertEqual(u'BadRequest', browser.json[u'type'])
+        self.assertEqual(u'It is not possible to add E-mails as document, '
+                         'use portal_type ftw.mail.mail instead.',
+                         browser.json[u'translated_message'])
 
     @browsing
     def test_raises_if_quota_is_exceeded(self, browser):
@@ -346,7 +346,7 @@ class TestDocumentPatch(IntegrationTestCase):
                 headers={'Accept': 'application/json',
                          'Content-Type': 'application/json'})
         self.assertEqual(
-            browser.json['error']['message'],
+            browser.json["translated_message"],
             'Document not checked-out by current user.')
 
     @browsing
@@ -366,7 +366,7 @@ class TestDocumentPatch(IntegrationTestCase):
                 headers={'Accept': 'application/json',
                          'Content-Type': 'application/json'})
         self.assertEqual(
-            browser.json['error']['message'],
+            browser.json["translated_message"],
             'Document not checked-out by current user.')
 
     @browsing
@@ -445,7 +445,7 @@ class TestDocumentPatch(IntegrationTestCase):
                 method="PATCH",
                 headers=self.api_headers)
         self.assertEqual(
-            browser.json["error"]["message"],
+            browser.json["translated_message"],
             "Mime type must be "
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document "
             "for proposal documents."
@@ -473,7 +473,7 @@ class TestDocumentPatch(IntegrationTestCase):
                 method="PATCH",
                 headers=self.api_headers)
         self.assertEqual(
-            browser.json["error"]["message"],
+            browser.json["translated_message"],
             'File extension must be .docx for proposal documents.'
         )
 
@@ -489,14 +489,14 @@ class TestDocumentPatch(IntegrationTestCase):
             "file": None
         }
 
-        browser.exception_bubbling = True
         with browser.expect_http_error(code=403, reason="Forbidden"):
             browser.open(
                 document,
                 data=json.dumps(data),
                 method="PATCH",
                 headers=self.api_headers)
+
         self.assertEqual(
-            browser.json["error"]["message"],
-            "It's not possible to have no file in proposal documents."
+            browser.json["translated_message"],
+            "Proposal documents require a file."
         )

--- a/opengever/api/tests/test_errors.py
+++ b/opengever/api/tests/test_errors.py
@@ -1,0 +1,43 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+import json
+
+
+class TestGeverErrorHandling(IntegrationTestCase):
+
+    @browsing
+    def test_validation_errors_are_extendend_with_translated_field_errors(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        with browser.expect_http_error(code=400):
+            browser.open(self.empty_repofolder, method='PATCH',
+                         headers=self.api_headers,
+                         data=json.dumps({'reference_number_prefix': u'1'}))
+
+        self.assertEqual(
+            {u'type': u'BadRequest',
+             u'additional_metadata': {
+                 u'fields': [
+                     {u'field': u'reference_number',
+                      u'translated_message': u'The reference_number 1 is already in use.',
+                      u'type': u'ValidationError'}
+                 ]},
+             u'translated_message': u'Inputs not valid',
+             u'message': u"[{'field': 'reference_number', 'message': u'msg_reference_already_in_use', 'error': 'ValidationError'}]"},
+            browser.json)
+
+    @browsing
+    def test_errros_with_message_factory_messages_are_extended_with_translation(self, browser):
+        self.login(self.regular_user, browser)
+
+        with browser.expect_http_error(code=403):
+            browser.open(self.private_dossier, view='/@move',
+                         data=json.dumps({"source": self.document.absolute_url()}),
+                         method='POST', headers=self.api_headers)
+
+        self.assertEqual(
+            {u'additional_metadata': {},
+             u'message': u'msg_docs_cant_be_moved_from_repo_to_private_repo',
+             u'translated_message': u'Documents within the repository cannot be moved to the private repository.',
+             u'type': u'Forbidden'},
+            browser.json)

--- a/opengever/api/tests/test_move.py
+++ b/opengever/api/tests/test_move.py
@@ -47,9 +47,12 @@ class TestMove(IntegrationTestCase):
                          data=json.dumps({"source": self.document.absolute_url()}),
                          method='POST', headers=self.api_headers)
 
-        self.assertEqual({u'type': u'Forbidden', u'message':
-                          u'Documents within the repository cannot be moved to the templates.'},
-                         browser.json)
+        self.assertEqual(
+            {u'additional_metadata': {},
+             u'message': u'msg_docs_cant_be_moved_from_repo_to_templates',
+             u'translated_message': u'Documents within the repository cannot be moved to the templates.',
+             u'type': u'Forbidden'},
+            browser.json)
 
     @browsing
     def test_document_within_inbox_cannot_be_moved_to_templates(self, browser):
@@ -60,9 +63,12 @@ class TestMove(IntegrationTestCase):
                          data=json.dumps({"source": self.inbox_document.absolute_url()}),
                          method='POST', headers=self.api_headers)
 
-        self.assertEqual({u'type': u'Forbidden', u'message':
-                          u'Documents within the inbox cannot be moved to the templates.'},
-                         browser.json)
+        self.assertEqual(
+            {u'additional_metadata': {},
+             u'message': u'msg_docs_cant_be_moved_from_inbox_to_templates',
+             u'translated_message': u'Documents within the inbox cannot be moved to the templates.',
+             u'type': u'Forbidden'},
+            browser.json)
 
     @browsing
     def test_move_document_within_private_folder_is_possible(self, browser):
@@ -91,8 +97,10 @@ class TestMove(IntegrationTestCase):
                          method='POST', headers=self.api_headers)
 
         self.assertEqual(
-            {u'type': u'Forbidden', u'message':
-             u'Documents within the repository cannot be moved to the private repository.'},
+            {u'additional_metadata': {},
+             u'message': u'msg_docs_cant_be_moved_from_repo_to_private_repo',
+             u'translated_message': u'Documents within the repository cannot be moved to the private repository.',
+             u'type': u'Forbidden'},
             browser.json)
 
     @browsing
@@ -116,8 +124,10 @@ class TestMove(IntegrationTestCase):
                          method='POST', headers=self.api_headers)
 
         self.assertEqual(
-            {u'type': u'Forbidden', u'message':
-             u'Documents within the inbox cannot be moved to the private repository.'},
+            {u'additional_metadata': {},
+             u'message': u'msg_docs_cant_be_moved_from_inbox_to_private_repo',
+             u'translated_message': u'Documents within the inbox cannot be moved to the private repository.',
+             u'type': u'Forbidden'},
             browser.json)
 
     @browsing
@@ -129,8 +139,12 @@ class TestMove(IntegrationTestCase):
                          data=json.dumps({"source": self.taskdocument.absolute_url()}),
                          method='POST', headers=self.api_headers)
 
-        self.assertEqual({u'type': u'Forbidden', u'message':
-                          u'Documents inside a task cannot be moved.'}, browser.json)
+        self.assertEqual(
+            {u'additional_metadata': {},
+             u'message': u'msg_doc_inside_task_cant_be_moved',
+             u'translated_message': u'Documents inside a task cannot be moved.',
+             u'type': u'Forbidden'},
+            browser.json)
 
     @browsing
     def test_mail_inside_a_task_cannot_be_moved(self, browser):
@@ -142,8 +156,12 @@ class TestMove(IntegrationTestCase):
                          data=json.dumps({"source": mail.absolute_url()}),
                          method='POST', headers=self.api_headers)
 
-        self.assertEqual({u'type': u'Forbidden', u'message':
-                          u'Documents inside a task cannot be moved.'}, browser.json)
+        self.assertEqual(
+            {u'additional_metadata': {},
+             u'message': u'msg_doc_inside_task_cant_be_moved',
+             u'translated_message': u'Documents inside a task cannot be moved.',
+             u'type': u'Forbidden'},
+            browser.json)
 
     @browsing
     def test_document_inside_a_proposal_cannot_be_moved(self, browser):
@@ -154,8 +172,12 @@ class TestMove(IntegrationTestCase):
                          data=json.dumps({"source": self.proposaldocument.absolute_url()}),
                          method='POST', headers=self.api_headers)
 
-        self.assertEqual({u'type': u'Forbidden', u'message':
-                          u'Documents inside a proposal cannot be moved.'}, browser.json)
+        self.assertEqual(
+            {u'additional_metadata': {},
+             u'message': u'msg_doc_inside_proposal_cant_be_moved',
+             u'translated_message': u'Documents inside a proposal cannot be moved.',
+             u'type': u'Forbidden'},
+            browser.json)
 
     @browsing
     def test_mail_inside_a_proposal_cannot_be_moved(self, browser):
@@ -167,8 +189,12 @@ class TestMove(IntegrationTestCase):
                          data=json.dumps({"source": mail.absolute_url()}),
                          method='POST', headers=self.api_headers)
 
-        self.assertEqual({u'type': u'Forbidden', u'message':
-                          u'Documents inside a proposal cannot be moved.'}, browser.json)
+        self.assertEqual(
+            {u'additional_metadata': {},
+             u'message': u'msg_doc_inside_proposal_cant_be_moved',
+             u'translated_message': u'Documents inside a proposal cannot be moved.',
+             u'type': u'Forbidden'},
+            browser.json)
 
     @browsing
     def test_document_inside_a_closed_dossier_cannot_be_moved(self, browser):
@@ -179,8 +205,12 @@ class TestMove(IntegrationTestCase):
                          data=json.dumps({"source": self.expired_document.absolute_url()}),
                          method='POST', headers=self.api_headers)
 
-        self.assertEqual({u'type': u'Forbidden', u'message':
-                          u'Documents inside a closed dossier cannot be moved.'}, browser.json)
+        self.assertEqual(
+            {u'additional_metadata': {},
+             u'message': u'msg_doc_inside_closed_dossier',
+             u'translated_message': u'Documents inside a closed dossier cannot be moved.',
+             u'type': u'Forbidden'},
+            browser.json)
 
     @browsing
     def test_mail_inside_a_closed_dossier_cannot_be_moved(self, browser):
@@ -192,8 +222,12 @@ class TestMove(IntegrationTestCase):
                          data=json.dumps({"source": self.mail_eml.absolute_url()}),
                          method='POST', headers=self.api_headers)
 
-        self.assertEqual({u'type': u'Forbidden', u'message':
-                          u'Documents inside a closed dossier cannot be moved.'}, browser.json)
+        self.assertEqual(
+            {u'additional_metadata': {},
+             u'message': u'msg_doc_inside_closed_dossier',
+             u'translated_message': u'Documents inside a closed dossier cannot be moved.',
+             u'type': u'Forbidden'},
+            browser.json)
 
     @browsing
     def test_moving_dossier_respects_maximum_dossier_depth(self, browser):
@@ -205,7 +239,9 @@ class TestMove(IntegrationTestCase):
                          method='POST', headers=self.api_headers)
 
         self.assertEqual(
-            {u'message': u'This would exceed maximally allowed dossier depth.',
+            {u'additional_metadata': {},
+             u'message': u'msg_would_exceed_max_dossier_level',
+             u'translated_message': u'This would exceed the maximally allowed dossier depth.',
              u'type': u'Forbidden'},
             browser.json)
 
@@ -231,7 +267,9 @@ class TestMove(IntegrationTestCase):
                          method='POST', headers=self.api_headers)
 
         self.assertEqual(
-            {u'message': u'This would exceed maximally allowed dossier depth.',
+            {u'additional_metadata': {},
+             u'message': u'msg_would_exceed_max_dossier_level',
+             u'translated_message': u'This would exceed the maximally allowed dossier depth.',
              u'type': u'Forbidden'},
             browser.json)
 

--- a/opengever/api/tests/test_participation.py
+++ b/opengever/api/tests/test_participation.py
@@ -506,13 +506,10 @@ class TestParticipationDelete(IntegrationTestCase):
                 method='DELETE',
                 headers=http_headers()
             )
-        self.assertEqual(
-            browser.json,
-            {
-                u'message': u'At least one principal must remain admin.',
-                u'type': u'BadRequest'
-            }
-        )
+
+        self.assertEqual(u'BadRequest', browser.json[u'type'])
+        self.assertEqual(u'At least one principal must remain admin.',
+                         browser.json[u'translated_message'])
 
     @browsing
     def test_cannot_delete_the_last_folder_admin_role_assignment(self, browser):
@@ -527,13 +524,10 @@ class TestParticipationDelete(IntegrationTestCase):
                 method='DELETE',
                 headers=http_headers()
             )
-        self.assertEqual(
-            browser.json,
-            {
-                u'message': u'At least one principal must remain admin.',
-                u'type': u'BadRequest'
-            }
-        )
+
+        self.assertEqual(u'BadRequest', browser.json[u'type'])
+        self.assertEqual(u'At least one principal must remain admin.',
+                         browser.json[u'translated_message'])
 
     @browsing
     def test_guest_cannot_use_the_endpoint(self, browser):
@@ -698,13 +692,10 @@ class TestParticipationPatch(IntegrationTestCase):
                 data=data,
                 headers=http_headers()
             )
-        self.assertEqual(
-            browser.json,
-            {
-                u'message': u'At least one principal must remain admin.',
-                u'type': u'BadRequest'
-            }
-        )
+
+        self.assertEqual(u'BadRequest', browser.json[u'type'])
+        self.assertEqual(u'At least one principal must remain admin.',
+                         browser.json[u'translated_message'])
 
     @browsing
     def test_cannot_modify_the_last_folder_admin_role_assignment(self, browser):
@@ -724,13 +715,10 @@ class TestParticipationPatch(IntegrationTestCase):
                 data=data,
                 headers=http_headers()
             )
-        self.assertEqual(
-            browser.json,
-            {
-                u'message': u'At least one principal must remain admin.',
-                u'type': u'BadRequest'
-            }
-        )
+
+        self.assertEqual(u'BadRequest', browser.json[u'type'])
+        self.assertEqual(u'At least one principal must remain admin.',
+                         browser.json[u'translated_message'])
 
     @browsing
     def test_modify_a_users_local_role_on_folder(self, browser):

--- a/opengever/api/tests/test_repository_folder.py
+++ b/opengever/api/tests/test_repository_folder.py
@@ -24,11 +24,15 @@ class TestRepositoryFolderPost(IntegrationTestCase):
             browser.open(self.repository_root, data=json.dumps(data),
                          method='POST', headers=self.api_headers)
 
+        self.assertEqual(u'BadRequest', browser.json[u'type'])
         self.assertEqual(
-            u"[{'field': 'reference_number', "
-            "'message': 'The reference_number 1 is already in use.', "
-            "'error': 'ValidationError'}]",
-            browser.json['message'])
+            u'Inputs not valid', browser.json[u'translated_message'])
+        self.assertEqual(
+            {u'fields': [
+                {u'field': u'reference_number',
+                 u'translated_message': u'The reference_number 1 is already in use.',
+                 u'type': u'ValidationError'}]},
+            browser.json[u'additional_metadata'])
 
 
 class TestRepositoryFolderPatch(IntegrationTestCase):
@@ -46,11 +50,15 @@ class TestRepositoryFolderPatch(IntegrationTestCase):
             browser.open(self.empty_repofolder, data=json.dumps(data),
                          method='PATCH', headers=self.api_headers)
 
+        self.assertEqual(u'BadRequest', browser.json[u'type'])
         self.assertEqual(
-            u"[{'field': 'reference_number', "
-            "'message': 'The reference_number 1 is already in use.', "
-            "'error': 'ValidationError'}]",
-            browser.json['message'])
+            u'Inputs not valid', browser.json[u'translated_message'])
+        self.assertEqual(
+            {u'fields': [
+                {u'field': u'reference_number',
+                 u'translated_message': u'The reference_number 1 is already in use.',
+                 u'type': u'ValidationError'}]},
+            browser.json[u'additional_metadata'])
 
     @browsing
     def test_patch_allows_unchanged_reference_number_prefix(self, browser):

--- a/opengever/api/tests/test_team.py
+++ b/opengever/api/tests/test_team.py
@@ -139,8 +139,15 @@ class TestTeamPost(IntegrationTestCase):
                          data=json.dumps(self.valid_data))
 
         self.assertEquals(
-            {u'message': u"[{'field': 'groupid', 'message': u'Constraint not satisfied', 'error': ConstraintNotSatisfied(u'not-existing')}]",
-             u'type': u'BadRequest'},
+            {u'type': u'BadRequest',
+             u'additional_metadata': {
+                 u'fields': [
+                     {u'field': u'groupid',
+                      u'translated_message': u'Constraint not satisfied',
+                      u'type': u'not-existing'}]},
+             u'translated_message': u'Inputs not valid',
+             u'message': u"[{'field': 'groupid', 'message': u'Constraint "
+             "not satisfied', 'error': ConstraintNotSatisfied(u'not-existing')}]"},
             browser.json)
 
     @browsing
@@ -155,8 +162,15 @@ class TestTeamPost(IntegrationTestCase):
                          data=json.dumps(self.valid_data))
 
         self.assertEquals(
-            {u'message': u"[{'field': 'groupid', 'message': u'Required input is missing.', 'error': RequiredMissing('groupid')}]",
-             u'type': u'BadRequest'},
+            {u'type': u'BadRequest',
+             u'additional_metadata': {
+                 u'fields': [
+                     {u'field': u'groupid',
+                      u'translated_message': u'Required input is missing.',
+                      u'type': u'groupid'}]
+             },
+             u'translated_message': u'Inputs not valid',
+             u'message': u"[{'field': 'groupid', 'message': u'Required input is missing.', 'error': RequiredMissing('groupid')}]"},
             browser.json)
 
 
@@ -190,10 +204,14 @@ class TestTeamPatch(IntegrationTestCase):
             browser.open(url, method='PATCH', headers=self.api_headers,
                          data=json.dumps(data))
 
+        self.assertEquals(u'BadRequest', browser.json['type'])
         self.assertEquals(
-            {u'message': u"[{'field': 'groupid', 'message': u'Constraint not satisfied', 'error': ConstraintNotSatisfied(u'not-existing')}]",
-             u'type': u'BadRequest'},
-            browser.json)
+            u'Inputs not valid', browser.json['translated_message'])
+        self.assertEquals(
+            {u'fields': [{u'field': u'groupid',
+                          u'translated_message': u'Constraint not satisfied',
+                          u'type': u'not-existing'}]},
+            browser.json['additional_metadata'])
 
     @browsing
     def test_raises_not_found_for_not_existing_team(self, browser):

--- a/opengever/api/tests/test_trash.py
+++ b/opengever/api/tests/test_trash.py
@@ -26,8 +26,9 @@ class TestTrashAPI(IntegrationTestCase):
         with browser.expect_http_error(code=400, reason='Bad Request'):
             browser.open(self.document.absolute_url() + '/@trash',
                          method='POST', headers={'Accept': 'application/json'})
+
         self.assertEqual(
-            browser.json[u'error'][u'message'], u'Already trashed')
+            browser.json['translated_message'], u'Already trashed')
 
     @browsing
     def test_trash_checked_out_document_gives_bad_request(self, browser):
@@ -39,7 +40,7 @@ class TestTrashAPI(IntegrationTestCase):
             browser.open(self.document.absolute_url() + '/@trash',
                          method='POST', headers={'Accept': 'application/json'})
         self.assertEqual(
-            browser.json[u'error'][u'message'],
+            browser.json['translated_message'],
             u'Cannot trash a checked-out document')
 
     @browsing
@@ -53,7 +54,7 @@ class TestTrashAPI(IntegrationTestCase):
             browser.open(excerpt.absolute_url() + '/@trash',
                          method='POST', headers={'Accept': 'application/json'})
         self.assertEqual(
-            browser.json[u'error'][u'message'],
+            browser.json['translated_message'],
             u'Cannot trash a document that has been returned as excerpt')
 
     @browsing
@@ -65,7 +66,7 @@ class TestTrashAPI(IntegrationTestCase):
                          method='POST', headers={'Accept': 'application/json'})
 
         self.assertEqual(
-            browser.json[u'error'][u'message'],
+            browser.json['translated_message'],
             u'Object is not trashable')
 
     @browsing
@@ -88,6 +89,7 @@ class TestTrashAPI(IntegrationTestCase):
         with browser.expect_http_error(code=401, reason='Unauthorized'):
             browser.open(self.normal_template, view='/@trash',
                          method='POST', headers={'Accept': 'application/json'})
+
         self.assertEqual(
             browser.json[u'message'],
             u'You are not authorized to access this resource.')

--- a/opengever/api/tests/test_update.py
+++ b/opengever/api/tests/test_update.py
@@ -1,0 +1,27 @@
+from ftw.testbrowser import browsing
+from opengever.dossier.behaviors.protect_dossier import IProtectDossier
+from opengever.testing import IntegrationTestCase
+from plone.locking.interfaces import IRefreshableLockable
+import json
+
+
+class TestGeverContentPatch(IntegrationTestCase):
+
+    @browsing
+    def test_extend_locked_error_with_translation(self, browser):
+        self.login(self.administrator)
+        IRefreshableLockable(self.dossier, None).lock()
+
+        self.login(self.regular_user, browser=browser)
+
+        with browser.expect_http_error(code=403):
+            browser.open(self.dossier,
+                         data=json.dumps({'title': 'New title'}),
+                         method='PATCH', headers=self.api_headers)
+
+        self.assertEqual(
+            {u'additional_metadata': {},
+             u'message': u'msg_resource_locked',
+             u'translated_message': u'Resource is locked.',
+             u'type': u'Forbidden'},
+            browser.json)

--- a/opengever/api/tests/test_upload_structure.py
+++ b/opengever/api/tests/test_upload_structure.py
@@ -27,7 +27,7 @@ class TestUploadStructure(SolrIntegrationTestCase):
                          method='POST',
                          headers=self.api_headers)
 
-        self.assertEqual(message, browser.json['message'])
+        self.assertEqual(message, browser.json['translated_message'])
         self.assertEqual(u'BadRequest', browser.json['type'])
 
     @browsing
@@ -108,8 +108,12 @@ class TestUploadStructure(SolrIntegrationTestCase):
                          data=json.dumps(payload),
                          method='POST',
                          headers=self.api_headers)
+
         self.assertEqual(
-            {u'message': u"Property 'files' is required", u'type': u'BadRequest'},
+            {u'additional_metadata': {},
+             u'message': u'msg_prop_file_required',
+             u'translated_message': u"Property 'files' is required",
+             u'type': u'BadRequest'},
             browser.json)
 
     @browsing

--- a/opengever/api/trash.py
+++ b/opengever/api/trash.py
@@ -1,6 +1,8 @@
+from opengever.api import _
 from opengever.trash.trash import ITrasher
 from opengever.trash.trash import TrashError
 from plone.restapi.services import Service
+from zExceptions import BadRequest
 from zope.interface import alsoProvides
 import plone.protect.interfaces
 
@@ -18,37 +20,26 @@ class TrashPost(Service):
         try:
             trasher.trash()
         except TrashError as exc:
-            self.request.response.setStatus(400)
             if exc.message == 'Already trashed':
-                return {'error': {
-                    'type': 'Bad Request',
-                    'message': 'Already trashed',
-                }}
+                raise BadRequest(
+                    _(u'msg_already_trashed', default=u'Already trashed'))
             elif exc.message == 'Document checked out':
-                return {'error': {
-                    'type': 'Bad Request',
-                    'message': 'Cannot trash a checked-out document',
-                }}
+                raise BadRequest(
+                    _(u'msg_trash_checked_out_doc',
+                      default=u'Cannot trash a checked-out document'))
             elif exc.message == 'The document is locked':
-                return {'error': {
-                    'type': 'Bad Request',
-                    'message': 'Cannot trash a locked document',
-                }}
+                raise BadRequest(
+                    _(u'msg_trash_locked_doc', default=u'Cannot trash a locked document'))
             elif exc.message == 'The document has been returned as excerpt':
-                return {'error': {
-                    'type': 'Bad Request',
-                    'message': 'Cannot trash a document that has been returned as excerpt',
-                }}
+                raise BadRequest(
+                    _(u'msg_trash_doc_returned_as_excerpt',
+                      default=u'Cannot trash a document that has been returned as excerpt'))
             elif exc.message == 'Not trashable':
-                return {'error': {
-                    'type': 'Bad Request',
-                    'message': 'Object is not trashable',
-                }}
+                raise BadRequest(
+                    _(u'msg_obj_not_trashable', default=u'Object is not trashable'))
             else:
-                return {'error': {
-                    'type': 'Bad Request',
-                    'message': 'Object is not trashable',
-                }}
+                raise BadRequest(
+                    _(u'msg_obj_not_trashable', default=u'Object is not trashable'))
 
         self.request.response.setStatus(204)
         return super(TrashPost, self).reply()

--- a/opengever/api/update.py
+++ b/opengever/api/update.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
+from opengever.api import _
 from opengever.dossier.behaviors.protect_dossier import IProtectDossier
 from opengever.dossier.behaviors.protect_dossier import IProtectDossierMarker
 from plone.restapi.deserializer import json_body
 from plone.restapi.services.content.update import ContentPatch
+from zExceptions import Forbidden
 from zope.schema import getFieldNames
 
 
@@ -11,6 +13,14 @@ class GeverContentPatch(ContentPatch):
     """
     def reply(self):
         result = super(GeverContentPatch, self).reply()
+
+        if self.request.response.status == 403 and \
+           result.get('error', {}).get('message') == u'Resource is locked.':
+            # Check if its a locked error and raise Forbiden instead of
+            # setting the status directly. So we can return a translated
+            # error message.
+            raise Forbidden(
+                _(u'msg_resource_locked', default=u'Resource is locked.'))
 
         if IProtectDossierMarker.providedBy(self.context):
             protect_fields = getFieldNames(IProtectDossier)

--- a/opengever/api/upload_structure.py
+++ b/opengever/api/upload_structure.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 from ftw.solr.interfaces import ISolrSearch
 from ftw.solr.query import make_path_filter
+from opengever.api import _
 from opengever.document.document import is_email_upload
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.interfaces import IDossierContainerTypes
@@ -165,7 +166,9 @@ class DefaultUploadStructureAnalyser(object):
         allowed = [fti.getId() for fti in self.context.allowedContentTypes()]
         for portal_type in portal_types:
             if portal_type not in allowed:
-                raise TypeNotAddable("Some of the objects cannot be added here")
+                raise TypeNotAddable(
+                    _('msg_some_objects_not_addable',
+                      u'Some of the objects cannot be added here'))
 
 
 class DossierDepthCheckMixin(object):
@@ -184,9 +187,11 @@ class DossierDepthCheckMixin(object):
         max_depth = api.portal.get_registry_record(
             name='maximum_dossier_depth',
             interface=IDossierContainerTypes
-            )
+        )
         if self.current_depth + self.structure["max_container_depth"] > max_depth + 1:
-            raise MaximalDepthExceeded("Maximum dossier depth exceeded")
+            raise MaximalDepthExceeded(
+                _(u'msg_max_dossier_depth_exceeded',
+                  default=u'Maximum dossier depth exceeded'))
 
 
 @adapter(IDossierMarker)
@@ -273,10 +278,15 @@ class UploadStructurePost(Service):
         data = json_body(self.request)
         files = data.get("files", None)
         if not files:
-            raise BadRequest("Property 'files' is required")
+            raise BadRequest(_(u'msg_prop_file_required',
+                               default=u"Property 'files' is required"))
         for file in files:
             if not file:
-                raise BadRequest("Empty filename not supported")
+                raise BadRequest(
+                    _(u'msg_filename_required',
+                      default=u"Empty filename not supported"))
+
+                raise BadRequest("")
         return files
 
     def reply(self):

--- a/opengever/base/monkey/patches/__init__.py
+++ b/opengever/base/monkey/patches/__init__.py
@@ -3,7 +3,6 @@ from .cmf_catalog_aware import PatchCMFCatalogAware
 from .cmf_catalog_aware import PatchCMFCatalogAwareHandlers
 from .content_history_viewlet import PatchFullHistory
 from .default_values import PatchBuilderCreate
-from .default_values import PatchDeserializeFromJson
 from .default_values import PatchDexterityContentGetattr
 from .default_values import PatchDexterityDefaultAddForm
 from .default_values import PatchDXCreateContentInContainer
@@ -51,7 +50,6 @@ PatchCMFCatalogAwareHandlers()()
 PatchCMFEditonsHistoryHandlerTool()()
 PatchContentRulesHandlerOnLogin()()
 PatchCopyContainerVerifyObjectPaste()()
-PatchDeserializeFromJson()()
 PatchDexterityContentGetattr()()
 PatchDexterityDefaultAddForm()()
 PatchDXContainerPastePermission()()

--- a/opengever/base/monkey/patches/default_values.py
+++ b/opengever/base/monkey/patches/default_values.py
@@ -526,33 +526,3 @@ class PatchTransmogrifyDXSchemaUpdater(MonkeyPatch):
         self.patch_refs(
             DexterityUpdateSection, 'update_field',
             update_field)
-
-
-class PatchDeserializeFromJson(MonkeyPatch):
-    """Patch default JSON deserializer from plone.restapi, to make sure not
-    set values are prefilled with default or missing values.
-    """
-
-    def __call__(self):
-        from Acquisition import aq_inner
-        from Acquisition import aq_parent
-        from opengever.base.default_values import set_default_values
-        from plone.restapi.deserializer import json_body
-
-        def __call__(self, validate_all=False, data=None, create=False):
-            if data is None:
-                data = json_body(self.request)
-
-            # set default values
-            if create:
-                container = aq_parent(aq_inner(self.context))
-                set_default_values(self.context, container, data)
-
-            # super call
-            return original___call__(self, validate_all, data, create)
-
-        from plone.restapi.deserializer.dxcontent import DeserializeFromJson
-        locals()['__patch_refs__'] = False
-        original___call__ = DeserializeFromJson.__call__
-
-        self.patch_refs(DeserializeFromJson, '__call__', __call__)

--- a/opengever/core/tests/test_view_security.py
+++ b/opengever/core/tests/test_view_security.py
@@ -41,6 +41,7 @@ WHITELIST = (
     # during traversal or publish, in both cases security may not yet
     # properly set up
     'opengever.base.browser.errors.ErrorHandlingView',
+    'opengever.api.errors.GeverErrorHandling',
 
     # These views are registered for the IInternalOpengeverRequestLayer only
     # and thus are not reachable with a normal request:

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-09-08 14:44+0000\n"
+"POT-Creation-Date: 2021-11-05 08:34+0000\n"
 "PO-Revision-Date: 2017-10-13 14:27+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -679,6 +679,46 @@ msgstr "Dieses Dokument wird von ${creator} gerade in Office Online bearbeitet."
 #: ./opengever/document/checkout/cancel.py
 msgid "msg_cancel_checkout_on_mail_not_possible"
 msgstr "Das Dokument `${title}` konnte nicht ausgecheckt werden, da Mails den Check-in-/Check-out-Prozess nicht unterstützen."
+
+#. Default: "Documents inside a closed dossier cannot be moved."
+#: ./opengever/document/move.py
+msgid "msg_doc_inside_closed_dossier"
+msgstr "Dokumente innerhalb von abgeschlossenen Dossiers können nicht verschoben werden."
+
+#. Default: "Documents inside a proposal cannot be moved."
+#: ./opengever/document/move.py
+msgid "msg_doc_inside_proposal_cant_be_moved"
+msgstr "Dokumente innerhalb von Anträgen können nicht verschoben werden."
+
+#. Default: "Documents inside a task cannot be moved."
+#: ./opengever/document/move.py
+msgid "msg_doc_inside_task_cant_be_moved"
+msgstr "Dokumente innerhalb von Aufgaben können nicht verschoben werden."
+
+#. Default: "Documents within the inbox cannot be moved to the private repository."
+#: ./opengever/document/move.py
+msgid "msg_docs_cant_be_moved_from_inbox_to_private_repo"
+msgstr "Dokumente in der Inbox können nicht in die private Ablage verschoben werden."
+
+#. Default: "Documents within the inbox cannot be moved to the templates."
+#: ./opengever/document/move.py
+msgid "msg_docs_cant_be_moved_from_inbox_to_templates"
+msgstr "Dokumente in der Inbox können nicht in eine Vorlage verschoben werden."
+
+#. Default: "Documents within the repository cannot be moved to the private repository."
+#: ./opengever/document/move.py
+msgid "msg_docs_cant_be_moved_from_repo_to_private_repo"
+msgstr "Dokumente im Ordnungssystem können nicht in die private Ablage verschoben werden."
+
+#. Default: "Documents within the repository cannot be moved to the templates."
+#: ./opengever/document/move.py
+msgid "msg_docs_cant_be_moved_from_repo_to_templates"
+msgstr "Dokumente im Ordnungssystem können nicht in eine Vorlage verschoben werden."
+
+#. Default: "Locked documents cannot be moved."
+#: ./opengever/document/move.py
+msgid "msg_locked_doc_cant_be_moved"
+msgstr "Gesperrte Dokumente können nicht verschoben werden."
 
 #. Default: "PDF generation error"
 #: ./opengever/document/browser/save_pdf_document_under.py

--- a/opengever/document/locales/en/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/en/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-09-08 14:44+0000\n"
+"POT-Creation-Date: 2021-11-05 08:34+0000\n"
 "PO-Revision-Date: 2017-10-13 14:27+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -820,6 +820,46 @@ msgstr "This document is being edited in Office Online by ${creator}."
 #: ./opengever/document/checkout/cancel.py
 msgid "msg_cancel_checkout_on_mail_not_possible"
 msgstr "Could not cancel checkout for document ${title}, emails do not support the checkout process."
+
+#. Default: "Documents inside a closed dossier cannot be moved."
+#: ./opengever/document/move.py
+msgid "msg_doc_inside_closed_dossier"
+msgstr "Documents inside a closed dossier cannot be moved."
+
+#. Default: "Documents inside a proposal cannot be moved."
+#: ./opengever/document/move.py
+msgid "msg_doc_inside_proposal_cant_be_moved"
+msgstr "Documents inside a proposal cannot be moved."
+
+#. Default: "Documents inside a task cannot be moved."
+#: ./opengever/document/move.py
+msgid "msg_doc_inside_task_cant_be_moved"
+msgstr "Documents inside a task cannot be moved."
+
+#. Default: "Documents within the inbox cannot be moved to the private repository."
+#: ./opengever/document/move.py
+msgid "msg_docs_cant_be_moved_from_inbox_to_private_repo"
+msgstr "Documents within the inbox cannot be moved to the private repository."
+
+#. Default: "Documents within the inbox cannot be moved to the templates."
+#: ./opengever/document/move.py
+msgid "msg_docs_cant_be_moved_from_inbox_to_templates"
+msgstr "Documents within the inbox cannot be moved to the templates."
+
+#. Default: "Documents within the repository cannot be moved to the private repository."
+#: ./opengever/document/move.py
+msgid "msg_docs_cant_be_moved_from_repo_to_private_repo"
+msgstr "Documents within the repository cannot be moved to the private repository."
+
+#. Default: "Documents within the repository cannot be moved to the templates."
+#: ./opengever/document/move.py
+msgid "msg_docs_cant_be_moved_from_repo_to_templates"
+msgstr "Documents within the repository cannot be moved to the templates."
+
+#. Default: "Locked documents cannot be moved."
+#: ./opengever/document/move.py
+msgid "msg_locked_doc_cant_be_moved"
+msgstr "Locked documents cannot be moved."
 
 #. German translation: Fehler beim PDF generieren
 #. Default: "PDF generation error"

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-09-08 14:44+0000\n"
+"POT-Creation-Date: 2021-11-05 08:34+0000\n"
 "PO-Revision-Date: 2017-09-03 08:50+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-document/fr/>\n"
@@ -676,6 +676,46 @@ msgstr "${creator} modifie actuellement ce document dans Office Online."
 #: ./opengever/document/checkout/cancel.py
 msgid "msg_cancel_checkout_on_mail_not_possible"
 msgstr "Le document `${title}` n'a pas pu être verrouillé, car les e-mails ne sont pas supportés par le processus de check-in / check-out."
+
+#. Default: "Documents inside a closed dossier cannot be moved."
+#: ./opengever/document/move.py
+msgid "msg_doc_inside_closed_dossier"
+msgstr ""
+
+#. Default: "Documents inside a proposal cannot be moved."
+#: ./opengever/document/move.py
+msgid "msg_doc_inside_proposal_cant_be_moved"
+msgstr ""
+
+#. Default: "Documents inside a task cannot be moved."
+#: ./opengever/document/move.py
+msgid "msg_doc_inside_task_cant_be_moved"
+msgstr ""
+
+#. Default: "Documents within the inbox cannot be moved to the private repository."
+#: ./opengever/document/move.py
+msgid "msg_docs_cant_be_moved_from_inbox_to_private_repo"
+msgstr ""
+
+#. Default: "Documents within the inbox cannot be moved to the templates."
+#: ./opengever/document/move.py
+msgid "msg_docs_cant_be_moved_from_inbox_to_templates"
+msgstr ""
+
+#. Default: "Documents within the repository cannot be moved to the private repository."
+#: ./opengever/document/move.py
+msgid "msg_docs_cant_be_moved_from_repo_to_private_repo"
+msgstr ""
+
+#. Default: "Documents within the repository cannot be moved to the templates."
+#: ./opengever/document/move.py
+msgid "msg_docs_cant_be_moved_from_repo_to_templates"
+msgstr ""
+
+#. Default: "Locked documents cannot be moved."
+#: ./opengever/document/move.py
+msgid "msg_locked_doc_cant_be_moved"
+msgstr ""
 
 #. Default: "PDF generation error"
 #: ./opengever/document/browser/save_pdf_document_under.py

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-09-08 14:44+0000\n"
+"POT-Creation-Date: 2021-11-05 08:34+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -673,6 +673,46 @@ msgstr ""
 #. Default: "Could not cancel checkout on document ${title}, mails does not support the checkin checkout process."
 #: ./opengever/document/checkout/cancel.py
 msgid "msg_cancel_checkout_on_mail_not_possible"
+msgstr ""
+
+#. Default: "Documents inside a closed dossier cannot be moved."
+#: ./opengever/document/move.py
+msgid "msg_doc_inside_closed_dossier"
+msgstr ""
+
+#. Default: "Documents inside a proposal cannot be moved."
+#: ./opengever/document/move.py
+msgid "msg_doc_inside_proposal_cant_be_moved"
+msgstr ""
+
+#. Default: "Documents inside a task cannot be moved."
+#: ./opengever/document/move.py
+msgid "msg_doc_inside_task_cant_be_moved"
+msgstr ""
+
+#. Default: "Documents within the inbox cannot be moved to the private repository."
+#: ./opengever/document/move.py
+msgid "msg_docs_cant_be_moved_from_inbox_to_private_repo"
+msgstr ""
+
+#. Default: "Documents within the inbox cannot be moved to the templates."
+#: ./opengever/document/move.py
+msgid "msg_docs_cant_be_moved_from_inbox_to_templates"
+msgstr ""
+
+#. Default: "Documents within the repository cannot be moved to the private repository."
+#: ./opengever/document/move.py
+msgid "msg_docs_cant_be_moved_from_repo_to_private_repo"
+msgstr ""
+
+#. Default: "Documents within the repository cannot be moved to the templates."
+#: ./opengever/document/move.py
+msgid "msg_docs_cant_be_moved_from_repo_to_templates"
+msgstr ""
+
+#. Default: "Locked documents cannot be moved."
+#: ./opengever/document/move.py
+msgid "msg_locked_doc_cant_be_moved"
 msgstr ""
 
 #. Default: "PDF generation error"

--- a/opengever/document/move.py
+++ b/opengever/document/move.py
@@ -1,5 +1,6 @@
 from OFS.CopySupport import ResourceLockedError
 from opengever.base.adapters import DefaultMovabilityChecker
+from opengever.document import _
 from opengever.document.behaviors import IBaseDocument
 from opengever.dossier.templatefolder.utils import is_within_templates
 from opengever.inbox.utils import is_within_inbox
@@ -15,27 +16,39 @@ class DocumentMovabiliyChecker(DefaultMovabilityChecker):
 
     def validate_movement(self, target):
         if self.context.is_inside_a_task():
-            raise Forbidden(u'Documents inside a task cannot be moved.')
+            raise Forbidden(
+                _(u'msg_doc_inside_task_cant_be_moved',
+                  u'Documents inside a task cannot be moved.'))
         if self.context.is_inside_a_proposal():
-            raise Forbidden(u'Documents inside a proposal cannot be moved.')
+            raise Forbidden(
+                _(u'msg_doc_inside_proposal_cant_be_moved',
+                  u'Documents inside a proposal cannot be moved.'))
         if self.context.is_inside_a_closed_dossier():
-            raise Forbidden(u'Documents inside a closed dossier cannot be moved.')
+            raise Forbidden(
+                _(u'msg_doc_inside_closed_dossier',
+                  default=u'Documents inside a closed dossier cannot be moved.'))
         if ILockable(self.context).locked():
-            raise ResourceLockedError(u'Locked documents cannot be moved.')
+            raise ResourceLockedError(
+                _('msg_locked_doc_cant_be_moved',
+                  default=u'Locked documents cannot be moved.'))
 
         if is_within_repository(self.context):
             if is_within_templates(target):
                 raise Forbidden(
-                    u'Documents within the repository cannot be moved to the templates.')
+                    _(u'msg_docs_cant_be_moved_from_repo_to_templates',
+                      u'Documents within the repository cannot be moved to the templates.'))
             if is_within_private_root(target):
                 raise Forbidden(
-                    u'Documents within the repository cannot be moved to the private repository.')
+                    _(u'msg_docs_cant_be_moved_from_repo_to_private_repo',
+                      u'Documents within the repository cannot be moved to the private repository.'))
             return
 
         if is_within_inbox(self.context):
             if is_within_templates(target):
                 raise Forbidden(
-                    u'Documents within the inbox cannot be moved to the templates.')
+                    _(u'msg_docs_cant_be_moved_from_inbox_to_templates',
+                      u'Documents within the inbox cannot be moved to the templates.'))
             if is_within_private_root(target):
                 raise Forbidden(
-                    u'Documents within the inbox cannot be moved to the private repository.')
+                    _(u'msg_docs_cant_be_moved_from_inbox_to_private_repo',
+                      u'Documents within the inbox cannot be moved to the private repository.'))

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-09-10 06:35+0000\n"
+"POT-Creation-Date: 2021-11-05 08:34+0000\n"
 "PO-Revision-Date: 2017-05-23 04:53+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -959,6 +959,11 @@ msgstr "Änderungen gespeichert"
 #: ./opengever/dossier/browser/redirect_to_maindossier.py
 msgid "msg_main_dossier_not_found"
 msgstr "Das Object `${title}` ist nicht in einem Dossier abgelegt."
+
+#. Default: "This would exceed maximally allowed dossier depth."
+#: ./opengever/dossier/move_items.py
+msgid "msg_would_exceed_max_dossier_level"
+msgstr "Würde die maximale Anzahl an Subdossier-Ebenen überschreiten."
 
 #: ./opengever/dossier/resolve.py
 msgid "not all documents and tasks are stored in a subdossier."

--- a/opengever/dossier/locales/en/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/en/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-09-10 06:35+0000\n"
+"POT-Creation-Date: 2021-11-05 08:34+0000\n"
 "PO-Revision-Date: 2017-05-23 04:53+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -1165,6 +1165,11 @@ msgstr "Changes saved"
 #: ./opengever/dossier/browser/redirect_to_maindossier.py
 msgid "msg_main_dossier_not_found"
 msgstr "Object `${title}` is not stored inside a dossier."
+
+#. Default: "This would exceed maximally allowed dossier depth."
+#: ./opengever/dossier/move_items.py
+msgid "msg_would_exceed_max_dossier_level"
+msgstr "This would exceed the maximally allowed dossier depth."
 
 #. German translation: Es sind nicht alle Dokumente und Aufgaben in Subdossiers abgelegt.
 #: ./opengever/dossier/resolve.py

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-09-10 06:35+0000\n"
+"POT-Creation-Date: 2021-11-05 08:34+0000\n"
 "PO-Revision-Date: 2017-12-03 11:16+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/fr/>\n"
@@ -957,6 +957,11 @@ msgstr "Modifications sauvegardées"
 #: ./opengever/dossier/browser/redirect_to_maindossier.py
 msgid "msg_main_dossier_not_found"
 msgstr "L'objet `${title}`n'est déposé dans aucun dossier."
+
+#. Default: "This would exceed maximally allowed dossier depth."
+#: ./opengever/dossier/move_items.py
+msgid "msg_would_exceed_max_dossier_level"
+msgstr ""
 
 #: ./opengever/dossier/resolve.py
 msgid "not all documents and tasks are stored in a subdossier."

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-09-10 06:35+0000\n"
+"POT-Creation-Date: 2021-11-05 08:34+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -955,6 +955,11 @@ msgstr ""
 #. Default: "The object `${title}` is not stored inside a dossier."
 #: ./opengever/dossier/browser/redirect_to_maindossier.py
 msgid "msg_main_dossier_not_found"
+msgstr ""
+
+#. Default: "This would exceed maximally allowed dossier depth."
+#: ./opengever/dossier/move_items.py
+msgid "msg_would_exceed_max_dossier_level"
 msgstr ""
 
 #: ./opengever/dossier/resolve.py

--- a/opengever/dossier/move_items.py
+++ b/opengever/dossier/move_items.py
@@ -119,27 +119,28 @@ class MoveItemsForm(form.Form):
                 try:
                     IMovabilityChecker(obj).validate_movement(destination)
                 except Forbidden as exc:
-                    if exc.message == u'Documents inside a task cannot be moved.':
+                    if exc.message == u'msg_doc_inside_task_cant_be_moved':
                         msg = _(
                             'label_not_movable_since_inside_task',
                             default=u'Document ${name} is inside a task and '
                                     u'therefore not movable. Move the task '
                                     u'instead',
                             mapping=dict(name=obj.title))
-                    elif exc.message == u'Documents inside a proposal cannot be moved.':
+                    elif exc.message == u'msg_doc_inside_task_cant_be_moved':
                         msg = _(
                             'label_not_movable_since_inside_proposal',
                             default=u'Document ${name} is inside a proposal '
                                     u'and therefore not movable. Move the '
                                     u'proposal instead',
                             mapping=dict(name=obj.title))
-                    elif exc.message == u'This would exceed maximally allowed dossier depth.':
+                    elif exc.message == u'msg_would_exceed_max_dossier_level':
                         msg = _(
                             'label_not_movable_since_exceeds_maximum_depth',
                             default=u'Dossier ${name} cannot be moved because '
                             'it would exceed the maximum allowed dossier depth.',
                             mapping=dict(name=obj.title))
                     else:
+                        import pdb; pdb.set_trace()
                         raise Exception(
                             'Failed to determine the reason for unmovable object. '
                             'Did IMovabilityChecker change?'
@@ -383,7 +384,9 @@ class DossierMovabiliyChecker(DefaultMovabilityChecker):
         substructure_depth = self.dossier_structure_depth()
 
         if not target.is_dossier_structure_addable(substructure_depth):
-            raise Forbidden(u'This would exceed maximally allowed dossier depth.')
+            raise Forbidden(
+                _(u'msg_would_exceed_max_dossier_level',
+                  u'This would exceed maximally allowed dossier depth.'))
 
     def dossier_structure_depth(self):
         subdossiers = self.context.get_subdossiers(unrestricted=True)

--- a/opengever/locking/tests/test_locks.py
+++ b/opengever/locking/tests/test_locks.py
@@ -262,9 +262,11 @@ class TestDocumentsLockedWithMeetingSubmittedLock(IntegrationTestCase, MoveItems
 
         self.assertEqual(400, browser.status_code)
         self.assertEqual(
-            {u'message': u'Cannot trash a locked document',
-             u'type': u'Bad Request'},
-            browser.json['error'])
+            {u'type': u'BadRequest',
+             u'additional_metadata': {},
+             u'translated_message': u'Cannot trash a locked document',
+             u'message': u'msg_trash_locked_doc'},
+            browser.json)
         self.assertFalse(ITrashed.providedBy(self.document))
 
 

--- a/opengever/virusscan/tests/test_virusscan_validator.py
+++ b/opengever/virusscan/tests/test_virusscan_validator.py
@@ -190,10 +190,8 @@ class TestVirusScanValidator(IntegrationTestCase):
 
         self.assertEqual(400, browser.status_code)
         self.assertEqual(0, len(children['added']))
-        self.assertEqual(
-            u"[{'message': 'file_infected', "
-            u"'error': 'ValidationError'}]",
-            browser.json['message'])
+        self.assertEqual(u'Error - Virus detected!',
+                         browser.json['translated_message'])
 
         data['file']['data'] = "No virus"
         with self.observe_children(self.empty_dossier) as children:
@@ -228,10 +226,8 @@ class TestVirusScanValidator(IntegrationTestCase):
                          method='PATCH', headers=self.api_headers)
 
         self.assertEqual(400, browser.status_code)
-        self.assertEqual(
-            u"[{'message': 'file_infected', "
-            u"'error': 'ValidationError'}]",
-            browser.json['message'])
+        self.assertEqual(u'Error - Virus detected!',
+                         browser.json['translated_message'])
 
         data['file']['data'] = "No virus"
         browser.open(self.document, data=json.dumps(data),
@@ -251,10 +247,8 @@ class TestVirusScanValidator(IntegrationTestCase):
                          method='POST', headers=self.api_headers)
 
         self.assertEqual(0, len(children['added']))
-        self.assertEqual(
-            u"[{'message': 'file_infected', "
-            u"'error': 'ValidationError'}]",
-            browser.json['message'])
+        self.assertEqual(u'Error - Virus detected!',
+                         browser.json['translated_message'])
 
         data['archival_file']['data'] = "No virus"
         with self.observe_children(self.empty_dossier) as children:
@@ -293,9 +287,11 @@ class TestVirusScanValidator(IntegrationTestCase):
         self.assertEqual(400, browser.status_code)
         self.assertEqual(0, len(children['added']))
         self.assertEqual(
-            u"[{'message': 'file_infected', "
-            u"'error': 'ValidationError'}]",
-            browser.json['message'])
+            {u'type': u'BadRequest',
+             u'additional_metadata': {},
+             u'translated_message': u'Error - Virus detected!',
+             u'message': u"[{'message': u'file_infected', 'error': 'ValidationError'}]"},
+            browser.json)
 
         data['message']['data'] = "No virus"
         with self.observe_children(self.empty_dossier) as children:
@@ -318,9 +314,11 @@ class TestVirusScanValidator(IntegrationTestCase):
         self.assertEqual(400, browser.status_code)
         self.assertEqual(0, len(children['added']))
         self.assertEqual(
-            u"[{'message': 'file_infected', "
-            u"'error': 'ValidationError'}]",
-            browser.json['message'])
+            {u'type': u'BadRequest',
+             u'additional_metadata': {},
+             u'translated_message': u'Error - Virus detected!',
+             u'message': u"[{'message': u'file_infected', 'error': 'ValidationError'}]"},
+            browser.json)
 
         msg = base64.b64encode(load('testmail.msg'))
         data['message']['data'] = msg

--- a/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-11-03 13:04+0000\n"
+"POT-Creation-Date: 2021-11-05 08:53+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -281,6 +281,11 @@ msgstr "Videokonferenz URL"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_workspaces"
 msgstr "Teamräume"
+
+#. Default: "At least one principal must remain admin."
+#: ./opengever/workspace/participation/browser/manage_participants.py
+msgid "msg_one_must_remain_admin"
+msgstr "Mindestens ein Teilnehmer muss Administrator bleiben."
 
 #. Default: "Comment"
 #: ./opengever/workspace/content_sharing_mailer.py

--- a/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-11-03 13:04+0000\n"
+"POT-Creation-Date: 2021-11-05 08:53+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -329,6 +329,11 @@ msgstr "Video conferencing URL"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_workspaces"
 msgstr "Workspaces"
+
+#. Default: "At least one principal must remain admin."
+#: ./opengever/workspace/participation/browser/manage_participants.py
+msgid "msg_one_must_remain_admin"
+msgstr "At least one principal must remain admin."
 
 #. German translation: Kommentar
 #. Default: "Comment"

--- a/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-11-03 13:04+0000\n"
+"POT-Creation-Date: 2021-11-05 08:53+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -281,6 +281,11 @@ msgstr "URL de vidéoconférence"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_workspaces"
 msgstr "Teamraüme"
+
+#. Default: "At least one principal must remain admin."
+#: ./opengever/workspace/participation/browser/manage_participants.py
+msgid "msg_one_must_remain_admin"
+msgstr ""
 
 #. Default: "Comment"
 #: ./opengever/workspace/content_sharing_mailer.py

--- a/opengever/workspace/locales/opengever.workspace.pot
+++ b/opengever/workspace/locales/opengever.workspace.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-11-03 13:04+0000\n"
+"POT-Creation-Date: 2021-11-05 08:53+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -277,6 +277,11 @@ msgstr ""
 #. Default: "Workspaces"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_workspaces"
+msgstr ""
+
+#. Default: "At least one principal must remain admin."
+#: ./opengever/workspace/participation/browser/manage_participants.py
+msgid "msg_one_must_remain_admin"
 msgstr ""
 
 #. Default: "Comment"

--- a/opengever/workspace/participation/browser/manage_participants.py
+++ b/opengever/workspace/participation/browser/manage_participants.py
@@ -3,6 +3,7 @@ from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.base.role_assignments import SharingRoleAssignment
 from opengever.ogds.base.actor import Actor
 from opengever.ogds.base.sources import PotentialWorkspaceMembersSource
+from opengever.workspace import _
 from opengever.workspace.participation import can_manage_member
 from opengever.workspace.participation import invitation_to_item
 from opengever.workspace.participation.storage import IInvitationStorage
@@ -176,7 +177,9 @@ class ManageParticipants(BrowserView):
             if ADMIN_ROLE in assignment.get('roles', []):
                 return
 
-        raise BadRequest('At least one principal must remain admin.')
+        raise BadRequest(
+            _(u'msg_one_must_remain_admin',
+              default=u'At least one principal must remain admin.'))
 
     def search(self):
         """ A traversable method to search for users"""


### PR DESCRIPTION
To provide translated and specific error message in the GEVER frontend, we need to extend the default error representation. This PR adds a Custom API errorHandling,  to return also a translated error message and further translated informations (ValidationErrors) if possible.

The custom handling only adds keys, so does not change the existing error format. A little example ...
_before:_
```json
{
  "message": "[{'fields': '' ... }]", 
  "type": "ValidationError",
}
```

_after:_
```json
{
  "message": "[{'fields': '' ... }]",
  "translated_message": "Validierung fehlgeschlagen"
  "type": "ValidationError",
  "additional_data:": {
    "fields": [
      {
        "field_name": "receipient_mail",
        "type": "RequiredMissing",
        "translated_message": "Fehlende Eingabe"
      }
    ]
  }
}
```

Furthermore the PR changes the error raising at some places and raise an Exception with a MessageFactory object instead of plain string message. So the CustomHandling automatically translates the message and the translated error message is uses by the gever-ui (see https://github.com/4teamwork/gever-ui/pull/2020).

For [CA-408]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
- New translations
  - [x] All msg-strings are unicode


[CA-408]: https://4teamwork.atlassian.net/browse/CA-408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ