### PR TITLE
Revert "Add hard limit for number of ToDos in a single workspace."

### DIFF
--- a/changes/CA-1679-4.other
+++ b/changes/CA-1679-4.other
@@ -1,0 +1,1 @@
+Remove hardlimit of 500 todos per workspace. [elioschmutz]

--- a/opengever/workspace/configure.zcml
+++ b/opengever/workspace/configure.zcml
@@ -37,12 +37,6 @@
 
   <subscriber
       for="opengever.workspace.interfaces.IToDo
-           OFS.interfaces.IObjectWillBeAddedEvent"
-      handler=".subscribers.check_todo_add_preconditions"
-      />
-
-  <subscriber
-      for="opengever.workspace.interfaces.IToDo
            zope.lifecycleevent.interfaces.IObjectAddedEvent"
       handler=".subscribers.todo_added"
       />

--- a/opengever/workspace/subscribers.py
+++ b/opengever/workspace/subscribers.py
@@ -9,9 +9,7 @@ from opengever.workspace.activities import ToDoReopenedActivity
 from opengever.workspace.activities import WorkspaceWatcherManager
 from opengever.workspace.indexers import INDEXED_IN_MEETING_SEARCHABLE_TEXT
 from opengever.workspace.todo import COMPLETE_TODO_TRANSITION
-from plone import api
 from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
-from zExceptions import Forbidden
 from zope.container.interfaces import IContainerModifiedEvent
 from zope.globalrequest import getRequest
 
@@ -43,25 +41,6 @@ def check_delete_preconditions(todolist, event):
     if len(todolist.objectValues()):
         raise ValueError(
             'The todolist is not empty, therefore deletion is not allowed.')
-
-
-class ForbiddenByToDoLimit(Forbidden):
-    """Hard limit for the number of ToDos allowed in a
-    workspace has been reached."""
-
-
-TODO_NUMBER_LIMIT = 500
-
-
-def check_todo_add_preconditions(todo, event):
-    """We set a hard limit on the number of todos in a workspace
-    """
-    catalog = api.portal.get_tool("portal_catalog")
-    todos = catalog.unrestrictedSearchResults(
-                path=event.newParent.absolute_url_path(),
-                portal_type=todo.portal_type)
-    if len(todos) >= TODO_NUMBER_LIMIT:
-        raise ForbiddenByToDoLimit()
 
 
 def is_attribute_changed(event, attribute, schema):

--- a/opengever/workspace/tests/test_todo.py
+++ b/opengever/workspace/tests/test_todo.py
@@ -14,7 +14,6 @@ from unittest import skip
 from zExceptions import BadRequest
 from zope.schema import getSchemaValidationErrors
 import json
-import opengever.workspace.subscribers
 
 
 class TestToDo(SolrIntegrationTestCase):
@@ -114,31 +113,6 @@ class TestToDo(SolrIntegrationTestCase):
         self.commit_solr()
 
         self.assertTrue(solr_data_for(self.todo, 'is_completed'))
-
-    @browsing
-    def test_todo_number_hard_limit(self, browser):
-        self.login(self.workspace_member, browser)
-
-        catalog = api.portal.get_tool("portal_catalog")
-        todos = catalog.unrestrictedSearchResults(
-                    path=self.workspace.absolute_url_path(),
-                    portal_type='opengever.workspace.todo')
-        opengever.workspace.subscribers.TODO_NUMBER_LIMIT = len(todos) + 1
-
-        browser.visit(self.workspace)
-        factoriesmenu.add('To-do item')
-        form = browser.find_form_by_field('Title')
-        form.fill({'Title': u'Ein ToDo'})
-        form.save()
-
-        assert_no_error_messages(browser)
-
-        browser.visit(self.workspace)
-        factoriesmenu.add('To-do item')
-        form = browser.find_form_by_field('Title')
-        form.fill({'Title': u'Ein anderes ToDo'})
-        with browser.expect_http_error(500):
-            form.save()
 
     def test_todo_supports_responses(self):
         self.login(self.workspace_member)


### PR DESCRIPTION
This reverts commit 5c25a0be584a23c73d79dadca3d42d954180272a.

Since we improved the performance for todo listings, we do no longer need a hard limit.

For [CA-1679]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-1679]: https://4teamwork.atlassian.net/browse/CA-1679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ