### PR TITLE
Fix create-policy command.

### DIFF
--- a/changes/CA-3132.bugfix
+++ b/changes/CA-3132.bugfix
@@ -1,0 +1,1 @@
+Fix create-policy command. [njohner]

--- a/opengever/policytemplates/cli.py
+++ b/opengever/policytemplates/cli.py
@@ -34,6 +34,8 @@ class CreatePolicyCLI(object):
         args.append(template)
 
         args.append('--config={}'.format(init_file))
+        if 'opengever.core.testserver.OPENGEVER_TESTSERVER' in remainder:
+            remainder.remove('opengever.core.testserver.OPENGEVER_TESTSERVER')
         if remainder:
             args.extend(remainder)
 


### PR DESCRIPTION
It seems that the create-policy command was broken when improving the test-server. The changes (https://github.com/4teamwork/opengever.core/commit/d7730d5f04a4c0cd348afd51ca03f70b7d5794a8#diff-2ecaec2b2900eb97131d5ac85d4c1ffa016b109208a4bbb8378075d79de9ce06L14) lead to an unrecognised argument being passed to the command. We simply fix this by removing the argument before calling mrbob.

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-3132]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-3132]: https://4teamwork.atlassian.net/browse/CA-3132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ