### PR TITLE
Remove value propagation of archival_value and custody_period.

### DIFF
--- a/changes/CA-3239.other
+++ b/changes/CA-3239.other
@@ -1,0 +1,1 @@
+Remove value propagation of archival_value and custody_period. [njohner]

--- a/opengever/base/behaviors/lifecycle.py
+++ b/opengever/base/behaviors/lifecycle.py
@@ -104,10 +104,7 @@ def propagate_vocab_restrictions_to_children(container, event):
        IContainerModifiedEvent.providedBy(event):
         return
 
-    restricted_fields = [
-        ILifeCycle['retention_period'],
-        ILifeCycle['archival_value'],
-        ILifeCycle['custody_period']]
+    restricted_fields = [ILifeCycle['retention_period']]
 
     propagate_vocab_restrictions(
         container, event, restricted_fields, ILifeCycleMarker)


### PR DESCRIPTION
`archival_value` and `custody_period` are not restricted anymore, so propagation of the minimally allowed value is not necessary anymore. This seems to have been forgotten in https://github.com/4teamwork/opengever.core/pull/6998 and https://github.com/4teamwork/opengever.core/pull/7140.

For [CA3239]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)