### PR TITLE
Extend API Support for dispositions

### DIFF
--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -12,6 +12,8 @@ Breaking Changes
 Other Changes
 ^^^^^^^^^^^^^
 - @reminders now returns 204 NoContent when no reminder is set.
+- Added API support for dispositions objects.
+
 
 2021.23.0 (2021-11-17)
 ----------------------

--- a/docs/public/dev-manual/api/dispositions.rst
+++ b/docs/public/dev-manual/api/dispositions.rst
@@ -1,0 +1,84 @@
+.. _dispositions:
+
+Aussonderungsangebote
+=====================
+
+Auch Aussonderungsangebote können via API gelesen, erstellt und bearbeitet werden. Die API verhält sich dabei gleich wie bei allen anderen Objekten und wie im Kapitel :ref:`operations` beschrieben.
+
+Einzig die Response eines GET Requests bietet unter dem Key ``dossier_details`` eine zusätzliche Zusammenfassung der angehängten Dossiers gruppiert nach Ordnungsposition. Dabei wird auch der Bewertungsentscheid der jeweiligen Dossiers zurück gegeben.
+
+
+**Auszug ``dossier_details``**:
+
+
+.. code:: json
+
+    {
+       "dossier_details": {
+           "active_dossiers": [
+               {
+                   "@id": "http://example.org/fd/ordnungssystem/bildung",
+                   "@type": "opengever.repository.repositoryfolder",
+                   "archival_value": {
+                       "title": "Nicht geprüft",
+                       "token": "unchecked"
+                   },
+                   "description": "",
+                   "dossiers": [
+                   {
+                       "appraisal": false,
+                       "archival_value": {
+                           "title": "Nicht geprüft",
+                           "token": "unchecked"
+                        },
+                        "archival_value_annotation": null,
+                        "end": "2021-11-23",
+                        "former_state": "dossier-state-resolved",
+                        "intid": 2053980678,
+                        "public_trial": {
+                            "title": "Nicht geprüft",
+                            "token": "unchecked"
+                        },
+                        "reference_number": "FD 2 / 1",
+                        "start": "2021-11-23",
+                        "title": "TEST",
+                        "uid": "9604019b72bb4f5096c2efe07d114dcf",
+                        "url": "http://example.org/fd/ordnungssystem/bildung/dossier-21"
+                    }
+                ],
+                "is_leafnode": true,
+                "review_state": "repositoryfolder-state-active",
+                "title": "2. Bildung"
+            }
+        ],
+        "inactive_dossiers": []
+    }
+
+Statusänderungen können wie bei anderen Objekten und im Kapitel :ref:`workflow` mittels ``@workflow`` Endpoint durchgeführt werden.
+
+
+Bewertungsentscheid ändern
+--------------------------
+
+Der Bewertungsentscheid lässt sich mit einem PATCH request auf den ``@appraisal`` Endpoint ändern. Es wird ein Mapping ``UID:Bewertungsentscheid`` erwartet. Somit lässt sich der Bewertungsentscheide von einzelnen oder mehreren Dossiers verändern:
+
+**Request**:
+
+ .. sourcecode:: http
+
+    PATCH http://example.org/fd/ordnungssystem/disposition-234/@appraisal HTTP/1.1
+    Accept: application/json
+    Content-Type: application/json
+
+    {
+      "9823u409823094": true,
+      "9823u409823021": false,
+    }
+
+
+ **Response**:
+
+ .. sourcecode:: http
+
+    HTTP/1.1 204 No Content
+    Content-Type: application/json

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -67,4 +67,5 @@ Inhalt:
    upload_structure.rst
    close_remote_task.rst
    reference_numbers.rst
+   dispositions.rst
    examples/index.rst

--- a/docs/public/dev-manual/api/schemas/opengever.workspace.meeting.inc
+++ b/docs/public/dev-manual/api/schemas/opengever.workspace.meeting.inc
@@ -17,7 +17,7 @@
    .. py:attribute:: start
 
        :Feldname: :field-title:`Beginn`
-       :Datentyp: ``Datetime``
+       :Datentyp: ``UTCDatetime``
        :Pflichtfeld: Ja :required:`(*)`
        
        
@@ -27,7 +27,7 @@
    .. py:attribute:: end
 
        :Feldname: :field-title:`Ende`
-       :Datentyp: ``Datetime``
+       :Datentyp: ``UTCDatetime``
        
        
        

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -1525,4 +1525,12 @@
       permission="cmf.ModifyPortalContent"
       />
 
+  <plone:service
+      method="PATCH"
+      name="@appraisal"
+      for="opengever.disposition.disposition.IDispositionSchema"
+      factory=".disposition.AppraisalPatch"
+      permission="cmf.ModifyPortalContent"
+      />
+
 </configure>

--- a/opengever/api/locales/de/LC_MESSAGES/opengever.api.po
+++ b/opengever/api/locales/de/LC_MESSAGES/opengever.api.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-11-08 14:06+0000\n"
+"POT-Creation-Date: 2021-11-24 14:12+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -63,6 +63,11 @@ msgstr "Der Dateiname muss zwingend definiert werden"
 #: ./opengever/api/errors.py
 msgid "msg_inputs_not_valid"
 msgstr "Eingaben sind ungültig"
+
+#. Default: "Dossier with the UID ${uid} is not part of the disposition"
+#: ./opengever/api/disposition.py
+msgid "msg_invalid_uid"
+msgstr "Das Dossier mit der UID ${uid} ist nicht Teil des Angebots"
 
 #. Default: "Maximum dossier depth exceeded"
 #: ./opengever/api/upload_structure.py

--- a/opengever/api/locales/en/LC_MESSAGES/opengever.api.po
+++ b/opengever/api/locales/en/LC_MESSAGES/opengever.api.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-11-08 14:06+0000\n"
+"POT-Creation-Date: 2021-11-24 14:12+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -63,6 +63,11 @@ msgstr "Empty filename not supported"
 #: ./opengever/api/errors.py
 msgid "msg_inputs_not_valid"
 msgstr "Inputs not valid"
+
+#. Default: "Dossier with the UID ${uid} is not part of the disposition"
+#: ./opengever/api/disposition.py
+msgid "msg_invalid_uid"
+msgstr "Dossier with the UID ${uid} is not part of the disposition"
 
 #. Default: "Maximum dossier depth exceeded"
 #: ./opengever/api/upload_structure.py

--- a/opengever/api/locales/fr/LC_MESSAGES/opengever.api.po
+++ b/opengever/api/locales/fr/LC_MESSAGES/opengever.api.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-11-08 14:06+0000\n"
+"POT-Creation-Date: 2021-11-24 14:12+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -63,6 +63,11 @@ msgstr "Les fichiers sans nom ne sont pas autorisés."
 #: ./opengever/api/errors.py
 msgid "msg_inputs_not_valid"
 msgstr "Saisie invalide"
+
+#. Default: "Dossier with the UID ${uid} is not part of the disposition"
+#: ./opengever/api/disposition.py
+msgid "msg_invalid_uid"
+msgstr ""
 
 #. Default: "Maximum dossier depth exceeded"
 #: ./opengever/api/upload_structure.py

--- a/opengever/api/locales/opengever.api.pot
+++ b/opengever/api/locales/opengever.api.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-11-08 14:06+0000\n"
+"POT-Creation-Date: 2021-11-24 14:12+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -65,6 +65,11 @@ msgstr ""
 #. Default: "Inputs not valid"
 #: ./opengever/api/errors.py
 msgid "msg_inputs_not_valid"
+msgstr ""
+
+#. Default: "Dossier with the UID ${uid} is not part of the disposition"
+#: ./opengever/api/disposition.py
+msgid "msg_invalid_uid"
 msgstr ""
 
 #. Default: "Maximum dossier depth exceeded"

--- a/opengever/api/tests/test_disposition.py
+++ b/opengever/api/tests/test_disposition.py
@@ -90,7 +90,7 @@ class TestDispositionPost(IntegrationTestCase):
                          api.content.get_state(self.expired_dossier))
 
 
-class TestDispositionSeriaization(IntegrationTestCase):
+class TestDispositionSerialization(IntegrationTestCase):
 
     @browsing
     def test_includes_sip_filename(self, browser):
@@ -103,3 +103,53 @@ class TestDispositionSeriaization(IntegrationTestCase):
         self.assertEqual(u'Angebot 31.8.2016', browser.json['title'])
         self.assertEqual(None, browser.json['transfer_number'])
         self.assertEqual(u'SIP_20010101_PLONE.zip', browser.json['sip_filename'])
+
+    @browsing
+    def test_provides_dossier_details(self, browser):
+        self.login(self.records_manager, browser)
+        browser.open(self.disposition, method='GET', headers=self.api_headers)
+
+        self.assertItemsEqual(['active_dossiers', 'inactive_dossiers'],
+                              browser.json['dossier_details'].keys())
+        self.assertEqual(
+            [
+                {u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen',
+                 u'@type': u'opengever.repository.repositoryfolder',
+                 u'description': u'',
+                 u'is_leafnode': True,
+                 u'review_state': u'repositoryfolder-state-active',
+                 u'title': u'1.1. Vertr\xe4ge und Vereinbarungen',
+                 u'dossiers': [{u'appraisal': True,
+                                u'archival_value': u'archival worthy',
+                                u'archival_value_annotation': None,
+                                u'end': u'2000-01-31',
+                                u'former_state': u'dossier-state-resolved',
+                                u'intid': 1019013300,
+                                u'public_trial': u'unchecked',
+                                u'reference_number': u'Client1 1.1 / 12',
+                                u'start': u'2000-01-01',
+                                u'title': u'Hannah Baufrau',
+                                u'url': self.offered_dossier_to_archive.absolute_url()}]
+                }
+            ],
+            browser.json['dossier_details']['active_dossiers'])
+
+        self.assertEqual(
+            [{u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen',
+              u'@type': u'opengever.repository.repositoryfolder',
+              u'description': u'',
+              u'dossiers': [{u'appraisal': False,
+                             u'archival_value': u'not archival worthy',
+                             u'archival_value_annotation': None,
+                             u'end': u'2000-01-15',
+                             u'former_state': u'dossier-state-inactive',
+                             u'intid': 1019053300,
+                             u'public_trial': u'unchecked',
+                             u'reference_number': u'Client1 1.1 / 14',
+                             u'start': u'2000-01-01',
+                             u'title': u'Hans Baumann',
+                             u'url': self.offered_dossier_to_destroy.absolute_url()}],
+              u'is_leafnode': True,
+              u'review_state': u'repositoryfolder-state-active',
+              u'title': u'1.1. Vertr\xe4ge und Vereinbarungen'}],
+            browser.json['dossier_details']['inactive_dossiers'])

--- a/opengever/api/tests/test_disposition.py
+++ b/opengever/api/tests/test_disposition.py
@@ -117,6 +117,8 @@ class TestDispositionSerialization(IntegrationTestCase):
             [
                 {u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen',
                  u'@type': u'opengever.repository.repositoryfolder',
+                 u'archival_value': {u'title': u'not assessed',
+                                     u'token': u'unchecked'},
                  u'description': u'',
                  u'is_leafnode': True,
                  u'review_state': u'repositoryfolder-state-active',
@@ -144,6 +146,8 @@ class TestDispositionSerialization(IntegrationTestCase):
             [
                 {u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen',
                  u'@type': u'opengever.repository.repositoryfolder',
+                 u'archival_value': {u'title': u'not assessed',
+                                     u'token': u'unchecked'},
                  u'description': u'',
                  u'is_leafnode': True,
                  u'review_state': u'repositoryfolder-state-active',

--- a/opengever/api/tests/test_disposition.py
+++ b/opengever/api/tests/test_disposition.py
@@ -112,6 +112,7 @@ class TestDispositionSerialization(IntegrationTestCase):
 
         self.assertItemsEqual(['active_dossiers', 'inactive_dossiers'],
                               browser.json['dossier_details'].keys())
+
         self.assertEqual(
             [
                 {u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen',
@@ -121,38 +122,47 @@ class TestDispositionSerialization(IntegrationTestCase):
                  u'review_state': u'repositoryfolder-state-active',
                  u'title': u'1.1. Vertr\xe4ge und Vereinbarungen',
                  u'dossiers': [{u'appraisal': True,
-                                u'archival_value': u'archival worthy',
+                                u'archival_value': {
+                                    u'title': u'archival worthy',
+                                    u'token': u'archival worthy'},
                                 u'archival_value_annotation': None,
                                 u'end': u'2000-01-31',
                                 u'former_state': u'dossier-state-resolved',
                                 u'intid': 1019013300,
-                                u'public_trial': u'unchecked',
+                                u'public_trial': {
+                                    u'title': u'not assessed',
+                                    u'token': u'unchecked'},
                                 u'reference_number': u'Client1 1.1 / 12',
                                 u'start': u'2000-01-01',
                                 u'title': u'Hannah Baufrau',
+                                u'uid': u'createoffereddossiers00000000001',
                                 u'url': self.offered_dossier_to_archive.absolute_url()}]
-                }
-            ],
+                }],
             browser.json['dossier_details']['active_dossiers'])
 
         self.assertEqual(
-            [{u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen',
-              u'@type': u'opengever.repository.repositoryfolder',
-              u'description': u'',
-              u'dossiers': [{u'appraisal': False,
-                             u'archival_value': u'not archival worthy',
-                             u'archival_value_annotation': None,
-                             u'end': u'2000-01-15',
-                             u'former_state': u'dossier-state-inactive',
-                             u'intid': 1019053300,
-                             u'public_trial': u'unchecked',
-                             u'reference_number': u'Client1 1.1 / 14',
-                             u'start': u'2000-01-01',
-                             u'title': u'Hans Baumann',
-                             u'url': self.offered_dossier_to_destroy.absolute_url()}],
-              u'is_leafnode': True,
-              u'review_state': u'repositoryfolder-state-active',
-              u'title': u'1.1. Vertr\xe4ge und Vereinbarungen'}],
+            [
+                {u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen',
+                 u'@type': u'opengever.repository.repositoryfolder',
+                 u'description': u'',
+                 u'is_leafnode': True,
+                 u'review_state': u'repositoryfolder-state-active',
+                 u'title': u'1.1. Vertr\xe4ge und Vereinbarungen',
+                 u'dossiers': [{u'appraisal': False,
+                                u'archival_value': {u'title': u'not archival worthy',
+                                                    u'token': u'not archival worthy'},
+                                u'archival_value_annotation': None,
+                                u'end': u'2000-01-15',
+                                u'former_state': u'dossier-state-inactive',
+                                u'intid': 1019053300,
+                                u'public_trial': {u'title': u'not assessed',
+                                                  u'token': u'unchecked'},
+                                u'reference_number': u'Client1 1.1 / 14',
+                                u'start': u'2000-01-01',
+                                u'title': u'Hans Baumann',
+                                u'uid': u'createoffereddossiers00000000003',
+                                u'url': self.offered_dossier_to_destroy.absolute_url()}],
+                }],
             browser.json['dossier_details']['inactive_dossiers'])
 
 

--- a/opengever/api/tests/test_disposition.py
+++ b/opengever/api/tests/test_disposition.py
@@ -169,6 +169,43 @@ class TestDispositionSerialization(IntegrationTestCase):
                 }],
             browser.json['dossier_details']['inactive_dossiers'])
 
+    @browsing
+    def test_shows_limited_information_for_removed_content(self, browser):
+        # close disposition (remove dossiers)
+        self.login(self.archivist, browser)
+        api.content.transition(self.disposition_with_sip,
+                               'disposition-transition-archive')
+        self.login(self.records_manager, browser)
+        api.content.transition(self.disposition_with_sip,
+                               'disposition-transition-close')
+
+        browser.open(self.disposition_with_sip,
+                     method='GET', headers=self.api_headers)
+
+        self.assertEqual(
+            {
+                u'active_dossiers': [
+                    {
+                        u'title': u'1.1. Vertr\xe4ge und Vereinbarungen',
+                        u'dossiers': [
+                            {u'appraisal': True,
+                             u'archival_value': None,
+                             u'archival_value_annotation': None,
+                             u'end': None,
+                             u'former_state': u'dossier-state-resolved',
+                             u'intid': 1019033300,
+                             u'public_trial': None,
+                             u'reference_number': u'Client1 1.1 / 13',
+                             u'start': None,
+                             u'title': u'Dossier for SIP',
+                             u'uid': None,
+                             u'url': None}],
+                    }
+                ],
+                u'inactive_dossiers': []
+            },
+            browser.json['dossier_details'])
+
 
 class TestAppraisalUpdate(IntegrationTestCase):
 

--- a/opengever/disposition/browser/overview.py
+++ b/opengever/disposition/browser/overview.py
@@ -6,16 +6,8 @@ from opengever.disposition.delivery import DeliveryScheduler
 from opengever.disposition.interfaces import IHistoryStorage
 from plone import api
 from plone.protect.utils import addTokenToUrl
-from Products.CMFPlone.CatalogTool import num_sort_regex
-from Products.CMFPlone.CatalogTool import zero_fill
 from Products.Five.browser import BrowserView
 from zope.i18n import translate
-
-
-def sort_on_sortable_title(item):
-    if isinstance(item[0], unicode):
-        return num_sort_regex.sub(zero_fill, item[0])
-    return num_sort_regex.sub(zero_fill, item[0].Title())
 
 
 class DispositionOverview(BrowserView):
@@ -25,21 +17,8 @@ class DispositionOverview(BrowserView):
         return super(DispositionOverview, self).__call__()
 
     def init_dossiers(self):
-        dossiers = self.context.get_dossier_representations()
-        active_dossiers = {}
-        inactive_dossiers = {}
-
-        for dossier in dossiers:
-            if dossier.was_inactive():
-                self._add_to(inactive_dossiers, dossier)
-            else:
-                self._add_to(active_dossiers, dossier)
-
-        self.active_dossiers = sorted(
-            active_dossiers.items(), key=sort_on_sortable_title)
-
-        self.inactive_dossiers = sorted(
-            inactive_dossiers.items(), key=sort_on_sortable_title)
+        self.active_dossiers, self.inactive_dossiers = \
+            self.context.get_grouped_dossier_representations()
 
     def _add_to(self, mapping, dossier):
         key = dossier.get_grouping_key()

--- a/opengever/disposition/disposition.py
+++ b/opengever/disposition/disposition.py
@@ -27,6 +27,7 @@ from plone import api
 from plone.autoform.directives import write_permission
 from plone.dexterity.content import Container
 from plone.namedfile.file import NamedBlobFile
+from plone.restapi.serializer.converters import json_compatible
 from plone.supermodel import model
 from Products.CMFPlone.CatalogTool import num_sort_regex
 from Products.CMFPlone.CatalogTool import zero_fill
@@ -67,6 +68,7 @@ class DossierDispositionInformation(object):
         self.title = dossier.title
         self.intid = getUtility(IIntIds).getId(dossier)
         self.url = dossier.absolute_url()
+        self.uid = dossier.UID()
         self.reference_number = dossier.get_reference_number()
         self.parent = aq_parent(aq_inner(dossier))
         self.start = IDossier(dossier).start
@@ -101,6 +103,21 @@ class DossierDispositionInformation(object):
             'appraisal': self.appraisal,
             'former_state': self.former_state})
 
+    def jsonify(self):
+        return json_compatible({
+            'title': self.title,
+            'intid': self.intid,
+            'appraisal': self.appraisal,
+            'reference_number': self.reference_number,
+            'url': self.url,
+            'uid': self.uid,
+            'start': self.start,
+            'end': self.end,
+            'public_trial': self.public_trial,
+            'archival_value': self.archival_value,
+            'archival_value_annotation': self.archival_value_annotation,
+            'former_state': self.former_state})
+
 
 class RemovedDossierDispositionInformation(DossierDispositionInformation):
 
@@ -111,6 +128,7 @@ class RemovedDossierDispositionInformation(DossierDispositionInformation):
         self.reference_number = dossier_mapping.get('reference_number')
         self.repository_title = dossier_mapping.get('repository_title')
         self.url = None
+        self.uid = None
         self.start = None
         self.end = None
         self.public_trial = None


### PR DESCRIPTION
- Add an additional key `dossier_details`, which contains a summary of all contained dossiers, grouped by repository and separated in two lists `active_dossiers` and `inactive_dossiers`
- Add a separate `@appraisal` PATCH endpoint

For [CA-2116]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry 
- New translations
  - [x] All msg-strings are unicode

[CA-2116]: https://4teamwork.atlassian.net/browse/CA-2116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ