### PR TITLE
Handle KuB feature when creating a document from template.

### DIFF
--- a/changes/CA-2452.feature
+++ b/changes/CA-2452.feature
@@ -1,0 +1,1 @@
+Add support for KuB contacts in document-from-template endpoint. [njohner]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -9,6 +9,7 @@ API Changelog
 Breaking Changes
 ^^^^^^^^^^^^^^^^
 
+- Support recipient in ``@document-from-template`` endpoint when KuB feature is enabled.
 - Contact feature in the ``@config`` endpoint is now one of ``plone``, ``sql`` and ``kub``.
 
 Other Changes

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -9,6 +9,8 @@ API Changelog
 Breaking Changes
 ^^^^^^^^^^^^^^^^
 
+- Contact feature in the ``@config`` endpoint is now one of ``plone``, ``sql`` and ``kub``. [njohner]
+
 Other Changes
 ^^^^^^^^^^^^^
 - Add new endpoint ``@external-activities`` (see :ref:`docs <external-activities>`)

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -9,14 +9,14 @@ API Changelog
 Breaking Changes
 ^^^^^^^^^^^^^^^^
 
-- Contact feature in the ``@config`` endpoint is now one of ``plone``, ``sql`` and ``kub``. [njohner]
+- Contact feature in the ``@config`` endpoint is now one of ``plone``, ``sql`` and ``kub``.
 
 Other Changes
 ^^^^^^^^^^^^^
 - Add new endpoint ``@external-activities`` (see :ref:`docs <external-activities>`)
 - Include sip_delivery_status in the disposition serialization.
 - Disposition serialization contains now responses.
-- @xhr-upload: new endpoint to upload documents as a multipart/form-data xhr request. [elioschmutz]
+- ``@xhr-upload``: new endpoint to upload documents as a multipart/form-data xhr request.
 - Include is_completed in sql task serialization.
 - ``@listing``: Add retention_expiration column.
 - New endpoints ``@my-substitutes`` and ``@substitutes`` are added (see :ref:`substitutes`).
@@ -29,12 +29,12 @@ Other Changes
 
 Breaking Changes
 ^^^^^^^^^^^^^^^^
-- @complete-successor-task: ``documents`` payload: Now requires relative paths to the siteroot instead physical paths. The physical path is for internal use only. [elioschmutz]
+- @complete-successor-task: ``documents`` payload: Now requires relative paths to the siteroot instead physical paths. The physical path is for internal use only.
 - Error message and response status code for ForbiddenByQuota errors have changed.
 
 Other Changes
 ^^^^^^^^^^^^^
-- @complete-successor-task: ``documents`` payload: now also resolves document references by @id. [elioschmutz]
+- @complete-successor-task: ``documents`` payload: now also resolves document references by @id.
 - @reminders now returns 204 NoContent when no reminder is set.
 - Added API support for dispositions objects.
 - Added ``@kub`` endpoint to resolve KuB entities by their ID.
@@ -45,8 +45,8 @@ Other Changes
 Breaking Changes
 ^^^^^^^^^^^^^^^^
 - Some error messages have been renamed, but the format how an error is returned stays the same, only the response now usually contains a translated error message and may contain additional metadata.
-- Toggling a Workspace Todos review state from active to completed and back can be done thorugh the newly introduced `@toggle` endpiont for todos. [elioschmutz]
-- Workspace Todos do no longer provide a completed-field. Completing a todo is now done through a workflow transition. [elioschmutz]
+- Toggling a Workspace Todos review state from active to completed and back can be done thorugh the newly introduced `@toggle` endpiont for todos.
+- Workspace Todos do no longer provide a completed-field. Completing a todo is now done through a workflow transition.
 - The ``completed`` field in the ``@listing`` is now longer supported, use the ``is_completed`` field instead.
 
 Other Changes

--- a/docs/public/dev-manual/api/templatefolder.rst
+++ b/docs/public/dev-manual/api/templatefolder.rst
@@ -31,3 +31,8 @@ Der Endpoint erwartet zwei Parameter:
 
 Als Response wird die JSON-Repräsentation des neu erstellten Dokuments geliefert,
 siehe :ref:`Inhaltstypen <content-types>`.
+
+Mit Kontakt- und Behördenverzeichnis
+------------------------------------
+
+Wenn OneGov GEVER mit der Kontakt- und Behördenverzeichnis Applikation verlinkt ist, kann zusätzlich noch ein ``recipient`` mitgegeben werden, dessen Daten als docproperties verwendet werden. Valide ``recipient`` können von ``@globalsources/contacts`` auf Stufe PloneSiteRoot abgefragt werden.

--- a/opengever/api/kub.py
+++ b/opengever/api/kub.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
 from opengever.api.utils import create_proxy_request_error_handler
 from opengever.api.utils import default_http_error_code_mapping
-from opengever.kub.client import KuBClient
+from opengever.kub.entity import KuBEntity
 from plone.restapi.services import Service
 from zExceptions import BadRequest
 from zope.interface import implements
@@ -39,8 +39,8 @@ class KuBGet(Service):
     @kub_request_error_handler
     def reply(self):
         _id = self.read_params().decode('utf-8')
-        client = KuBClient()
-        return client.get_full_entity_by_id(_id)
+        entity = KuBEntity(_id, full=True)
+        return entity.serialize()
 
     def read_params(self):
         if len(self.params) != 1:

--- a/opengever/api/schema/globalsources.py
+++ b/opengever/api/schema/globalsources.py
@@ -1,4 +1,5 @@
 from opengever.api.schema.querysources import GEVERQuerySourcesGet
+from opengever.contact.sources import PloneSqlOrKubContactSourceBinder
 from opengever.ogds.base.sources import AllFilteredGroupsSourceBinder
 from opengever.ogds.base.sources import AllUsersAndGroupsSourceBinder
 from opengever.ogds.base.sources import CurrentAdminUnitOrgUnitsSourceBinder
@@ -19,6 +20,10 @@ class IGlobalSourceSchema(model.Schema):
 
     current_admin_unit_org_units = schema.Choice(
         source=CurrentAdminUnitOrgUnitsSourceBinder(),
+    )
+
+    contacts = schema.Choice(
+        source=PloneSqlOrKubContactSourceBinder()
     )
 
 

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -60,7 +60,7 @@ class TestConfig(IntegrationTestCase):
                 u'archival_file_conversion': False,
                 u'archival_file_conversion_blacklist': [],
                 u'changed_for_end_date': True,
-                u'contacts': False,
+                u'contacts': 'plone',
                 u'disposition_disregard_retention_period': False,
                 u'disposition_transport_filesystem': False,
                 u'disposition_transport_ftps': False,

--- a/opengever/base/configuration.py
+++ b/opengever/base/configuration.py
@@ -25,6 +25,7 @@ from opengever.dossier.interfaces import IDossierContainerTypes
 from opengever.dossier.interfaces import IDossierResolveProperties
 from opengever.dossier.interfaces import ITemplateFolderProperties
 from opengever.ech0147.interfaces import IECH0147Settings
+from opengever.kub import is_kub_feature_enabled
 from opengever.mail.interfaces import IMailDownloadSettings
 from opengever.meeting.interfaces import IMeetingSettings
 from opengever.nightlyjobs.interfaces import INightlyJobsSettings
@@ -139,7 +140,7 @@ class GeverSettingsAdpaterV1(object):
         features['archival_file_conversion'] = api.portal.get_registry_record('archival_file_conversion_enabled', interface=IDossierResolveProperties)  # noqa
         features['archival_file_conversion_blacklist'] = api.portal.get_registry_record('archival_file_conversion_blacklist', interface=IDossierResolveProperties)  # noqa
         features['changed_for_end_date'] = api.portal.get_registry_record('use_changed_for_end_date', interface=IDossierResolveProperties)  # noqa
-        features['contacts'] = api.portal.get_registry_record('is_feature_enabled', interface=IContactSettings)
+        features['contacts'] = self._get_contact_type()
         features['disposition_disregard_retention_period'] = api.portal.get_registry_record('disregard_retention_period', interface=IDispositionSettings)  # noqa
         features['disposition_transport_filesystem'] = api.portal.get_registry_record('enabled', interface=IFilesystemTransportSettings)  # noqa
         features['disposition_transport_ftps'] = api.portal.get_registry_record('enabled', interface=IFTPSTransportSettings)  # noqa
@@ -178,3 +179,10 @@ class GeverSettingsAdpaterV1(object):
 
     def is_filing_number_feature_installed(self):
         return IFilingNumberActivatedLayer.providedBy(getRequest())
+
+    def _get_contact_type(self):
+        if api.portal.get_registry_record('is_feature_enabled', interface=IContactSettings):
+            return "sql"
+        elif is_kub_feature_enabled():
+            return "kub"
+        return "plone"

--- a/opengever/contact/sources.py
+++ b/opengever/contact/sources.py
@@ -1,8 +1,12 @@
+from opengever.contact import is_contact_feature_enabled
 from opengever.contact.models import Contact
 from opengever.contact.models import Organization
 from opengever.contact.models import OrgRole
 from opengever.contact.models import Person
 from opengever.contact.ogdsuser import OgdsUserToContactAdapter
+from opengever.kub import is_kub_feature_enabled
+from opengever.kub.sources import KuBContactsSourceBinder
+from opengever.ogds.base.sources import UsersContactsInboxesSourceBinder
 from opengever.ogds.models.exceptions import RecordNotFound
 from opengever.ogds.models.service import ogds_service
 from z3c.formwidget.query.interfaces import IQuerySource
@@ -96,3 +100,19 @@ class ContactsSourceBinder(object):
 
     def __call__(self, context):
         return ContactsSource(context)
+
+
+@implementer(IContextSourceBinder)
+class PloneSqlOrKubContactSourceBinder(object):
+    """A vocabulary factory for currently active contact type.
+    """
+
+    implements(IVocabularyFactory)
+
+    def __call__(self, context):
+        if is_kub_feature_enabled():
+            return KuBContactsSourceBinder()(context)
+        elif is_contact_feature_enabled():
+            return ContactsSourceBinder()(context)
+        else:
+            return UsersContactsInboxesSourceBinder()(context)

--- a/opengever/dossier/indexers.py
+++ b/opengever/dossier/indexers.py
@@ -4,8 +4,7 @@ from collective import dexteritytextindexer
 from opengever.base.interfaces import IReferenceNumber
 from opengever.base.interfaces import ISequenceNumber
 from opengever.base.utils import ensure_str
-from opengever.contact import is_contact_feature_enabled
-from opengever.contact.sources import ContactsSource
+from opengever.contact.sources import PloneSqlOrKubContactSourceBinder
 from opengever.document.behaviors.name_from_title import DOCUMENT_NAME_PREFIX
 from opengever.dossier import _
 from opengever.dossier.behaviors.customproperties import IDossierCustomProperties
@@ -20,9 +19,6 @@ from opengever.dossier.participations import IParticipationData
 from opengever.dossier.resolve import AfterResolveJobs
 from opengever.dossier.utils import get_main_dossier
 from opengever.inbox.inbox import IInbox
-from opengever.kub import is_kub_feature_enabled
-from opengever.kub.sources import KuBContactsSourceBinder
-from opengever.ogds.base.sources import UsersContactsInboxesSourceBinder
 from opengever.private.dossier import IPrivateDossier
 from plone import api
 from plone.dexterity.interfaces import IDexterityContent
@@ -337,12 +333,7 @@ class ParticipationIndexHelper(object):
         """
         if participant_id == self.any_participant_marker:
             return translate(_(u'any_participant'), context=getRequest())
-        if is_kub_feature_enabled():
-            source = KuBContactsSourceBinder()(api.portal.get())
-        elif is_contact_feature_enabled():
-            source = ContactsSource(api.portal.get())
-        else:
-            source = UsersContactsInboxesSourceBinder()(api.portal.get())
+        source = PloneSqlOrKubContactSourceBinder()(api.portal.get())
         try:
             term = source.getTermByToken(participant_id)
             return term.title

--- a/opengever/dossier/templatefolder/form.py
+++ b/opengever/dossier/templatefolder/form.py
@@ -5,11 +5,13 @@ from opengever.base.browser.wizard.interfaces import IWizardDataStorage
 from opengever.base.model import create_session
 from opengever.base.oguid import Oguid
 from opengever.base.schema import TableChoice
+from opengever.contact import _ as contact_mf
 from opengever.contact import is_contact_feature_enabled
 from opengever.contact.sources import ContactsSourceBinder
 from opengever.document.behaviors.metadata import IDocumentMetadata
 from opengever.dossier import _
 from opengever.dossier.command import CreateDocumentFromTemplateCommand
+from opengever.kub import is_kub_feature_enabled
 from opengever.officeconnector.helpers import is_client_ip_in_office_connector_disallowed_ip_ranges
 from opengever.tabbedview.helper import document_with_icon
 from plone import api
@@ -17,6 +19,7 @@ from plone.autoform import directives as form
 from plone.autoform.form import AutoExtensibleForm
 from plone.supermodel import model
 from plone.z3cform.layout import FormWrapper
+from Products.statusmessages.interfaces import IStatusMessage
 from sqlalchemy import inspect
 from sqlalchemy.exc import NoInspectionAvailable
 from z3c.form import button
@@ -171,6 +174,11 @@ class SelectTemplateDocumentWizardStep(
             self.fields = self.fields.omit('recipient')
         if is_client_ip_in_office_connector_disallowed_ip_ranges():
             self.fields = self.fields.omit('edit_after_creation')
+        if is_kub_feature_enabled():
+            msg = contact_mf(
+                u'warning_kub_contact_new_ui_only',
+                default=u'Kub contacts are only supported in the new frontend')
+            IStatusMessage(self.request).addStatusMessage(msg, type=u'error')
 
     @property
     def schema(self):

--- a/opengever/kub/docprops.py
+++ b/opengever/kub/docprops.py
@@ -1,0 +1,172 @@
+from opengever.base.docprops import BaseDocPropertyProvider
+
+
+class KuBEntityDocPropertyProvider(object):
+
+    def __init__(self, entity):
+        # avoid circular imports
+        from opengever.kub.entity import KuBEntity
+
+        self.person = None
+        self.organization = None
+        self.membership = None
+        if entity.is_person():
+            self.person = entity
+        elif entity.is_organization():
+            self.organization = entity
+        elif entity.is_membership():
+            self.person = KuBEntity("person:" + entity["person"]["id"], full=True)
+            self.organization = KuBEntity("organization:" + entity["organization"]["id"], full=True)
+            self.membership = entity
+
+    @property
+    def person_or_organization(self):
+        return self.person or self.organization
+
+    @property
+    def organization_or_person(self):
+        return self.organization or self.person
+
+    def get_properties(self, prefix=None):
+        properties = {}
+        properties.update(self.get_contact_properties(prefix))
+        properties.update(self.get_person_properties(prefix))
+        properties.update(self.get_organization_properties(prefix))
+        properties.update(self.get_membership_properties(prefix))
+        properties.update(self.get_address_properties(prefix))
+        properties.update(self.get_email_properties(prefix))
+        properties.update(self.get_phone_properties(prefix))
+        properties.update(self.get_url_properties(prefix))
+        return properties
+
+    def get_contact_properties(self, prefix):
+        provider = KuBContactDocPropertyProvider(self.person_or_organization)
+        return provider.get_properties(prefix)
+
+    def get_person_properties(self, prefix):
+        if self.person is None:
+            return {}
+        return KuBPersonDocPropertyProvider(self.person).get_properties(prefix)
+
+    def get_organization_properties(self, prefix):
+        if self.organization is None:
+            return {}
+        return KuBOrganizationDocPropertyProvider(self.organization).get_properties(prefix)
+
+    def get_membership_properties(self, prefix):
+        if self.membership is None:
+            return {}
+        return KuBMembershipDocPropertyProvider(self.membership).get_properties(prefix)
+
+    def get_address_properties(self, prefix):
+        provider = KuBAddressDocPropertyProvider(self.organization_or_person)
+        return provider.get_properties(prefix)
+
+    def get_email_properties(self, prefix):
+        provider = KuBEmailDocPropertyProvider(self.person_or_organization)
+        return provider.get_properties(prefix)
+
+    def get_phone_properties(self, prefix):
+        provider = KuBPhoneNumberDocPropertyProvider(self.person_or_organization)
+        return provider.get_properties(prefix)
+
+    def get_url_properties(self, prefix):
+        provider = KuBURLDocPropertyProvider(self.organization_or_person)
+        return provider.get_properties(prefix)
+
+
+class KuBContactDocPropertyProvider(BaseDocPropertyProvider):
+    """Doc property provider for contacts."""
+
+    DEFAULT_PREFIX = ('contact',)
+
+    def _collect_properties(self):
+        return {
+            'title': self.context.get("text"),
+            'description': self.context.get("description"),
+        }
+
+
+class KuBPersonDocPropertyProvider(BaseDocPropertyProvider):
+
+    DEFAULT_PREFIX = ('person',)
+
+    def _collect_properties(self):
+        return {
+            'salutation': self.context.get("salutation"),
+            'academic_title': self.context.get("title"),
+            'firstname': self.context.get("firstName"),
+            'lastname': self.context.get("officialName"),
+        }
+
+
+class KuBOrganizationDocPropertyProvider(BaseDocPropertyProvider):
+
+    DEFAULT_PREFIX = ('organization',)
+
+    def _collect_properties(self):
+        return {'name': self.context.get("name")}
+
+
+class KuBMembershipDocPropertyProvider(BaseDocPropertyProvider):
+    """Provides doc-properties for an org-role and its associated person."""
+
+    DEFAULT_PREFIX = ('orgrole',)
+
+    def _collect_properties(self):
+        return {
+            'function': self.context.get("role"),
+            'description': self.context.get("description"),
+            'department': self.context.get("department"),
+        }
+
+
+class KuBAddressDocPropertyProvider(BaseDocPropertyProvider):
+    """Provides doc-properties for an address."""
+
+    DEFAULT_PREFIX = ('address',)
+
+    def _collect_properties(self):
+        address = self.context.get("primaryAddress") or {}
+        return {
+            'street': address.get("street"),
+            'zip_code': address.get("swissZipCode"),
+            'city': address.get("town"),
+            'country': address.get("countryName"),
+        }
+
+
+class KuBEmailDocPropertyProvider(BaseDocPropertyProvider):
+    """Provides doc-properties for a mail-address."""
+
+    DEFAULT_PREFIX = ('email',)
+
+    def _collect_properties(self):
+        email = self.context.get("primaryEmail") or {}
+        return {
+            'address': email.get("email"),
+        }
+
+
+class KuBPhoneNumberDocPropertyProvider(BaseDocPropertyProvider):
+    """Provides doc-properties for a phone-number."""
+
+    DEFAULT_PREFIX = ('phone',)
+
+    def _collect_properties(self):
+        phone_number = self.context.get("primaryPhoneNumber") or {}
+        return {
+            'number': phone_number.get("phoneNumber"),
+        }
+
+
+class KuBURLDocPropertyProvider(BaseDocPropertyProvider):
+    """Provides doc-properties for an url."""
+
+    DEFAULT_PREFIX = ('url',)
+
+    def _collect_properties(self):
+        url = self.context.get("primaryUrl") or {}
+        return {
+            'url': url.get("url"),
+        }

--- a/opengever/kub/entity.py
+++ b/opengever/kub/entity.py
@@ -1,0 +1,20 @@
+from opengever.kub.client import KuBClient
+
+
+class KuBEntity(object):
+
+    def __init__(self, type_id, full=False):
+        self.identifier = type_id
+        if full:
+            self.data = KuBClient().get_full_entity_by_id(self.identifier)
+        else:
+            self.data = KuBClient().get_by_id(self.identifier)
+
+    def __getitem__(self, key):
+        return self.data[key]
+
+    def get(self, key, default=None):
+        return self.data.get(key, default)
+
+    def serialize(self):
+        return self.data

--- a/opengever/kub/entity.py
+++ b/opengever/kub/entity.py
@@ -1,4 +1,5 @@
 from opengever.kub.client import KuBClient
+from opengever.kub.docprops import KuBEntityDocPropertyProvider
 
 
 class KuBEntity(object):
@@ -18,3 +19,15 @@ class KuBEntity(object):
 
     def serialize(self):
         return self.data
+
+    def is_person(self):
+        return self.get("type") == "person"
+
+    def is_organization(self):
+        return self.get("type") == "organization"
+
+    def is_membership(self):
+        return self.get("type") == "membership"
+
+    def get_doc_property_provider(self):
+        return KuBEntityDocPropertyProvider(self)

--- a/opengever/kub/testing.py
+++ b/opengever/kub/testing.py
@@ -45,7 +45,9 @@ KUB_RESPONSES = {
             "thirdPartyId": None,
             "text": "Dupont Julie",
             "created": "2021-11-14T00:00:00+01:00",
-            "modified": "2021-11-14T00:00:00+01:00"
+            "modified": "2021-11-14T00:00:00+01:00",
+            "htmlUrl": "http://localhost:8000/people/0e623708-2d0d-436a-82c6-c1a9c27b65dc",
+            "url": "http://localhost:8000/api/v1/people/0e623708-2d0d-436a-82c6-c1a9c27b65dc"
         }
     ],
     "http://localhost:8000/api/v1/search?q=4Teamwork": [
@@ -56,7 +58,9 @@ KUB_RESPONSES = {
             "thirdPartyId": None,
             "text": "4Teamwork",
             "created": "2021-11-13T00:00:00+01:00",
-            "modified": "2021-11-13T00:00:00+01:00"
+            "modified": "2021-11-13T00:00:00+01:00",
+            "htmlUrl": "http://localhost:8000/organizations/30bab83d-300a-4886-97d4-ff592e88a56a",
+            "url": "http://localhost:8000/api/v1/organizations/30bab83d-300a-4886-97d4-ff592e88a56a"
         },
         {
             "id": "8345fcfe-2d67-4b75-af46-c25b2f387448",
@@ -66,7 +70,8 @@ KUB_RESPONSES = {
             "text": "Dupont Jean - 4Teamwork (CEO)",
             "created": "2021-11-18T00:00:00+01:00",
             "modified": "2021-11-18T00:00:00+01:00",
-            "organization": "30bab83d-300a-4886-97d4-ff592e88a56a"
+            "organization": "30bab83d-300a-4886-97d4-ff592e88a56a",
+            "url": "http://localhost:8000/api/v1/memberships/8345fcfe-2d67-4b75-af46-c25b2f387448"
         }
     ],
     "http://localhost:8000/api/v1/search?id=person:9af7d7cc-b948-423f-979f-587158c6bc65": [
@@ -77,7 +82,9 @@ KUB_RESPONSES = {
             "thirdPartyId": None,
             "text": "Dupont Jean",
             "created": "2021-11-17T00:00:00+01:00",
-            "modified": "2021-11-17T00:00:00+01:00"
+            "modified": "2021-11-17T00:00:00+01:00",
+            "htmlUrl": "http://localhost:8000/people/9af7d7cc-b948-423f-979f-587158c6bc65",
+            "url": "http://localhost:8000/api/v1/people/9af7d7cc-b948-423f-979f-587158c6bc65"
         }
     ],
     "http://localhost:8000/api/v1/search?id=membership:8345fcfe-2d67-4b75-af46-c25b2f387448": [
@@ -89,7 +96,8 @@ KUB_RESPONSES = {
             "text": "Dupont Jean - 4Teamwork (CEO)",
             "created": "2021-11-18T00:00:00+01:00",
             "modified": "2021-11-18T00:00:00+01:00",
-            "organization": "30bab83d-300a-4886-97d4-ff592e88a56a"
+            "organization": "30bab83d-300a-4886-97d4-ff592e88a56a",
+            "url": "http://localhost:8000/api/v1/memberships/8345fcfe-2d67-4b75-af46-c25b2f387448"
         }
     ],
     "http://localhost:8000/api/v1/search?id=organization:30bab83d-300a-4886-97d4-ff592e88a56a": [
@@ -100,38 +108,188 @@ KUB_RESPONSES = {
             "thirdPartyId": None,
             "text": "4Teamwork",
             "created": "2021-11-13T00:00:00+01:00",
-            "modified": "2021-11-13T00:00:00+01:00"
+            "modified": "2021-11-13T00:00:00+01:00",
+            "htmlUrl": "http://localhost:8000/organizations/30bab83d-300a-4886-97d4-ff592e88a56a",
+            "url": "http://localhost:8000/api/v1/organizations/30bab83d-300a-4886-97d4-ff592e88a56a"
         }
     ],
     "http://localhost:8000/api/v1/search?id=invalid-id": [],
     "http://localhost:8000/api/v1/people/0e623708-2d0d-436a-82c6-c1a9c27b65dc": {
-        "addresses": [],
-        "canton": None,
+        "id": "0e623708-2d0d-436a-82c6-c1a9c27b65dc",
+        "salutation": "Frau",
+        "title": "",
+        "firstName": "Julie",
+        "officialName": "Dupont",
+        "fullName": "Dupont Julie",
+        "dateOfBirth": None,
+        "sex": 2,
+        "maritalStatus": 2,
         "country": "",
         "countryIdISO2": "",
-        "created": "2021-11-14T00:00:00+01:00",
-        "dateOfBirth": None,
-        "description": "",
-        "emailAddresses": [],
-        "firstName": "Julie",
-        "fullName": "Dupont Julie",
-        "id": "0e623708-2d0d-436a-82c6-c1a9c27b65dc",
         "languageOfCorrespondance": "fr",
-        "maritalStatus": 2,
-        "memberships": [],
-        "modified": "2021-11-14T00:00:00+01:00",
-        "officialName": "Dupont",
-        "organizations": [],
         "originName": "Paris",
+        "canton": None,
+        "status": 1,
+        "thirdPartyId": None,
+        "description": "",
+        "tags": [],
+        "addresses": [],
+        "emailAddresses": [],
         "phoneNumbers": [],
+        "urls": [],
+        "memberships": [],
+        "organizations": [],
         "primaryEmail": None,
         "primaryPhoneNumber": None,
-        "salutation": "Frau",
-        "sex": 2,
+        "modified": "2021-11-14T00:00:00+01:00",
+        "created": "2021-11-14T00:00:00+01:00",
+        "htmlUrl": "http://localhost:8000/people/0e623708-2d0d-436a-82c6-c1a9c27b65dc",
+        "url": "http://localhost:8000/api/v1/people/0e623708-2d0d-436a-82c6-c1a9c27b65dc",
+        "typedId": "person:0e623708-2d0d-436a-82c6-c1a9c27b65dc",
+        "type": "person"
+    },
+    "http://localhost:8000/api/v1/organizations/30bab83d-300a-4886-97d4-ff592e88a56a": {
+        "id": "30bab83d-300a-4886-97d4-ff592e88a56a",
+        "name": "4Teamwork",
+        "description": "Web application specialist",
         "status": 1,
-        "tags": [],
         "thirdPartyId": None,
-        "title": "",
-        "urls": []
+        "memberCount": 1,
+        "addresses": [
+            {
+                "id": "ad0de780-3f62-400c-921a-0feb9e79c062",
+                "label": "Standort Bern",
+                "isDefault": True,
+                "organisationName": "",
+                "organisationNameAddOn1": "",
+                "organisationNameAddOn2": "",
+                "addressLine1": "",
+                "addressLine2": "",
+                "street": "Dammweg",
+                "houseNumber": "9",
+                "dwellingNumber": "",
+                "postOfficeBox": "",
+                "postOfficeBoxText": "",
+                "swissZipCode": "3013",
+                "swissZipCodeAddOn": "",
+                "swissZipCodeId": "",
+                "foreignZipCode": "",
+                "locality": "",
+                "town": "Bern",
+                "countryIdISO2": "CH",
+                "countryName": "Schweiz",
+                "thirdPartyId": None,
+                "modified": "2021-11-18T00:00:00+01:00",
+                "created": "2021-11-18T00:00:00+01:00"
+            },
+            {
+                "id": "602a873f-262f-4cc8-893b-41f5cb8e8b31",
+                "label": "Standort St. Gallen",
+                "isDefault": False,
+                "organisationName": "",
+                "organisationNameAddOn1": "",
+                "organisationNameAddOn2": "",
+                "addressLine1": "",
+                "addressLine2": "",
+                "street": "Oberer Graben",
+                "houseNumber": "46",
+                "dwellingNumber": "",
+                "postOfficeBox": "",
+                "postOfficeBoxText": "",
+                "swissZipCode": "9001",
+                "swissZipCodeAddOn": "",
+                "swissZipCodeId": "",
+                "foreignZipCode": "",
+                "locality": "",
+                "town": "St. Gallen",
+                "countryIdISO2": "CH",
+                "countryName": "Schweiz",
+                "thirdPartyId": None,
+                "modified": "2021-11-18T00:00:00+01:00",
+                "created": "2021-11-18T00:00:00+01:00"
+            }
+        ],
+        "emailAddresses": [],
+        "phoneNumbers": [],
+        "urls": [],
+        "memberships": [
+            {
+                "id": "8345fcfe-2d67-4b75-af46-c25b2f387448",
+                "person": {
+                    "id": "9af7d7cc-b948-423f-979f-587158c6bc65",
+                    "firstName": "Jean",
+                    "officialName": "Dupont",
+                    "fullName": "Dupont Jean",
+                    "thirdPartyId": None,
+                    "description": "",
+                    "modified": "2021-11-17T00:00:00+01:00",
+                    "created": "2021-11-17T00:00:00+01:00",
+                    "htmlUrl": "http://localhost:8000/people/9af7d7cc-b948-423f-979f-587158c6bc65",
+                    "url": "http://localhost:8000/api/v1/people/9af7d7cc-b948-423f-979f-587158c6bc65"
+                },
+                "role": "CEO",
+                "description": "",
+                "department": "",
+                "thirdPartyId": None,
+                "start": "1990-02-24",
+                "end": None
+            }
+        ],
+        "primaryEmail": None,
+        "primaryPhoneNumber": None,
+        "tags": [
+            "Bude"
+        ],
+        "modified": "2021-11-13T00:00:00+01:00",
+        "created": "2021-11-13T00:00:00+01:00",
+        "htmlUrl": "http://localhost:8000/organizations/30bab83d-300a-4886-97d4-ff592e88a56a",
+        "typedId": "organization:30bab83d-300a-4886-97d4-ff592e88a56a",
+        "type": "organization",
+        "url": "http://localhost:8000/api/v1/organizations/30bab83d-300a-4886-97d4-ff592e88a56a"
+    },
+    "http://localhost:8000/api/v1/memberships/8345fcfe-2d67-4b75-af46-c25b2f387448": {
+        "id": "8345fcfe-2d67-4b75-af46-c25b2f387448",
+        "person": {
+            "id": "9af7d7cc-b948-423f-979f-587158c6bc65",
+            "salutation": "Herr",
+            "title": "",
+            "firstName": "Jean",
+            "officialName": "Dupont",
+            "fullName": "Dupont Jean",
+            "primaryEmail": {
+                "id": "3bc940de-ee8a-43b0-b373-3f1640122021",
+                "label": "Private",
+                "email": "Jean.dupon@example.com",
+                "isDefault": True,
+                "thirdPartyId": None,
+                "modified": "2021-11-18T00:00:00+01:00",
+                "created": "2021-11-18T00:00:00+01:00"
+            },
+            "created": "2021-11-17T00:00:00+01:00",
+            "modified": "2021-11-17T00:00:00+01:00",
+            "htmlUrl": "http://localhost:8000/people/9af7d7cc-b948-423f-979f-587158c6bc65",
+            "url": "http://localhost:8000/api/v1/people/9af7d7cc-b948-423f-979f-587158c6bc65"
+        },
+        "organization": {
+            "id": "30bab83d-300a-4886-97d4-ff592e88a56a",
+            "name": "4Teamwork",
+            "status": 1,
+            "description": "Web application specialist",
+            "memberCount": 1,
+            "created": "2021-11-13T00:00:00+01:00",
+            "modified": "2021-11-13T00:00:00+01:00",
+            "thirdPartyId": None,
+            "htmlUrl": "http://localhost:8000/organizations/30bab83d-300a-4886-97d4-ff592e88a56a",
+            "url": "http://localhost:8000/api/v1/organizations/30bab83d-300a-4886-97d4-ff592e88a56a"
+        },
+        "role": "CEO",
+        "description": "",
+        "department": "",
+        "thirdPartyId": None,
+        "start": "1990-02-24",
+        "end": None,
+        "typedId": "membership:8345fcfe-2d67-4b75-af46-c25b2f387448",
+        "type": "membership",
+        "url": "http://localhost:8000/api/v1/memberships/8345fcfe-2d67-4b75-af46-c25b2f387448"
     }
 }

--- a/opengever/kub/testing.py
+++ b/opengever/kub/testing.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from opengever.kub.client import KuBClient
 from opengever.kub.interfaces import IKuBSettings
 from opengever.testing import IntegrationTestCase
@@ -291,5 +292,151 @@ KUB_RESPONSES = {
         "typedId": "membership:8345fcfe-2d67-4b75-af46-c25b2f387448",
         "type": "membership",
         "url": "http://localhost:8000/api/v1/memberships/8345fcfe-2d67-4b75-af46-c25b2f387448"
+    },
+    "http://localhost:8000/api/v1/people/9af7d7cc-b948-423f-979f-587158c6bc65": {
+        "id": "9af7d7cc-b948-423f-979f-587158c6bc65",
+        "salutation": "Herr",
+        "title": "",
+        "firstName": "Jean",
+        "officialName": "Dupont",
+        "fullName": "Dupont Jean",
+        "dateOfBirth": "1992-05-15",
+        "sex": None,
+        "maritalStatus": 2,
+        "country": "",
+        "countryIdISO2": "",
+        "languageOfCorrespondance": "fr",
+        "originName": "Paris",
+        "canton": None,
+        "status": 1,
+        "thirdPartyId": None,
+        "description": "",
+        "tags": [],
+        "addresses": [
+            {
+                "id": "72b3120e-429f-423b-8bb7-31233d89026c",
+                "label": "Home",
+                "isDefault": True,
+                "organisationName": "",
+                "organisationNameAddOn1": "",
+                "organisationNameAddOn2": "",
+                "addressLine1": "",
+                "addressLine2": "",
+                "street": "Teststrasse",
+                "houseNumber": "43",
+                "dwellingNumber": "",
+                "postOfficeBox": "",
+                "postOfficeBoxText": "",
+                "swissZipCode": "9999",
+                "swissZipCodeAddOn": "",
+                "swissZipCodeId": "",
+                "foreignZipCode": "",
+                "locality": "",
+                "town": "Bern",
+                "countryIdISO2": "CH",
+                "countryName": "Schweiz",
+                "thirdPartyId": None,
+                "modified": "2021-11-18T00:00:00+01:00",
+                "created": "2021-11-18T00:00:00+01:00"
+            }
+        ],
+        "emailAddresses": [
+            {
+                "id": "3bc940de-ee8a-43b0-b373-3f1640122021",
+                "label": "Private",
+                "email": "Jean.dupon@example.com",
+                "isDefault": True,
+                "thirdPartyId": None,
+                "modified": "2021-11-18T00:00:00+01:00",
+                "created": "2021-11-18T00:00:00+01:00"
+            }
+        ],
+        "phoneNumbers": [
+            {
+                "id": "e1046ad8-c4d7-4cac-93ac-d7c8298795e5",
+                "label": "Mobile",
+                "phoneNumber": "666 666 66 66",
+                "phoneCategory": 2,
+                "otherPhoneCategory": None,
+                "phoneCategoryText": "Private Mobilnummer",
+                "isDefault": True,
+                "thirdPartyId": None,
+                "modified": "2021-11-18T00:00:00+01:00",
+                "created": "2021-11-18T00:00:00+01:00"
+            },
+            {
+                "id": "c62732e1-114e-4de7-a0b7-842c325bb068",
+                "label": "Work",
+                "phoneNumber": "999 999 99 99",
+                "phoneCategory": 7,
+                "otherPhoneCategory": None,
+                "phoneCategoryText": "Geschäftliche Mobilnummer",
+                "isDefault": False,
+                "thirdPartyId": None,
+                "modified": "2021-11-18T00:00:00+01:00",
+                "created": "2021-11-18T00:00:00+01:00"
+            }
+        ],
+        "urls": [],
+        "memberships": [
+            {
+                "id": "8345fcfe-2d67-4b75-af46-c25b2f387448",
+                "organization": {
+                    "id": "30bab83d-300a-4886-97d4-ff592e88a56a",
+                    "name": "4Teamwork",
+                    "description": "Web application specialist",
+                    "status": 1,
+                    "thirdPartyId": None,
+                    "memberCount": 1,
+                    "modified": "2021-11-13T00:00:00+01:00",
+                    "created": "2021-11-13T00:00:00+01:00"
+                },
+                "role": "CEO",
+                "description": "",
+                "department": "",
+                "thirdPartyId": None,
+                "start": "1990-02-24",
+                "end": None
+            }
+        ],
+        "organizations": [
+            {
+                "id": "30bab83d-300a-4886-97d4-ff592e88a56a",
+                "name": "4Teamwork",
+                "description": "Web application specialist",
+                "status": 1,
+                "thirdPartyId": None,
+                "memberCount": 1,
+                "modified": "2021-11-13T00:00:00+01:00",
+                "created": "2021-11-13T00:00:00+01:00"
+            }
+        ],
+        "primaryEmail": {
+            "id": "3bc940de-ee8a-43b0-b373-3f1640122021",
+            "label": "Private",
+            "email": "Jean.dupon@example.com",
+            "isDefault": True,
+            "thirdPartyId": None,
+            "modified": "2021-11-18T00:00:00+01:00",
+            "created": "2021-11-18T00:00:00+01:00"
+        },
+        "primaryPhoneNumber": {
+            "id": "e1046ad8-c4d7-4cac-93ac-d7c8298795e5",
+            "label": "Mobile",
+            "phoneNumber": "666 666 66 66",
+            "phoneCategory": 2,
+            "otherPhoneCategory": None,
+            "phoneCategoryText": "Private Mobilnummer",
+            "isDefault": True,
+            "thirdPartyId": None,
+            "modified": "2021-11-18T00:00:00+01:00",
+            "created": "2021-11-18T00:00:00+01:00"
+        },
+        "modified": "2021-11-17T00:00:00+01:00",
+        "created": "2021-11-17T00:00:00+01:00",
+        "htmlUrl": "http://localhost:8000/people/9af7d7cc-b948-423f-979f-587158c6bc65",
+        "url": "http://localhost:8000/api/v1/people/9af7d7cc-b948-423f-979f-587158c6bc65",
+        "typedId": "person:9af7d7cc-b948-423f-979f-587158c6bc65",
+        "type": "person"
     }
 }

--- a/opengever/kub/tests/test_docprops.py
+++ b/opengever/kub/tests/test_docprops.py
@@ -1,0 +1,71 @@
+from opengever.kub.docprops import KuBEntityDocPropertyProvider
+from opengever.kub.entity import KuBEntity
+from opengever.kub.testing import KuBIntegrationTestCase
+import requests_mock
+
+
+@requests_mock.Mocker()
+class TestKuBEntityDocPropertyProvider(KuBIntegrationTestCase):
+
+    def test_docproperties_for_kub_person(self, mocker):
+        self.mock_get_full_entity_by_id(mocker, self.person_julie)
+        entity = KuBEntity(self.person_julie, full=True)
+        properties = KuBEntityDocPropertyProvider(entity).get_properties()
+        self.assertDictEqual(
+            {'ogg.address.city': None,
+             'ogg.address.country': None,
+             'ogg.address.street': None,
+             'ogg.address.zip_code': None,
+             'ogg.contact.description': u'',
+             'ogg.contact.title': None,
+             'ogg.email.address': None,
+             'ogg.person.academic_title': u'',
+             'ogg.person.firstname': u'Julie',
+             'ogg.person.lastname': u'Dupont',
+             'ogg.person.salutation': u'Frau',
+             'ogg.phone.number': None,
+             'ogg.url.url': None},
+            properties)
+
+    def test_docproperties_for_kub_organization(self, mocker):
+        self.mock_get_full_entity_by_id(mocker, self.org_ftw)
+        entity = KuBEntity(self.org_ftw, full=True)
+        properties = KuBEntityDocPropertyProvider(entity).get_properties()
+        self.assertDictEqual(
+            {'ogg.address.city': None,
+             'ogg.address.country': None,
+             'ogg.address.street': None,
+             'ogg.address.zip_code': None,
+             'ogg.contact.description': u'Web application specialist',
+             'ogg.contact.title': None,
+             'ogg.email.address': None,
+             'ogg.organization.name': u'4Teamwork',
+             'ogg.phone.number': None,
+             'ogg.url.url': None},
+            properties)
+
+    def test_docproperties_for_kub_membership(self, mocker):
+        self.mock_get_full_entity_by_id(mocker, self.memb_jean_ftw)
+        self.mock_get_full_entity_by_id(mocker, self.org_ftw)
+        self.mock_get_full_entity_by_id(mocker, self.person_jean)
+        entity = KuBEntity(self.memb_jean_ftw, full=True)
+        properties = KuBEntityDocPropertyProvider(entity).get_properties()
+        self.assertDictEqual(
+            {'ogg.address.city': None,
+             'ogg.address.country': None,
+             'ogg.address.street': None,
+             'ogg.address.zip_code': None,
+             'ogg.contact.description': u'',
+             'ogg.contact.title': None,
+             'ogg.email.address': u'Jean.dupon@example.com',
+             'ogg.organization.name': u'4Teamwork',
+             'ogg.orgrole.department': u'',
+             'ogg.orgrole.description': u'',
+             'ogg.orgrole.function': u'CEO',
+             'ogg.person.academic_title': u'',
+             'ogg.person.firstname': u'Jean',
+             'ogg.person.lastname': u'Dupont',
+             'ogg.person.salutation': u'Herr',
+             'ogg.phone.number': u'666 666 66 66',
+             'ogg.url.url': None},
+            properties)

--- a/opengever/kub/tests/test_kub_entity.py
+++ b/opengever/kub/tests/test_kub_entity.py
@@ -27,3 +27,24 @@ class TestKuBEntity(KuBIntegrationTestCase):
         url = self.mock_get_full_entity_by_id(mocker, self.person_julie)
         entity = KuBEntity(self.person_julie, full=True)
         self.assertDictEqual(KUB_RESPONSES[url], entity.serialize())
+
+    def test_person_entity(self, mocker):
+        self.mock_get_by_id(mocker, self.person_jean)
+        entity = KuBEntity(self.person_jean)
+        self.assertTrue(entity.is_person())
+        self.assertFalse(entity.is_organization())
+        self.assertFalse(entity.is_membership())
+
+    def test_organization_entity(self, mocker):
+        self.mock_get_by_id(mocker, self.org_ftw)
+        entity = KuBEntity(self.org_ftw)
+        self.assertFalse(entity.is_person())
+        self.assertTrue(entity.is_organization())
+        self.assertFalse(entity.is_membership())
+
+    def test_membership_entity(self, mocker):
+        self.mock_get_by_id(mocker, self.memb_jean_ftw)
+        entity = KuBEntity(self.memb_jean_ftw)
+        self.assertFalse(entity.is_person())
+        self.assertFalse(entity.is_organization())
+        self.assertTrue(entity.is_membership())

--- a/opengever/kub/tests/test_kub_entity.py
+++ b/opengever/kub/tests/test_kub_entity.py
@@ -1,0 +1,29 @@
+from opengever.kub.testing import KuBIntegrationTestCase
+from opengever.kub.testing import KUB_RESPONSES
+from opengever.kub.entity import KuBEntity
+import requests_mock
+
+
+@requests_mock.Mocker()
+class TestKuBEntity(KuBIntegrationTestCase):
+
+    def test_data_contains_kub_response(self, mocker):
+        url = self.mock_get_by_id(mocker, self.person_jean)
+        entity = KuBEntity(self.person_jean)
+        self.assertDictEqual(KUB_RESPONSES[url][0], entity.data)
+
+    def test_full_entity_data(self, mocker):
+        url = self.mock_get_full_entity_by_id(mocker, self.person_julie)
+        entity = KuBEntity(self.person_julie, full=True)
+        self.assertDictEqual(KUB_RESPONSES[url], entity.data)
+
+    def test_proxies_getitem_to_data(self, mocker):
+        url = self.mock_get_by_id(mocker, self.person_jean)
+        entity = KuBEntity(self.person_jean)
+        for key, value in KUB_RESPONSES[url][0].items():
+            self.assertEqual(value, entity[key])
+
+    def test_serialization_returns_kub_data(self, mocker):
+        url = self.mock_get_full_entity_by_id(mocker, self.person_julie)
+        entity = KuBEntity(self.person_julie, full=True)
+        self.assertDictEqual(KUB_RESPONSES[url], entity.serialize())

--- a/opengever/ogds/base/actor.py
+++ b/opengever/ogds/base/actor.py
@@ -31,7 +31,7 @@ from opengever.contact.models import Person
 from opengever.contact.utils import get_contactfolder_url
 from opengever.inbox.utils import get_inbox_for_org_unit
 from opengever.kub import is_kub_feature_enabled
-from opengever.kub.client import KuBClient
+from opengever.kub.entity import KuBEntity
 from opengever.ogds.base import _
 from opengever.ogds.base.browser.userdetails import UserDetails
 from opengever.ogds.base.interfaces import IActor
@@ -761,7 +761,7 @@ class ActorLookup(object):
     def create_kub_contact_actor(self, contact=None):
         if not contact:
             try:
-                contact = KuBClient().get_by_id(self.identifier)
+                contact = KuBEntity(self.identifier)
             except LookupError:
                 return self.create_null_actor()
 

--- a/opengever/ogds/base/tests/test_actor.py
+++ b/opengever/ogds/base/tests/test_actor.py
@@ -205,7 +205,7 @@ class TestKuBContactActor(KuBIntegrationTestCase):
         self.assertIsInstance(actor, KuBContactActor)
         self.assertEqual(u'Dupont Jean', actor.get_label())
         self.assertEqual(None, actor.get_profile_url())
-        self.assertEqual(KUB_RESPONSES[url][0], actor.represents())
+        self.assertEqual(KUB_RESPONSES[url][0], actor.represents().data)
 
     def test_organization_actor_lookup(self, mocker):
         url = self.mock_get_by_id(mocker, self.org_ftw)
@@ -215,7 +215,7 @@ class TestKuBContactActor(KuBIntegrationTestCase):
         self.assertIsInstance(actor, KuBContactActor)
         self.assertEqual(u'4Teamwork', actor.get_label())
         self.assertEqual(None, actor.get_profile_url())
-        self.assertEqual(KUB_RESPONSES[url][0], actor.represents())
+        self.assertEqual(KUB_RESPONSES[url][0], actor.represents().data)
 
     def test_membership_actor_lookup(self, mocker):
         url = self.mock_get_by_id(mocker, self.memb_jean_ftw)
@@ -225,7 +225,7 @@ class TestKuBContactActor(KuBIntegrationTestCase):
         self.assertIsInstance(actor, KuBContactActor)
         self.assertEqual(u'Dupont Jean - 4Teamwork (CEO)', actor.get_label())
         self.assertEqual(None, actor.get_profile_url())
-        self.assertEqual(KUB_RESPONSES[url][0], actor.represents())
+        self.assertEqual(KUB_RESPONSES[url][0], actor.represents().data)
 
     def test_kub_contact_actor_lookup_for_not_existing_contact(self, mocker):
         contact_id = "invalid-id"


### PR DESCRIPTION
We add support for using KuB contacts as recipients when creating a document from a template. The data of that recipient is then passed as docproperties when creating the document.  Note that we are using the same docproperties with the same keys as were used with SQL contacts. This should allow existing templates to still work after a switch to KuB. Also note that KuB currently does not return a `primaryEmail` and `primaryUrl`, but that should change in the near future.

Note that we do not support KuB contacts in the classic-UI and therefore display an error message when a user tries to create a document from a template with the KuB feature active. This will not prevent creation from a document
from a template, but it does not allow to select a recipient either.

The config endpoint now distinguishes the three contact feature types, so returns a string (`plone`, `sql`, `kub`) instead of a boolean. This is a small breaking change.

For [CA-2452]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [x] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed

[CA-2452]: https://4teamwork.atlassian.net/browse/CA-2452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ