### PR TITLE
Include documents manually added to submitted proposal in meeting Zip and protocol data.

### DIFF
--- a/changes/CA-3230.bugfix
+++ b/changes/CA-3230.bugfix
@@ -1,0 +1,1 @@
+Include documents manually added to submitted proposal in meeting Zip and protocol data. [njohner]

--- a/opengever/api/tests/test_proposal.py
+++ b/opengever/api/tests/test_proposal.py
@@ -198,7 +198,7 @@ class TestProposalSerialization(IntegrationTestCase):
             browser.json['predecessor_proposal'])
 
 
-class TestSubmitAdditionalDocumentsNJ(IntegrationTestCase):
+class TestSubmitAdditionalDocuments(IntegrationTestCase):
 
     features = (
         'meeting',
@@ -287,7 +287,10 @@ class TestSubmitAdditionalDocumentsNJ(IntegrationTestCase):
 
         model = self.proposal.load_model()
         self.assertEqual(1, len(model.submitted_documents))
-        previously_submitted = model.resolve_submitted_documents()[0]
+        documents = model.resolve_submitted_proposal().get_documents()
+        self.assertEqual(1, len(documents))
+
+        previously_submitted = documents[0]
 
         data = json.dumps({
             'documents': [self.subdocument.UID(), self.mail_eml.UID()]
@@ -307,8 +310,10 @@ class TestSubmitAdditionalDocumentsNJ(IntegrationTestCase):
 
         self.assertEqual(2, len(children["added"]))
         self.assertEqual(3, len(model.submitted_documents))
+        documents = model.resolve_submitted_proposal().get_documents()
+        self.assertEqual(3, len(documents))
         self.assertItemsEqual(list(children['added']) + [previously_submitted],
-                              model.resolve_submitted_documents())
+                              documents)
 
     @browsing
     def test_submitting_additional_document_already_up_to_date(self, browser):
@@ -333,7 +338,9 @@ class TestSubmitAdditionalDocumentsNJ(IntegrationTestCase):
 
         model = self.proposal.load_model()
         self.assertEqual(1, len(model.submitted_documents))
-        self.assertEqual(model.resolve_submitted_documents()[0].file.data,
+        documents = model.resolve_submitted_proposal().get_documents()
+        self.assertEqual(1, len(documents))
+        self.assertEqual(documents[0].file.data,
                          self.document.file.data)
 
         versioner = Versioner(self.document)
@@ -343,7 +350,9 @@ class TestSubmitAdditionalDocumentsNJ(IntegrationTestCase):
 
         model = self.proposal.load_model()
         self.assertEqual(1, len(model.submitted_documents))
-        self.assertNotEqual(model.resolve_submitted_documents()[0].file.data,
+        documents = model.resolve_submitted_proposal().get_documents()
+        self.assertEqual(1, len(documents))
+        self.assertNotEqual(documents[0].file.data,
                             self.document.file.data)
 
         data = json.dumps({
@@ -361,6 +370,8 @@ class TestSubmitAdditionalDocumentsNJ(IntegrationTestCase):
 
         model = self.proposal.load_model()
         self.assertEqual(1, len(model.submitted_documents))
-        self.assertEqual(model.resolve_submitted_documents()[0].file.data,
+        documents = model.resolve_submitted_proposal().get_documents()
+        self.assertEqual(1, len(documents))
+        self.assertEqual(documents[0].file.data,
                          self.document.file.data)
-        self.assertEqual("New", model.resolve_submitted_documents()[0].file.data)
+        self.assertEqual("New", documents[0].file.data)

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -106,7 +106,7 @@ class AgendaItem(Base):
         if not self.has_proposal:
             return
 
-        documents = self.proposal.resolve_submitted_documents()
+        documents = self.get_documents()
         if not documents:
             return
 

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -293,6 +293,11 @@ class AgendaItem(Base):
     def has_submitted_documents(self):
         return self.has_proposal and self.proposal.has_submitted_documents()
 
+    def get_documents(self):
+        if not self.has_proposal:
+            return []
+        return self.proposal.resolve_submitted_proposal().get_documents()
+
     def resolve_submitted_documents(self):
         if not self.has_proposal:
             return []

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -298,12 +298,6 @@ class AgendaItem(Base):
             return []
         return self.proposal.resolve_submitted_proposal().get_documents()
 
-    def resolve_submitted_documents(self):
-        if not self.has_proposal:
-            return []
-
-        return self.proposal.resolve_submitted_documents()
-
     def has_submitted_excerpt_document(self):
         return self.has_proposal and self.proposal.has_submitted_excerpt_document()
 

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -287,9 +287,6 @@ class Proposal(Base):
     def resolve_submitted_proposal(self):
         return self.submitted_oguid.resolve_object()
 
-    def resolve_submitted_documents(self):
-        return [doc.resolve_submitted() for doc in self.submitted_documents]
-
     def has_submitted_documents(self):
         return bool(self.submitted_documents)
 

--- a/opengever/meeting/tests/test_protocol_json_data.py
+++ b/opengever/meeting/tests/test_protocol_json_data.py
@@ -124,6 +124,20 @@ class TestProtocolJsonData(FunctionalTestCase):
         expected_data['meeting']['date'] = '13.12.2011'
         self.assertDictEqual(expected_data, data)
 
+    def test_protocol_json_includes_documents_manually_added_to_submitted_proposals(self):
+        self.doc3 = create(Builder("document")
+                           .titled(u'Nachtrag')
+                           .within(self.submitted_proposal)
+                           .attach_file_containing("lorem ipsum",
+                                                   name=u"nachtrag.txt"))
+        with freeze(datetime(2018, 5, 4)):
+            data = ProtocolData(self.meeting).get_processed_data()
+
+        expected_data = copy.deepcopy(SAMPLE_MEETING_DATA['agenda_items'][0])
+        expected_data['attachments'].append(
+            {'filename': u'Nachtrag.txt', 'title': u'Nachtrag'})
+        self.assertEqual(expected_data, data["agenda_items"][0])
+
     def test_date_formatting_string_affects_protocol_json(self):
         api.portal.set_registry_record("sablon_date_format_string", u'%Y %m %d', interface=IMeetingSettings)
         with freeze(datetime(2018, 5, 4)):

--- a/opengever/meeting/tests/test_traverser.py
+++ b/opengever/meeting/tests/test_traverser.py
@@ -1,6 +1,8 @@
-from opengever.testing import IntegrationTestCase
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import factoriesmenu
 from opengever.meeting.traverser import MeetingDocumentWithFileTraverser
 from opengever.meeting.traverser import MeetingTraverser
+from opengever.testing import IntegrationTestCase
 
 
 class MeetingTraverserTestImplementation(MeetingTraverser):
@@ -33,8 +35,15 @@ class TestMeetingTraverser(IntegrationTestCase):
 
     features = ('meeting',)
 
-    def test_meeting_traverser_traverses_all_documents(self):
-        self.login(self.committee_responsible)
+    @browsing
+    def test_meeting_traverser_traverses_all_documents(self, browser):
+        self.login(self.committee_responsible, browser)
+
+        browser.open(self.submitted_proposal)
+        factoriesmenu.add(u'Document')
+        browser.fill({
+            u'Title': "Doc added in submitted proposal",
+            u'File': ("Lorem ipsum", 'new.txt', 'text/plain')}).save()
 
         proposal_agenda_item = self.schedule_proposal(
             self.meeting, self.submitted_proposal)

--- a/opengever/meeting/traverser.py
+++ b/opengever/meeting/traverser.py
@@ -69,7 +69,7 @@ class MeetingTraverser(object):
         return agenda_item.resolve_document()
 
     def _get_agenda_item_attachments(self, agenda_item):
-        return agenda_item.resolve_submitted_documents()
+        return agenda_item.get_documents()
 
     def _get_agenda_item_excerpts(self, agenda_item):
         return agenda_item.get_excerpt_documents()


### PR DESCRIPTION
With this PR we fix a bug where documents added to a submitted proposal would not get included in the meeting Zip file. I also decided to include such documents in the `ProtocolData`.

For [CA-3230]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-3230]: https://4teamwork.atlassian.net/browse/CA-3230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ