### PR TITLE
Skip dossier_depth check if only files are uploaded.

### DIFF
--- a/changes/CA-3296.bugfix
+++ b/changes/CA-3296.bugfix
@@ -1,0 +1,1 @@
+- Fix file upload into subdossiers which exceed the current max dossier depth. [phgross]

--- a/opengever/api/tests/test_upload_structure.py
+++ b/opengever/api/tests/test_upload_structure.py
@@ -1,3 +1,5 @@
+from ftw.builder import Builder
+from ftw.builder import create
 from ftw.testbrowser import browsing
 from opengever.api.upload_structure import IUploadStructureAnalyser
 from opengever.testing import SolrIntegrationTestCase
@@ -158,6 +160,23 @@ class TestUploadStructure(SolrIntegrationTestCase):
             self.subdossier,
             ['/folder/file.txt'],
             u'Maximum dossier depth exceeded')
+
+    @browsing
+    def test_upload_structure_allows_document_upload_even_max_dossier_depth_is_already_exceeded(self, browser):
+        self.login(self.regular_user, browser)
+
+        subsubdossier = create(Builder('dossier').within(self.subdossier))
+
+        self.assert_upload_structure_raises_bad_request(
+            browser,
+            subsubdossier,
+            ['/folder/file.txt'],
+            u'Maximum dossier depth exceeded')
+
+        self.assert_upload_structure_returns_ok(
+            browser,
+            subsubdossier,
+            ['file.txt'])
 
     @browsing
     def test_upload_structure_ignores_maximal_depth_in_workspace_area(self, browser):

--- a/opengever/api/upload_structure.py
+++ b/opengever/api/upload_structure.py
@@ -184,6 +184,10 @@ class DossierDepthCheckMixin(object):
         return 0
 
     def check_dossier_depth(self):
+        # It is only a file upload
+        if self.structure["max_container_depth"] == 0:
+            return
+
         max_depth = api.portal.get_registry_record(
             name='maximum_dossier_depth',
             interface=IDossierContainerTypes


### PR DESCRIPTION
Fix file upload into subdossiers which exceed the current max dossier depth. 

Needs backport to `2021.22.x`

For [CA-3296]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-3296]: https://4teamwork.atlassian.net/browse/CA-3296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ