### PR TITLE
Use Gever API error handling for ForbiddenByQuota errors.

### DIFF
--- a/changes/CA-1929.feature
+++ b/changes/CA-1929.feature
@@ -1,0 +1,1 @@
+Use Gever API error handling for ForbiddenByQuota errors. [tinagerber]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -8,6 +8,7 @@ API Changelog
 
 Breaking Changes
 ^^^^^^^^^^^^^^^^
+- Error message and response status code for ForbiddenByQuota errors have changed.
 
 Other Changes
 ^^^^^^^^^^^^^

--- a/opengever/api/add.py
+++ b/opengever/api/add.py
@@ -16,6 +16,7 @@ from plone.restapi.services.content.utils import add
 from plone.restapi.services.content.utils import create
 from Products.CMFPlone.utils import safe_hasattr
 from zExceptions import BadRequest
+from zExceptions import Forbidden
 from zExceptions import Unauthorized
 from zope.component import ComponentLookupError
 from zope.component import getMultiAdapter
@@ -206,8 +207,7 @@ class GeverFolderPost(FolderPost):
             self.add_object_to_context()
         except ForbiddenByQuota as exc:
             transaction.abort()
-            self.request.response.setStatus(507)
-            return dict(error=dict(type="ForbiddenByQuota", message=str(exc)))
+            raise Forbidden(exc.message)
 
         self.request.response.setStatus(201)
         self.request.response.setHeader("Location", self.obj.absolute_url())

--- a/opengever/api/tests/test_document.py
+++ b/opengever/api/tests/test_document.py
@@ -283,12 +283,11 @@ class TestDocumentPost(IntegrationTestCase):
                                        name='size_hard_limit', value=1)
 
         with self.observe_children(self.private_dossier) as children:
-            with browser.expect_http_error(code=507, reason='Insufficient Storage'):
+            with browser.expect_http_error(code=403, reason='Forbidden'):
                 data = {'@type': 'opengever.document.document',
                         'file': {'data': 'foo bar', 'filename': 'test.docx'}}
                 browser.open(self.private_dossier, data=json.dumps(data), method='POST',
                              headers=self.api_headers)
-
         self.assertEqual(0, len(children["added"]))
 
 

--- a/opengever/api/tests/test_tus.py
+++ b/opengever/api/tests/test_tus.py
@@ -202,7 +202,7 @@ class TestTUSUpload(IntegrationTestCase):
 
         with self.observe_children(self.private_dossier) as children:
             self.assert_tus_upload_fails(
-                self.private_dossier, browser, code=507, reason='Insufficient Storage')
+                self.private_dossier, browser, code=403, reason='Forbidden')
 
         self.assertEqual(0, len(children["added"]))
 

--- a/opengever/api/tus.py
+++ b/opengever/api/tus.py
@@ -32,9 +32,7 @@ class GeverUploadPatch(UploadPatch):
             noLongerProvides(self.request, IDuringContentCreation)
         except ForbiddenByQuota as exc:
             transaction.abort()
-            self.request.response.setStatus(507)
-            return dict(error=dict(type="ForbiddenByQuota", message=str(exc)))
-
+            raise Forbidden(exc.message)
         return data
 
     def create_or_modify_content(self, tus_upload):


### PR DESCRIPTION
We now also have the translated message in the error response. The status code of the response has changed from 507 to 403.

For [CA-1929]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [x] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed

[CA-1929]: https://4teamwork.atlassian.net/browse/CA-1929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ