### PR TITLE
Fix tika uninstall upgradestep.

### DIFF
--- a/opengever/core/upgrades/20211119083157_uninstall_ftw_tika/upgrade.py
+++ b/opengever/core/upgrades/20211119083157_uninstall_ftw_tika/upgrade.py
@@ -6,4 +6,10 @@ class UninstallFtwTika(UpgradeStep):
     """
 
     def __call__(self):
+        # In some cases the tika product is still installed but the profile is
+        # no longer installed. This makes it hard to uninstall the product.
+        # Therefore we reinstall the profile and uninstall the product
+        # afterwards.
+        self.setup_install_profile('ftw.tika:default')
+
         self.uninstall_product('ftw.tika')


### PR DESCRIPTION
When deploying #7249 on dev, I realized a problem with the uninstall profile in tika. 

It seems that in some cases the tika product is still installed but the profile is no longer installed. This makes is hard to uninstall the product. Therefore we reinstall the profile and uninstall the product afterwards.
For [CA-1212]

## Checklist
- [x] Changelog entry _(not necessary)_
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-1212]: https://4teamwork.atlassian.net/browse/CA-1212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ