### PR TITLE
Add @xhr-upload endpoint to upload documents with a multipart/form-data xhr request

### DIFF
--- a/changes/CA-1742.feature
+++ b/changes/CA-1742.feature
@@ -1,0 +1,1 @@
+-  Add @xhr-upload endpoint to upload documents with a multipart/form-data xhr request. [elioschmutz]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,6 +11,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- @xhr-upload: new endpoint to upload documents as a multipart/form-data xhr request. [elioschmutz]
 
 2021.24.0 (2021-11-30)
 ----------------------

--- a/docs/public/dev-manual/api/documents.rst
+++ b/docs/public/dev-manual/api/documents.rst
@@ -398,3 +398,40 @@ Für die Bearbeitung des Öffentlichkeitsstatus eines Dokuments in einem abgesch
   .. sourcecode:: http
 
     HTTP/1.1 204 No Content
+
+Dokument über einen XHR-Request als multipart/form-data erstellen
+-----------------------------------------------------------------
+Neben dem ``@tus-upload``-Endpoint gibt es auch die Mögilchkeit, Dokumente über einen normalen XHR-Request als multipart/form-data zu erstellen.
+
+**Beispiel-Request**:
+
+  .. sourcecode:: http
+
+    POST http://example.com/ordnungssystem/dossier-1/@xhr-upload HTTP/1.1
+    Authorization: [AUTH_DATA]
+    Accept: application/json
+    Content-Type: multipart/form-data; boundary=------------------------b3e801e2d0fb0cc9
+    Content-Length: [NUMBER_OF_BYTES_IN_ENTIRE_REQUEST_BODY]
+
+    --------------------------b3e801e2d0fb0cc9
+    Content-Disposition: form-data; name="title"
+
+    Hello Worlds
+    --------------------------b3e801e2d0fb0cc9
+    Content-Disposition: form-data; name="file"; filename="helloworld.pdf"
+    Content-Type: application/octet-stream
+
+    [FILE_DATA]
+
+
+**Beispiel-Response**:
+
+  .. sourcecode:: http
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    {
+      "@id": "http://example.com/ordnungssystem/dossier-1/document-1",
+      "...": "..."
+    }

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -1325,6 +1325,14 @@
 
   <plone:service
       method="POST"
+      name="@xhr-upload"
+      for="Products.CMFCore.interfaces.IContentish"
+      factory=".xhr.XHRUploadPost"
+      permission="cmf.AddPortalContent"
+      />
+
+  <plone:service
+      method="POST"
       name="@save-document-as-pdf"
       for="opengever.dossier.behaviors.dossier.IDossierMarker"
       factory=".save_document_as_pdf.SaveDocumentAsPdfPost"

--- a/opengever/api/tests/test_xhr_upload.py
+++ b/opengever/api/tests/test_xhr_upload.py
@@ -1,0 +1,97 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+from requests_toolbelt.multipart.encoder import MultipartEncoder
+from zExceptions import BadRequest
+
+
+class TestXHRUpload(IntegrationTestCase):
+
+    def prepare_request(self, fields):
+        encoder = MultipartEncoder(fields=fields)
+        return encoder.to_string(), {
+            'Content-Type': encoder.content_type,
+            'Accept': 'application/json',
+        }
+
+    @browsing
+    def test_create_document(self, browser):
+        fields = {
+            'title': 'My document',
+            'file': ('mydocument.txt', 'my text', 'text/plain'),
+        }
+
+        self.login(self.regular_user, browser)
+        body, headers = self.prepare_request(fields)
+
+        with self.observe_children(self.dossier) as children:
+            browser.open(self.dossier.absolute_url() + '/@xhr-upload',
+                         method='POST',
+                         headers=headers,
+                         data=body)
+
+        self.assertEqual(201, browser.status_code)
+
+        doc = children["added"].pop()
+        self.assertEqual('My document', doc.Title())
+        self.assertFalse(doc.is_mail)
+
+    @browsing
+    def test_create_document_without_title_will_use_file_name_as_title(self, browser):
+        fields = {
+            'file': ('mydocument.txt', 'my text', 'text/plain'),
+        }
+
+        self.login(self.regular_user, browser)
+        body, headers = self.prepare_request(fields)
+
+        with self.observe_children(self.dossier) as children:
+            browser.open(self.dossier.absolute_url() + '/@xhr-upload',
+                         method='POST',
+                         headers=headers,
+                         data=body)
+
+        self.assertEqual(201, browser.status_code)
+
+        doc = children["added"].pop()
+        self.assertEqual('mydocument', doc.Title())
+
+    @browsing
+    def test_create_document_without_file_will_raise_bad_request(self, browser):
+        fields = {
+            'title': 'My document',
+        }
+
+        self.login(self.regular_user, browser)
+        body, headers = self.prepare_request(fields)
+
+        browser.exception_bubbling = True
+        with self.assertRaises(BadRequest) as cm:
+            browser.open(self.dossier.absolute_url() + '/@xhr-upload',
+                         method='POST',
+                         headers=headers,
+                         data=body)
+
+        self.assertEqual('Property "file" is required',
+                         str(cm.exception))
+
+    @browsing
+    def test_create_email(self, browser):
+        fields = {
+            'title': 'My E-Mail',
+            'file': ('mymail.eml', 'my text', 'text/plain'),
+        }
+
+        self.login(self.regular_user, browser)
+        body, headers = self.prepare_request(fields)
+
+        with self.observe_children(self.dossier) as children:
+            browser.open(self.dossier.absolute_url() + '/@xhr-upload',
+                         method='POST',
+                         headers=headers,
+                         data=body)
+
+        self.assertEqual(201, browser.status_code)
+
+        mail = children["added"].pop()
+        self.assertEqual('My E-Mail', mail.Title())
+        self.assertTrue(mail.is_mail)

--- a/opengever/api/xhr.py
+++ b/opengever/api/xhr.py
@@ -1,0 +1,46 @@
+from ftw.mail.mail import IMail
+from opengever.api.add import GeverFolderPost
+from opengever.document.document import IDocumentSchema
+from opengever.document.document import is_email_upload
+from zExceptions import BadRequest
+
+
+class XHRUploadPost(GeverFolderPost):
+    """XHR document upload endpoint with multipart/form-data
+    """
+
+    @property
+    def request_data(self):
+        form_data = self.request.form
+        title = form_data.get('title', '').decode('utf-8')
+        request_data = {
+            '@type': 'ftw.mail.mail' if is_email_upload(self.filename) else 'opengever.document.document'
+            }
+
+        if title:
+            request_data['title'] = title
+
+        return request_data
+
+    def extract_data(self):
+        self.file_upload = self.request.form.get('file')
+
+        if not self.file_upload:
+            raise BadRequest('Property "file" is required')
+
+        self.filename = self.file_upload.filename.decode('utf-8')
+        self.content_type = self.file_upload.headers.get('Content-Type')
+
+        return super(XHRUploadPost, self).extract_data()
+
+    def before_deserialization(self, obj):
+        field = IDocumentSchema['file']
+        if obj.is_mail:
+            field = IMail['message']
+
+        namedblobfile = field._type(
+            data=self.file_upload,
+            contentType=self.content_type,
+            filename=self.filename)
+
+        field.set(field.interface(obj), namedblobfile)


### PR DESCRIPTION
This PR adds a new endpoint `@xhr-upload` to upload documents with a `multipart/form-data` xhr request

This endpoint was introduced beside of the already existing `@tus-upload` endpoint. It's because be don't have access to the response of an uploaded document if using tus.

For [CA-1742]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [x] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-1742]: https://4teamwork.atlassian.net/browse/CA-1742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ