### PR TITLE
Improve complete successor task endpoint when using urls or relative paths as document references

### DIFF
--- a/changes/CA-3193.bugfix
+++ b/changes/CA-3193.bugfix
@@ -1,0 +1,1 @@
+@complete-successor-task: 'documents' payload now uses relative paths instead the physical path to resolve references  [elioschmutz]

--- a/changes/CA-3193.other
+++ b/changes/CA-3193.other
@@ -1,0 +1,1 @@
+@complete-successor-task: 'documents' payload also accepts urls [elioschmutz]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -8,6 +8,7 @@ API Changelog
 
 Breaking Changes
 ^^^^^^^^^^^^^^^^
+- @complete-successor-task: ``documents`` payload: Now requires relative paths to the siteroot instead physical paths. The physical path is for internal use only. [elioschmutz]
 - Error message and response status code for ForbiddenByQuota errors have changed.
 
 Other Changes

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -13,6 +13,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- @complete-successor-task: ``documents`` payload: now also resolves document references by @id. [elioschmutz]
 - @reminders now returns 204 NoContent when no reminder is set.
 - Added API support for dispositions objects.
 

--- a/docs/public/dev-manual/api/complete_successor_task.rst
+++ b/docs/public/dev-manual/api/complete_successor_task.rst
@@ -7,7 +7,7 @@ Der ``@complete-successor-task`` Endpoint auf Aufgaben erlaubt es, eine mandante
 
 Durch das Abschliessen der Nachfolgeaufgabe wird das Backend auch die Vorgänger-Aufgabe auf dem Remote-Mandanten abschliessen, und ggf. die angegebenen Dokumente an die Vorgängeraufgabe zurück übermitteln.
 
-Dokumente, welche zurück übermittelt werden sollen, können über den Parameter ``documents`` angegeben werden. Dieser Parameter erlaubt die Referenzierung von Dokumenten (im selben Dossier wie die Nachfolgeaufgabe) über IntId (``1423795951``), OGUID (``rk:1423795951``) oder Pfad (``/ordnungssystem/dossier-17/document-23``).
+Dokumente, welche zurück übermittelt werden sollen, können über den Parameter ``documents`` angegeben werden. Dieser Parameter erlaubt die Referenzierung von Dokumenten (im selben Dossier wie die Nachfolgeaufgabe) über IntId (``1423795951``), OGUID (``rk:1423795951``), Pfad (``/ordnungssystem/dossier-17/document-23``) oder URL (``https://example.com/ordnungssystem/dossier-17/document-23``).
 
 Optional kann im Parameter ``text`` ein Kommentar zum Abschliessen der Aufgabe angegeben werden.
 

--- a/docs/public/dev-manual/api/complete_successor_task.rst
+++ b/docs/public/dev-manual/api/complete_successor_task.rst
@@ -7,7 +7,7 @@ Der ``@complete-successor-task`` Endpoint auf Aufgaben erlaubt es, eine mandante
 
 Durch das Abschliessen der Nachfolgeaufgabe wird das Backend auch die Vorgänger-Aufgabe auf dem Remote-Mandanten abschliessen, und ggf. die angegebenen Dokumente an die Vorgängeraufgabe zurück übermitteln.
 
-Dokumente, welche zurück übermittelt werden sollen, können über den Parameter ``documents`` angegeben werden. Dieser Parameter erlaubt die Referenzierung von Dokumenten (im selben Dossier wie die Nachfolgeaufgabe) über IntId (``1423795951``), OGUID (``rk:1423795951``) oder Pfad (``/rk/dossier-17/document-23``).
+Dokumente, welche zurück übermittelt werden sollen, können über den Parameter ``documents`` angegeben werden. Dieser Parameter erlaubt die Referenzierung von Dokumenten (im selben Dossier wie die Nachfolgeaufgabe) über IntId (``1423795951``), OGUID (``rk:1423795951``) oder Pfad (``/ordnungssystem/dossier-17/document-23``).
 
 Optional kann im Parameter ``text`` ein Kommentar zum Abschliessen der Aufgabe angegeben werden.
 

--- a/opengever/api/relationfield.py
+++ b/opengever/api/relationfield.py
@@ -1,5 +1,6 @@
 from opengever.api.utils import get_obj_by_path
 from opengever.base.interfaces import IOpengeverBaseLayer
+from opengever.base.oguid import Oguid
 from plone.dexterity.interfaces import IDexterityContent
 from plone.restapi.deserializer.relationfield import RelationChoiceFieldDeserializer
 from plone.restapi.interfaces import IFieldDeserializer
@@ -36,6 +37,9 @@ def relationfield_value_to_object(value, context, request):
         elif value.startswith("/"):
             # Resolve by path
             return get_obj_by_path(portal, value.lstrip("/")), "path"
+        elif Oguid.is_oguid(value):
+            # Resolve by OGUID
+            return Oguid.parse(value).resolve_object(), "oguid"
         else:
             # Resolve by UID
             catalog = getToolByName(context, "portal_catalog")

--- a/opengever/api/tests/test_relationfield.py
+++ b/opengever/api/tests/test_relationfield.py
@@ -1,6 +1,7 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from opengever.base.oguid import Oguid
 from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.base.role_assignments import SharingRoleAssignment
 from opengever.dossier.behaviors.dossier import IDossier
@@ -36,6 +37,22 @@ class GeverRelationChoiceFieldDeserializer(IntegrationTestCase):
             method='PATCH',
             data=json.dumps(
                 {'relatedDossier': [relative_path]}
+            ),
+            headers=self.api_headers)
+
+        self.assertEquals(
+            [self.empty_dossier],
+            [rel.to_object for rel in IDossier(self.dossier).relatedDossier])
+
+    @browsing
+    def test_relation_by_oguid_is_possible(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(
+            self.dossier.absolute_url(),
+            method='PATCH',
+            data=json.dumps(
+                {'relatedDossier': [Oguid.for_object(self.empty_dossier).id]}
             ),
             headers=self.api_headers)
 

--- a/opengever/base/oguid.py
+++ b/opengever/base/oguid.py
@@ -6,6 +6,7 @@ from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.ogds.models.service import ogds_service
 from zope.component import getUtility
 from zope.intid.interfaces import IIntIds
+import re
 
 
 class Oguid(object):
@@ -50,6 +51,11 @@ class Oguid(object):
             raise MalformedOguid(oguid)
         admin_unit_id, int_id = parts[0], int(parts[1])
         return cls(admin_unit_id, int_id)
+
+    @classmethod
+    def is_oguid(cls, oguid):
+        # Matches characters except : and / followed by a colon (:) and any numbers
+        return re.match(r'^[^\:\/]+:{1}\d+$', oguid)
 
     def __init__(self, admin_unit_id, int_id):
         self.admin_unit_id = admin_unit_id

--- a/opengever/base/tests/test_oguid.py
+++ b/opengever/base/tests/test_oguid.py
@@ -33,6 +33,16 @@ class TestOguid(TestCase):
         self.assertNotEqual(Oguid('foo', 3), Oguid('foo', 2))
         self.assertNotEqual(Oguid('bar', 2), Oguid('foo', 2))
 
+    def test_is_oguid(self):
+        self.assertTrue(Oguid.is_oguid('fd:123'))
+        self.assertTrue(Oguid.is_oguid('fd_1:123'))
+
+        self.assertFalse(Oguid.is_oguid('http://example.com'))
+        self.assertFalse(Oguid.is_oguid(':123'))
+        self.assertFalse(Oguid.is_oguid('fd:'))
+        self.assertFalse(Oguid.is_oguid('fd/:123'))
+        self.assertFalse(Oguid.is_oguid('fd:rk:123'))
+
 
 class TestOguidFunctional(IntegrationTestCase):
 


### PR DESCRIPTION
Extends the `documents` payload parameter of the `@complete-successor-task` endpoint to also accept URLs.

We do this by reusing the already existing method `relationfield_value_to_object` which provides resolving a value to an object by multiple ways, also by URL.

By using this method, we change the behavior of resolving paths. Currently, the endpoint expects physical paths for the `documents` parameter. But physical paths are for internal use only. It now supports relative paths which is the correct way of resolving objects paths provided by a client. [breaking change]

For [CA-3193]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [x] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-3193]: https://4teamwork.atlassian.net/browse/CA-3193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CA-3197]: https://4teamwork.atlassian.net/browse/CA-3197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ