### PR TITLE
Support invalid participation IDs in listing endpoint.

### DIFF
--- a/opengever/dossier/indexers.py
+++ b/opengever/dossier/indexers.py
@@ -343,8 +343,11 @@ class ParticipationIndexHelper(object):
             source = ContactsSource(api.portal.get())
         else:
             source = UsersContactsInboxesSourceBinder()(api.portal.get())
-        term = source.getTermByToken(participant_id)
-        return term.title
+        try:
+            term = source.getTermByToken(participant_id)
+            return term.title
+        except LookupError:
+            return participant_id
 
     def index_value_to_label(self, value):
         """Returns a translated label of the form 'participant label|role label'

--- a/opengever/dossier/tests/test_indexer.py
+++ b/opengever/dossier/tests/test_indexer.py
@@ -6,11 +6,13 @@ from opengever.dossier.behaviors.customproperties import IDossierCustomPropertie
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.behaviors.filing import IFilingNumber
 from opengever.dossier.behaviors.participation import IParticipationAware
+from opengever.dossier.indexers import ParticipationIndexHelper
 from opengever.dossier.interfaces import IDossierArchiver
 from opengever.kub.testing import KuBIntegrationTestCase
 from opengever.sharing.events import LocalRolesAcquisitionActivated
 from opengever.sharing.events import LocalRolesAcquisitionBlocked
 from opengever.testing import index_data_for
+from opengever.testing import IntegrationTestCase
 from opengever.testing import obj2brain
 from opengever.testing import solr_data_for
 from opengever.testing import SolrIntegrationTestCase
@@ -422,3 +424,10 @@ class TestDossierParticipationsIndexerWithBuB(SolrIntegrationTestCase, KuBIntegr
             u'any-participant|final-drawing',
             u'{}|any-role'.format(self.person_jean)]
         self.assertItemsEqual(expected, indexed_value)
+
+
+class TestParticipationIndexHelper(IntegrationTestCase):
+
+    def test_participant_id_to_label_handles_invalid_ids(self):
+        helper = ParticipationIndexHelper()
+        self.assertEqual("invalid-id", helper.participant_id_to_label("invalid-id"))


### PR DESCRIPTION
This is to handle 2 situations:
- There are participations on a dossier that are not of the type of the currently activated contact feature (for example on dev.onegovgever.ch/rk, I activated KuB but there are plone participations that were not migrated)
- There are participations for a contact that does not exist anymore (currently contacts can be deleted in KuB).

Both these cases should not really happen in production as I understand it because:
- There will be some sort of migration when switching to KuB contacts (https://4teamwork.atlassian.net/browse/CA-2605)
- KuB plans on implementing deactivation of contacts instead of deletion.

But still, we can't afford that the whole dossier listing fails because of an unknown participant ID.

For [CA-2606]

## Checklist
- [ ] Changelog entry : no CL entry IMO
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-2606]: https://4teamwork.atlassian.net/browse/CA-2606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ