### PR TITLE
Improve teamraum meeting PDF style.

### DIFF
--- a/changes/CA-3249.other
+++ b/changes/CA-3249.other
@@ -1,0 +1,1 @@
+Improve teamraum meeting PDF style. [njohner]

--- a/opengever/workspace/browser/templates/meeting_minutes.pt
+++ b/opengever/workspace/browser/templates/meeting_minutes.pt
@@ -41,14 +41,25 @@ li > p {
   margin-top: 0.25em;
   margin-bottom: 0.25em;
 }
-table, figure {
+figure {
   page-break-inside: avoid;
+}
+table {
+  margin-top: 10pt;
+  margin-bottom: 15pt;
+  border-collapse: collapse;
+  page-break-inside: auto;
 }
 th {
   text-align: left;
 }
 td, th {
+  padding-left: 10pt;
   padding-right: 10pt;
+  border: 1px solid black;
+}
+table.borderless td, table.borderless th {
+  border: none;
 }
 a {
   text-decoration: none;
@@ -78,7 +89,7 @@ a {
 
   <h1 i18n:translate="heading_meeting_minutes">Meeting Minutes: <span i18n:name="title" tal:replace="context/title">Title</span></h1>
 
-  <table>
+  <table class="borderless" >
     <tr tal:condition="context/location">
       <th><span i18n:translate="label_location">Location</span>:</th>
       <td tal:content="context/location"></td>


### PR DESCRIPTION
With this PR we try to improve the layout and style of the Teamraum meeting PDFs. The main changes are that we allow tables to get split over several pages and we add borders to the tables. I include 2 PDFs showing the difference between the old style and the new style:

[old_style.pdf](https://github.com/4teamwork/opengever.core/files/7649764/old_style.pdf)
[new_style.pdf](https://github.com/4teamwork/opengever.core/files/7649765/new_style.pdf)

Note that the output PDF does not respect the column widths set by the user. This is because the `wdith` attribute is only presentational hint. `weasyprint` does have a parameter that should force respecting these attributes (https://doc.courtbouillon.org/weasyprint/stable/api_reference.html#cmdoption-p), which I tried and did not help. 🤷 

For [CA-3249]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-3249]: https://4teamwork.atlassian.net/browse/CA-3249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ