### PR TITLE
Update CL with recent backport releases.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,30 @@ Versions are of the form MAJOR.MINOR.PATCH. Each MINOR release (MAJOR.MINOR.0) i
 
 .. towncrier release notes start
 
+2021.23.3 (2021-11-25)
+----------------------
+
+Other changes:
+
+
+- Split upgrade with high memory consumption into two. [deiferni]
+
+
+2021.23.2 (2021-11-22)
+----------------------
+
+Bug fixes:
+
+
+- Include documents manually added to submitted proposal in meeting Zip and protocol data. [njohner]
+
+
+2021.23.1 (2021-11-19)
+----------------------
+
+No significant changes.
+
+
 2021.23.0 (2021-11-17)
 ----------------------
 


### PR DESCRIPTION
According to https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/168166594/GEVER+Releases+erstellen#Patchlevel-Release-erstellen we always update the `master` CL with backport releases. It seems we did not do so for any if the `2021.23.X` so far so i'm including all of them now.

For [CA-2746](https://4teamwork.atlassian.net/browse/CA-2746)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)