### PR TITLE
Add API Support for the disposition history.

### DIFF
--- a/changes/CA-2118.feature
+++ b/changes/CA-2118.feature
@@ -1,0 +1,1 @@
+Add API Support for the disposition history. [phgross]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,6 +11,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- Disposition serialization contains now responses. [phgross]
 - @xhr-upload: new endpoint to upload documents as a multipart/form-data xhr request. [elioschmutz]
 
 - Include is_completed in sql task serialization.

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -42,6 +42,7 @@
   <adapter factory=".actors.SerializeActorToJson" />
   <adapter factory=".disposition.DeserializeDispositionFromJson" />
   <adapter factory=".disposition.SerializeDispositionToJson" />
+  <adapter factory=".disposition.SerializeDispositionResponseToJson" />
   <adapter factory=".repositoryfolder.DeserializeRepositoryFolderFromJson" />
   <adapter factory=".repositoryfolder.SerializeRepositoryFolderToJson" />
   <adapter factory=".inbox.SerializeInboxToJson" />

--- a/opengever/api/disposition.py
+++ b/opengever/api/disposition.py
@@ -1,11 +1,13 @@
 from opengever.api import _
 from opengever.api.deserializer import GeverDeserializeFromJson
 from opengever.api.relationfield import relationfield_value_to_object
+from opengever.api.response import SerializeResponseToJson
 from opengever.api.serializer import GeverSerializeFolderToJson
 from opengever.base.behaviors.lifecycle import ILifeCycle
 from opengever.base.utils import unrestrictedUuidToObject
 from opengever.disposition.disposition import IDispositionSchema
 from opengever.disposition.interfaces import IAppraisal
+from opengever.disposition.response import IDispositionResponse
 from opengever.disposition.validators import OfferedDossiersValidator
 from opengever.repository.interfaces import IRepositoryFolder
 from plone.restapi.deserializer import json_body
@@ -13,6 +15,7 @@ from plone.restapi.interfaces import IDeserializeFromJson
 from plone.restapi.interfaces import IFieldSerializer
 from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.interfaces import ISerializeToJsonSummary
+from plone.restapi.serializer.converters import json_compatible
 from plone.restapi.services import Service
 from zExceptions import BadRequest
 from zope.component import adapter
@@ -128,3 +131,15 @@ class AppraisalPatch(Service):
             return serializer()
 
         return self.reply_no_content()
+
+
+@implementer(ISerializeToJson)
+@adapter(IDispositionResponse, Interface)
+class SerializeDispositionResponseToJson(SerializeResponseToJson):
+
+    def __call__(self, *args, **kwargs):
+        result = super(SerializeDispositionResponseToJson, self).__call__(
+            *args, **kwargs)
+
+        result['dossiers'] = json_compatible(self.context.dossiers)
+        return result

--- a/opengever/api/tests/test_disposition.py
+++ b/opengever/api/tests/test_disposition.py
@@ -206,6 +206,44 @@ class TestDispositionSerialization(IntegrationTestCase):
             },
             browser.json['dossier_details'])
 
+    @browsing
+    def test_contains_responses_list_with_additional_dossiers_list(self, browser):
+        self.login(self.records_manager, browser)
+        browser.open(self.disposition_with_sip,
+                     method='GET', headers=self.api_headers)
+
+        self.assertEqual(
+            [
+                {u'creator': {u'token': u'ramon.flucht', u'title': u'Flucht Ramon'},
+                 u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/disposition-2/@responses/1472663373000000',
+                 u'created': u'2016-08-31T19:09:33',
+                 u'response_id': 1472663373000000,
+                 u'response_type': u'added',
+                 u'dossiers': [
+                     {u'reference_number': u'Client1 1.1 / 13',
+                      u'title': u'Dossier for SIP',
+                      u'former_state': u'dossier-state-resolved',
+                      u'repository_title': u'1.1. Vertr\xe4ge und Vereinbarungen',
+                      u'intid': 1019033300,
+                      u'appraisal': True}],
+                 u'text': u'',
+                 u'changes': []},
+                {u'creator': {u'token': u'ramon.flucht', u'title': u'Flucht Ramon'},
+                 u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/disposition-2/@responses/1472663493000000',
+                 u'created': u'2016-08-31T19:11:33',
+                 u'response_id': 1472663493000000,
+                 u'response_type': u'disposition-transition-dispose',
+                 u'dossiers': [
+                     {u'reference_number': u'Client1 1.1 / 13',
+                      u'title': u'Dossier for SIP',
+                      u'former_state': u'dossier-state-resolved',
+                      u'repository_title': u'1.1. Vertr\xe4ge und Vereinbarungen',
+                      u'intid': 1019033300,
+                      u'appraisal': True}],
+                 u'text': u'',
+                 u'changes': []}],
+            browser.json['responses'])
+
 
 class TestAppraisalUpdate(IntegrationTestCase):
 

--- a/opengever/core/upgrades/20211203182308_migrate_disposition_history/upgrade.py
+++ b/opengever/core/upgrades/20211203182308_migrate_disposition_history/upgrade.py
@@ -1,0 +1,38 @@
+from ftw.upgrade import UpgradeStep
+from opengever.base.response import IResponseContainer
+from opengever.disposition.response import DispositionResponse
+from zope.annotation import IAnnotations
+
+
+class MigrateDispositionHistory(UpgradeStep):
+    """Migrate disposition history.
+    """
+
+    deferrable = True
+
+    old_key = 'disposition_history'
+
+    def __call__(self):
+        self.install_upgrade_profile()
+
+        for disposition in self.objects(
+                {'portal_type': 'opengever.disposition.disposition'},
+                'Migrate disposition history'):
+
+            self.migrate_history(disposition)
+
+    def migrate_history(self, disposition):
+        ann = IAnnotations(disposition)
+        if self.old_key not in ann.keys():
+            return
+
+        container = IResponseContainer(disposition)
+
+        for item in ann.get(self.old_key):
+            response = DispositionResponse(response_type=item.get('transition'))
+            response.created = item.get('date')
+            response.creator = item.get('actor_id')
+            response.dossiers = item.get('dossiers')
+            container.add(response)
+
+        ann.pop(self.old_key)

--- a/opengever/disposition/activities.py
+++ b/opengever/disposition/activities.py
@@ -1,5 +1,6 @@
 from opengever.activity.base import BaseActivity
 from opengever.disposition import _
+from opengever.disposition.history import DispositionHistory
 from opengever.ogds.base.actor import Actor
 from opengever.ogds.base.utils import get_current_admin_unit
 from Products.CMFPlone import PloneMessageFactory
@@ -43,16 +44,17 @@ class DispositionStateChangedActivity(BaseActivity):
 
     @property
     def kind(self):
-        return self.entry.transition
+        return self.entry.response_type
 
     @property
     def label(self):
         return self.translate_to_all_languages(
-            PloneMessageFactory(self.entry.transition))
+            PloneMessageFactory(self.entry.response_type))
 
     @property
     def summary(self):
-        return self.translate_to_all_languages(self.entry.msg())
+        history = DispositionHistory.get(self.entry)
+        return self.translate_to_all_languages(history.msg())
 
     @property
     def description(self):

--- a/opengever/disposition/browser/overview.py
+++ b/opengever/disposition/browser/overview.py
@@ -3,7 +3,6 @@ from opengever.base.behaviors.lifecycle import ILifeCycle
 from opengever.disposition import _
 from opengever.disposition.delivery import DELIVERY_STATUS_LABELS
 from opengever.disposition.delivery import DeliveryScheduler
-from opengever.disposition.interfaces import IHistoryStorage
 from plone import api
 from plone.protect.utils import addTokenToUrl
 from Products.Five.browser import BrowserView
@@ -99,7 +98,7 @@ class DispositionOverview(BrowserView):
         return api.content.get_state(self.context) == 'disposition-state-closed'
 
     def get_history(self):
-        return IHistoryStorage(self.context).get_history()
+        return self.context.get_history()
 
     def get_states(self):
         """Returns a sorted list of all disposition states.

--- a/opengever/disposition/configure.zcml
+++ b/opengever/disposition/configure.zcml
@@ -13,7 +13,6 @@
   <include package=".viewlets" />
 
   <adapter factory=".appraisal.Appraisal" />
-  <adapter factory=".history.HistoryStorage" />
   <adapter factory=".validators.OfferedDossiersValidator" />
 
   <adapter

--- a/opengever/disposition/disposition.py
+++ b/opengever/disposition/disposition.py
@@ -7,17 +7,18 @@ from opengever.activity import notification_center
 from opengever.activity.roles import DISPOSITION_ARCHIVIST_ROLE
 from opengever.activity.roles import DISPOSITION_RECORDS_MANAGER_ROLE
 from opengever.base.behaviors.classification import IClassification
-from opengever.base.behaviors.classification import IClassification
 from opengever.base.behaviors.lifecycle import ILifeCycle
+from opengever.base.response import IResponseContainer
+from opengever.base.response import IResponseSupported
 from opengever.base.security import elevated_privileges
 from opengever.base.source import SolrObjPathSourceBinder
 from opengever.disposition import _
 from opengever.disposition.appraisal import IAppraisal
 from opengever.disposition.delivery import DeliveryScheduler
 from opengever.disposition.ech0160.sippackage import SIPPackage
+from opengever.disposition.history import DispositionHistory
 from opengever.disposition.interfaces import IDisposition
 from opengever.disposition.interfaces import IDuringDossierDestruction
-from opengever.disposition.interfaces import IHistoryStorage
 from opengever.dossier.base import DOSSIER_STATES_OFFERABLE
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.ogds.base.utils import get_current_admin_unit
@@ -225,7 +226,8 @@ class IDispositionSchema(model.Schema):
 
 
 class Disposition(Container):
-    implements(IDisposition)
+    implements(IDisposition, IResponseSupported)
+
 
     destroyed_key = 'destroyed_dossiers'
 
@@ -252,7 +254,10 @@ class Disposition(Container):
         return [relation.to_object for relation in self.dossiers]
 
     def get_history(self):
-        return IHistoryStorage(self).get_history()
+        history = [DispositionHistory.get(response)
+                   for response in IResponseContainer(self)]
+        history.reverse()
+        return history
 
     def get_destroyed_dossiers(self):
         annotations = IAnnotations(self)

--- a/opengever/disposition/history.py
+++ b/opengever/disposition/history.py
@@ -30,7 +30,7 @@ class DispositionHistory(object):
 
     @classmethod
     def get(cls, mapping):
-        description = cls.registry.get(mapping.get('transition'))
+        description = cls.registry.get(mapping.response_type)
         if not description:
             raise ValueError(
                 'No specific entry found for {}'.format(
@@ -43,18 +43,18 @@ class DispositionHistory(object):
 
     @property
     def transition(self):
-        return self.mapping.get('transition')
+        return self.mapping.response_type
 
     @property
     def transition_label(self):
-        return translate(self.mapping.get('transition'),
+        return translate(self.mapping.response_type,
                          domain="plone",
                          context=getRequest())
 
     @property
     def date(self):
         return api.portal.get_localized_time(
-            datetime=self.mapping.get('date'), long_format=True)
+            datetime=self.mapping.created, long_format=True)
 
     def msg(self):
         _('msg_disposition_updated', default=u'Updated by ${user}')
@@ -62,14 +62,14 @@ class DispositionHistory(object):
 
     @property
     def actor_label(self):
-        return Actor.lookup(self.mapping.get('actor_id')).get_label()
+        return Actor.lookup(self.mapping.creator).get_label()
 
     @property
     def _msg_mapping(self):
-        return {'user': Actor.lookup(self.mapping.get('actor_id')).get_link()}
+        return {'user': Actor.lookup(self.mapping.creator).get_link()}
 
     def details(self):
-        return self.mapping.get('dossiers')
+        return self.mapping.dossiers
 
 
 class Added(DispositionHistory):

--- a/opengever/disposition/history.py
+++ b/opengever/disposition/history.py
@@ -1,16 +1,8 @@
-from datetime import datetime
 from opengever.disposition import _
-from opengever.disposition.interfaces import IDisposition
-from opengever.disposition.interfaces import IHistoryStorage
 from opengever.ogds.base.actor import Actor
-from persistent.dict import PersistentDict
-from persistent.list import PersistentList
 from plone import api
-from zope.annotation.interfaces import IAnnotations
-from zope.component import adapter
 from zope.globalrequest import getRequest
 from zope.i18n import translate
-from zope.interface import implementer
 
 
 class DispositionHistory(object):
@@ -174,41 +166,3 @@ class Refused(DispositionHistory):
             mapping=self._msg_mapping)
 
 DispositionHistory.add_description(Refused)
-
-
-@implementer(IHistoryStorage)
-@adapter(IDisposition)
-class HistoryStorage(object):
-
-    key = 'disposition_history'
-
-    def __init__(self, context):
-        self.context = context
-        self._annotations = IAnnotations(self.context)
-        if self.key not in self._annotations.keys():
-            self._annotations[self.key] = PersistentList()
-
-    @property
-    def _storage(self):
-        return self._annotations[self.key]
-
-    def add(self, transition, actor_id, dossiers):
-        """Adds a new history entry to the storage.
-        transition: string
-        actor_id: user_id as string
-        dossiers: a list of dossier representations.
-        """
-
-        dossier_list = PersistentList(
-            [dossier.get_storage_representation() for dossier in dossiers])
-        self._storage.append(
-            PersistentDict({'transition': transition,
-                            'actor_id': actor_id,
-                            'date': datetime.now(),
-                            'dossiers': dossier_list}))
-
-    def get_history(self):
-        entries = [DispositionHistory.get(mapping)
-                   for mapping in self._storage]
-        entries.reverse()
-        return entries

--- a/opengever/disposition/interfaces.py
+++ b/opengever/disposition/interfaces.py
@@ -6,10 +6,6 @@ class IAppraisal(Interface):
     """The appraisal adapter Interface."""
 
 
-class IHistoryStorage(Interface):
-    """The history storage adapter Interface."""
-
-
 class IDisposition(Interface):
     """The disposition Interface."""
 

--- a/opengever/disposition/response.py
+++ b/opengever/disposition/response.py
@@ -1,0 +1,17 @@
+from opengever.base.response import IResponse
+from opengever.base.response import Response
+from persistent.list import PersistentList
+from zope.interface import implements
+
+
+class IDispositionResponse(IResponse):
+    """Marker interface for disposition responses."""
+
+
+class DispositionResponse(Response):
+
+    implements(IDispositionResponse)
+
+    def __init__(self, *args, **kwargs):
+        super(DispositionResponse, self).__init__(*args, **kwargs)
+        self.dossiers = PersistentList()

--- a/opengever/disposition/tests/test_history.py
+++ b/opengever/disposition/tests/test_history.py
@@ -6,10 +6,10 @@ from opengever.disposition.history import AppraisedToClosed
 from opengever.disposition.history import Archived
 from opengever.disposition.history import Closed
 from opengever.disposition.history import Disposed
+from opengever.disposition.history import DispositionHistory
 from opengever.disposition.history import Edited
 from opengever.disposition.history import Refused
 from opengever.disposition.interfaces import IAppraisal
-from opengever.disposition.interfaces import IHistoryStorage
 from opengever.ogds.base.actor import ActorLookup
 from opengever.testing import IntegrationTestCase
 from plone import api
@@ -27,7 +27,7 @@ class TestHistoryEntries(IntegrationTestCase):
     def test_add_history_entry_when_created_a_disposition(self):
         self.login(self.records_manager)
 
-        entry = IHistoryStorage(self.disposition).get_history()[0]
+        entry = self.disposition.get_history()[0]
 
         self.assertTrue(isinstance(entry, Added))
         self.assertEquals('add', entry.css_class)
@@ -43,7 +43,7 @@ class TestHistoryEntries(IntegrationTestCase):
                                    self.offered_dossier_to_destroy]})
         browser.find('Save').click()
 
-        entry = IHistoryStorage(self.disposition).get_history()[0]
+        entry = self.disposition.get_history()[0]
 
         self.assertTrue(isinstance(entry, Edited))
         self.assertEquals('edit', entry.css_class)
@@ -55,7 +55,7 @@ class TestHistoryEntries(IntegrationTestCase):
         api.content.transition(obj=self.disposition,
                                transition='disposition-transition-appraise')
 
-        entry = IHistoryStorage(self.disposition).get_history()[0]
+        entry = self.disposition.get_history()[0]
 
         self.assertTrue(isinstance(entry, Appraised))
         self.assertEquals('appraise', entry.css_class)
@@ -70,7 +70,7 @@ class TestHistoryEntries(IntegrationTestCase):
             api.content.transition(obj=self.disposition,
                                    transition='disposition-transition-dispose')
 
-        entry = IHistoryStorage(self.disposition).get_history()[0]
+        entry = self.disposition.get_history()[0]
 
         self.assertTrue(isinstance(entry, Disposed))
         self.assertEquals('dispose', entry.css_class)
@@ -88,7 +88,7 @@ class TestHistoryEntries(IntegrationTestCase):
             api.content.transition(obj=self.disposition,
                                    transition='disposition-transition-appraised-to-closed')
 
-        entry = IHistoryStorage(self.disposition).get_history()[0]
+        entry = self.disposition.get_history()[0]
 
         self.assertTrue(isinstance(entry, AppraisedToClosed))
         self.assertEquals('close', entry.css_class)
@@ -107,7 +107,7 @@ class TestHistoryEntries(IntegrationTestCase):
             api.content.transition(obj=self.disposition,
                                    transition='disposition-transition-archive')
 
-        entry = IHistoryStorage(self.disposition).get_history()[0]
+        entry = self.disposition.get_history()[0]
 
         self.assertTrue(isinstance(entry, Archived))
         self.assertEquals('archive', entry.css_class)
@@ -127,7 +127,7 @@ class TestHistoryEntries(IntegrationTestCase):
             api.content.transition(obj=self.disposition,
                                    transition='disposition-transition-close')
 
-        entry = IHistoryStorage(self.disposition).get_history()[0]
+        entry = self.disposition.get_history()[0]
 
         self.assertTrue(isinstance(entry, Closed))
         self.assertEquals('close', entry.css_class)
@@ -141,7 +141,7 @@ class TestHistoryEntries(IntegrationTestCase):
         api.content.transition(obj=self.disposition,
                                transition='disposition-transition-refuse')
 
-        entry = IHistoryStorage(self.disposition).get_history()[0]
+        entry = self.disposition.get_history()[0]
 
         self.assertTrue(isinstance(entry, Refused))
         self.assertEquals('refuse', entry.css_class)
@@ -167,7 +167,7 @@ class TestHistoryEntries(IntegrationTestCase):
             ['disposition-transition-close', 'disposition-transition-archive',
              'disposition-transition-dispose', 'disposition-transition-appraise',
              'added'],
-            [item.transition for item in IHistoryStorage(self.disposition).get_history()]
+            [item.transition for item in self.disposition.get_history()]
         )
 
 

--- a/opengever/disposition/tests/test_listing.py
+++ b/opengever/disposition/tests/test_listing.py
@@ -4,8 +4,9 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testing import freeze
 from lxml.cssselect import CSSSelector
+from opengever.base.response import IResponseContainer
 from opengever.base.security import elevated_privileges
-from opengever.disposition.interfaces import IHistoryStorage
+from opengever.disposition.response import DispositionResponse
 from opengever.latex.listing import ILaTexListing
 from opengever.testing import IntegrationTestCase
 from opengever.testing import SolrIntegrationTestCase
@@ -167,8 +168,8 @@ class TestDispositionHistoryListing(BaseLatexListingTest):
         self.login(self.records_manager)
 
         with freeze(datetime(2016, 11, 1, 11, 0)):
-            storage = IHistoryStorage(self.disposition)
-            storage.add('edited', api.user.get_current().getId(), [])
+            response = DispositionResponse(response_type='edited')
+            IResponseContainer(self.disposition).add(response)
 
         with freeze(datetime(2016, 11, 6, 12, 33)), elevated_privileges():
             api.content.transition(self.disposition,
@@ -197,8 +198,8 @@ class TestDispositionHistoryListing(BaseLatexListingTest):
     def test_transition_label_for_added_and_edited_entries_is_translated_correctly(self):
         self.login(self.records_manager)
 
-        storage = IHistoryStorage(self.disposition)
-        storage.add('edited', api.user.get_current().getId(), [])
+        response = DispositionResponse(response_type='edited')
+        IResponseContainer(self.disposition).add(response)
 
         rows = self.get_listing_rows(self.disposition,
                                      'disposition_history',


### PR DESCRIPTION
To be able to reuse the existing response extension and `@response` endpoint,  I transformed the existing HistoryStorage to a regular IResponsesContainer. Including a migration for existing disposition objects. The upgradestep deferrable, but the migration shouldn't take long time, because there aren't any disposition objects in production yet.


For [CA-2118]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- API change:
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))


[CA-2118]: https://4teamwork.atlassian.net/browse/CA-2118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ