### PR TITLE
Document serializer respects the file_extension of the currently requested version

### DIFF
--- a/changes/CA-3315.bugfix
+++ b/changes/CA-3315.bugfix
@@ -1,0 +1,1 @@
+Document serializer respects the file_extension of the currently requested version [elioschmutz]

--- a/opengever/api/document.py
+++ b/opengever/api/document.py
@@ -48,7 +48,7 @@ class SerializeDocumentToJson(GeverSerializeToJson):
             obj, 'preview')
         result[u'pdf_url'] = bumblebee_service.get_representation_url(
             obj, 'pdf')
-        result[u'file_extension'] = self.context.get_file_extension()
+        result[u'file_extension'] = obj.get_file_extension()
 
         extend_with_backreferences(
             result, self.context, self.request, 'relatedItems',

--- a/opengever/api/tests/test_document.py
+++ b/opengever/api/tests/test_document.py
@@ -157,6 +157,26 @@ class TestDocumentSerializer(IntegrationTestCase):
             u'ccc4a73154625a6820cb6b50dc1455eb4cf26399299d4f9ce77b2/preview')
 
     @browsing
+    def test_respects_version_specific_file_extension(self, browser):
+        self.login(self.regular_user, browser)
+
+        versioner = Versioner(self.document)
+        versioner.create_initial_version()
+
+        self.checkout_document(self.document)
+        self.document.file = NamedBlobFile(
+            data='PDF TEST DATA', filename=u'final.pdf')
+        self.checkin_document(self.document)
+
+        url = '{}/@history/0'.format(self.document.absolute_url())
+        browser.open(url, headers=self.api_headers)
+        self.assertEqual(browser.json.get(u'file_extension'), u'.docx')
+
+        url = '{}/@history/1'.format(self.document.absolute_url())
+        browser.open(url, headers=self.api_headers)
+        self.assertEqual(browser.json.get(u'file_extension'), u'.pdf')
+
+    @browsing
     def test_document_serialization_contains_tr_connect_links_on_gever_doc(self, browser):
         self.login(self.workspace_member, browser)
 


### PR DESCRIPTION
This PR fixes an issue where the `file_extension` of the serialized document have not respected the currently requested version.

For [CA-3315]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-3315]: https://4teamwork.atlassian.net/browse/CA-3315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ