### PR TITLE
Fix task documents method/property collision

### DIFF
--- a/changes/CA-3272-2.bugfix
+++ b/changes/CA-3272-2.bugfix
@@ -1,0 +1,1 @@
+Task delegation does no longer set an unwanted documents-property on the subtask. [elioschmutz]

--- a/changes/CA-3272.bugfix
+++ b/changes/CA-3272.bugfix
@@ -1,0 +1,1 @@
+Fix task overview in old ui for tasks created by task delegation. [elioschmutz]

--- a/opengever/api/tests/test_task_from_template.py
+++ b/opengever/api/tests/test_task_from_template.py
@@ -29,8 +29,8 @@ class TestSequentialTaskPassDocumentsToNextTask(IntegrationTestCase):
 
         self.seq_subtask_1.reindexObject()
         self.assertItemsEqual([self.document, self.seq_subtask_1_document],
-                              self.seq_subtask_1.documents())
-        self.assertItemsEqual([], self.seq_subtask_2.documents())
+                              self.seq_subtask_1.task_documents())
+        self.assertItemsEqual([], self.seq_subtask_2.task_documents())
 
     @browsing
     def test_can_pass_documents_to_next_task_with_open_resolved_transition(self, browser):

--- a/opengever/task/browser/overview.py
+++ b/opengever/task/browser/overview.py
@@ -28,7 +28,7 @@ class Overview(BrowserView, GeverTabMixin):
 
     def documents(self):
         # merge and sort the two different lists
-        document_list = self.context.documents()
+        document_list = self.context.task_documents()
         document_list.sort(lambda a, b: cmp(b.modified(), a.modified()))
 
         return IContentListing(document_list)

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -717,7 +717,7 @@ class Task(Container, TaskReminderSupport):
                 obj=self, transition='task-transition-open-planned')
             self.sync()
 
-    def documents(self):
+    def task_documents(self):
         """Returns contained documents and related documents."""
         def _get_documents():
             """Return documents in this task and subtasks."""

--- a/opengever/task/tests/test_delegate.py
+++ b/opengever/task/tests/test_delegate.py
@@ -59,6 +59,26 @@ class TestDelegateTaskForm(IntegrationTestCase):
         self.assertEqual('task-15', subtask.id)
 
     @browsing
+    def test_delegate_does_not_set_documents_attribute_on_subtask(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(self.task, view='delegate_recipients')
+
+        # step 1
+        form = browser.find_form_by_field('Responsibles')
+        form.find_widget('Responsibles').fill(self.dossier_responsible)
+        browser.css('#form-buttons-save').first.click()
+
+        # step 2
+        browser.css('#form-buttons-save').first.click()
+
+        subtask = self.task.objectValues()[-1]
+        self.assertFalse(
+            hasattr(subtask, 'documents'),
+            'The transition-extender should not pass the documents-property to the dexterity createContent method.'
+            )
+
+    @browsing
     def test_issuer_is_prefilled_with_current_user(self, browser):
         self.login(self.regular_user, browser=browser)
 

--- a/opengever/task/tests/test_task.py
+++ b/opengever/task/tests/test_task.py
@@ -129,7 +129,7 @@ class TestTaskIntegration(SolrIntegrationTestCase):
             RelationValue(intids.getId(self.document))]
 
         self.assertIn(self.taskdocument, self.task.listFolderContents())
-        self.assertItemsEqual([self.taskdocument, self.document], self.task.documents())
+        self.assertItemsEqual([self.taskdocument, self.document], self.task.task_documents())
 
     def test_addresponse(self):
         self.login(self.dossier_responsible)

--- a/opengever/task/transition.py
+++ b/opengever/task/transition.py
@@ -212,7 +212,7 @@ class DefaultTransitionExtender(TransitionExtender):
         intids = getUtility(IIntIds)
 
         current_document_ids = [intids.getId(document) for document
-                                in self.context.documents()]
+                                in self.context.task_documents()]
         next_task_related_items = [item.to_id for item
                                    in ITask(next_task).relatedItems]
         ITask(next_task).relatedItems = [

--- a/opengever/task/transition.py
+++ b/opengever/task/transition.py
@@ -439,7 +439,7 @@ class DelegateTransitionExtender(DefaultTransitionExtender):
     def after_transition_hook(self, transition, disable_sync, transition_params):
         create_subtasks(self.context,
                         transition_params.pop('responsibles'),
-                        transition_params.get('documents', []),
+                        transition_params.pop('documents', []),
                         transition_params)
 
 


### PR DESCRIPTION
This PR fixes an issue where we have a conflict between a method called `documents` on a task (introduced in https://github.com/4teamwork/opengever.core/pull/7217) and a property callled `documents`.

![Bildschirmfoto 2021-12-02 um 16 16 21](https://user-images.githubusercontent.com/557005/144496800-47e4088e-b989-443c-be34-3bb7a29c558a.png)

Since the property wins over a method, we have had an issue when rendering the `task/browser/overview.py` because it expects a function under `documents`.

![Bildschirmfoto 2021-12-02 um 16 27 21](https://user-images.githubusercontent.com/557005/144495071-5a711c73-fc40-4fec-959f-26bc795fa2a5.png)

The main issue is when delegating tasks. The transition-extender passes `documents` coming from the `transition_params` further to the dexterity's [createContent](https://github.com/plone/plone.dexterity/blob/2.2.8/plone/dexterity/utils.py#L150) method which will then add a property `documents` to the created content, even if it's not defined in a schema-definition.

Since the refactoring of https://github.com/4teamwork/opengever.core/pull/7217, we also define a method on the task object called `documents`. So the user visible issue exists since this refactoring.

To fix the issue we:

- rename the `documents` method to `task_documents``
- no longer forward the `documents` transition-param to the `createContent` method

We decided to not create an upgrade step for this issue. It would be a quite expensive upgradestep without any benefit (right now...) => This is still up for discussion if we want an upgrade-step or not

For [CA-3272]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-3272]: https://4teamwork.atlassian.net/browse/CA-3272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ