### PR TITLE
Fix sending notification mails from or to users with long mail addresses.

### DIFF
--- a/changes/CA-3277.bugfix
+++ b/changes/CA-3277.bugfix
@@ -1,0 +1,1 @@
+Fix sending notification mails from or to users with long mail addresses. [phgross]

--- a/opengever/activity/digest.py
+++ b/opengever/activity/digest.py
@@ -95,7 +95,7 @@ class DigestMailer(Mailer):
                   default=u'Daily Digest for ${username}',
                   mapping={'username': user.fullname()}),
                 context=self.request)
-            msg = self.prepare_mail(
+            msg, mail_to, mail_from = self.prepare_mail(
                 subject=subject,
                 to_userid=userid,
                 data={'notifications': self.prepare_data(notifications),
@@ -103,7 +103,7 @@ class DigestMailer(Mailer):
                       'title': title,
                       'today': today})
 
-            self.send_mail(msg)
+            self.send_mail(msg, mail_to, mail_from)
             self.mark_as_sent(notifications)
             self.record_digest(userid)
             logger.info('  Digest sent for %s (%s)' % (userid, user.email))

--- a/opengever/activity/mail.py
+++ b/opengever/activity/mail.py
@@ -36,13 +36,13 @@ class PloneNotificationMailer(NotificationDispatcher, Mailer):
                 'user %r.' % (notification.notification_id, recipient_user))
             return
 
-        msg = self.prepare_mail(
+        msg, mail_to, mail_from = self.prepare_mail(
             subject=data.get('subject'),
             to_userid=notification.userid,
             from_userid=notification.activity.actor_id,
             data=data
         )
-        self.send_mail(msg)
+        self.send_mail(msg, mail_to, mail_from)
 
     def get_subject(self, notification_data):
         prefix = translate(_(u'subject_prefix', default=u'GEVER Activity'),

--- a/opengever/activity/tests/test_mail.py
+++ b/opengever/activity/tests/test_mail.py
@@ -158,7 +158,11 @@ class TestEmailNotification(IntegrationTestCase):
         self.create_task_via_browser(browser)
         process_mail_queue()
 
-        mail = email.message_from_string(Mailing(self.portal).pop())
+        message, = Mailing(self.portal).get_mailhost().messages
+        self.assertEqual('foo@example.com', message.mto)
+        self.assertEqual('test@localhost', message.mfrom)
+
+        mail = email.message_from_string(message.messageText)
         self.assertEquals('foo@example.com', mail.get('To'))
         self.assertEquals('Ziegler Robert <test@localhost>', get_header(mail, 'From'))
         self.assertEquals('Ziegler Robert <robert.ziegler@gever.local>', get_header(mail, 'Reply-To'))

--- a/opengever/workspace/content_sharing_mailer.py
+++ b/opengever/workspace/content_sharing_mailer.py
@@ -48,7 +48,8 @@ class ContentSharingMailer(Mailer):
             'comment_title': comment_title,
             'comment': comment.splitlines(),
         }
-        msg = self.prepare_mail(subject=subject, to_email=to_email, cc_email=cc_email,
-                                from_userid=sender_id, data=data)
+        msg, mail_to, mail_from = self.prepare_mail(
+            subject=subject, to_email=to_email, cc_email=cc_email,
+            from_userid=sender_id, data=data)
 
-        self.send_mail(msg)
+        self.send_mail(msg, mail_to, mail_from)

--- a/opengever/workspace/participation/invitation_mailer.py
+++ b/opengever/workspace/participation/invitation_mailer.py
@@ -88,7 +88,8 @@ class InvitationMailer(Mailer):
             'comment': invitation['comment'].splitlines(),
             'public_url': get_current_admin_unit().public_url,
         }
-        msg = self.prepare_mail(subject=subject, to_email=invitation['recipient_email'],
-                                from_userid=invitation['inviter'], data=data)
+        msg, mail_to, mail_from = self.prepare_mail(
+            subject=subject, to_email=invitation['recipient_email'],
+            from_userid=invitation['inviter'], data=data)
 
-        self.send_mail(msg)
+        self.send_mail(msg, mail_to, mail_from)


### PR DESCRIPTION
Pass in from and to mail adresses when sending mails to avoid problems for users with long fullname or mail addresses.

possibly needs backport to 2021.22.x 

For [CA-3277]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-3277]: https://4teamwork.atlassian.net/browse/CA-3277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ