### PR TITLE
Register disposition actions as ui-context-actions

### DIFF
--- a/changes/CA-2119.feature
+++ b/changes/CA-2119.feature
@@ -1,0 +1,1 @@
+Provide disposition actions in the @actions endpoint. [phgross]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,9 +11,9 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
-- Disposition serialization contains now responses. [phgross]
+- Include sip_delivery_status in the disposition serialization.
+- Disposition serialization contains now responses.
 - @xhr-upload: new endpoint to upload documents as a multipart/form-data xhr request. [elioschmutz]
-
 - Include is_completed in sql task serialization.
 - ``@listing``: Add retention_expiration column.
 

--- a/opengever/api/disposition.py
+++ b/opengever/api/disposition.py
@@ -65,6 +65,7 @@ class SerializeDispositionToJson(GeverSerializeFolderToJson):
     def __call__(self, *args, **kwargs):
         result = super(SerializeDispositionToJson, self).__call__(*args, **kwargs)
         result[u'sip_filename'] = self.context.get_sip_filename()
+        result[u'sip_delivery_status'] = self.context.get_delivery_status_infos()
         result[u'dossier_details'] = self.get_dossier_details()
         return result
 

--- a/opengever/core/locales/de/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/de/LC_MESSAGES/opengever.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-11-25 12:03+0000\n"
+"POT-Creation-Date: 2021-12-07 12:24+0000\n"
 "PO-Revision-Date: 2017-09-18 15:21+0200\n"
 "Last-Translator: Philippe Gross <p.gross@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -129,6 +129,11 @@ msgid "Download ICal"
 msgstr "ICal herunterladen"
 
 #: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20211207105652_add_disposition_actions/actions.xml
+msgid "Download disposition package"
+msgstr "Ablieferungspaket herunterladen"
+
+#: ./opengever/core/profiles/default/actions.xml
 #: ./opengever/core/upgrades/20210319175529_add_meeting_minutes_pdf_action/actions.xml
 msgid "Download meeting minutes PDF"
 msgstr "Protokoll als PDF herunterladen"
@@ -146,6 +151,11 @@ msgstr "Metadaten bearbeiten"
 #: ./opengever/core/upgrades/20211026174552_add_edit_public_trial_status_action/actions.xml
 msgid "Edit public trial status"
 msgstr "Öffentlichkeitsstatus bearbeiten"
+
+#: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20211207105652_add_disposition_actions/actions.xml
+msgid "Export appraisal list as excel"
+msgstr "Bewertungsliste als Excel exportieren"
 
 #: ./opengever/core/profiles/default/actions.xml
 msgid "Export as Zip"

--- a/opengever/core/locales/en/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/en/LC_MESSAGES/opengever.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-11-25 12:03+0000\n"
+"POT-Creation-Date: 2021-12-07 12:24+0000\n"
 "PO-Revision-Date: 2017-09-18 15:21+0200\n"
 "Last-Translator: Philippe Gross <p.gross@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -155,6 +155,11 @@ msgid "Download ICal"
 msgstr "Download ICal"
 
 #: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20211207105652_add_disposition_actions/actions.xml
+msgid "Download disposition package"
+msgstr "Download disposal package"
+
+#: ./opengever/core/profiles/default/actions.xml
 #: ./opengever/core/upgrades/20210319175529_add_meeting_minutes_pdf_action/actions.xml
 msgid "Download meeting minutes PDF"
 msgstr "Download meeting minutes as PDF"
@@ -173,6 +178,11 @@ msgstr "Edit metadata"
 #: ./opengever/core/upgrades/20211026174552_add_edit_public_trial_status_action/actions.xml
 msgid "Edit public trial status"
 msgstr "Change public access level assessment"
+
+#: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20211207105652_add_disposition_actions/actions.xml
+msgid "Export appraisal list as excel"
+msgstr "Export appraisal list as an Excel file"
 
 #. German translation: Als Zip-Datei exportieren
 #: ./opengever/core/profiles/default/actions.xml

--- a/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-11-25 12:03+0000\n"
+"POT-Creation-Date: 2021-12-07 12:24+0000\n"
 "PO-Revision-Date: 2013-03-27 10:44+0100\n"
 "Last-Translator: Philippe Gross <p.gross@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -126,6 +126,11 @@ msgid "Download ICal"
 msgstr "Télécharger ICal"
 
 #: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20211207105652_add_disposition_actions/actions.xml
+msgid "Download disposition package"
+msgstr "Télécharger le colis de livraison"
+
+#: ./opengever/core/profiles/default/actions.xml
 #: ./opengever/core/upgrades/20210319175529_add_meeting_minutes_pdf_action/actions.xml
 msgid "Download meeting minutes PDF"
 msgstr "Télécharger le procès-verbal en PDF"
@@ -143,6 +148,11 @@ msgstr "Modifier les méta-données"
 #: ./opengever/core/upgrades/20211026174552_add_edit_public_trial_status_action/actions.xml
 msgid "Edit public trial status"
 msgstr "Modifier le statut public"
+
+#: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20211207105652_add_disposition_actions/actions.xml
+msgid "Export appraisal list as excel"
+msgstr "Exporter la liste d'évaluation en excel"
 
 #: ./opengever/core/profiles/default/actions.xml
 msgid "Export as Zip"

--- a/opengever/core/locales/opengever.core.pot
+++ b/opengever/core/locales/opengever.core.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-11-25 12:03+0000\n"
+"POT-Creation-Date: 2021-12-07 12:24+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -129,6 +129,11 @@ msgid "Download ICal"
 msgstr ""
 
 #: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20211207105652_add_disposition_actions/actions.xml
+msgid "Download disposition package"
+msgstr ""
+
+#: ./opengever/core/profiles/default/actions.xml
 #: ./opengever/core/upgrades/20210319175529_add_meeting_minutes_pdf_action/actions.xml
 msgid "Download meeting minutes PDF"
 msgstr ""
@@ -145,6 +150,11 @@ msgstr ""
 #: ./opengever/core/profiles/default/actions.xml
 #: ./opengever/core/upgrades/20211026174552_add_edit_public_trial_status_action/actions.xml
 msgid "Edit public trial status"
+msgstr ""
+
+#: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20211207105652_add_disposition_actions/actions.xml
+msgid "Export appraisal list as excel"
 msgstr ""
 
 #: ./opengever/core/profiles/default/actions.xml

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -1249,6 +1249,48 @@
       <property name="visible">True</property>
     </object>
 
+    <object name="download-appraisal-list" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Export appraisal list as excel</property>
+      <property name="description" i18n:translate="" />
+      <property name="url_expr">string:${object_url}/download_excel</property>
+      <property name="icon_expr" />
+      <property name="available_expr">
+        python:context.restrictedTraverse('@@plone_interface_info').provides('opengever.disposition.interfaces.IDisposition')
+      </property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
+    <object name="download-sip" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Download disposition package</property>
+      <property name="description" i18n:translate="" />
+      <property name="url_expr">string:${object_url}/ech0160_download</property>
+      <property name="icon_expr" />
+      <property name="available_expr">
+        python:context.restrictedTraverse('@@plone_interface_info').provides('opengever.disposition.interfaces.IDisposition') and object.sip_download_available()
+      </property>
+      <property name="permissions">
+        <element value="opengever.disposition: Download SIP Package" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
+    <object name="download-removal-protocol" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Download disposition package</property>
+      <property name="description" i18n:translate="" />
+      <property name="url_expr">string:${object_url}/ech0160_download</property>
+      <property name="icon_expr" />
+      <property name="available_expr">
+        python:context.restrictedTraverse('@@plone_interface_info').provides('opengever.disposition.interfaces.IDisposition') and object.removal_protocol_available()
+      </property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
   </object>
 
 </object>

--- a/opengever/core/upgrades/20211207105652_add_disposition_actions/actions.xml
+++ b/opengever/core/upgrades/20211207105652_add_disposition_actions/actions.xml
@@ -1,0 +1,51 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="portal_actions" meta_type="Plone Actions Tool">
+
+  <!-- Gever UI actions for a context -->
+  <object name="ui_context_actions" meta_type="CMF Action Category">
+
+
+    <object name="download-appraisal-list" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Export appraisal list as excel</property>
+      <property name="description" i18n:translate="" />
+      <property name="url_expr">string:${object_url}/download_excel</property>
+      <property name="icon_expr" />
+      <property name="available_expr">
+        python:context.restrictedTraverse('@@plone_interface_info').provides('opengever.disposition.interfaces.IDisposition')
+      </property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
+    <object name="download-sip" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Download disposition package</property>
+      <property name="description" i18n:translate="" />
+      <property name="url_expr">string:${object_url}/ech0160_download</property>
+      <property name="icon_expr" />
+      <property name="available_expr">
+        python:context.restrictedTraverse('@@plone_interface_info').provides('opengever.disposition.interfaces.IDisposition') and object.sip_download_available()
+      </property>
+      <property name="permissions">
+        <element value="opengever.disposition: Download SIP Package" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
+    <object name="download-removal-protocol" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Download disposition package</property>
+      <property name="description" i18n:translate="" />
+      <property name="url_expr">string:${object_url}/ech0160_download</property>
+      <property name="icon_expr" />
+      <property name="available_expr">
+        python:context.restrictedTraverse('@@plone_interface_info').provides('opengever.disposition.interfaces.IDisposition') and object.removal_protocol_available()
+      </property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
+  </object>
+
+</object>

--- a/opengever/core/upgrades/20211207105652_add_disposition_actions/upgrade.py
+++ b/opengever/core/upgrades/20211207105652_add_disposition_actions/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddDispositionActions(UpgradeStep):
+    """Add disposition actions.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/disposition/browser/overview.py
+++ b/opengever/disposition/browser/overview.py
@@ -67,24 +67,15 @@ class DispositionOverview(BrowserView):
              'label': _('label_dispositon_package_download',
                         default=u'Download disposition package'),
              'url': '{}/ech0160_download'.format(self.context.absolute_url()),
-             'visible': self.sip_download_available(),
+             'visible': self.context.sip_download_available(),
              'class': 'sip_download'},
             {'id': 'removal_protocol',
              'label': _('label_download_removal_protocol',
                         default=u'Download removal protocol'),
              'url': '{}/removal_protocol'.format(self.context.absolute_url()),
-             'visible': self.removal_protocol_available(),
+             'visible': self.context.removal_protocol_available(),
              'class': 'removal_protocol'}
         ]
-
-    def sip_download_available(self):
-        if api.user.has_permission(
-            'opengever.disposition: Download SIP Package',
-                obj=self.context):
-
-            return self.context.has_sip_package()
-
-        return None
 
     def sip_store_available(self):
         return api.user.has_permission(
@@ -93,9 +84,6 @@ class DispositionOverview(BrowserView):
 
     def appraisal_buttons_available(self):
         return api.content.get_state(self.context) == 'disposition-state-in-progress'
-
-    def removal_protocol_available(self):
-        return api.content.get_state(self.context) == 'disposition-state-closed'
 
     def get_history(self):
         return self.context.get_history()

--- a/opengever/disposition/browser/overview.py
+++ b/opengever/disposition/browser/overview.py
@@ -1,12 +1,9 @@
 from opengever.base.behaviors.lifecycle import ARCHIVAL_VALUE_UNWORTHY
 from opengever.base.behaviors.lifecycle import ILifeCycle
 from opengever.disposition import _
-from opengever.disposition.delivery import DELIVERY_STATUS_LABELS
-from opengever.disposition.delivery import DeliveryScheduler
 from plone import api
 from plone.protect.utils import addTokenToUrl
 from Products.Five.browser import BrowserView
-from zope.i18n import translate
 
 
 class DispositionOverview(BrowserView):
@@ -45,15 +42,6 @@ class DispositionOverview(BrowserView):
         wftool = api.portal.get_tool(name='portal_workflow')
         infos = wftool.listActionInfos(object=self.context, check_condition=False)
         return infos
-
-    def get_delivery_status_infos(self):
-        """Get translated delivery status infos in a template friendly format.
-        """
-        statuses = DeliveryScheduler(self.context).get_statuses()
-        status_infos = [
-            {'name': n, 'status': translate(DELIVERY_STATUS_LABELS[s], context=self.request)}
-            for n, s in statuses.items()]
-        return status_infos
 
     def get_actions(self):
         return [

--- a/opengever/disposition/browser/templates/overview.pt
+++ b/opengever/disposition/browser/templates/overview.pt
@@ -38,7 +38,7 @@
 
             <tal:deliverystatus tal:condition="python:view.get_current_state() == 'disposition-state-disposed'">
                 <h3 class="metadata" i18n:translate="label_delivery_status">Delivery Status</h3>
-                <table class="listing" id="delivery-status" tal:define="status_infos view/get_delivery_status_infos">
+                <table class="listing" id="delivery-status" tal:define="status_infos context/get_delivery_status_infos">
                     <tr tal:repeat="status_info status_infos">
                         <td tal:condition="python: len(status_infos) > 1" tal:content="status_info/name" />
                         <td tal:content="status_info/status"/>

--- a/opengever/disposition/disposition.py
+++ b/opengever/disposition/disposition.py
@@ -417,3 +417,14 @@ class Disposition(Container):
 
     def get_sip_filename(self):
         return u'{}.zip'.format(self.get_sip_name())
+
+    def sip_download_available(self):
+        if api.user.has_permission(
+                'opengever.disposition: Download SIP Package', obj=self):
+
+            return self.has_sip_package()
+
+        return None
+
+    def removal_protocol_available(self):
+        return api.content.get_state(self) == 'disposition-state-closed'

--- a/opengever/disposition/disposition.py
+++ b/opengever/disposition/disposition.py
@@ -14,6 +14,7 @@ from opengever.base.security import elevated_privileges
 from opengever.base.source import SolrObjPathSourceBinder
 from opengever.disposition import _
 from opengever.disposition.appraisal import IAppraisal
+from opengever.disposition.delivery import DELIVERY_STATUS_LABELS
 from opengever.disposition.delivery import DeliveryScheduler
 from opengever.disposition.ech0160.sippackage import SIPPackage
 from opengever.disposition.history import DispositionHistory
@@ -45,6 +46,7 @@ from zope import schema
 from zope.annotation import IAnnotations
 from zope.component import getMultiAdapter
 from zope.component import getUtility
+from zope.globalrequest import getRequest
 from zope.globalrequest import getRequest
 from zope.i18n import translate
 from zope.interface import alsoProvides
@@ -428,3 +430,12 @@ class Disposition(Container):
 
     def removal_protocol_available(self):
         return api.content.get_state(self) == 'disposition-state-closed'
+
+    def get_delivery_status_infos(self):
+        """Get translated delivery status infos in a template friendly format.
+        """
+        statuses = DeliveryScheduler(self).get_statuses()
+        status_infos = [
+            {'name': n, 'status': translate(DELIVERY_STATUS_LABELS[s], context=getRequest())}
+            for n, s in statuses.items()]
+        return status_infos

--- a/opengever/disposition/disposition.py
+++ b/opengever/disposition/disposition.py
@@ -47,7 +47,6 @@ from zope.annotation import IAnnotations
 from zope.component import getMultiAdapter
 from zope.component import getUtility
 from zope.globalrequest import getRequest
-from zope.globalrequest import getRequest
 from zope.i18n import translate
 from zope.interface import alsoProvides
 from zope.interface import implements
@@ -229,7 +228,6 @@ class IDispositionSchema(model.Schema):
 
 class Disposition(Container):
     implements(IDisposition, IResponseSupported)
-
 
     destroyed_key = 'destroyed_dossiers'
 

--- a/opengever/disposition/tests/test_actions.py
+++ b/opengever/disposition/tests/test_actions.py
@@ -1,0 +1,75 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.base.behaviors.lifecycle import ARCHIVAL_VALUE_SAMPLING
+from opengever.base.behaviors.lifecycle import ILifeCycle
+from opengever.base.security import elevated_privileges
+from opengever.testing import IntegrationTestCase
+import os
+from plone import api
+from zope.component import getUtility
+from zope.intid.interfaces import IIntIds
+from z3c.relationfield.relation import RelationValue
+
+
+class TestDispositionActions(IntegrationTestCase):
+
+    @browsing
+    def test_download_appraisal_list_only_available_on_dipsositions(self, browser):
+        self.login(self.records_manager, browser)
+
+        browser.open(u'{}/@actions'.format(self.disposition.absolute_url()),
+                     headers=self.api_headers)
+        self.assertIn(
+            'download-appraisal-list',
+            [action['id'] for action in browser.json['ui_context_actions']])
+
+        browser.open(u'{}/@actions'.format(self.dossier.absolute_url()),
+                     headers=self.api_headers)
+        self.assertNotIn(
+            'download-appraisal-list',
+            [action['id'] for action in browser.json['ui_context_actions']])
+
+    @browsing
+    def test_download_sip_available_if_sip_exist(self, browser):
+        self.login(self.records_manager, browser)
+
+        # without sip
+        browser.open(u'{}/@actions'.format(self.disposition.absolute_url()),
+                     headers=self.api_headers)
+        self.assertNotIn(
+            'download-sip',
+            [action['id'] for action in browser.json['ui_context_actions']])
+
+        # with sip
+        browser.open(
+            u'{}/@actions'.format(self.disposition_with_sip.absolute_url()),
+            headers=self.api_headers)
+        self.assertIn(
+            'download-sip',
+            [action['id'] for action in browser.json['ui_context_actions']])
+
+        # only for dispositions
+        browser.open(u'{}/@actions'.format(self.dossier.absolute_url()),
+                     headers=self.api_headers)
+        self.assertNotIn(
+            'download-sip',
+            [action['id'] for action in browser.json['ui_context_actions']])
+
+    @browsing
+    def test_download_removal_protocol_only_available_for_closed_dispositions(self, browser):
+        self.login(self.records_manager, browser)
+        url = u'{}/@actions'.format(self.disposition_with_sip.absolute_url())
+
+        browser.open(url, headers=self.api_headers)
+        self.assertNotIn(
+            'download-removal-protocol',
+            [action['id'] for action in browser.json['ui_context_actions']])
+
+        self.set_workflow_state('disposition-state-closed',
+                                self.disposition_with_sip)
+
+        browser.open(url, headers=self.api_headers)
+        self.assertIn(
+            'download-removal-protocol',
+            [action['id'] for action in browser.json['ui_context_actions']])


### PR DESCRIPTION
Necessary to show the actions in the gever-ui, but have the condition if the action is available still in the backend.

The PR also extends the disposition serialization with the `sip_delivery_status` key.

For [CA-2119]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- API change:
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
- Upgrade steps (changes in profile):
- New translations
  - [x] All msg-strings are unicode


[CA-2119]: https://4teamwork.atlassian.net/browse/CA-2119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ