### PR TITLE
Fix repositoryfolder addable types constraints

### DIFF
--- a/changes/CA-2116.bugfix
+++ b/changes/CA-2116.bugfix
@@ -1,0 +1,1 @@
+Fix repositoryfolder addable types constraints, make dispositions always addable. [phgross]

--- a/opengever/repository/constrains.py
+++ b/opengever/repository/constrains.py
@@ -90,8 +90,10 @@ class RepositoryFolderConstrainTypes(object):
 
         # Filter content types, if required
         if not self.context.is_leaf_node():
-            # only allow same types
-            types = filter(lambda a: a == fti, types)
+            # only allow same types, except dispositions
+            types = filter(
+                lambda a: a == fti or a.id == 'opengever.disposition.disposition',
+                types)
 
         # Finally: remove not enabled resticted content types
         marker_behavior = 'opengever.dossier.behaviors.restricteddossier.' + \

--- a/opengever/repository/tests/test_repositoryfolder.py
+++ b/opengever/repository/tests/test_repositoryfolder.py
@@ -114,7 +114,7 @@ class TestRepositoryFolder(IntegrationTestCase):
     @browsing
     def test_only_repofolder_addable_when_already_contains_repositories(self, browser):
         """A repository folder should not contain other repository folders AND
-        dossiers at the same time.
+        dossiers at the same time, except dispositions.
         Therefore dossiers should not be addable in branch repository folders.
         """
         self.login(self.administrator, browser)
@@ -126,6 +126,14 @@ class TestRepositoryFolder(IntegrationTestCase):
         self.assertEquals(
             ['Repository Folder'],
             factoriesmenu.addable_types())
+
+        # check dispositions always addable
+        self.login(self.records_manager, browser)
+        browser.open(self.branch_repofolder)
+        self.assertEquals(
+            ['Disposition'],
+            factoriesmenu.addable_types())
+
 
     @browsing
     def test_repofolder_not_addable_when_repofolder_is_deactivated(self, browser):


### PR DESCRIPTION
Make dispositions always addable, it doesn't matter if the repositoryfolder is a leaf or a branch folder.

For [CA-2116]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-2116]: https://4teamwork.atlassian.net/browse/CA-2116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ