### PR TITLE
CA-3284 Include is_completed in sql task serialization.

### DIFF
--- a/changes/CA-2274.bugfix
+++ b/changes/CA-2274.bugfix
@@ -1,0 +1,1 @@
+Include is_completed in sql task serialization. [tinagerber]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -12,6 +12,9 @@ Breaking Changes
 Other Changes
 ^^^^^^^^^^^^^
 
+- Include is_completed in sql task serialization.
+
+
 2021.24.0 (2021-11-30)
 ----------------------
 

--- a/docs/public/dev-manual/api/globalindex.rst
+++ b/docs/public/dev-manual/api/globalindex.rst
@@ -28,6 +28,7 @@ Die Felder ``issuer_fullname`` und ``responsible_fullname`` sind überholt und d
           "containing_subdossier": "",
           "created": "2016-08-31T18:27:33",
           "deadline": "2020-01-01",
+          "is_completed": false,
           "is_private": true,
           "is_subtask": false,
           "issuer": "robert.ziegler",

--- a/opengever/api/task.py
+++ b/opengever/api/task.py
@@ -166,6 +166,7 @@ class SerializeTaskModelToJson(SerializeSQLModelToJsonBase):
     def add_additional_metadata(self, data):
         data.update({
             '@id': self.context.absolute_url(),
+            'is_completed': self.context.is_completed,
             # XXX deprecated
             'issuer_fullname': display_name(self.context.issuer),
             'issuer_actor': serialize_actor_id_to_json_summary(self.context.issuer),

--- a/opengever/api/tests/test_globalindex.py
+++ b/opengever/api/tests/test_globalindex.py
@@ -25,6 +25,7 @@ class TestGlobalIndexGet(IntegrationTestCase):
              u'containing_subdossier': u'',
              u'created': u'2016-08-31T18:27:33',
              u'deadline': u'2020-01-01',
+             u'is_completed': False,
              u'is_private': True,
              u'is_subtask': False,
              u'issuer': u'robert.ziegler',

--- a/opengever/globalindex/model/task.py
+++ b/opengever/globalindex/model/task.py
@@ -13,10 +13,12 @@ from opengever.base.query import BaseQuery
 from opengever.base.types import UnicodeCoercingText
 from opengever.base.utils import escape_html
 from opengever.globalindex.model.reminder_settings import ReminderSetting
+from opengever.inbox import FINAL_FORWARDING_STATES
 from opengever.inbox import FORWARDING_TASK_TYPE_ID
 from opengever.ogds.base.actor import Actor
 from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.ogds.models.service import ogds_service
+from opengever.task import FINAL_TASK_STATES
 from plone import api
 from Products.CMFPlone.utils import safe_unicode
 from sqlalchemy import and_
@@ -160,6 +162,11 @@ class Task(Base):
 
     def is_open(self):
         return self.review_state in self.OPEN_STATES
+
+    @property
+    def is_completed(self):
+        return self.review_state in FINAL_TASK_STATES \
+            or self.review_state in FINAL_FORWARDING_STATES
 
     @property
     def issuer_actor(self):

--- a/opengever/globalindex/tests/test_sql_task.py
+++ b/opengever/globalindex/tests/test_sql_task.py
@@ -153,6 +153,44 @@ class TestGlobalindexTask(TestCase):
 
         self.assertTrue(task_with_pred.is_successor)
 
+    def test_is_completed(self):
+        open_task = create(Builder('globalindex_task')
+                           .having(int_id=1, review_state='task-state-open'))
+        self.assertFalse(open_task.is_completed)
+        planned_task = create(Builder('globalindex_task')
+                              .having(int_id=2, review_state='task-state-planned'))
+        self.assertFalse(planned_task.is_completed)
+        in_progress_task = create(Builder('globalindex_task')
+                                  .having(int_id=3, review_state='task-state-in-progress'))
+        self.assertFalse(in_progress_task.is_completed)
+        rejected_task = create(Builder('globalindex_task')
+                               .having(int_id=4, review_state='task-state-rejected'))
+        self.assertFalse(rejected_task.is_completed)
+        resolved_task = create(Builder('globalindex_task')
+                               .having(int_id=5, review_state='task-state-resolved'))
+        self.assertFalse(resolved_task.is_completed)
+
+        closed_task = create(Builder('globalindex_task')
+                             .having(int_id=6, review_state='task-state-tested-and-closed'))
+        self.assertTrue(closed_task.is_completed)
+        cancelled_task = create(Builder('globalindex_task')
+                                .having(int_id=7, review_state='task-state-cancelled'))
+        self.assertTrue(cancelled_task.is_completed)
+        skipped_task = create(Builder('globalindex_task')
+                              .having(int_id=8, review_state='task-state-skipped'))
+        self.assertTrue(skipped_task.is_completed)
+
+        open_forwarding = create(Builder('globalindex_task')
+                                 .having(int_id=9, review_state='forwarding-state-open'))
+        self.assertFalse(open_forwarding.is_completed)
+        refused_forwarding = create(Builder('globalindex_task')
+                                    .having(int_id=10, review_state='forwarding-state-refused'))
+        self.assertFalse(refused_forwarding.is_completed)
+
+        closed_forwarding = create(Builder('globalindex_task')
+                                   .having(int_id=11, review_state='forwarding-state-closed'))
+        self.assertTrue(closed_forwarding.is_completed)
+
     def test_has_remote_predecessor(self):
         predecessor = create(Builder('globalindex_task')
                              .having(int_id=1, admin_unit_id='fd'))


### PR DESCRIPTION
In task listings, we now use `is_completed` to display whether a task is completed. For this to work for task listings that use the `@globalindex` endpoint, the attribute must be present in the SQL task serialization.

For [CA-3284]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))

[CA-3284]: https://4teamwork.atlassian.net/browse/CA-3284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ