### PR TITLE
Support KuB participations in listing endpoint.

### DIFF
--- a/changes/CA-2606_4.feature
+++ b/changes/CA-2606_4.feature
@@ -1,0 +1,1 @@
+Support KuB participations in listing endpoint. [njohner]

--- a/opengever/dossier/indexers.py
+++ b/opengever/dossier/indexers.py
@@ -20,6 +20,8 @@ from opengever.dossier.participations import IParticipationData
 from opengever.dossier.resolve import AfterResolveJobs
 from opengever.dossier.utils import get_main_dossier
 from opengever.inbox.inbox import IInbox
+from opengever.kub import is_kub_feature_enabled
+from opengever.kub.sources import KuBContactsSourceBinder
 from opengever.ogds.base.sources import UsersContactsInboxesSourceBinder
 from opengever.private.dossier import IPrivateDossier
 from plone import api
@@ -335,12 +337,13 @@ class ParticipationIndexHelper(object):
         """
         if participant_id == self.any_participant_marker:
             return translate(_(u'any_participant'), context=getRequest())
-        if is_contact_feature_enabled():
+        if is_kub_feature_enabled():
+            source = KuBContactsSourceBinder()(api.portal.get())
+        elif is_contact_feature_enabled():
             source = ContactsSource(api.portal.get())
-            term = source.getTermByToken(participant_id)
         else:
             source = UsersContactsInboxesSourceBinder()(api.portal.get())
-            term = source.getTermByToken(participant_id)
+        term = source.getTermByToken(participant_id)
         return term.title
 
     def index_value_to_label(self, value):


### PR DESCRIPTION
Add support for KuB participations in the `@listing` endpoint.

For [CA-3260], [CA-2606], maybe [CA-3098] ...

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-2606]: https://4teamwork.atlassian.net/browse/CA-2606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CA-3098]: https://4teamwork.atlassian.net/browse/CA-3098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CA-3260]: https://4teamwork.atlassian.net/browse/CA-3260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ