### PR TITLE
Small correction to description of read/write access for dossier protection.

### DIFF
--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -346,7 +346,7 @@ msgstr "Wählen Sie Benutzer und Gruppen aus, welche im Dossier ausschliesslich 
 #. Default: "Choose users and groups which have readable and writing access to the dossier"
 #: ./opengever/dossier/behaviors/protect_dossier.py
 msgid "description_reading_and_writing"
-msgstr "Wählen Sie Benutzer und Gruppen aus, welche im Dossier lesend und schreibend Zugriff erhalten sollen. Die Benutzer dieser Gruppe werden dazu berechtigt, das Dossier zu bearbeiten, Inhalte zu erstellen und zu bearbeiten,  und der Status des Dossiers anzupassen (abschliessen, wieder eröffnen, stornieren und aktivieren)."
+msgstr "Wählen Sie Benutzer und Gruppen aus, welche im Dossier lesend und schreibend Zugriff erhalten sollen. Die Benutzer dieser Gruppe werden entsprechend dazu berechtigt, das Dossier zu bearbeiten, Inhalte zu erstellen und zu bearbeiten, und den Status des Dossiers anzupassen (abschliessen, wieder eröffnen, stornieren und reaktivieren)."
 
 #. Default: "The user can choose only from the defined keywords in a new dossier from template. It also prevents the user for creating new keywords"
 #: ./opengever/dossier/dossiertemplate/behaviors.py

--- a/opengever/dossier/locales/en/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/en/LC_MESSAGES/opengever.dossier.po
@@ -431,7 +431,7 @@ msgstr "Select users and/or groups that should get read-only access to this doss
 #. Default: "Choose users and groups which have readable and writing access to the dossier"
 #: ./opengever/dossier/behaviors/protect_dossier.py
 msgid "description_reading_and_writing"
-msgstr "Select users and/or groups that should get read/write access to this dossier. These users will be able to modify the dossier itself, add and edit content in it, as well as change its status (resolve, reopen, deactivate and activate)."
+msgstr "Select users and/or groups that should get read/write access to this dossier. These users will be able to modify the dossier itself, add and edit content in it, as well as change its status (resolve, reopen, deactivate and reactivate)."
 
 #. German translation: Durch Aktivieren dieser Option stehen bei der Erstellung des Dossiers ab Vorlage nur noch die in der Vorlage angegebenen Schlagwörter zur Auswahl.<br>Der Benutzer kann dadurch auch keine neuen Schlagwörter erfassen.
 #. Default: "The user can choose only from the defined keywords in a new dossier from template. It also prevents the user for creating new keywords"

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -344,7 +344,7 @@ msgstr "Choisissez les utilisateurs ou groupes obtenant accès en lecture seule 
 #. Default: "Choose users and groups which have readable and writing access to the dossier"
 #: ./opengever/dossier/behaviors/protect_dossier.py
 msgid "description_reading_and_writing"
-msgstr "Choisissez les utilisateurs ou groupes obtenant accès en lecture et écriture au dossier. Les utilisateurs de ce groupe seront autorisés à traiter le dossier (y compris le fermer, le rouvrir, l'annuler et l'activer), ainsi qu'à créer et modifier des contenus."
+msgstr "Choisissez les utilisateurs ou groupes obtenant accès en lecture et écriture au dossier. Les utilisateurs de ce groupe seront autorisés à traiter le dossier (y compris le fermer, le rouvrir, l'annuler et le réactiver), ainsi qu'à créer et modifier des contenus."
 
 #. Default: "The user can choose only from the defined keywords in a new dossier from template. It also prevents the user for creating new keywords"
 #: ./opengever/dossier/dossiertemplate/behaviors.py


### PR DESCRIPTION
There was a typo and the PO wants "reactivate" instead of "activate" for the activate transition. No changelog entry as there is already one from https://github.com/4teamwork/opengever.core/pull/7231.

For [CA-3131]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-3131]: https://4teamwork.atlassian.net/browse/CA-3131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ