### PR TITLE
Make sure preferred language is also used for API PATCH requests,

### DIFF
--- a/changes/CA-408.bugfix
+++ b/changes/CA-408.bugfix
@@ -1,0 +1,1 @@
+Make sure preferred language is used for API PATCH requests. [phgross]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -16,6 +16,7 @@ Breaking Changes
 Other Changes
 ^^^^^^^^^^^^^
 - Tasks provides an additional attribute ``is_completed``.
+- Patch request now returns translated values and error messages.
 
 
 2021.22.0 (2021-11-03)

--- a/opengever/api/tests/test_language.py
+++ b/opengever/api/tests/test_language.py
@@ -1,0 +1,30 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+import json
+
+
+class TestLanguageToolPatch(IntegrationTestCase):
+
+    @browsing
+    def test_patch_returns_translated_error_message(self, browser):
+        self.login(self.administrator, browser)
+
+        headers = {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+            'Accept-Language': 'de-ch'}
+        data = {'reference_number_prefix': '1'}
+        with browser.expect_http_error(code=400, reason='Bad Request'):
+            browser.open(self.empty_repofolder, data=json.dumps(data),
+                         method='PATCH', headers=headers)
+
+        self.assertEqual(u'BadRequest', browser.json[u'type'])
+        self.assertEqual(
+            u'Inputs not valid', browser.json[u'translated_message'])
+
+        self.assertEqual(
+            {u'fields': [{
+                u'field': u'reference_number',
+                u'translated_message': u'Das Aktenzeichen 1 wird bereits verwendet.',
+                u'type': u'ValidationError'}]},
+            browser.json['additional_metadata'])

--- a/opengever/base/monkey/patches/__init__.py
+++ b/opengever/base/monkey/patches/__init__.py
@@ -16,6 +16,7 @@ from .extendedpathindex import PatchExtendedPathIndex
 from .filter_trashed_from_catalog import PatchCatalogToFilterTrashedDocs
 from .history_handler_tool import PatchCMFEditonsHistoryHandlerTool
 from .jsonschema_for_portal_type import PatchGetJsonschemaForPortalType
+from .language_tool import PatchLanguageToolCall
 from .namedfile_data_converter import PatchNamedfileNamedDataConverter
 from .paste_permission import PatchDXContainerPastePermission
 from .plone_43rc1_upgrade import PatchPlone43RC1Upgrade
@@ -75,6 +76,7 @@ PatchZ2LogTimezone()()
 PatchZ3CFormChangedField()()
 PatchZ3CFormWidgetUpdate()()
 ScrubBoboExceptions()()
+PatchLanguageToolCall()()
 
 # These three patches implement role and permission filtering during RO mode.
 # We only apply these conditionally when RO mode actually is active.

--- a/opengever/base/monkey/patches/language_tool.py
+++ b/opengever/base/monkey/patches/language_tool.py
@@ -1,0 +1,30 @@
+from opengever.base.monkey.patching import MonkeyPatch
+from Products.PloneLanguageTool.LanguageTool import LanguageTool
+from ZPublisher.HTTPRequest import HTTPRequest
+
+
+class PatchLanguageToolCall(MonkeyPatch):
+    """"Patch LangugageTool to make sure the setLanguageBindings is also done
+    for PATCH requests
+    """
+
+    def __call__(self):
+
+        def __new__call__(self, container, req):
+            if req.other.has_key('LANGUAGE_TOOL'):
+                return None
+            if req.__class__ is not HTTPRequest:
+                return None
+
+            # patch: add PATCH to requests methods
+            if not req['REQUEST_METHOD'] in ('HEAD', 'GET', 'PUT', 'POST', 'PATCH'):
+                return None
+            if req.environ.has_key('WEBDAV_SOURCE_PORT'):
+                return None
+            # Bind the languages
+            self.setLanguageBindings()
+
+        locals()['__patch_refs__'] = False
+        original_call = LanguageTool.__call__
+
+        self.patch_refs(LanguageTool, '__call__', __new__call__)


### PR DESCRIPTION
by patching the language tool and add the `PATCH` request method to the supported ones.

this fix two issues: 
 - translate error messages also in PATCH requests
 - translate vocabulary values etc. when `return=representation` header is sent

For [CA-408]

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))


[CA-408]: https://4teamwork.atlassian.net/browse/CA-408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ