### PR TITLE
Expose retention_expiration column in @listing endpoint.

### DIFF
--- a/changes/CA-2115.feature
+++ b/changes/CA-2115.feature
@@ -1,0 +1,1 @@
+Expose retention_expiration column in @listing endpoint. [tinagerber]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -14,6 +14,7 @@ Other Changes
 - @xhr-upload: new endpoint to upload documents as a multipart/form-data xhr request. [elioschmutz]
 
 - Include is_completed in sql task serialization.
+- ``@listing``: Add retention_expiration column.
 
 
 2021.24.0 (2021-11-30)

--- a/docs/public/dev-manual/api/listings.rst
+++ b/docs/public/dev-manual/api/listings.rst
@@ -117,6 +117,7 @@ werden. Folgende Felder stehen zur Verfügung:
 - ``relative_path``: Pfad
 - ``responsible_fullname``: Federführung oder Auftragnehmer (Anzeigename)
 - ``responsible``: Federführung (Benutzername)
+- ``retention_expiration``: Ablauf der Aufbewahrungsfrist
 - ``review_state_label``: Status (Anzeigewert)
 - ``review_state``: Status
 - ``sequence_number``: Laufnummer

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -347,13 +347,14 @@ FIELDS_WITH_MAPPING = [
 date_fields = set([
     'changed',
     'created',
+    'deadline',
     'delivery_date',
     'document_date',
     'end',
     'modified',
     'receipt_date',
+    'retention_expiration',
     'start',
-    'deadline',
     'touched',
 ])
 

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -238,6 +238,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
             'columns=public_trial',
             'columns=reference',
             'columns=title',
+            'columns=retention_expiration',
             'columns=review_state',
             'columns=relative_path',
             'columns=UID',
@@ -268,6 +269,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
              u'public_trial': u'Nicht gepr\xfcft',
              u'trashed': False,
              u'reference': u'Client1 1.1 / 1',
+             u'retention_expiration': None,
              u'title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
              u'relative_path': u'ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1'},
             results['items'][-1])
@@ -731,6 +733,22 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
         start_dates = list(set(map(lambda x: x['start'], items)))
         self.assertEqual(1, len(start_dates))
         self.assertEqual('2016-01-01T00:00:00Z', start_dates[0])
+
+    @browsing
+    def test_filter_by_retention_expiration(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        view = ('@listing?name=dossiers&columns:list=title'
+                '&columns:list=retention_expiration'
+                '&filters.retention_expiration:record=*TO2016-05-01')
+        browser.open(self.repository_root, view=view,
+                     headers=self.api_headers)
+
+        self.assertEqual(4, browser.json['items_total'])
+        items = browser.json['items']
+        retention_expirations = list(set(map(lambda x: x['retention_expiration'], items)))
+        self.assertEqual(2, len(retention_expirations))
+        self.assertEqual([u'2013-01-01T00:00:00Z', u'2016-01-01T00:00:00Z'], retention_expirations)
 
     @browsing
     def test_wildcard_is_supported_by_date_filters(self, browser):


### PR DESCRIPTION
This is needed to add a filter for expired dossiers in the new frontend.

For [CA-2115]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))

[CA-2115]: https://4teamwork.atlassian.net/browse/CA-2115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ