### PR TITLE
Docker for testserver

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1230,6 +1230,12 @@ The connection from the ``testserverctl`` to the XMLRPC-Server can be tested wit
 This will result in a "Connection refused" error as long as the testserver is starting and will do nothing when the server is ready for the first ``isolate`` or ``zodb_setup``.
 This can be used as docker healthcheck.
 
+Testserver in docker
+~~~~~~~~~~~~~~~~~~~~
+
+You can run testserver with docker-compose: ``docker-compose up testserver``.
+See the `testerver docker readme <docker/testserver/README.md>`_.
+
 
 Testing Inbound Mail
 --------------------

--- a/changes/testserver-docker.feature
+++ b/changes/testserver-docker.feature
@@ -1,0 +1,1 @@
+Docker support for testserver. [jone]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -153,6 +153,44 @@ services:
     profiles:
       - all
       - ianus
+  testserver-solr:
+    image: 4teamwork/ogsolr:latest
+    build:
+      context: .
+      dockerfile: ./docker/solr/Dockerfile
+    command:
+      - solr-precreate
+      - testserver
+      - /opt/solr/server/solr/configsets/ogsite
+    ports:
+      - 18983:8983
+    profiles:
+      - testserver
+  testserver:
+    build:
+      context: .
+      dockerfile: ./docker/testserver/Dockerfile
+    image: 4teamwork/ogtestserver:latest
+    ports:
+      - 55001:55001
+      - 55002:55002
+    environment:
+      - SOLR_HOSTNAME=testserver-solr
+      - TESTSERVER_REUSE_RUNNING_SOLR=8983
+      - SOLR_PORT=8983
+      - MSGCONVERT_URL=http://msgconvert:8080/
+      - SABLON_URL=http://sablon:8080/
+      - PDFLATEX_URL=http://pdflatex:8080/
+      - WEASYPRINT_URL=http://weasyprint:8080/
+    depends_on:
+      - msgconvert
+      - sablon
+      - pdflatex
+      - weasyprint
+      - testserver-solr
+    profiles:
+      - testserver
+
 
 networks:
   default:

--- a/docker/testserver/Dockerfile
+++ b/docker/testserver/Dockerfile
@@ -1,0 +1,20 @@
+FROM 4teamwork/ogcore:latest
+
+USER root
+WORKDIR /app
+
+COPY ./docker/testserver/requirements-testserver.txt /app/
+RUN --mount=type=cache,target=/root/.cache \
+    pip install \
+    --extra-index-url https://buildout:buildout@psc.4teamwork.ch/simple \
+    -r requirements-testserver.txt \
+    -c requirements-core.txt \
+    -c requirements-deployment.txt
+
+HEALTHCHECK --start-period=2m CMD /app/bin/testserverctl connectiontest
+COPY ./bin/testserverctl ./docker/testserver/bin/testserver /app/bin
+COPY ./docker/testserver/docker-entrypoint.sh /app/
+
+USER plone
+EXPOSE 55001
+EXPOSE 55002

--- a/docker/testserver/README.md
+++ b/docker/testserver/README.md
@@ -1,0 +1,38 @@
+# Running the testserver with Docker
+
+## Overview
+
+Because the testserver requires some services (such as solr, sablon, etc),
+it should be run with **docker compose**.
+
+The `docker compose.yml` in the root of `opengever.core` includes the necessary definitions
+for running the testserver in docker.
+
+## Usage
+
+Start testserver:
+
+```
+$ cd opengever.core
+$ docker compose up testserver
+$ bin/testserverctl isolate
+```
+
+You can also run `testserverctl` from within docker:
+
+```
+docker compose exec testserver bin/testserverctl isolate
+```
+
+After executing the ``isolate`` command you can open http://localhost:55001/plone
+
+
+## Build image
+
+```
+$ cd opengever.core
+$ docker compose build testserver
+```
+
+The image needs to be built manually at the moment.
+Published images may not be up to date.

--- a/docker/testserver/bin/testserver
+++ b/docker/testserver/bin/testserver
@@ -1,0 +1,22 @@
+#!/app/bin/python
+
+import sys
+sys.argv.insert(1, 'opengever.core.testserver.OPENGEVER_TESTSERVER')
+
+import Products.Archetypes
+import Products.Archetypes.atapi
+
+# Enable c.indexing during tests, but patch it to not defer operations
+from opengever.testing.patch import patch_collective_indexing
+patch_collective_indexing()
+
+from collective.indexing import monkey
+
+# Patch readonly support onto DemoStorage during tests
+from opengever.testing.patch import patch_demostorage_to_support_readonly_mode
+patch_demostorage_to_support_readonly_mode()
+
+import opengever.core.testserver_zope2server
+
+if __name__ == '__main__':
+    sys.exit(opengever.core.testserver_zope2server.server())

--- a/docker/testserver/docker-entrypoint.sh
+++ b/docker/testserver/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#! /bin/sh
+
+export GEVER_READ_ONLY_MODE="true"
+export FTW_STRUCTLOG_MUTE_SETUP_ERRORS="true"
+export PYTHONUNBUFFERED="1"
+export ZSERVER_PORT="55001"
+export LISTENER_HOST="0.0.0.0"
+export LISTENER_PORT="55002"
+
+exec "/app/bin/python" "/app/bin/testserver" "-vv"

--- a/docker/testserver/requirements-testserver.txt
+++ b/docker/testserver/requirements-testserver.txt
@@ -1,0 +1,16 @@
+Babel==1.3
+ftw.flamegraph==1.1.0
+ftw.testbrowser==1.30.1
+ftw.testing==1.20.2
+glob2==0.6
+plone.app.robotframework==1.2.4
+plone.app.testing==4.2.7
+plone.testing==4.1.3
+pyquery==1.4.0
+requests_mock==1.5.2
+requests_toolbelt==0.8.0
+robotframework==3.0.4
+robotframework_selenium2library==1.7.4
+robotsuite==1.7.0
+selenium==3.141.0
+zope.testrunner==4.8.1

--- a/opengever/core/solr_testing.py
+++ b/opengever/core/solr_testing.py
@@ -28,11 +28,12 @@ class SolrServer(object):
             klass._instance = klass()
         return klass._instance
 
-    def configure(self, port, core):
+    def configure(self, port, core, hostname='localhost'):
         self._configured = True
+        self.hostname = hostname
         self.port = int(port)
         self.core = core
-        SolrReplicationAPIClient.get_instance().configure(port, core)
+        SolrReplicationAPIClient.get_instance().configure(port, core, hostname)
         return self
 
     def start(self):
@@ -87,7 +88,9 @@ class SolrServer(object):
     def is_ready(self):
         """Check whether the solr server is ready to accept connections.
         """
-        response = requests.get(url='http://localhost:{}/solr/{}/admin/ping'.format(self.port, self.core))
+        url = 'http://{}:{}/solr/{}/admin/ping'.format(
+            self.hostname, self.port, self.core)
+        response = requests.get(url=url)
         return response.ok
 
     def await_ready(self, timeout=60, interval=0.1, verbose=False):
@@ -155,11 +158,12 @@ class SolrReplicationAPIClient(object):
             klass._instance = klass()
         return klass._instance
 
-    def configure(self, port, core):
+    def configure(self, port, core, hostname='localhost'):
         self._configured = True
+        self.hostname = hostname
         self.port = int(port)
         self.core = core
-        self.base_url = 'http://localhost:{}/solr/{}'.format(port, core)
+        self.base_url = 'http://{}:{}/solr/{}'.format(self.hostname, port, core)
         return self
 
     def __init__(self):
@@ -317,7 +321,7 @@ if __name__ == '__main__':
     # ./bin/zopepy opengever/core/solr_testing.py
     port = 18988
     core = 'fritz'
-    SolrReplicationAPIClient.get_instance().configure(port, core)
+    SolrReplicationAPIClient.get_instance().configure(port, core, 'localhost')
     server = SolrServer.get_instance().configure(port, core)
 
     server.start()

--- a/opengever/core/testserver.py
+++ b/opengever/core/testserver.py
@@ -101,12 +101,24 @@ class TestserverLayer(OpengeverFixture):
         # Solr must be started before registering the connection since ftw.solr
         # will get the schema from solr and cache it.
         solr.await_ready()
+
+        solr_connection_additional_attributes = ''
+        if SOLR_HOSTNAME != 'localhost':
+            # When the testserver does not run on the same host as solr (such as
+            # when running in docker), we need to upload the blobs over HTTP
+            # since solr cannout access the /tmp of the testserver via disk.
+            solr_connection_additional_attributes = 'upload_blobs="true"'
+
         xmlconfig.string(
             '<configure xmlns:solr="http://namespaces.plone.org/solr">'
             '  <solr:connection host="{SOLR_HOSTNAME}"'
             '                   port="{SOLR_PORT}"'
-            '                   base="/solr/{SOLR_CORE}" />'
-            '</configure>'.format(SOLR_HOSTNAME=SOLR_HOSTNAME, SOLR_PORT=SOLR_PORT, SOLR_CORE=SOLR_CORE),
+            '                   base="/solr/{SOLR_CORE}"'
+            '                   {attrs} />'
+            '</configure>'.format(SOLR_HOSTNAME=SOLR_HOSTNAME,
+                                  SOLR_PORT=SOLR_PORT,
+                                  SOLR_CORE=SOLR_CORE,
+                                  attrs=solr_connection_additional_attributes),
             context=configurationContext)
 
         # Clear solr from potential artefacts of the previous run.


### PR DESCRIPTION
### Goal

The goal is to be able to run the testserver in docker, so that:
1. it can be easily used for testing other components (e.g. RIS)
2. devs who are developing services using GEVER can run the testserver locally without having to run buildout.

### Scope

This pull request makes it possible to run the testserver with docker-compose. It is not yet very optimized and the build process is not automated.

### Details

- The testserver is integrated in the `docker-compose.yml`, so that it can be easily run with docker compose and shares the services (such as sablon).
- The testserver has to be changed so that it supports the case that solr is running on a different host than `localhost`, so that the solr container can be accessed over the docker compose network.
- The Dockerfile of the testserver currently needs to re-copy the code (`/opengever`), because this PR contains code that is not yet incorporated in the latest ogcore image. Once the PR is merged and the image is re-published with the new code, this copy statement can be removed from the Dockerfile.

### Usage

```
$ cd opengever.core
$ docker-compose up testserver
# have patience
$ ./bin/testserverctl isolate
```

Access http://localhost:55001 and have fun.

### Caveats

Booting the testserver is still very slow. We could optimize that by building the fixture into an image. I think this should be an image on top of this one (e.g. `testserver-ogfixture`), so that we can have a similar one with the RIS fixture.
The challenge here is that building the testserver fixture requires other services such as `sablon`, which cannot be access during build time (at least I couldn't figure it out).
Dumping the databases with the fixture could be done with the existing `DBCacheManager` class.

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [X] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
