### PR TITLE
Handle KuB contacts and participations in classic UI

### DIFF
--- a/changes/CA-2606_3.feature
+++ b/changes/CA-2606_3.feature
@@ -1,0 +1,1 @@
+Handle KuB contacts and participations in classic UI. [njohner]

--- a/opengever/contact/browser/participation_add_view.py
+++ b/opengever/contact/browser/participation_add_view.py
@@ -1,5 +1,8 @@
 from opengever.contact import is_contact_feature_enabled
+from opengever.kub import is_kub_feature_enabled
 from Products.Five.browser import BrowserView
+from Products.statusmessages.interfaces import IStatusMessage
+from opengever.contact import _ as contact_mf
 
 
 class ParticipationAddView(BrowserView):
@@ -10,6 +13,12 @@ class ParticipationAddView(BrowserView):
     """
 
     def __call__(self):
+        if is_kub_feature_enabled():
+            msg = contact_mf(
+                u'warning_kub_contact_new_ui_only',
+                default=u'Kub contacts are only supported in the new frontend')
+            IStatusMessage(self.request).addStatusMessage(msg, type=u'error')
+            return self.request.RESPONSE.redirect(self.context.absolute_url())
         if is_contact_feature_enabled():
             return self.request.RESPONSE.redirect(
                 self.get_url('add-sql-participation'))

--- a/opengever/contact/browser/tabbed.py
+++ b/opengever/contact/browser/tabbed.py
@@ -1,12 +1,24 @@
 from ftw.tabbedview.browser.tabbed import TabbedView
 from opengever.contact import _
 from opengever.contact import is_contact_feature_enabled
+from opengever.kub import is_kub_feature_enabled
+from Products.statusmessages.interfaces import IStatusMessage
 
 
 class ContactFolderTabbedView(TabbedView):
 
+    def __call__(self, *args, **kwargs):
+        if is_kub_feature_enabled():
+            msg = _(
+                u'warning_kub_contact_new_ui_only',
+                default=u'Kub contacts are only supported in the new frontend')
+            IStatusMessage(self.request).addStatusMessage(msg, type=u'info')
+        return super(ContactFolderTabbedView, self).__call__(*args, **kwargs)
+
     def get_tabs(self):
-        if is_contact_feature_enabled():
+        if is_kub_feature_enabled():
+            tabs = []
+        elif is_contact_feature_enabled():
             tabs = [
                 {'id': 'persons',
                  'title': _(u'label_persons', default=u'Persons'),

--- a/opengever/contact/locales/de/LC_MESSAGES/opengever.contact.po
+++ b/opengever/contact/locales/de/LC_MESSAGES/opengever.contact.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-01-08 11:40+0000\n"
+"POT-Creation-Date: 2021-11-24 14:55+0000\n"
 "PO-Revision-Date: 2011-01-05 15:15+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -490,3 +490,8 @@ msgstr "${amount} Treffer"
 #: ./opengever/contact/contact.py
 msgid "telefon"
 msgstr "Telefon"
+
+#. Default: "Kub contacts are only supported in the new frontend"
+#: ./opengever/contact/browser/tabbed.py
+msgid "warning_kub_contact_new_ui_only"
+msgstr "Das Kontakt- und Behördenverzeichnis wird nur in der neuen Ansicht unterstützt."

--- a/opengever/contact/locales/en/LC_MESSAGES/opengever.contact.po
+++ b/opengever/contact/locales/en/LC_MESSAGES/opengever.contact.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-01-13 14:31+0000\n"
+"POT-Creation-Date: 2021-11-24 14:55+0000\n"
 "PO-Revision-Date: 2011-01-05 15:15+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -586,3 +586,8 @@ msgstr "${amount} matches"
 #: ./opengever/contact/contact.py
 msgid "telefon"
 msgstr "Phone"
+
+#. Default: "Kub contacts are only supported in the new frontend"
+#: ./opengever/contact/browser/tabbed.py
+msgid "warning_kub_contact_new_ui_only"
+msgstr "The Contact and Authorities directory is only supported in the new UI."

--- a/opengever/contact/locales/fr/LC_MESSAGES/opengever.contact.po
+++ b/opengever/contact/locales/fr/LC_MESSAGES/opengever.contact.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-08 11:40+0000\n"
+"POT-Creation-Date: 2021-11-24 14:55+0000\n"
 "PO-Revision-Date: 2017-11-29 11:04+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-contact/fr/>\n"
@@ -492,3 +492,8 @@ msgstr "Résultat(s): ${amount}"
 #: ./opengever/contact/contact.py
 msgid "telefon"
 msgstr "Téléphone"
+
+#. Default: "Kub contacts are only supported in the new frontend"
+#: ./opengever/contact/browser/tabbed.py
+msgid "warning_kub_contact_new_ui_only"
+msgstr "L'annuaire des contacts et des autorités n'est supporté que dans la nouvelle interface"

--- a/opengever/contact/locales/opengever.contact.pot
+++ b/opengever/contact/locales/opengever.contact.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-08 11:40+0000\n"
+"POT-Creation-Date: 2021-11-24 14:55+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -492,4 +492,9 @@ msgstr ""
 #. Default: "Telefon"
 #: ./opengever/contact/contact.py
 msgid "telefon"
+msgstr ""
+
+#. Default: "Kub contacts are only supported in the new frontend"
+#: ./opengever/contact/browser/tabbed.py
+msgid "warning_kub_contact_new_ui_only"
 msgstr ""

--- a/opengever/dossier/browser/forms.py
+++ b/opengever/dossier/browser/forms.py
@@ -3,6 +3,7 @@ from ftw.keywordwidget.widget import KeywordWidget
 from opengever.base.behaviors.utils import hide_fields_from_behavior
 from opengever.base.behaviors.utils import omit_classification_group
 from opengever.base.vocabulary import wrap_vocabulary
+from opengever.contact import _ as contact_mf
 from opengever.dossier import _
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.behaviors.dossier import IDossierMarker
@@ -11,6 +12,7 @@ from opengever.dossier.behaviors.participation import IParticipationAware
 from opengever.dossier.behaviors.protect_dossier import IProtectDossier
 from opengever.dossier.behaviors.protect_dossier import IProtectDossierMarker
 from opengever.dossier.widget import referenceNumberWidgetFactory
+from opengever.kub import is_kub_feature_enabled
 from opengever.ogds.base.sources import AllUsersAndGroupsSourceBinder
 from plone import api
 from plone.autoform.widgets import ParameterizedWidget
@@ -235,6 +237,12 @@ class DeleteParticipants(BrowserView):
         if not oids:
             msg = _(u'warning_no_participants_selected',
                     default=u'You didn\'t select any participants.')
+            IStatusMessage(self.request).addStatusMessage(msg, type='error')
+            return self.request.RESPONSE.redirect(self.redirect_url)
+        if is_kub_feature_enabled():
+            msg = contact_mf(
+                u'warning_kub_contact_new_ui_only',
+                default=u'Kub contacts are only supported in the new frontend')
             IStatusMessage(self.request).addStatusMessage(msg, type='error')
             return self.request.RESPONSE.redirect(self.redirect_url)
         phandler = IParticipationAware(self.context)

--- a/opengever/dossier/tests/test_tabbed.py
+++ b/opengever/dossier/tests/test_tabbed.py
@@ -1,5 +1,6 @@
 from ftw.testbrowser import browsing
 from opengever.dossier.dossiertemplate.interfaces import IDossierTemplateSettings
+from opengever.kub.interfaces import IKuBSettings
 from opengever.testing import IntegrationTestCase
 from plone import api
 
@@ -8,6 +9,19 @@ class TestParticipationTab(IntegrationTestCase):
 
     @browsing
     def test_is_plone_object_implementation_when_contact_feature_is_disabled(self, browser):
+        self.login(self.dossier_responsible, browser)
+
+        browser.open(self.dossier, view='tabbed_view')
+        browser.click_on('Participants')
+
+        self.assertEqual(
+            'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/#participants',
+            browser.url)
+
+    @browsing
+    def test_is_plone_object_implementation_when_kub_feature_is_enabled(self, browser):
+        api.portal.set_registry_record(
+            'base_url', u'http://localhost:8000', IKuBSettings)
         self.login(self.dossier_responsible, browser)
 
         browser.open(self.dossier, view='tabbed_view')


### PR DESCRIPTION
Or rather, inform the user that we do not handle KuB participations in the classic UI...

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-2606]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-2606]: https://4teamwork.atlassian.net/browse/CA-2606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ