### PR TITLE
Include custom properties in the eCH-0160 export.

### DIFF
--- a/changes/CA-2612.feature
+++ b/changes/CA-2612.feature
@@ -1,0 +1,1 @@
+Include custom properties in the eCH-0160 export. [phgross]

--- a/opengever/disposition/ech0160/model/additional_data.py
+++ b/opengever/disposition/ech0160/model/additional_data.py
@@ -1,0 +1,32 @@
+from opengever.disposition import _
+from opengever.disposition.ech0160.bindings import arelda
+from opengever.propertysheets.utils import get_custom_properties
+from zope.globalrequest import getRequest
+from zope.i18n import translate
+
+
+def get_additional_data(obj):
+    custom_props = get_custom_properties(obj)
+    zusatzdaten = arelda.zusatzDaten()
+    for key, value in custom_props.items():
+        if value is None:
+            continue
+
+        if isinstance(value, list):
+            value = u', '.join(value)
+
+        if isinstance(value, bool):
+            if value:
+                value = translate(
+                    _(u'label_yes', default=u'Yes'), context=getRequest())
+            else:
+                value = translate(
+                    _(u'label_no', default=u'No'), context=getRequest())
+
+        zusatzdaten.merkmal.append(value)
+        zusatzdaten.merkmal[-1].name = key
+
+    if len(zusatzdaten.merkmal):
+        return zusatzdaten
+
+    return None

--- a/opengever/disposition/ech0160/model/document.py
+++ b/opengever/disposition/ech0160/model/document.py
@@ -1,5 +1,6 @@
 from opengever.base.behaviors.changed import IChanged
 from opengever.disposition.ech0160.bindings import arelda
+from opengever.disposition.ech0160.model.additional_data import get_additional_data
 from opengever.disposition.ech0160.utils import set_classification_attributes
 from opengever.disposition.ech0160.utils import voc_term_title
 from opengever.document.behaviors.metadata import IDocumentMetadata
@@ -38,6 +39,10 @@ class Document(object):
             IChanged(self.obj).changed.date())
 
         set_classification_attributes(dokument, self.obj)
+
+        additional_data = get_additional_data(self.obj)
+        if additional_data:
+            dokument.zusatzDaten = additional_data
 
         for file_ref in self.file_refs:
             dokument.dateiRef.append(file_ref)

--- a/opengever/disposition/ech0160/model/dossier.py
+++ b/opengever/disposition/ech0160/model/dossier.py
@@ -4,6 +4,7 @@ from opengever.base.interfaces import IReferenceNumber
 from opengever.disposition.ech0160.bindings import arelda
 from opengever.disposition.ech0160.model import Document
 from opengever.disposition.ech0160.model import NOT_SPECIFIED
+from opengever.disposition.ech0160.model.additional_data import get_additional_data
 from opengever.disposition.ech0160.utils import set_classification_attributes
 from opengever.document.behaviors import IBaseDocument
 from opengever.dossier.behaviors.dossier import IDossier
@@ -84,6 +85,10 @@ class Dossier(object):
                 dossier_obj.end)
 
         dossier.schutzfrist = unicode(ILifeCycle(self.obj).custody_period)
+
+        additional_data = get_additional_data(self.obj)
+        if additional_data:
+            dossier.zusatzDaten = additional_data
 
         for d in self.dossiers.values():
             dossier.dossier.append(d.binding())

--- a/opengever/propertysheets/utils.py
+++ b/opengever/propertysheets/utils.py
@@ -1,0 +1,40 @@
+from opengever.document.behaviors import IBaseDocument
+from opengever.document.behaviors.customproperties import IDocumentCustomProperties
+from opengever.dossier.behaviors.customproperties import IDossierCustomProperties
+from opengever.dossier.behaviors.dossier import IDossierMarker
+from opengever.propertysheets.storage import PropertySheetSchemaStorage
+from zope.schema import getFields
+
+
+def get_custom_properties(obj):
+    data = {}
+
+    if IDossierMarker.providedBy(obj):
+        customprops_behavior = IDossierCustomProperties
+    elif IBaseDocument.providedBy(obj):
+        customprops_behavior = IDocumentCustomProperties
+    else:
+        return data
+
+    adapted = customprops_behavior(obj, None)
+    if not adapted:
+        return data
+
+    custom_properties = adapted.custom_properties
+    if not custom_properties:
+        return data
+
+    field = getFields(customprops_behavior).get('custom_properties')
+    active_slot = field.get_active_assignment_slot(obj)
+    for slot in [active_slot, field.default_slot]:
+        if slot not in custom_properties:
+            continue
+
+        definition = PropertySheetSchemaStorage().query(slot)
+        if not definition:
+            continue
+
+        for name, field in definition.get_fields():
+            data[name] = custom_properties[slot].get(name)
+
+    return data


### PR DESCRIPTION
The custom properties are included in the `zusatzDaten` attribute.

For [CA-2612]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- New functionality:
  - [x] for `document` also works for `mail`

[CA-2612]: https://4teamwork.atlassian.net/browse/CA-2612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ