### PR TITLE
@reminders does not raise anymore when no reminder is set.

### DIFF
--- a/changes/CA-3066.bugfix
+++ b/changes/CA-3066.bugfix
@@ -1,0 +1,1 @@
+@reminders does not raise anymore when no reminder is set. [njohner]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,7 +11,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
-
+- @reminders now returns 204 NoContent when no reminder is set.
 
 2021.23.0 (2021-11-17)
 ----------------------

--- a/opengever/api/reminder.py
+++ b/opengever/api/reminder.py
@@ -27,7 +27,7 @@ class TaskReminderGet(Service):
     def reply(self):
         reminder = self.context.get_reminder()
         if not reminder:
-            raise NotFound
+            return self.reply_no_content()
 
         reminder_data = reminder.serialize(json_compat=True)
         reminder_data['@id'] = '/'.join((self.context.absolute_url(), '@reminder'))

--- a/opengever/api/tests/test_reminder.py
+++ b/opengever/api/tests/test_reminder.py
@@ -37,6 +37,17 @@ class TestTaskReminderAPI(IntegrationTestCase):
             browser.json)
 
     @browsing
+    def test_get_returns_no_content_when_no_reminder_is_set(self, browser):
+        self.login(self.regular_user, browser)
+
+        browser.open(
+            self.task.absolute_url() + '/@reminder',
+            method='GET',
+            headers=self.http_headers,
+        )
+        self.assertEqual(204, browser.status_code)
+
+    @browsing
     def test_post_adds_task_reminder(self, browser):
         self.login(self.regular_user, browser)
         payload = {'option_type': ReminderOneDayBefore.option_type}


### PR DESCRIPTION
I would not consider that a breaking API change...

For [CA-3066]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- API change:
  - [ ] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed

[CA-3066]: https://4teamwork.atlassian.net/browse/CA-3066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ