### PR TITLE
Fix meeting reopen action

### DIFF
--- a/changes/CA-3319.bugfix
+++ b/changes/CA-3319.bugfix
@@ -1,0 +1,1 @@
+Restrict check whether meeting is reopenable to meetings from same period. [njohner]

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -196,6 +196,10 @@ class Meeting(Base, SQLFormSupport):
     def __repr__(self):
         return '<Meeting at "{}">'.format(self.start)
 
+    def get_period(self):
+        return Period.get_current(self.committee.resolve_committee(),
+                                  date=self.start.date())
+
     def generate_meeting_number(self):
         """Generate meeting number for self.
 
@@ -203,8 +207,7 @@ class Meeting(Base, SQLFormSupport):
         meeting_sequence_number against concurrent updates.
 
         """
-        period = Period.get_current(self.committee.resolve_committee(),
-                                    date=self.start.date())
+        period = self.get_period()
         self.meeting_number = period.get_next_meeting_sequence_number()
 
     def get_meeting_number(self):
@@ -214,8 +217,7 @@ class Meeting(Base, SQLFormSupport):
         if not self.meeting_number:
             return None
 
-        period = Period.get_current(
-            self.committee.resolve_committee(), date=self.start.date())
+        period = self.get_period()
         if not period:
             return str(self.meeting_number)
 
@@ -229,8 +231,7 @@ class Meeting(Base, SQLFormSupport):
         decision_sequence_number against concurrent updates.
 
         """
-        period = Period.get_current(self.committee.resolve_committee(),
-                                    date=self.start.date())
+        period = self.get_period()
 
         for agenda_item in self.agenda_items:
             agenda_item.generate_decision_number(period)

--- a/opengever/meeting/reopen.py
+++ b/opengever/meeting/reopen.py
@@ -49,6 +49,11 @@ class ReopenMeeting(object):
         newer_held_meetings = Meeting.query.by_committee(
             self.meeting.committee).filter(
             Meeting.meeting_number > self.meeting_number).all()
+
+        newer_held_meetings = filter(
+            lambda meeting: meeting.get_period() == self.period,
+            newer_held_meetings)
+
         if newer_held_meetings:
             errors.append(u"The meetings '{}' need to be reopened first.".format(
                 u"', '".join(each.get_title() for each in newer_held_meetings))


### PR DESCRIPTION
The check whether there are newer already closed meetings was broken, because it filters on meeting numbers but did not restrict the check to meetings from the same period, although meeting numbering is per Period.

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-3319]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-3319]: https://4teamwork.atlassian.net/browse/CA-3319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ