### PR TITLE
Update local roles after moving document when creating forwarding.

### DIFF
--- a/changes/CA-3085.bugfix
+++ b/changes/CA-3085.bugfix
@@ -1,0 +1,1 @@
+Update local roles after moving document when creating forwarding. [njohner]

--- a/opengever/inbox/forwarding.py
+++ b/opengever/inbox/forwarding.py
@@ -258,9 +258,9 @@ def move_documents_into_forwarding(context, event):
 
     for relation in relations:
         obj = relation.to_object
-        RoleAssignmentManager(obj).clear_by_reference(context)
         clipboard = aq_parent(aq_inner(obj)).manage_cutObjects(obj.id)
         context.manage_pasteObjects(clipboard)
+        RoleAssignmentManager(obj).clear_by_reference(context)
 
     context.relatedItems = []
 


### PR DESCRIPTION
Somehow this fixes an issue where creating a forwarding leads to the documents being moved into the forwarding appearing twice in the catalog: once with the old path and once with the new. It seems to have something to do with reindexing and event order, but I wasn't really able to pin it down.

I could not reproduce the issue in a test, probably because the issue is linked to collective indexing.

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-3085]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-3085]: https://4teamwork.atlassian.net/browse/CA-3085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ