### PR TITLE
Improve translations of the disposition module.

### DIFF
--- a/changes/CA-2646.other
+++ b/changes/CA-2646.other
@@ -1,0 +1,1 @@
+Improve translations of the disposition module. [njohner]

--- a/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
@@ -202,7 +202,7 @@ msgstr "Tageszusammenfassung"
 #. Default: "Dispositions"
 #: ./opengever/activity/browser/settings.py
 msgid "label_dispositions"
-msgstr "Aussonderung"
+msgstr "Aussonderungen"
 
 #. Default: "Documents"
 #: ./opengever/activity/browser/settings.py

--- a/opengever/activity/locales/en/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/en/LC_MESSAGES/opengever.activity.po
@@ -82,14 +82,14 @@ msgstr "Created"
 #: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "disposition-added"
-msgstr "Disposition added"
+msgstr "Offer added"
 
 #. German translation: Bewertung finalisiert
 #. Default: "Disposition appraised"
 #: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "disposition-transition-appraise"
-msgstr "Disposition appraised"
+msgstr "Appraisal finalised"
 
 #. German translation: Archivierung bestätigt
 #. Default: "Disposition archived"
@@ -103,7 +103,7 @@ msgstr "Archival confirmed"
 #: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "disposition-transition-close"
-msgstr "Disposition closed"
+msgstr "Offer closed"
 
 #. German translation: Zur Archivierung angeboten
 #. Default: "Disposition disposed"
@@ -117,7 +117,7 @@ msgstr "Offered for archival"
 #: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "disposition-transition-refuse"
-msgstr "Disposition refused"
+msgstr "Offer refused"
 
 #. Default: "Document author changed"
 #: ./opengever/activity/__init__.py
@@ -233,7 +233,7 @@ msgstr "Daily Digest"
 #. Default: "Dispositions"
 #: ./opengever/activity/browser/settings.py
 msgid "label_dispositions"
-msgstr "Dispositions"
+msgstr "Disposals"
 
 #. Default: "Documents"
 #: ./opengever/activity/browser/settings.py

--- a/opengever/api/tests/test_disposition.py
+++ b/opengever/api/tests/test_disposition.py
@@ -25,7 +25,7 @@ class TestDispositionPost(IntegrationTestCase):
         self.assertEqual(
             {u'type': u'BadRequest',
              u'additional_metadata': {},
-             u'translated_message': u'The dossier Dossier for SIP is already offered in a different disposition.',
+             u'translated_message': u'The dossier Dossier for SIP is already in another offer.',
              u'message': u'error_offered_in_a_different_disposition'},
             browser.json)
 

--- a/opengever/disposition/locales/en/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/en/LC_MESSAGES/opengever.disposition.po
@@ -33,7 +33,7 @@ msgstr "All"
 #. Default: "appraisal_list"
 #: ./opengever/disposition/browser/excel_export.py
 msgid "appraisal_list"
-msgstr "appraisal list"
+msgstr "appraisal_list"
 
 #. German translation: Laufnummer
 #. Default: "Sequence Number"
@@ -56,7 +56,7 @@ msgstr "The dossier ${title} is still active."
 #. Default: "The dossier ${title} is already offered in a different disposition."
 #: ./opengever/disposition/validators.py
 msgid "error_offered_in_a_different_disposition"
-msgstr "The dossier ${title} is already offered in a different disposition."
+msgstr "The dossier ${title} is already in another offer."
 
 #. German translation: Die Aufbewahrungsfrist der selektierten Dossiers ist nicht abgelaufen.
 #. Default: "The retention period of the selected dossiers is not expired."
@@ -146,26 +146,26 @@ msgstr "Details:"
 #. Default: "Disposition"
 #: ./opengever/disposition/disposition.py
 msgid "label_disposition"
-msgstr "Disposition"
+msgstr "Offer"
 
 #. German translation: Angebot hinzugefügt
 #. Default: "Disposition added"
 #: ./opengever/disposition/activities.py
 #: ./opengever/disposition/history.py
 msgid "label_disposition_added"
-msgstr "Disposition added"
+msgstr "Offer added"
 
 #. German translation: Angebot bearbeitet
 #. Default: "Disposition edited"
 #: ./opengever/disposition/history.py
 msgid "label_disposition_edited"
-msgstr "Disposition edited"
+msgstr "Offer edited"
 
 #. German translation: Ablieferungspaket herunterladen
 #. Default: "Download disposition package"
 #: ./opengever/disposition/browser/overview.py
 msgid "label_dispositon_package_download"
-msgstr "Download disposition package"
+msgstr "Download disposal package"
 
 #. German translation: Nicht archivieren
 #. Default: "Don't archive"
@@ -333,13 +333,13 @@ msgstr "Archival confirmed by ${user}"
 #. Default: "Disposition closed and all dossiers destroyed by ${user}"
 #: ./opengever/disposition/history.py
 msgid "msg_disposition_close"
-msgstr "Disposition closed and all dossiers destroyed by ${user}"
+msgstr "Offer closed and all dossiers destroyed by ${user}"
 
 #. German translation: Zur Archivierung angeboten durch ${user}
 #. Default: "Disposition disposed for the archive by ${user}"
 #: ./opengever/disposition/history.py
 msgid "msg_disposition_disposed"
-msgstr "Disposition offered for archival by ${user}"
+msgstr "Offered for archival by ${user}"
 
 #. German translation: Editiert durch ${user}
 #. Default: "Edited by ${user}"
@@ -351,7 +351,7 @@ msgstr "Edited by ${user}"
 #. Default: "Disposition refused by ${user}"
 #: ./opengever/disposition/history.py
 msgid "msg_disposition_refuse"
-msgstr "Disposition refused by ${user}"
+msgstr "Offer refused by ${user}"
 
 #. German translation: Aktualisiert durch ${user}
 #. Default: "Updated by ${user}"
@@ -363,7 +363,7 @@ msgstr "Updated by ${user}"
 #. Default: "No SIP Package generated for this disposition."
 #: ./opengever/disposition/browser/ech0160.py
 msgid "msg_no_sip_package_generated"
-msgstr "No SIP package generated yet for this disposition."
+msgstr "No SIP package generated yet for this offer."
 
 #. German translation: SIP Paket erfolgreich generiert.
 #. Default: "SIP Package generated successfully."
@@ -388,7 +388,7 @@ msgstr "Progress"
 #. Default: "New disposition added by ${user} on admin unit ${admin_unit}"
 #: ./opengever/disposition/activities.py
 msgid "summary_disposition_added"
-msgstr "New disposition added by ${user} on admin unit ${admin_unit}"
+msgstr "New offer added by ${user} on admin unit ${admin_unit}"
 
 #. German translation: Löschprotokoll zu ${disposition}
 #. Default: "Removal protocol for ${disposition}"

--- a/opengever/disposition/locales/fr/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/fr/LC_MESSAGES/opengever.disposition.po
@@ -31,7 +31,7 @@ msgstr "Tous"
 #. Default: "appraisal_list"
 #: ./opengever/disposition/browser/excel_export.py
 msgid "appraisal_list"
-msgstr "liste_evaluation"
+msgstr "liste_evaluations"
 
 #. Default: "Sequence Number"
 #: ./opengever/disposition/browser/listing.py
@@ -333,4 +333,4 @@ msgstr "Nouvelle offre ajoutée par ${user} dans le mandataire ${admin_unit}"
 #. Default: "Removal protocol for ${disposition}"
 #: ./opengever/disposition/browser/removal_protocol.py
 msgid "title_removal_protocol"
-msgstr "Protocole de supression pour ${disposition}"
+msgstr "Protocole de suppression pour ${disposition}"

--- a/opengever/disposition/tests/test_activities.py
+++ b/opengever/disposition/tests/test_activities.py
@@ -40,10 +40,10 @@ class TestDispositionNotifications(IntegrationTestCase):
         activity = Activity.query.one()
         self.assertEquals('disposition-added', activity.kind)
         self.assertEquals(
-            u'New disposition added by {} on admin unit Hauptmandant'.format(
+            u'New offer added by {} on admin unit Hauptmandant'.format(
                 actor.get_label(with_principal=False)),
             activity.summary)
-        self.assertEquals(u'Disposition added', activity.label)
+        self.assertEquals(u'Offer added', activity.label)
         self.assertIsNone(activity.description)
         self.assertEquals(u'Angebot 13.49', activity.title)
 
@@ -76,7 +76,7 @@ class TestDispositionNotifications(IntegrationTestCase):
         activity = Activity.query.all()[-1]
         self.assertEquals('disposition-transition-dispose', activity.kind)
         self.assertEquals(
-            u'Disposition offered for archival by {}'.format(actor.get_link()),
+            u'Offered for archival by {}'.format(actor.get_link()),
             activity.summary)
         self.assertEquals(u'Submit disposition', activity.label)
         self.assertIsNone(activity.description)
@@ -95,7 +95,7 @@ class TestDispositionNotifications(IntegrationTestCase):
         activity = Activity.query.all()[-1]
         self.assertEquals('disposition-transition-appraised-to-closed', activity.kind)
         self.assertEquals(
-            u'Disposition closed and all dossiers destroyed by {}'.format(
+            u'Offer closed and all dossiers destroyed by {}'.format(
                 actor.get_link()),
             activity.summary)
         self.assertEquals(u'Dispose of dossiers', activity.label)
@@ -128,7 +128,7 @@ class TestDispositionNotifications(IntegrationTestCase):
         activity = Activity.query.all()[-1]
         self.assertEquals('disposition-transition-close', activity.kind)
         self.assertEquals(
-            u'Disposition closed and all dossiers '
+            u'Offer closed and all dossiers '
             'destroyed by {}'.format(actor.get_link()), activity.summary)
         self.assertEquals(u'Dispose of dossiers', activity.label)
         self.assertIsNone(activity.description)
@@ -144,7 +144,7 @@ class TestDispositionNotifications(IntegrationTestCase):
         activity = Activity.query.all()[-1]
         self.assertEquals('disposition-transition-refuse', activity.kind)
         self.assertEquals(
-            u'Disposition refused by {}'.format(actor.get_link()),
+            u'Offer refused by {}'.format(actor.get_link()),
             activity.summary)
         self.assertEquals(u'Refuse', activity.label)
         self.assertIsNone(activity.description)

--- a/opengever/disposition/tests/test_disposition.py
+++ b/opengever/disposition/tests/test_disposition.py
@@ -40,7 +40,7 @@ class TestDisposition(IntegrationTestCase):
         """Expected format:
         Disposition {adminiunit-abbreviation} {today's date}'.
         """
-        expected = 'Disposition Client1 Jan 01, 2014'
+        expected = 'Offer Client1 Jan 01, 2014'
 
         self.login(self.archivist, browser)
         with freeze(datetime(2014, 1, 1)):
@@ -110,8 +110,8 @@ class TestDisposition(IntegrationTestCase):
         browser.find('Save').click()
 
         self.assertEquals(['There were some errors.'], error_messages())
-        self.assertEquals(['The dossier {} is already offered in a different '
-                           'disposition.'.format(self.offered_dossier_to_archive.Title())],
+        self.assertEquals(['The dossier {} is already in another offer.'
+                           ''.format(self.offered_dossier_to_archive.Title())],
                           browser.css('.fieldErrorBox .error').text)
 
     @browsing
@@ -266,7 +266,7 @@ class TestDispositionEditForm(IntegrationTestCase):
 
         # Download is possible
         self.assertIn(
-            'Download disposition package', browser.css('ul.actions li').text)
+            'Download disposal package', browser.css('ul.actions li').text)
 
     @browsing
     def test_sip_package_is_removed_on_close(self, browser):

--- a/opengever/disposition/tests/test_ech0160export.py
+++ b/opengever/disposition/tests/test_ech0160export.py
@@ -53,7 +53,7 @@ class TestECH0160DownloadView(IntegrationTestCase):
 
         self.set_workflow_state('disposition-state-disposed', self.disposition)
         browser.open(self.disposition, view='ech0160_download')
-        self.assertEquals([u'No SIP package generated yet for this disposition.'],
+        self.assertEquals([u'No SIP package generated yet for this offer.'],
                           error_messages())
 
     @browsing

--- a/opengever/disposition/tests/test_excel_export.py
+++ b/opengever/disposition/tests/test_excel_export.py
@@ -75,5 +75,5 @@ class TestDispositionExcelExport(IntegrationTestCase):
         browser.open(self.disposition, view='download_excel')
         fname = eval(browser.headers.get(
             "content-disposition").split(";")[1].split("=")[1])
-        expected = "liste_evaluation_angebot-31-8-2016.xlsx"
+        expected = "liste_evaluations_angebot-31-8-2016.xlsx"
         self.assertEquals(expected, fname)

--- a/opengever/disposition/tests/test_history.py
+++ b/opengever/disposition/tests/test_history.py
@@ -75,7 +75,7 @@ class TestHistoryEntries(IntegrationTestCase):
         self.assertTrue(isinstance(entry, Disposed))
         self.assertEquals('dispose', entry.css_class)
         self.assertEquals(
-            u'Disposition offered for archival by {}'.format(self.current_user_link),
+            u'Offered for archival by {}'.format(self.current_user_link),
             translate(entry.msg(), context=self.request))
 
     def test_add_history_entry_when_directly_close_a_disposition(self):
@@ -93,7 +93,7 @@ class TestHistoryEntries(IntegrationTestCase):
         self.assertTrue(isinstance(entry, AppraisedToClosed))
         self.assertEquals('close', entry.css_class)
         self.assertEquals(
-            u'Disposition closed and all dossiers destroyed by {}'.format(
+            u'Offer closed and all dossiers destroyed by {}'.format(
                 self.current_user_link),
             translate(entry.msg(), context=self.request))
 
@@ -132,7 +132,7 @@ class TestHistoryEntries(IntegrationTestCase):
         self.assertTrue(isinstance(entry, Closed))
         self.assertEquals('close', entry.css_class)
         self.assertEquals(
-            u'Disposition closed and all dossiers destroyed by {}'.format(
+            u'Offer closed and all dossiers destroyed by {}'.format(
                 self.current_user_link),
             translate(entry.msg(), context=self.request))
 
@@ -146,7 +146,7 @@ class TestHistoryEntries(IntegrationTestCase):
         self.assertTrue(isinstance(entry, Refused))
         self.assertEquals('refuse', entry.css_class)
         self.assertEquals(
-            u'Disposition refused by {}'.format(self.current_user_link),
+            u'Offer refused by {}'.format(self.current_user_link),
             translate(entry.msg(), context=self.request))
 
     def test_ignores_modified_events_during_dossier_destruction(self):

--- a/opengever/disposition/tests/test_listing.py
+++ b/opengever/disposition/tests/test_listing.py
@@ -188,8 +188,8 @@ class TestDispositionHistoryListing(BaseLatexListingTest):
             ['Nov 16, 2016 08:12 AM', 'Flucht Ramon (ramon.flucht)', 'Confirm archival'],
             ['Nov 06, 2016 12:33 PM', 'Flucht Ramon (ramon.flucht)', 'Submit disposition'],
             ['Nov 06, 2016 12:33 PM', 'Flucht Ramon (ramon.flucht)', 'Appraise disposition'],
-            ['Nov 01, 2016 11:00 AM', 'Flucht Ramon (ramon.flucht)', 'Disposition edited'],
-            ['Aug 31, 2016 07:07 PM', 'Flucht Ramon (ramon.flucht)', 'Disposition added']]
+            ['Nov 01, 2016 11:00 AM', 'Flucht Ramon (ramon.flucht)', 'Offer edited'],
+            ['Aug 31, 2016 07:07 PM', 'Flucht Ramon (ramon.flucht)', 'Offer added']]
 
         for row, expected_row in zip(rows, expected_rows):
             self.assert_row_values(expected_row, row)
@@ -205,6 +205,6 @@ class TestDispositionHistoryListing(BaseLatexListingTest):
                                      self.disposition.get_history())
 
         self.assert_row_values(
-            ['Disposition edited'], rows[0][2])
+            ['Offer edited'], rows[0][2])
         self.assert_row_values(
-            ['Disposition added'], rows[1][2])
+            ['Offer added'], rows[1][2])

--- a/opengever/disposition/tests/test_overview.py
+++ b/opengever/disposition/tests/test_overview.py
@@ -154,12 +154,12 @@ class TestDispositionOverview(IntegrationTestCase):
         browser.find('Submit disposition').click()
 
         self.assertEquals(['Export appraisal list as an Excel file',
-                           'Download disposition package'],
+                           'Download disposal package'],
                           browser.css('ul.actions li').text)
 
         self.assertEquals(
             os.path.join(self.disposition.absolute_url(), 'ech0160_download'),
-            browser.find('Download disposition package').get('href'))
+            browser.find('Download disposal package').get('href'))
         self.assertEquals(
             os.path.join(self.disposition.absolute_url(), 'download_excel'),
             browser.find('Export appraisal list as an Excel file').get('href'))


### PR DESCRIPTION
For some reason in english we used `disposition` to translate both `Angebot` and `Aussonderung`. 
I've now consistently used `Offer` for `Angebot`, and `disposal` for `Aussonderung`.

Actually I might find it better to use `Disposal offer`, `Offre de triage` and `Aussonderungsangebot` instead of simply `Offer`, etc. I did not want to change everything now...

For [CA-2646]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-2646]: https://4teamwork.atlassian.net/browse/CA-2646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ