### PR TITLE
Add @my-substitutes, @substitutes and @out-of-office API endpoints

### DIFF
--- a/changes/CA-2274.feature
+++ b/changes/CA-2274.feature
@@ -1,0 +1,1 @@
+Add @my-substitutes, @subtitutes and @out-of-office API endpoints. [tinagerber]

--- a/docs/public/dev-manual/api/actors.rst
+++ b/docs/public/dev-manual/api/actors.rst
@@ -32,6 +32,7 @@ Ein actor ist kein Plone Inhaltstyp, deshalb beinhaltet die Response weniger Inf
         "active": true,
         "actor_type": "user",
         "identifier": "peter.mueller",
+        "is_absent": true,
         "label": "Mueller Peter",
         "portrait_url": "http://example.org/portraits/peter.mueller.png"
         "representatives": [
@@ -81,6 +82,7 @@ Via POST können die Daten von mehreren actors mit einem Request abgefragt werde
             "active": true,
             "actor_type": "user",
             "identifier": "peter.mueller",
+            "is_absent": false,
             "label": "Mueller Peter",
             "portrait_url": "http://example.org/portraits/peter.mueller.png",
             "representatives": [
@@ -99,6 +101,7 @@ Via POST können die Daten von mehreren actors mit einem Request abgefragt werde
             "active": true,
             "actor_type": "inbox",
             "identifier": "inbox:afi",
+            "is_absent": false,
             "label": "Eingangskorb",
             "portrait_url": null,
             "representatives": [

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -17,6 +17,9 @@ Other Changes
 - @xhr-upload: new endpoint to upload documents as a multipart/form-data xhr request. [elioschmutz]
 - Include is_completed in sql task serialization.
 - ``@listing``: Add retention_expiration column.
+- New endpoints ``@my-substitutes`` and ``@substitutes`` are added (see :ref:`substitutes`).
+- A new endpoint ``@out-of-office`` is added (see :ref:`out-of-office`).
+- Include is_absent in actors serialization.
 
 
 2021.24.0 (2021-11-30)

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -69,4 +69,5 @@ Inhalt:
    close_remote_task.rst
    reference_numbers.rst
    dispositions.rst
+   out_of_office.rst
    examples/index.rst

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -70,4 +70,5 @@ Inhalt:
    reference_numbers.rst
    dispositions.rst
    out_of_office.rst
+   substitutes.rst
    examples/index.rst

--- a/docs/public/dev-manual/api/out_of_office.rst
+++ b/docs/public/dev-manual/api/out_of_office.rst
@@ -1,0 +1,58 @@
+.. _out-of-office:
+
+Abwesenheit
+===========
+
+Mit dem ``@out-of-office`` Endpoint können für den aktuellen Benutzer eine Abwesenheit angezeigt und angepasst werden. Der Endpoint steht nur auf Stufe PloneSite zur Verfügung.
+
+
+Abwesenheit anzeigen:
+---------------------
+Mittels eines GET Request kann die Abwesenheit des aktuellen Benutzers angezeigt werden.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       GET /@out-of-office HTTP/1.1
+       Accept: application/json
+
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+          "@id": "http://localhost:8081/fd/@out-of-office",
+          "absent": true,
+          "absent_from": "2021-12-08",
+          "absent_to": "2021-12-15"
+      }
+
+
+Abwesenheit editieren:
+----------------------
+Die Abwesenheit des aktuellen Benutzers kann mittels PATCH Request editiert werden.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       PATCH /@out-of-office HTTP/1.1
+       Accept: application/json
+
+       {
+        "absent_to": "2021-12-22"
+       }
+
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 204 No content
+
+Gleich wie bei anderen PATCH Requests ist es auch hier möglich, die Repräsentation als Response zu erhalten, hierzu muss ein ``Prefer`` Header mit dem Wert ``return=representation`` gesetzt werden.

--- a/docs/public/dev-manual/api/substitutes.rst
+++ b/docs/public/dev-manual/api/substitutes.rst
@@ -1,0 +1,133 @@
+.. _substitutes:
+
+Stellvertreter
+==============
+
+Mit dem ``@my-substitutes`` Endpoint können für den aktuellen Benutzer Stellvertreter aufgelistet, hinzugefügt und gelöscht werden. Mit dem ``@substitutes`` Endpoint  können für einen beliebigen Benutzer Stellvertreter aufgelistet werden. Die Endpoints stehen nur auf Stufe PloneSite zur Verfügung.
+
+
+Eigene Stellvertreter auflisten:
+--------------------------------
+Mittels eines GET Request können Stellvertretungen des aktuellen Benutzers abgefragt werden. Es werden alle, also global über den ganzen Mandanten-Verbund, zurückgegeben.
+
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       GET /@my-substitutes HTTP/1.1
+       Accept: application/json
+
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+          "@id": "http://localhost:8081/fd/@my-substitutes",
+          "items": [
+              {
+                  "@id": "http://localhost:8081/fd/@my-substitutes/peter.mueller",
+                  "@type": "virtual.ogds.substitute",
+                  "substitution_id": 3,
+                  "substitute_userid": "peter.mueller",
+                  "userid": "kathi.barfuss"
+              },
+              {
+                  "@id": "http://localhost:8081/fd/@my-substitutes/nicole.kohler",
+                  "@type": "virtual.ogds.substitute",
+                  "substitution_id": 3,
+                  "substitute_userid": "nicole.kohler",
+                  "userid": "kathi.barfuss"
+              },
+          ],
+          "items_total": 2
+      }
+
+Stellvertreter eines Benutzers auflisten:
+-----------------------------------------
+Mittels eines GET Request können Stellvertretungen eines Benutzers abgefragt werden. Dabei wird die User-ID des Benutzers als Pfad-Parameter erwartet. Es werden alle, also global über den ganzen Mandanten-Verbund, zurückgegeben.
+
+
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       GET /@substitutes/kathi.barfuss HTTP/1.1
+       Accept: application/json
+
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+          "@id": "http://localhost:8081/fd/@substitutes/kathi.barfuss",
+          "items": [
+              {
+                  "@id": "http://localhost:8081/fd/@substitutes/peter.mueller",
+                  "@type": "virtual.ogds.substitute",
+                  "substitution_id": 3,
+                  "substitute_userid": "peter.mueller",
+                  "userid": "kathi.barfuss"
+              },
+              {
+                  "@id": "http://localhost:8081/fd/@substitutes/nicole.kohler",
+                  "@type": "virtual.ogds.substitute",
+                  "substitution_id": 3,
+                  "substitute_userid": "nicole.kohler",
+                  "userid": "kathi.barfuss"
+              },
+          ],
+          "items_total": 2
+      }
+
+
+Stellvertretung hinzufügen:
+---------------------------
+Eine Stellvertretung des aktuellen Benutzers kann mittels POST Request hinzugefügt werden. Dabei wird die User-ID als Parameter erwartet.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       POST /@my-substitutes HTTP/1.1
+       Accept: application/json
+
+       {
+        "userid": "peter.mueller"
+       }
+
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 204 No content
+
+
+Stellvertretung entfernen:
+--------------------------
+Eine bestehende Stellvertretung des aktuelllen Benutzers kann mittels DELETE Request wieder gelöscht werden. Als Pfad-Parameter wird die User-ID der Stellvertretung erwartet.
+
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       DELETE /@my-substitutes/peter.mueller HTTP/1.1
+       Accept: application/json
+
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 204 No Content

--- a/docs/public/dev-manual/api/users.rst
+++ b/docs/public/dev-manual/api/users.rst
@@ -27,6 +27,9 @@ Ein Benutzer wird lediglich durch einen Eintrag in der SQL Datenbank repräsenti
       {
         "@id": "http://example.org/fd/kontakte/@ogds-users/peter.mueller",
         "@type": "virtual.ogds.user",
+        "absent": false,
+        "absent_from": null,
+        "absent_to": null,
         "active": true,
         "address1": null,
         "...": "...",

--- a/docs/schema-dumps/_opengever.ogds.models.user.User.schema.json
+++ b/docs/schema-dumps/_opengever.ogds.models.user.User.schema.json
@@ -156,6 +156,27 @@
             "format": "date",
             "description": "",
             "_zope_schema_type": "Date"
+        },
+        "absent": {
+            "type": "boolean",
+            "title": "absent",
+            "description": "",
+            "_zope_schema_type": "Bool",
+            "default": false
+        },
+        "absent_from": {
+            "type": "string",
+            "title": "absent_from",
+            "format": "date",
+            "description": "",
+            "_zope_schema_type": "Date"
+        },
+        "absent_to": {
+            "type": "string",
+            "title": "absent_to",
+            "format": "date",
+            "description": "",
+            "_zope_schema_type": "Date"
         }
     },
     "required": [
@@ -183,6 +204,9 @@
         "zip_code",
         "city",
         "country",
-        "last_login"
+        "last_login",
+        "absent",
+        "absent_from",
+        "absent_to"
     ]
 }

--- a/opengever/api/actors.py
+++ b/opengever/api/actors.py
@@ -44,6 +44,7 @@ class SerializeActorToJson(object):
             'active': self.context.is_active,
             'actor_type': self.context.actor_type,
             'identifier': self.context.identifier,
+            'is_absent': self.context.is_absent,
             'label': self.context.get_label(with_principal=False),
             'portrait_url': self.context.get_portrait_url(),
             'representatives': [

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -53,6 +53,7 @@
   <adapter factory=".workspace.SerializeWorkspaceToJson" />
   <adapter factory=".response.ResponseDefaultFieldSerializer" />
   <adapter factory=".response.SerializeResponseToJson" />
+  <adapter factory=".substitutes.SerializeSubstituteToJson" />
   <adapter factory=".task.SerializeTaskToJson" />
   <adapter factory=".task.SerializeTaskResponseToJson" />
   <adapter factory=".task.TaskDeserializeFromJson" />
@@ -1571,6 +1572,38 @@
       name="@out-of-office"
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"
       factory=".out_of_office.OutOfOfficePatch"
+      permission="cmf.SetOwnProperties"
+      />
+
+  <plone:service
+      method="GET"
+      name="@substitutes"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      factory=".substitutes.SubstitutesGet"
+      permission="zope2.View"
+      />
+
+  <plone:service
+      method="GET"
+      name="@my-substitutes"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      factory=".substitutes.MySubstitutesGet"
+      permission="zope2.View"
+      />
+
+  <plone:service
+      method="POST"
+      name="@my-substitutes"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      factory=".substitutes.MySubstitutesPost"
+      permission="cmf.SetOwnProperties"
+      />
+
+  <plone:service
+      method="DELETE"
+      name="@my-substitutes"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      factory=".substitutes.MySubstitutesDelete"
       permission="cmf.SetOwnProperties"
       />
 

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -1558,4 +1558,20 @@
       permission="cmf.ModifyPortalContent"
       />
 
+  <plone:service
+      method="GET"
+      name="@out-of-office"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      factory=".out_of_office.OutOfOfficeGet"
+      permission="zope2.View"
+      />
+
+  <plone:service
+      method="PATCH"
+      name="@out-of-office"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      factory=".out_of_office.OutOfOfficePatch"
+      permission="cmf.SetOwnProperties"
+      />
+
 </configure>

--- a/opengever/api/out_of_office.py
+++ b/opengever/api/out_of_office.py
@@ -1,0 +1,73 @@
+from datetime import datetime
+from opengever.ogds.base.utils import ogds_service
+from plone import api
+from plone.restapi.deserializer import json_body
+from plone.restapi.serializer.converters import json_compatible
+from plone.restapi.services import Service
+from zExceptions import BadRequest
+
+
+class OutOfOfficeGet(Service):
+
+    def reply(self):
+        userid = api.user.get_current().getId()
+        user = ogds_service().fetch_user(userid)
+        result = {
+            '@id': '{}/@out-of-office'.format(self.context.absolute_url()),
+            'absent': user.absent,
+            'absent_from': json_compatible(user.absent_from),
+            'absent_to': json_compatible(user.absent_to)
+        }
+        return result
+
+
+class OutOfOfficePatch(Service):
+
+    def validate_dates(self, absent_from, absent_to):
+        if (absent_from or absent_to) is None:
+            return
+        if (absent_from and absent_to) is None:
+            raise BadRequest(u'Either absent_from and absent_to must both be set or neither.')
+
+        if absent_from > absent_to:
+            raise BadRequest(u'absent_from date must be before absent_to date.')
+
+    def reply(self):
+        data = json_body(self.request)
+
+        userid = api.user.get_current().getId()
+        user = ogds_service().fetch_user(userid)
+
+        if 'absent' in data:
+            user.absent = data['absent']
+
+        if 'absent_from' in data or 'absent_to' in data:
+            if 'absent_from' in data:
+                absent_from = data['absent_from']
+                if absent_from is not None:
+                    absent_from = datetime.strptime(absent_from, '%Y-%m-%d').date()
+                user.absent_from = absent_from
+            else:
+                absent_from = user.absent_from
+            if 'absent_to' in data:
+                absent_to = data['absent_to']
+
+                if absent_to is not None:
+                    absent_to = datetime.strptime(absent_to, '%Y-%m-%d').date()
+                user.absent_to = absent_to
+            else:
+                absent_to = user.absent_to
+
+            self.validate_dates(absent_from, absent_to)
+
+        prefer = self.request.getHeader('Prefer')
+        if prefer == 'return=representation':
+            self.request.response.setStatus(200)
+            return {
+                '@id': '{}/@out-of-office'.format(self.context.absolute_url()),
+                'absent': user.absent,
+                'absent_from': json_compatible(user.absent_from),
+                'absent_to': json_compatible(user.absent_to)
+            }
+
+        return self.reply_no_content()

--- a/opengever/api/substitutes.py
+++ b/opengever/api/substitutes.py
@@ -1,0 +1,123 @@
+from opengever.api.batch import SQLHypermediaBatch
+from opengever.base.interfaces import IOpengeverBaseLayer
+from opengever.ogds.base.substitute import SubstituteManager
+from opengever.ogds.models.substitute import Substitute
+from plone import api
+from plone.protect.interfaces import IDisableCSRFProtection
+from plone.restapi.deserializer import json_body
+from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.services import Service
+from zExceptions import BadRequest
+from zope.component import adapter
+from zope.component import getMultiAdapter
+from zope.interface import alsoProvides
+from zope.interface import implementer
+from zope.interface import implements
+from zope.publisher.interfaces import IPublishTraverse
+from opengever.api.serializer import SerializeSQLModelToJsonBase
+
+
+@implementer(ISerializeToJson)
+@adapter(Substitute, IOpengeverBaseLayer)
+class SerializeSubstituteToJson(SerializeSQLModelToJsonBase):
+
+    content_type = 'virtual.ogds.substitute'
+
+    def __call__(self):
+        data = super(SerializeSubstituteToJson, self).__call__()
+        if '@substitutes' in self.request.URL:
+            data['@id'] = '{}/@substitutes/{}/{}'.format(
+                api.portal.get().absolute_url(),
+                self.context.userid,
+                self.context.substitute_userid)
+        else:
+            data['@id'] = '{}/@my-substitutes/{}'.format(
+                api.portal.get().absolute_url(),
+                self.context.substitute_userid)
+
+        return data
+
+
+class MySubstitutesGet(Service):
+
+    def reply(self):
+        userid = self.get_userid()
+        results = SubstituteManager().list_substitutes_for(userid)
+        batch = SQLHypermediaBatch(self.request, results, 'substitute_userid')
+
+        serialized_terms = []
+        for substitute in batch:
+            serializer = getMultiAdapter(
+                (substitute, self.request), interface=ISerializeToJson
+            )
+            serialized_terms.append(serializer())
+
+        result = {
+            "@id": batch.canonical_url,
+            "items": serialized_terms,
+            "items_total": batch.items_total,
+        }
+        links = batch.links
+        if links:
+            result["batching"] = links
+        return result
+
+    def get_userid(self):
+        return api.user.get_current().getId()
+
+
+class SubstitutesGet(MySubstitutesGet):
+
+    implements(IPublishTraverse)
+
+    def __init__(self, context, request):
+        super(SubstitutesGet, self).__init__(context, request)
+        self.params = []
+
+    def publishTraverse(self, request, name):
+        self.params.append(name)
+        return self
+
+    def get_userid(self):
+        if len(self.params) != 1:
+            raise BadRequest("Must supply userid as path parameter.")
+        return self.params[0]
+
+
+class MySubstitutesPost(Service):
+
+    def reply(self):
+        alsoProvides(self.request, IDisableCSRFProtection)
+
+        substitute = json_body(self.request).get("userid", None)
+        if not substitute:
+            raise BadRequest("Property 'userid' is required")
+        if not api.user.get(substitute):
+            raise BadRequest("userid '{}' does not exist".format(substitute))
+        userid = api.user.get_current().getId()
+        SubstituteManager().add(userid, substitute)
+        return self.reply_no_content()
+
+
+class MySubstitutesDelete(Service):
+
+    implements(IPublishTraverse)
+
+    def __init__(self, context, request):
+        super(MySubstitutesDelete, self).__init__(context, request)
+        self.params = []
+
+    def publishTraverse(self, request, name):
+        self.params.append(name)
+        return self
+
+    def reply(self):
+        substitute = self.read_params()
+        userid = api.user.get_current().getId()
+        SubstituteManager().delete(userid, substitute)
+        return self.reply_no_content()
+
+    def read_params(self):
+        if len(self.params) != 1:
+            raise BadRequest("Must supply substitute userid as path parameter.")
+        return self.params[0]

--- a/opengever/api/tests/test_ogdsuser.py
+++ b/opengever/api/tests/test_ogdsuser.py
@@ -54,6 +54,9 @@ class TestOGDSUserGet(IntegrationTestCase):
         self.assertEqual(
             {u'@id': u'http://nohost/plone/@ogds-users/kathi.barfuss',
              u'@type': u'virtual.ogds.user',
+             u'absent': False,
+             u'absent_from': None,
+             u'absent_to': None,
              u'active': True,
              u'address1': u'Kappelenweg 13',
              u'address2': u'Postfach 1234',

--- a/opengever/api/tests/test_out_of_office.py
+++ b/opengever/api/tests/test_out_of_office.py
@@ -1,0 +1,119 @@
+from datetime import datetime
+from ftw.testbrowser import browsing
+from opengever.base.model import create_session
+from opengever.ogds.models.user import User
+from opengever.testing import IntegrationTestCase
+import json
+
+
+class TestOutOfOfficeGet(IntegrationTestCase):
+
+    @browsing
+    def test_get_out_of_office(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        sql_user = User.query.get(self.regular_user.getId())
+        sql_user.absent = True
+        sql_user.absent_from = datetime(2021, 11, 11).date()
+        sql_user.absent_to = datetime(2021, 12, 11).date()
+        create_session().flush()
+
+        browser.open(self.portal, view='@out-of-office', method='GET',
+                     headers=self.api_headers)
+
+        self.assertEqual(200, browser.status_code)
+        self.assertEqual({u'@id': u'http://nohost/plone/@out-of-office',
+                          u'absent': True,
+                          u'absent_from': u'2021-11-11',
+                          u'absent_to': u'2021-12-11'}, browser.json)
+
+
+class TestOutOfOfficePatch(IntegrationTestCase):
+
+    @browsing
+    def test_patch_out_of_office(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(self.portal, view='@out-of-office', method='PATCH',
+                     data=json.dumps({'absent': True, 'absent_from': '2021-11-11',
+                                      'absent_to': '2021-12-11'}),
+                     headers=self.api_headers)
+
+        self.assertEqual(204, browser.status_code)
+
+        browser.open(self.portal, view='@out-of-office', method='GET',
+                     headers=self.api_headers)
+
+        self.assertEqual({u'@id': u'http://nohost/plone/@out-of-office',
+                          u'absent': True,
+                          u'absent_from': u'2021-11-11',
+                          u'absent_to': u'2021-12-11'}, browser.json)
+
+    @browsing
+    def test_respects_prefer_header(self, browser):
+        self.login(self.regular_user, browser)
+        headers = self.api_headers.copy()
+        headers.update({'Prefer': 'return=representation'})
+
+        browser.open(self.portal, view='@out-of-office', method='PATCH',
+                     data=json.dumps({'absent_from': '2021-11-11',
+                                      'absent_to': '2021-12-11'}),
+                     headers=headers)
+        self.assertEqual(200, browser.status_code)
+
+        self.assertEqual({u'@id': u'http://nohost/plone/@out-of-office',
+                          u'absent': False,
+                          u'absent_from': u'2021-11-11',
+                          u'absent_to': u'2021-12-11'}, browser.json)
+
+    @browsing
+    def test_raises_if_only_one_date_is_set(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        with browser.expect_http_error(400):
+            browser.open(self.portal, view='@out-of-office', method='PATCH',
+                         data=json.dumps({'absent': True, 'absent_from': '2021-11-11'}),
+                         headers=self.api_headers)
+
+        self.assertEqual(
+            {u'message': u'Either absent_from and absent_to must both be set or neither.',
+             u'type': u'BadRequest'},
+            browser.json)
+
+    @browsing
+    def test_raises_if_absent_to_is_before_absent_from(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        with browser.expect_http_error(400):
+            browser.open(self.portal, view='@out-of-office', method='PATCH',
+                         data=json.dumps({'absent_from': '2021-11-16',
+                                          'absent_to': '2021-07-11'}),
+                         headers=self.api_headers)
+
+        self.assertEqual(
+            {u'message': u'absent_from date must be before absent_to date.',
+             u'type': u'BadRequest'},
+            browser.json)
+
+    @browsing
+    def test_can_set_dates_to_none(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        sql_user = User.query.get(self.regular_user.getId())
+        sql_user.absent_from = datetime(2021, 11, 11).date()
+        sql_user.absent_to = datetime(2021, 12, 11).date()
+        create_session().flush()
+
+        browser.open(self.portal, view='@out-of-office', method='PATCH',
+                     data=json.dumps({'absent_from': None,
+                                      'absent_to': None}),
+                     headers=self.api_headers)
+
+        browser.open(self.portal, view='@out-of-office', method='GET',
+                     headers=self.api_headers)
+
+        self.assertEqual(200, browser.status_code)
+        self.assertEqual({u'@id': u'http://nohost/plone/@out-of-office',
+                          u'absent': False,
+                          u'absent_from': None,
+                          u'absent_to': None}, browser.json)

--- a/opengever/api/tests/test_substitutes.py
+++ b/opengever/api/tests/test_substitutes.py
@@ -1,0 +1,198 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+import json
+
+
+class TestSubstitutesGet(IntegrationTestCase):
+
+    @browsing
+    def test_get_substitutes(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        create(Builder('substitute')
+               .for_user(self.administrator)
+               .with_substitute(self.meeting_user))
+
+        create(Builder('substitute')
+               .for_user(self.administrator)
+               .with_substitute(self.dossier_responsible))
+
+        create(Builder('substitute')
+               .for_user(self.regular_user)
+               .with_substitute(self.administrator))
+
+        browser.open(self.portal, view='@substitutes/nicole.kohler', method='GET',
+                     headers=self.api_headers)
+
+        self.assertEqual(200, browser.status_code)
+
+        self.assertEqual(
+            {u'@id': u'http://nohost/plone/@substitutes/nicole.kohler',
+             u'items': [{u'@id': u'http://nohost/plone/@substitutes/nicole.kohler/herbert.jager',
+                         u'@type': u'virtual.ogds.substitute',
+                         u'substitution_id': 1,
+                         u'substitute_userid': self.meeting_user.getId(),
+                         u'userid': self.administrator.getId()},
+                        {u'@id': u'http://nohost/plone/@substitutes/nicole.kohler/robert.ziegler',
+                         u'@type': u'virtual.ogds.substitute',
+                         u'substitution_id': 2,
+                         u'substitute_userid': self.dossier_responsible.getId(),
+                         u'userid': self.administrator.getId()}],
+             u'items_total': 2}, browser.json)
+
+    @browsing
+    def test_get_substitutes_raises_if_userid_is_missing(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        with browser.expect_http_error(400):
+            browser.open(self.portal, view='@substitutes', method='GET',
+                         headers=self.api_headers)
+
+        self.assertEqual({u"message": u"Must supply userid as path parameter.",
+                          u"type": u"BadRequest"}, browser.json)
+
+
+class TestMySubstitutesGet(IntegrationTestCase):
+
+    @browsing
+    def test_get_my_substitutes(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        create(Builder('substitute')
+               .for_user(self.regular_user)
+               .with_substitute(self.meeting_user))
+
+        create(Builder('substitute')
+               .for_user(self.administrator)
+               .with_substitute(self.dossier_responsible))
+
+        create(Builder('substitute')
+               .for_user(self.regular_user)
+               .with_substitute(self.administrator))
+
+        browser.open(self.portal, view='@my-substitutes', method='GET',
+                     headers=self.api_headers)
+
+        self.assertEqual(200, browser.status_code)
+
+        self.assertEqual({u'@id': u'http://nohost/plone/@my-substitutes',
+                          u'items': [{u'@id': u'http://nohost/plone/@my-substitutes/herbert.jager',
+                                      u'@type': u'virtual.ogds.substitute',
+                                      u'substitution_id': 1,
+                                      u'substitute_userid': self.meeting_user.getId(),
+                                      u'userid': self.regular_user.getId()},
+                                     {u'@id': u'http://nohost/plone/@my-substitutes/nicole.kohler',
+                                      u'@type': u'virtual.ogds.substitute',
+                                      u'substitution_id': 3,
+                                      u'substitute_userid': self.administrator.getId(),
+                                      u'userid': self.regular_user.getId()}],
+                          u'items_total': 2}, browser.json)
+
+
+class TestMySubstitutesPost(IntegrationTestCase):
+
+    @browsing
+    def test_post_my_substitutes(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(self.portal, view='@my-substitutes', method='POST',
+                     data=json.dumps({'userid': self.administrator.getId()}),
+                     headers=self.api_headers)
+
+        self.assertEqual(204, browser.status_code)
+
+        browser.open(self.portal, view='@my-substitutes', method='GET',
+                     headers=self.api_headers)
+
+        self.assertEqual([{u'@id': u'http://nohost/plone/@my-substitutes/nicole.kohler',
+                           u'@type': u'virtual.ogds.substitute',
+                           u'substitution_id': 1,
+                           u'substitute_userid': self.administrator.getId(),
+                           u'userid': self.regular_user.getId()}],
+                         browser.json['items'])
+
+    @browsing
+    def test_post_my_substitutes_raises_if_userid_is_missing(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        with browser.expect_http_error(400):
+            browser.open(self.portal, view='@my-substitutes', method='POST',
+                         data=json.dumps({}),
+                         headers=self.api_headers)
+
+        self.assertEqual(
+            {u"message": u"Property 'userid' is required", u"type": u"BadRequest"},
+            browser.json)
+
+    @browsing
+    def test_post_my_substitutes_raises_if_userid_is_invalid(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        with browser.expect_http_error(400):
+            browser.open(self.portal, view='@my-substitutes', method='POST',
+                         data=json.dumps({'userid': 'invalid'}),
+                         headers=self.api_headers)
+
+        self.assertEqual(
+            {u"message": u"userid 'invalid' does not exist", u"type": u"BadRequest"},
+            browser.json)
+
+    @browsing
+    def test_post_my_substitutes_raises_if_substitute_already_exists(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        create(Builder('substitute')
+               .for_user(self.regular_user)
+               .with_substitute(self.administrator))
+
+        with browser.expect_http_error(400):
+            browser.open(self.portal, view='@my-substitutes', method='POST',
+                         data=json.dumps({'userid': self.administrator.getId()}),
+                         headers=self.api_headers)
+
+        self.assertEqual(
+            {u'type': u'BadRequest', u'additional_metadata': {},
+             u'translated_message': u'This substitute already exists.',
+             u'message': u'msg_substitute_already_exists'},
+            browser.json)
+
+
+class TestMySubstitutesDelete(IntegrationTestCase):
+
+    @browsing
+    def test_delete_my_substitutes(self, browser):
+        self.login(self.regular_user, browser=browser)
+        create(Builder('substitute')
+               .for_user(self.regular_user)
+               .with_substitute(self.administrator))
+
+        browser.open(self.portal, view='@my-substitutes/{}'.format(self.administrator.getId()),
+                     method='DELETE', headers=self.api_headers)
+
+        self.assertEqual(204, browser.status_code)
+
+        browser.open(self.portal, view='@my-substitutes', method='GET',
+                     headers=self.api_headers)
+
+        self.assertEqual([], browser.json['items'])
+
+    @browsing
+    def test_delete_my_substitutes_raises_if_userid_is_missing(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        with browser.expect_http_error(400):
+            browser.open(self.portal, view='@my-substitutes', method='DELETE',
+                         headers=self.api_headers)
+
+        self.assertEqual({u"message": u"Must supply substitute userid as path parameter.",
+                          u"type": u"BadRequest"}, browser.json)
+
+    @browsing
+    def test_delete_my_substitutes_raises_if_substitute_does_not_exist(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        with browser.expect_http_error(code=404, reason='Not Found'):
+            browser.open(self.portal, view='@my-substitutes/{}'.format(self.administrator.getId()),
+                         method='DELETE', headers=self.api_headers)

--- a/opengever/base/model/__init__.py
+++ b/opengever/base/model/__init__.py
@@ -39,6 +39,7 @@ tables = [
     'groups_users',
     'groups',
     'org_units',
+    'substitutes',
     'teams',
     'users',
     'user_settings',

--- a/opengever/core/upgrades/20211202155051_add_substitutes/upgrade.py
+++ b/opengever/core/upgrades/20211202155051_add_substitutes/upgrade.py
@@ -1,0 +1,29 @@
+from opengever.core.upgrade import SchemaMigration
+from opengever.base.model import USER_ID_LENGTH
+from opengever.ogds.models.user import User
+from sqlalchemy import Boolean
+from sqlalchemy import Column
+from sqlalchemy import Date
+from sqlalchemy import ForeignKey
+from sqlalchemy import String
+from sqlalchemy.schema import Sequence
+from sqlalchemy import Integer
+
+
+class AddSubstitutes(SchemaMigration):
+    """Add substitutes.
+    """
+
+    def migrate(self):
+        self.op.create_table(
+            'substitutes',
+            Column("id", Integer, Sequence("substitution_id_seq"), primary_key=True),
+            Column('userid', String(USER_ID_LENGTH), ForeignKey(User.userid)),
+            Column('substitute_userid', String(USER_ID_LENGTH), ForeignKey(User.userid))
+            )
+
+        self.ensure_sequence_exists('substitution_id_seq')
+
+        self.op.add_column('users', Column('absent', Boolean, default=False))
+        self.op.add_column('users', Column('absent_from', Date))
+        self.op.add_column('users', Column('absent_to', Date))

--- a/opengever/ogds/base/actor.py
+++ b/opengever/ogds/base/actor.py
@@ -707,8 +707,8 @@ class ActorLookup(object):
 
     def is_kub_contact(self):
         kub_contact_prefixes = ('organization:', 'person:', 'membership:')
-        return (any(map(self.identifier.startswith, kub_contact_prefixes)) and
-                is_kub_feature_enabled())
+        return (any(map(self.identifier.startswith, kub_contact_prefixes))
+                and is_kub_feature_enabled())
 
     def is_sql_contact(self):
         sql_contact_prefixes = ['organization:', 'person:', 'org_role:']

--- a/opengever/ogds/base/actor.py
+++ b/opengever/ogds/base/actor.py
@@ -48,6 +48,7 @@ from zope.component.hooks import getSite
 from zope.globalrequest import getRequest
 from zope.i18n import translate
 from zope.interface import implementer
+from datetime import datetime
 
 
 SYSTEM_ACTOR_ID = '__system__'
@@ -148,6 +149,10 @@ class Actor(object):
     def is_active(self):
         return True
 
+    @property
+    def is_absent(self):
+        return False
+
     def corresponds_to(self, user):
         raise NotImplementedError()
 
@@ -192,6 +197,10 @@ class NullActor(object):
     def is_active(self):
         return False
 
+    @property
+    def is_absent(self):
+        return False
+
     def represents(self):
         return None
 
@@ -232,6 +241,10 @@ class SystemActor(object):
 
     @property
     def is_active(self):
+        return False
+
+    @property
+    def is_absent(self):
         return False
 
     def represents(self):
@@ -559,6 +572,14 @@ class OGDSUserActor(Actor):
     @property
     def is_active(self):
         return self.user.active
+
+    @property
+    def is_absent(self):
+        if self.user.absent:
+            return True
+        if self.user.absent_from and self.user.absent_to:
+            return self.user.absent_from <= datetime.now().date() <= self.user.absent_to
+        return False
 
     @property
     def permission_identifier(self):

--- a/opengever/ogds/base/locales/de/LC_MESSAGES/opengever.ogds.base.po
+++ b/opengever/ogds/base/locales/de/LC_MESSAGES/opengever.ogds.base.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-01-29 12:29+0000\n"
+"POT-Creation-Date: 2021-12-08 15:51+0000\n"
 "PO-Revision-Date: 2016-07-22 16:54+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-ogds-base/de/>\n"
@@ -162,3 +162,13 @@ msgstr "Homepage"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "link_all_users"
 msgstr "Alle Benutzer anzeigen"
+
+#. Default: "This substitute already exists."
+#: ./opengever/ogds/base/substitute.py
+msgid "msg_substitute_already_exists"
+msgstr "Dieser Stellvertreter existiert bereits."
+
+#. Default: "This substitute does not exist."
+#: ./opengever/ogds/base/substitute.py
+msgid "msg_substitute_does_not_exist"
+msgstr "Dieser Stellvertreter existiert nicht."

--- a/opengever/ogds/base/locales/en/LC_MESSAGES/opengever.ogds.base.po
+++ b/opengever/ogds/base/locales/en/LC_MESSAGES/opengever.ogds.base.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-01-29 12:29+0000\n"
+"POT-Creation-Date: 2021-12-08 15:51+0000\n"
 "PO-Revision-Date: 2016-07-22 16:54+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-ogds-base/de/>\n"
@@ -189,3 +189,13 @@ msgstr "URL"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "link_all_users"
 msgstr "Show all users"
+
+#. Default: "This substitute already exists."
+#: ./opengever/ogds/base/substitute.py
+msgid "msg_substitute_already_exists"
+msgstr "This substitute already exists."
+
+#. Default: "This substitute does not exist."
+#: ./opengever/ogds/base/substitute.py
+msgid "msg_substitute_does_not_exist"
+msgstr "This substitute does not exist."

--- a/opengever/ogds/base/locales/fr/LC_MESSAGES/opengever.ogds.base.po
+++ b/opengever/ogds/base/locales/fr/LC_MESSAGES/opengever.ogds.base.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-29 12:29+0000\n"
+"POT-Creation-Date: 2021-12-08 15:51+0000\n"
 "PO-Revision-Date: 2017-12-03 11:29+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-ogds-base/fr/>\n"
@@ -162,3 +162,13 @@ msgstr "Site Internet"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "link_all_users"
 msgstr "Afficher tous les utilisateurs"
+
+#. Default: "This substitute already exists."
+#: ./opengever/ogds/base/substitute.py
+msgid "msg_substitute_already_exists"
+msgstr ""
+
+#. Default: "This substitute does not exist."
+#: ./opengever/ogds/base/substitute.py
+msgid "msg_substitute_does_not_exist"
+msgstr ""

--- a/opengever/ogds/base/locales/opengever.ogds.base.pot
+++ b/opengever/ogds/base/locales/opengever.ogds.base.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-29 12:29+0000\n"
+"POT-Creation-Date: 2021-12-08 15:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -162,4 +162,14 @@ msgstr ""
 #. Default: "Show all users"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "link_all_users"
+msgstr ""
+
+#. Default: "This substitute already exists."
+#: ./opengever/ogds/base/substitute.py
+msgid "msg_substitute_already_exists"
+msgstr ""
+
+#. Default: "This substitute does not exist."
+#: ./opengever/ogds/base/substitute.py
+msgid "msg_substitute_does_not_exist"
 msgstr ""

--- a/opengever/ogds/base/substitute.py
+++ b/opengever/ogds/base/substitute.py
@@ -1,0 +1,30 @@
+from opengever.base.model import create_session
+from opengever.ogds.base import _
+from opengever.ogds.models.substitute import Substitute
+from zExceptions import BadRequest
+from zExceptions import NotFound
+
+
+class SubstituteManager(object):
+
+    def delete(self, userid, substitute_userid):
+        substitute = Substitute.query.by_userid_and_substitute_userid(userid, substitute_userid).first()
+        if not substitute:
+            raise NotFound(_(u'msg_substitute_does_not_exist',
+                             default=u'This substitute does not exist.',
+                             mapping={'userid': substitute_userid}))
+
+        create_session().delete(substitute)
+
+    def add(self, userid, substitute_userid):
+        substitute = Substitute.query.by_userid_and_substitute_userid(userid, substitute_userid).first()
+        if substitute:
+            raise BadRequest(_(u'msg_substitute_already_exists',
+                               default='This substitute already exists.',
+                               mapping={'userid': substitute_userid}))
+        substitute = Substitute(userid=userid, substitute_userid=substitute_userid)
+        create_session().add(substitute)
+        return substitute
+
+    def list_substitutes_for(self, userid):
+        return Substitute.query.by_userid(userid=userid)

--- a/opengever/ogds/base/tests/test_ogds_updater.py
+++ b/opengever/ogds/base/tests/test_ogds_updater.py
@@ -22,7 +22,7 @@ from zope.component import getUtility
 
 
 FAKE_LDAP_USERFOLDER = FakeLDAPUserFolder()
-BLACKLISTED_USER_COLUMNS = {'last_login'}
+BLACKLISTED_USER_COLUMNS = {'absent', 'absent_from', 'absent_to', 'last_login'}
 BLACKLISTED_GROUP_COLUMNS = {'is_local'}
 
 

--- a/opengever/ogds/models/substitute.py
+++ b/opengever/ogds/models/substitute.py
@@ -1,0 +1,33 @@
+from opengever.base.model import Base
+from opengever.base.model import USER_ID_LENGTH
+from opengever.base.query import BaseQuery
+from opengever.ogds.models.user import User
+from sqlalchemy import Column
+from sqlalchemy import ForeignKey
+from sqlalchemy import Integer
+from sqlalchemy import String
+from sqlalchemy.schema import Sequence
+
+
+class SubstituteQuery(BaseQuery):
+
+    searchable_fields = ['userid', 'substitute_userid']
+
+    def by_userid(self, userid):
+        return self.filter_by(userid=userid)
+
+    def by_userid_and_substitute_userid(self, userid, substitute_userid):
+        return self.filter_by(userid=userid, substitute_userid=substitute_userid)
+
+
+class Substitute(Base):
+    """Substitute model
+    """
+
+    query_cls = SubstituteQuery
+
+    __tablename__ = 'substitutes'
+
+    substitution_id = Column("id", Integer, Sequence("substitution_id_seq"), primary_key=True)
+    userid = Column(String(USER_ID_LENGTH), ForeignKey(User.userid))
+    substitute_userid = Column(String(USER_ID_LENGTH), ForeignKey(User.userid))

--- a/opengever/ogds/models/user.py
+++ b/opengever/ogds/models/user.py
@@ -55,6 +55,10 @@ class User(Base):
 
     last_login = Column(Date, index=True)
 
+    absent = Column(Boolean, default=False)
+    absent_from = Column(Date)
+    absent_to = Column(Date)
+
     column_names_to_sync = {
         'userid', 'active', 'firstname', 'lastname', 'directorate',
         'directorate_abbr', 'department', 'department_abbr', 'email', 'email2',

--- a/opengever/testing/builders/sql.py
+++ b/opengever/testing/builders/sql.py
@@ -40,6 +40,7 @@ from opengever.meeting.proposal import ISubmittedProposal
 from opengever.ogds.base.interfaces import IAdminUnitConfiguration
 from opengever.ogds.base.utils import get_ou_selector
 from opengever.ogds.models.admin_unit import AdminUnit
+from opengever.ogds.models.substitute import Substitute
 from opengever.ogds.models.group import Group
 from opengever.ogds.models.org_unit import OrgUnit
 from opengever.ogds.models.team import Team
@@ -798,6 +799,23 @@ class FavoriteBuilder(SqlObjectBuilder):
 
 
 builder_registry.register('favorite', FavoriteBuilder)
+
+
+class SubstituteBuilder(SqlObjectBuilder):
+
+    mapped_class = Substitute
+    id_argument_name = 'substitution_id'
+
+    def with_substitute(self, user):
+        self.arguments['substitute_userid'] = user.getId()
+        return self
+
+    def for_user(self, user):
+        self.arguments['userid'] = user.getId()
+        return self
+
+
+builder_registry.register('substitute', SubstituteBuilder)
 
 
 class ReminderSettingsBuilder(SqlObjectBuilder):


### PR DESCRIPTION
With `@my-substitutes` we can list, add and delete substitutes of the current user.
With the `@substitutes` endpoint we can list the substitutes of any user.
With the `@out-of-office` endpoint, we can show and edit the absence settings of the current user.
The `@actors` endpoint indicates whether an actor is absent.

For [CA-2274]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
- DB-Schema migration
  - [x] All changes on a model (columns, etc) are included in a DB-schema migration.
- New translations
  - [x] All msg-strings are unicode

[CA-2274]: https://4teamwork.atlassian.net/browse/CA-2274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ