### PR TITLE
Add support for KuB participations

### DIFF
--- a/changes/CA-2606_2.feature
+++ b/changes/CA-2606_2.feature
@@ -1,0 +1,1 @@
+Add KuB participations. [phgross, njohner]

--- a/opengever/dossier/configure.zcml
+++ b/opengever/dossier/configure.zcml
@@ -330,7 +330,7 @@
       name="execute-after-resolve-jobs"
       />
 
-  <adapter factory=".participations.PloneParticipationData" />
+  <adapter factory=".participations.PloneOrKuBParticipationData" />
   <adapter factory=".participations.SQLParticipationData" />
 
   <adapter factory=".move_items.DossierMovabiliyChecker" />

--- a/opengever/dossier/participations.py
+++ b/opengever/dossier/participations.py
@@ -247,7 +247,7 @@ class IParticipationData(Interface):
 
 @implementer(IParticipationData)
 @adapter(IParticipation)
-class PloneParticipationData(object):
+class PloneOrKuBParticipationData(object):
 
     def __init__(self, participation):
         self._participation = participation

--- a/opengever/kub/client.py
+++ b/opengever/kub/client.py
@@ -32,3 +32,15 @@ class KuBClient(object):
             {'Authorization': 'Token {}'.format(self.kub_service_token)})
 
         return session
+
+    def query(self, query_str):
+        url = u'{}search?q={}'.format(self.kub_api_url, query_str)
+        res = self.session.get(url)
+        return res.json()
+
+    def get_by_id(self, _id):
+        url = u'{}search?id={}'.format(self.kub_api_url, _id)
+        res = self.session.get(url).json()
+        if len(res) != 1:
+            raise LookupError()
+        return res[0]

--- a/opengever/kub/sources.py
+++ b/opengever/kub/sources.py
@@ -1,0 +1,40 @@
+from opengever.kub.client import KuBClient
+from z3c.formwidget.query.interfaces import IQuerySource
+from zope.interface import implementer
+from zope.interface import implements
+from zope.schema.interfaces import IContextSourceBinder
+from zope.schema.interfaces import IVocabularyFactory
+from zope.schema.vocabulary import SimpleTerm
+
+
+@implementer(IQuerySource)
+class KuBContactsSource(object):
+
+    def __init__(self, context):
+        self.context = context
+        self.terms = []
+        self.client = KuBClient()
+
+    def getTermByToken(self, token):
+        if not token:
+            raise LookupError
+
+        item = self.client.get_by_id(token)
+        return SimpleTerm(value=item['typedId'], title=item['text'])
+
+    def search(self, query_string):
+        items = self.client.query(query_string)
+        self.terms = [
+            SimpleTerm(value=item['typedId'], title=item['text'])
+            for item in items]
+
+        return self.terms
+
+
+@implementer(IContextSourceBinder)
+class KuBContactsSourceBinder(object):
+
+    implements(IVocabularyFactory)
+
+    def __call__(self, context):
+        return KuBContactsSource(context)

--- a/opengever/kub/testing.py
+++ b/opengever/kub/testing.py
@@ -98,4 +98,5 @@ KUB_RESPONSES = {
             "modified": "2021-11-15T14:24:40.986000+01:00"
         }
     ],
+    "http://localhost:8000/api/v1/search?id=invalid-id": [],
 }

--- a/opengever/kub/testing.py
+++ b/opengever/kub/testing.py
@@ -1,0 +1,101 @@
+from opengever.kub.client import KuBClient
+from opengever.kub.interfaces import IKuBSettings
+from opengever.testing import IntegrationTestCase
+from plone import api
+
+
+class KuBIntegrationTestCase(IntegrationTestCase):
+
+    person_jean = "person:9af7d7cc-b948-423f-979f-587158c6bc65"
+    person_julie = "person:0e623708-2d0d-436a-82c6-c1a9c27b65dc"
+    org_ftw = "organization:30bab83d-300a-4886-97d4-ff592e88a56a"
+    memb_jean_ftw = "membership:8345fcfe-2d67-4b75-af46-c25b2f387448"
+
+    def setUp(self):
+        super(KuBIntegrationTestCase, self).setUp()
+        api.portal.set_registry_record(
+            'base_url', u'http://localhost:8000', IKuBSettings)
+        api.portal.set_registry_record('service_token', u'secret', IKuBSettings)
+        self.client = KuBClient()
+
+    def mock_get_by_id(self, mocker, _id):
+        url = u'{}search?id={}'.format(self.client.kub_api_url, _id)
+        mocker.get(url, json=KUB_RESPONSES[url])
+        return url
+
+    def mock_search(self, mocker, query_str):
+        url = u'{}search?q={}'.format(self.client.kub_api_url, query_str)
+        mocker.get(url, json=KUB_RESPONSES[url])
+        return url
+
+
+# These responses are taken from performing these exact requests against
+# the database defined in "fixtures/gever-testing.json" in the KUB repository.
+KUB_RESPONSES = {
+    "http://localhost:8000/api/v1/search?q=Julie": [
+        {
+            "id": "0e623708-2d0d-436a-82c6-c1a9c27b65dc",
+            "typedId": "person:0e623708-2d0d-436a-82c6-c1a9c27b65dc",
+            "type": "person",
+            "thirdPartyId": None,
+            "text": "Dupont Julie",
+            "created": "2021-11-15T12:31:36.571000+01:00",
+            "modified": "2021-11-15T12:31:36.571000+01:00"
+        }
+    ],
+    "http://localhost:8000/api/v1/search?q=4Teamwork": [
+        {
+            "id": "30bab83d-300a-4886-97d4-ff592e88a56a",
+            "typedId": "organization:30bab83d-300a-4886-97d4-ff592e88a56a",
+            "type": "organization",
+            "thirdPartyId": None,
+            "text": "4Teamwork",
+            "created": "2021-11-15T14:24:40.986000+01:00",
+            "modified": "2021-11-15T14:24:40.986000+01:00"
+        },
+        {
+            "id": "8345fcfe-2d67-4b75-af46-c25b2f387448",
+            "typedId": "membership:8345fcfe-2d67-4b75-af46-c25b2f387448",
+            "type": "membership",
+            "thirdPartyId": None,
+            "text": "Dupont Jean - 4Teamwork (CEO)",
+            "created": "2021-11-15T14:25:12.517000+01:00",
+            "modified": "2021-11-15T14:25:12.517000+01:00",
+            "organization": "30bab83d-300a-4886-97d4-ff592e88a56a"
+        }
+    ],
+    "http://localhost:8000/api/v1/search?id=person:9af7d7cc-b948-423f-979f-587158c6bc65": [
+        {
+            "id": "9af7d7cc-b948-423f-979f-587158c6bc65",
+            "typedId": "person:9af7d7cc-b948-423f-979f-587158c6bc65",
+            "type": "person",
+            "thirdPartyId": None,
+            "text": "Dupont Jean",
+            "created": "2021-11-15T12:31:03.461000+01:00",
+            "modified": "2021-11-15T12:31:03.461000+01:00"
+        }
+    ],
+    "http://localhost:8000/api/v1/search?id=membership:8345fcfe-2d67-4b75-af46-c25b2f387448": [
+        {
+            "id": "8345fcfe-2d67-4b75-af46-c25b2f387448",
+            "typedId": "membership:8345fcfe-2d67-4b75-af46-c25b2f387448",
+            "type": "membership",
+            "thirdPartyId": None,
+            "text": "Dupont Jean - 4Teamwork (CEO)",
+            "created": "2021-11-15T14:25:12.517000+01:00",
+            "modified": "2021-11-15T14:25:12.517000+01:00",
+            "organization": "30bab83d-300a-4886-97d4-ff592e88a56a"
+        }
+    ],
+    "http://localhost:8000/api/v1/search?id=organization:30bab83d-300a-4886-97d4-ff592e88a56a": [
+        {
+            "id": "30bab83d-300a-4886-97d4-ff592e88a56a",
+            "typedId": "organization:30bab83d-300a-4886-97d4-ff592e88a56a",
+            "type": "organization",
+            "thirdPartyId": None,
+            "text": "4Teamwork",
+            "created": "2021-11-15T14:24:40.986000+01:00",
+            "modified": "2021-11-15T14:24:40.986000+01:00"
+        }
+    ],
+}

--- a/opengever/kub/tests/test_kub_contact_source.py
+++ b/opengever/kub/tests/test_kub_contact_source.py
@@ -1,0 +1,62 @@
+from opengever.kub.sources import KuBContactsSource
+from opengever.kub.testing import KuBIntegrationTestCase
+import requests_mock
+
+
+@requests_mock.Mocker()
+class TestKubContactSource(KuBIntegrationTestCase):
+
+    def setUp(self):
+        super(TestKubContactSource, self).setUp()
+        self.source = KuBContactsSource(None)
+
+    def test_search_returns_persons(self, mocker):
+        query_str = "Julie"
+        self.mock_search(mocker, query_str)
+
+        terms = self.source.search(query_str)
+        self.assertItemsEqual([self.person_julie],
+                              [term.token for term in terms])
+        self.assertItemsEqual([self.person_julie],
+                              [term.value for term in terms])
+        self.assertItemsEqual(['Dupont Julie'],
+                              [term.title for term in terms])
+
+    def test_search_returns_memberships_and_organizations(self, mocker):
+        query_str = "4Teamwork"
+        self.mock_search(mocker, query_str)
+        terms = self.source.search(query_str)
+
+        self.assertItemsEqual([self.org_ftw, self.memb_jean_ftw],
+                              [term.token for term in terms])
+        self.assertItemsEqual([self.org_ftw, self.memb_jean_ftw],
+                              [term.value for term in terms])
+        self.assertItemsEqual(["Dupont Jean - 4Teamwork (CEO)", "4Teamwork"],
+                              [term.title for term in terms])
+
+    def test_get_term_by_token_handles_persons(self, mocker):
+        self.mock_get_by_id(mocker, self.person_jean)
+        term = self.source.getTermByToken(self.person_jean)
+        self.assertEqual(self.person_jean, term.token)
+        self.assertEqual(self.person_jean, term.value)
+        self.assertEqual('Dupont Jean', term.title)
+
+    def test_get_by_id_handles_organizations(self, mocker):
+        self.mock_get_by_id(mocker, self.org_ftw)
+        term = self.source.getTermByToken(self.org_ftw)
+        self.assertEqual(self.org_ftw, term.token)
+        self.assertEqual(self.org_ftw, term.value)
+        self.assertEqual('4Teamwork', term.title)
+
+    def test_get_by_id_handles_memberships(self, mocker):
+        self.mock_get_by_id(mocker, self.memb_jean_ftw)
+        term = self.source.getTermByToken(self.memb_jean_ftw)
+        self.assertEqual(self.memb_jean_ftw, term.token)
+        self.assertEqual(self.memb_jean_ftw, term.value)
+        self.assertEqual('Dupont Jean - 4Teamwork (CEO)', term.title)
+
+    def test_get_by_id_raises_lookup_error_for_invalid_token(self, mocker):
+        contact_id = "invalid-id"
+        self.mock_get_by_id(mocker, contact_id)
+        with self.assertRaises(LookupError):
+            self.source.getTermByToken(contact_id)

--- a/opengever/ogds/base/actor.py
+++ b/opengever/ogds/base/actor.py
@@ -708,10 +708,9 @@ class ActorLookup(object):
         return self.identifier.startswith('contact:')
 
     def is_kub_contact(self):
-        if not is_kub_feature_enabled():
-            return False
         kub_contact_prefixes = ('organization:', 'person:', 'membership:')
-        return any(map(self.identifier.startswith, kub_contact_prefixes))
+        return (any(map(self.identifier.startswith, kub_contact_prefixes)) and
+                is_kub_feature_enabled())
 
     def is_sql_contact(self):
         sql_contact_prefixes = ['organization:', 'person:', 'org_role:']


### PR DESCRIPTION
With this PR we add support for KuB participations.

For the tests I used real responses from a KUB deployment with data from a fixture (see https://github.com/4teamwork/kub/pull/49), so that we can easily update the responses if KuB were to change.

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-2606]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-2606]: https://4teamwork.atlassian.net/browse/CA-2606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ