### PR TITLE
Make workspace meeting start and end timezone aware.

### DIFF
--- a/changes/CA-3150.bugfix
+++ b/changes/CA-3150.bugfix
@@ -1,0 +1,1 @@
+Make workspace meeting start and end timezone aware. [njohner]

--- a/docs/schema-dumps/opengever.workspace.meeting.schema.json
+++ b/docs/schema-dumps/opengever.workspace.meeting.schema.json
@@ -16,14 +16,14 @@
             "title": "Beginn",
             "format": "datetime",
             "description": "",
-            "_zope_schema_type": "Datetime"
+            "_zope_schema_type": "UTCDatetime"
         },
         "end": {
             "type": "string",
             "title": "Ende",
             "format": "datetime",
             "description": "",
-            "_zope_schema_type": "Datetime"
+            "_zope_schema_type": "UTCDatetime"
         },
         "location": {
             "type": "string",

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -67,6 +67,7 @@
   <adapter factory=".field_deserializers.PersistentDatetimeFieldDeserializer" />
   <adapter factory=".field_deserializers.DateFieldDeserializer" />
   <adapter factory=".field_deserializers.DatetimeFieldDeserializer" />
+  <adapter factory=".field_deserializers.UTCDatetimeFieldDeserializer" />
   <adapter factory=".todo.SerializeToDoToJson" />
 
   <configure zcml:condition="installed z3c.relationfield">

--- a/opengever/api/tests/test_deserializer.py
+++ b/opengever/api/tests/test_deserializer.py
@@ -256,7 +256,7 @@ class TestDatetimeDeserialization(IntegrationTestCase):
         self.assertEqual(204, response.status_code)
 
     @browsing
-    def test_datetime_field_deserializer_rejects_year_before_1900(self, browser):
+    def test_utcdatetime_field_deserializer_rejects_year_before_1900(self, browser):
         self.login(self.workspace_member, browser)
         browser.raise_http_errors = False
 

--- a/opengever/base/schemadump/config.py
+++ b/opengever/base/schemadump/config.py
@@ -219,6 +219,8 @@ JSON_SCHEMA_FIELD_TYPES = {
         'type': 'string', 'format': 'date'},
     'Datetime': {
         'type': 'string', 'format': 'datetime'},
+    'UTCDatetime': {
+        'type': 'string', 'format': 'datetime'},
     'Float': {
         'type': 'number'},
     'Int': {

--- a/opengever/core/upgrades/20211105142527_make_workspace_meetings_timezone_aware/upgrade.py
+++ b/opengever/core/upgrades/20211105142527_make_workspace_meetings_timezone_aware/upgrade.py
@@ -1,0 +1,31 @@
+from ftw.upgrade import UpgradeStep
+from opengever.workspace.interfaces import IWorkspaceMeeting
+from pytz import utc
+
+
+class MakeWorkspaceMeetingsTimezoneAware(UpgradeStep):
+    """Make workspace meetings timezone aware.
+    """
+
+    def __call__(self):
+        query = {'object_provides': [IWorkspaceMeeting.__identifier__]}
+        for obj in self.objects(query, 'Ensure workspace meeting start and '
+                                'end are timezone aware'):
+            self.localize_field(obj, "start")
+            self.localize_field(obj, "end")
+            # This is somewhat a hack. By reindexing the full object we change
+            # the modified date, so that when checking whether the metadata has
+            # changed, we never reach the comparison with previous value for
+            # the start and end Fields, which would fail because we are
+            # comparing timezone naive and aware datetimes.
+            obj.reindexObject()
+
+    def localize_field(self, obj, fieldname):
+        value = getattr(obj, fieldname)
+        if not value:
+            return
+        if value.tzinfo is not None:
+            value = value.astimezone(utc)
+        else:
+            value = utc.localize(value)
+        setattr(obj, fieldname, value)

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -2219,7 +2219,7 @@ class OpengeverContentFixture(object):
             .within(self.workspace)
             .titled(u'Besprechung Kl\xe4ranlage')
             .having(
-                start=datetime(2016, 12, 8),
+                start=datetime(2016, 12, 8, tzinfo=pytz.UTC),
                 responsible=self.workspace_member.getId())
         ))
 

--- a/opengever/workspace/workspace_meeting.py
+++ b/opengever/workspace/workspace_meeting.py
@@ -1,3 +1,5 @@
+from ftw.datepicker.widget import DatePickerFieldWidget
+from opengever.base.schema import UTCDatetime
 from opengever.workspace import _
 from opengever.workspace.interfaces import IWorkspaceMeeting
 from plone.autoform import directives as form
@@ -7,7 +9,6 @@ from plone.supermodel import model
 from zope import schema
 from zope.interface import implements
 from zope.interface import provider
-from ftw.datepicker.widget import DatePickerFieldWidget
 
 
 @provider(IFormFieldProvider)
@@ -33,13 +34,13 @@ class IWorkspaceMeetingSchema(model.Schema):
 
     form.widget('start', DatePickerFieldWidget)
     form.order_after(start='responsible')
-    start = schema.Datetime(
+    start = UTCDatetime(
         title=_(u'label_start', default='Start'),
         required=True)
 
     form.widget('end', DatePickerFieldWidget)
     form.order_after(end='start')
-    end = schema.Datetime(
+    end = UTCDatetime(
         title=_(u'label_end', default='End'),
         required=False)
 


### PR DESCRIPTION
Start and end dates for `WorkspaceMeeting`s are sent as UTC from the frontend, but were stored as timezone naive on the objects. This leads to localization of the datetime when generating the PDF for the meeting to show the UTC start and end times. I chose to save the fields as localized datetimes on the objects instead.

Note that `UTCDatetime` fields are already stored as timezone aware in the classic UI, so would probably have been broken without the deserializer. As they were used only for meetings, which are not implemented in the new UI, this problem was not noticed before.

The upgrade step uses somewhat of a hack. By reindexing the full object we change the modified date, so that when checking whether the metadata has changed, we never reach the comparison with previous value for the start and end Fields, which would fail because we are comparing timezone naive and aware datetimes.

For [CA-3150]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed

[CA-3150]: https://4teamwork.atlassian.net/browse/CA-3150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ