### PR TITLE
Add flags to office connector url for attach action.

### DIFF
--- a/changes/CA-1815.feature
+++ b/changes/CA-1815.feature
@@ -1,0 +1,1 @@
+Add flags to office connector url for attach action. [tinagerber]


### PR DESCRIPTION
⚠️  Requires new OfficeConnector version.

The flags are used to tell the OfficeConnector which things are not needed in the mail. The interpretation of the flags is done in the OfficeConnector.

For [CA-1815]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-1815]: https://4teamwork.atlassian.net/browse/CA-1815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ