### PR TITLE
Add @kub endpoint allowing to resolve KuB entities by their ID.

### DIFF
--- a/changes/CA-2606_5.feature
+++ b/changes/CA-2606_5.feature
@@ -1,0 +1,1 @@
+Add @kub endpoint. [njohner]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -16,7 +16,7 @@ Other Changes
 - @complete-successor-task: ``documents`` payload: now also resolves document references by @id. [elioschmutz]
 - @reminders now returns 204 NoContent when no reminder is set.
 - Added API support for dispositions objects.
-
+- Added ``@kub`` endpoint to resolve KuB entities by their ID.
 
 2021.23.0 (2021-11-17)
 ----------------------

--- a/docs/public/dev-manual/api/users.rst
+++ b/docs/public/dev-manual/api/users.rst
@@ -366,3 +366,56 @@ Mit dem ``@reactivate-local-group`` Endpoint kann eine lokale, inaktive Gruppe w
 
       HTTP/1.1 204 No content
       Content-Type: application/json
+
+
+KuB Kontakte
+============
+
+Mit dem ``@kub`` Endpoint können Kontakte aus dem KuB geholt werden. Der Endpoint steht nur auf Stufe PloneSiteRoot zur Verfügung und erwartet als Pfad Parameter die UID des Kontaktes:
+
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+      GET /@kub/person:1234abdc HTTP/1.1
+      Accept: application/json
+
+**Beispiel-Response**:
+
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+        "addresses": [],
+        "canton": null,
+        "country": "",
+        "countryIdISO2": "",
+        "created": "2021-11-14T00:00:00+01:00",
+        "dateOfBirth": null,
+        "description": "",
+        "emailAddresses": [],
+        "firstName": "Julie",
+        "fullName": "Dupont Julie",
+        "id": "0e623708-2d0d-436a-82c6-c1a9c27b65dc",
+        "languageOfCorrespondance": "fr",
+        "maritalStatus": 2,
+        "memberships": [],
+        "modified": "2021-11-14T00:00:00+01:00",
+        "officialName": "Dupont",
+        "organizations": [],
+        "originName": "Paris",
+        "phoneNumbers": [],
+        "primaryEmail": null,
+        "primaryPhoneNumber": null,
+        "salutation": "Frau",
+        "sex": 2,
+        "status": 1,
+        "tags": [],
+        "thirdPartyId": null,
+        "title": "",
+        "urls": []
+      }

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -563,6 +563,14 @@
   <plone:service
       method="GET"
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      factory=".kub.KuBGet"
+      name="@kub"
+      permission="zope2.View"
+      />
+
+  <plone:service
+      method="GET"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
       factory=".actors.ActorsGet"
       name="@actors"
       permission="zope2.View"

--- a/opengever/api/kub.py
+++ b/opengever/api/kub.py
@@ -1,0 +1,49 @@
+from copy import deepcopy
+from opengever.api.utils import create_proxy_request_error_handler
+from opengever.api.utils import default_http_error_code_mapping
+from opengever.kub.client import KuBClient
+from plone.restapi.services import Service
+from zExceptions import BadRequest
+from zope.interface import implements
+from zope.publisher.interfaces import IPublishTraverse
+import logging
+
+logger = logging.getLogger('opengever.api: KuB')
+
+http_error_code_mapping = deepcopy(default_http_error_code_mapping)
+http_error_code_mapping[404] = {
+    "return_code": 404,
+    "return_message": u"Contact was not found in KuB."}
+
+kub_request_error_handler = create_proxy_request_error_handler(
+    logger, u'Error while communicating with KuB', http_error_code_mapping)
+
+
+class KuBGet(Service):
+    """API Endpoint that returns a single user from ogds.
+
+    GET /@ogds-users/user.id HTTP/1.1
+    """
+
+    implements(IPublishTraverse)
+
+    def __init__(self, context, request):
+        super(KuBGet, self).__init__(context, request)
+        self.params = []
+
+    def publishTraverse(self, request, name):
+        # Consume any path segments after service name as parameters
+        self.params.append(name)
+        return self
+
+    @kub_request_error_handler
+    def reply(self):
+        _id = self.read_params().decode('utf-8')
+        client = KuBClient()
+        return client.get_full_entity_by_id(_id)
+
+    def read_params(self):
+        if len(self.params) != 1:
+            raise BadRequest("Must supply ID as URL path parameter.")
+
+        return self.params[0]

--- a/opengever/api/solrsearch.py
+++ b/opengever/api/solrsearch.py
@@ -2,7 +2,7 @@ from ftw.solr.query import make_filters
 from ftw.solr.query import make_path_filter
 from ftw.solr.query import make_query
 from opengever.api.breadcrumbs import Breadcrumbs
-from opengever.api.linked_workspaces import request_error_handler
+from opengever.api.linked_workspaces import teamraum_request_error_handler
 from opengever.api.listing import FILTERS
 from opengever.api.solr_query_service import SolrQueryBaseService
 from opengever.base.interfaces import ISearchSettings
@@ -269,7 +269,7 @@ class SolrSearchGet(SolrQueryBaseService):
 
 class TeamraumSolrSearchGet(Service):
 
-    @request_error_handler
+    @teamraum_request_error_handler
     def reply(self):
         # Validation will be done on the remote system
         params = self.request.form.copy()

--- a/opengever/api/tests/test_kub.py
+++ b/opengever/api/tests/test_kub.py
@@ -1,0 +1,75 @@
+from ftw.testbrowser import browsing
+from ftw.testbrowser.exceptions import HTTPClientError
+from ftw.testbrowser.exceptions import HTTPServerError
+from opengever.kub.testing import KUB_RESPONSES
+from opengever.kub.testing import KuBIntegrationTestCase
+from plone import api
+import requests_mock
+
+
+@requests_mock.Mocker()
+class TestKubEndpoint(KuBIntegrationTestCase):
+
+    @browsing
+    def test_handles_errors_raised_by_remote_service(self, mocker, browser):
+        browser.exception_bubbling = True
+        self.login(self.regular_user, browser)
+
+        def assertErrorHandling(tested_error_code, raised_error_code, raised_http_exception, error_message):
+            self.mock_get_full_entity_by_id(
+                mocker, self.person_julie, status_code=tested_error_code)
+
+            with self.assertRaises(raised_http_exception):
+                browser.open(api.portal.get(),
+                             view='/@kub/{}'.format(self.person_julie),
+                             method='GET',
+                             headers=self.api_headers)
+
+            self.assertEqual(
+                raised_error_code,
+                browser.status_code,
+                '{} should raise a {}'.format(tested_error_code, raised_error_code))
+            self.assertEqual(
+                tested_error_code,
+                browser.json.get('service_error').get('status_code'),
+                'The service_error status code should contain the original status code')
+            self.assertEqual(error_message,
+                             browser.json.get('message'))
+
+        assertErrorHandling(tested_error_code=404,
+                            raised_error_code=404,
+                            raised_http_exception=HTTPClientError,
+                            error_message=u'Contact was not found in KuB.')
+
+        assertErrorHandling(tested_error_code=408,
+                            raised_error_code=504,
+                            raised_http_exception=HTTPServerError,
+                            error_message=u'Error while communicating with KuB')
+
+        assertErrorHandling(tested_error_code=500,
+                            raised_error_code=502,
+                            raised_http_exception=HTTPServerError,
+                            error_message=u'Error while communicating with KuB')
+
+        assertErrorHandling(tested_error_code=502,
+                            raised_error_code=502,
+                            raised_http_exception=HTTPServerError,
+                            error_message=u'Error while communicating with KuB')
+
+        assertErrorHandling(tested_error_code=504,
+                            raised_error_code=504,
+                            raised_http_exception=HTTPServerError,
+                            error_message=u'Error while communicating with KuB')
+
+    @browsing
+    def test_proxies_to_corresponding_kub_endpoint(self, mocker, browser):
+        self.login(self.regular_user, browser)
+        self.mock_get_full_entity_by_id(mocker, self.person_julie)
+        browser.open(api.portal.get(),
+                     view='/@kub/{}'.format(self.person_julie),
+                     method='GET',
+                     headers=self.api_headers)
+
+        uid = self.person_julie.split(":")[1]
+        url = "{}people/{}".format(self.client.kub_api_url, uid)
+        self.assertEqual(KUB_RESPONSES[url], browser.json)

--- a/opengever/api/utils.py
+++ b/opengever/api/utils.py
@@ -1,3 +1,12 @@
+from functools import wraps
+from opengever.base.sentry import maybe_report_exception
+from requests import HTTPError
+from requests import Timeout
+from zope.publisher.http import status_reasons
+import json
+import sys
+import traceback
+
 
 def raise_for_api_request(request, exc):
     if not request.get("error_as_message"):
@@ -18,3 +27,84 @@ def get_obj_by_path(portal, path):
         return None
 
     return parent.restrictedTraverse(path[-1], None)
+
+
+REQUEST_TIMEOUT = 408
+GATEWAY_TIMEOUT = 504
+BAD_GATEWAY = 502
+
+
+def create_proxy_request_error_handler(logger, http_error_message):
+    """Creates a Decorator function to handle requests to a service or external
+    aplication.
+
+    We handle HTTP and timeout-errors in a special way. All other request errors
+    are handled by the rest-api with a 500 Internal Server Error.
+    """
+
+    def request_error_handler(func):
+
+        def handle_http_error(obj, exception):
+            """Handles general http errors.
+
+            We group these errors in a 502 Bad Gateway error.
+
+            HTTP timeout errors will map to a 504 gateway timeout.
+            """
+            service_status_code = exception.response.status_code
+            service_error = {'status_code': service_status_code}
+
+            if service_status_code in [REQUEST_TIMEOUT, GATEWAY_TIMEOUT]:
+                status_code = GATEWAY_TIMEOUT
+                service_error['message'] = str(exception).decode('utf-8')
+            else:
+                status_code = BAD_GATEWAY
+
+            try:
+                service_error.update(json.loads(exception.response.text))
+            except ValueError:
+                # No response body
+                pass
+
+            obj.request.response.setStatus(status_code)
+            response = {
+                u'message': http_error_message,
+                u'type': status_reasons.get(status_code),
+                u'service_error': service_error
+            }
+            return response
+
+        def handle_timeout_error(obj, exception):
+            """Handles all timeout errors. This can be:
+
+            - ReadTimeout
+            - ConnectTimeout
+
+            We group these errors in a 504 Gateway Timeout error.
+            """
+            obj.request.response.setStatus(GATEWAY_TIMEOUT)
+            return {
+                u'message': str(exception).decode('utf-8'),
+                u'type': type(exception).__name__.decode('utf-8'),
+            }
+
+        def log_exception_to_sentry(obj):
+            e_type, e_value, tb = sys.exc_info()
+            maybe_report_exception(obj, obj.request, e_type, e_value, tb)
+            formatted_traceback = ''.join(traceback.format_exception(e_type, e_value, tb))
+            logger.error('Exception while requesting teamraum deployment:\n%s', formatted_traceback)
+
+        @wraps(func)
+        def handler(obj, *args, **kwargs):
+            try:
+                return func(obj, *args, **kwargs)
+            except HTTPError as exception:
+                log_exception_to_sentry(obj)
+                return handle_http_error(obj, exception)
+            except Timeout as exception:
+                log_exception_to_sentry(obj)
+                return handle_timeout_error(obj, exception)
+
+        return handler
+
+    return request_error_handler

--- a/opengever/kub/client.py
+++ b/opengever/kub/client.py
@@ -5,6 +5,12 @@ import requests
 
 KUB_API_VERSION = 'v1'
 
+ENDPOINT_BY_TYPE = {
+    "person": "people",
+    "membership": "memberships",
+    "organization": "organizations"
+}
+
 
 class KuBClient(object):
 
@@ -44,3 +50,17 @@ class KuBClient(object):
         if len(res) != 1:
             raise LookupError()
         return res[0]
+
+    def get_full_entity_by_id(self, _id):
+        url = self.get_resolve_url(_id)
+        resp = self.session.get(url)
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_resolve_url(self, _id):
+        if ":" not in _id:
+            raise LookupError
+        id_type, uid = _id.split(":", 1)
+        if id_type not in ENDPOINT_BY_TYPE:
+            raise LookupError
+        return u'{}{}/{}'.format(self.kub_api_url, ENDPOINT_BY_TYPE[id_type], uid)

--- a/opengever/kub/testing.py
+++ b/opengever/kub/testing.py
@@ -18,14 +18,19 @@ class KuBIntegrationTestCase(IntegrationTestCase):
         api.portal.set_registry_record('service_token', u'secret', IKuBSettings)
         self.client = KuBClient()
 
-    def mock_get_by_id(self, mocker, _id):
+    def mock_get_by_id(self, mocker, _id, **kwargs):
         url = u'{}search?id={}'.format(self.client.kub_api_url, _id)
-        mocker.get(url, json=KUB_RESPONSES[url])
+        mocker.get(url, json=KUB_RESPONSES[url], **kwargs)
         return url
 
-    def mock_search(self, mocker, query_str):
+    def mock_search(self, mocker, query_str, **kwargs):
         url = u'{}search?q={}'.format(self.client.kub_api_url, query_str)
-        mocker.get(url, json=KUB_RESPONSES[url])
+        mocker.get(url, json=KUB_RESPONSES[url], **kwargs)
+        return url
+
+    def mock_get_full_entity_by_id(self, mocker, _id, **kwargs):
+        url = self.client.get_resolve_url(_id)
+        mocker.get(url, json=KUB_RESPONSES[url], **kwargs)
         return url
 
 
@@ -99,4 +104,34 @@ KUB_RESPONSES = {
         }
     ],
     "http://localhost:8000/api/v1/search?id=invalid-id": [],
+    "http://localhost:8000/api/v1/people/0e623708-2d0d-436a-82c6-c1a9c27b65dc": {
+        "addresses": [],
+        "canton": None,
+        "country": "",
+        "countryIdISO2": "",
+        "created": "2021-11-14T00:00:00+01:00",
+        "dateOfBirth": None,
+        "description": "",
+        "emailAddresses": [],
+        "firstName": "Julie",
+        "fullName": "Dupont Julie",
+        "id": "0e623708-2d0d-436a-82c6-c1a9c27b65dc",
+        "languageOfCorrespondance": "fr",
+        "maritalStatus": 2,
+        "memberships": [],
+        "modified": "2021-11-14T00:00:00+01:00",
+        "officialName": "Dupont",
+        "organizations": [],
+        "originName": "Paris",
+        "phoneNumbers": [],
+        "primaryEmail": None,
+        "primaryPhoneNumber": None,
+        "salutation": "Frau",
+        "sex": 2,
+        "status": 1,
+        "tags": [],
+        "thirdPartyId": None,
+        "title": "",
+        "urls": []
+    }
 }

--- a/opengever/ogds/base/actor.py
+++ b/opengever/ogds/base/actor.py
@@ -490,10 +490,8 @@ class KuBContactActor(Actor):
         return self.contact
 
     def represents_url(self):
-        # XXX This should be an URL pointing to KUB, e.g.
-        # https://kub.4teamwork.ch/people/baa7c72e-7a3a-4f55-924c-e0c9857b30d1
-        # For now KuB does not return such an URL
-        return None
+        return '{}/@kub/{}'.format(
+            api.portal.getSite().absolute_url(), self.identifier)
 
     def get_portrait_url(self):
         return None


### PR DESCRIPTION
This endpoint basically proxies requests to the KuB service. This allows the frontend to resolve KuB entities without communicating directly with KuB.
Note that we currently need to parse the ID of the KuB contact to then request it from the correct endpoint from the KuB service. This will not be necessary anymore once KuB offers a `@resolve` endpoint (see https://4teamwork.atlassian.net/browse/HG-1995). Once we have that new endpoint we could also use it in the `KuBContactsSource` where we currently still use the `search` endpoint to resolve a given ID (because the other endpoints do not return the `text` and `TypeId` fields, which we use in the source as value and token respectively).

For [CA-2606]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed

[CA-2606]: https://4teamwork.atlassian.net/browse/CA-2606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ