### PR TITLE
For memberships use its own description and text as contact docprops.

### DIFF
--- a/opengever/kub/docprops.py
+++ b/opengever/kub/docprops.py
@@ -20,6 +20,10 @@ class KuBEntityDocPropertyProvider(object):
             self.membership = entity
 
     @property
+    def membership_person_or_organization(self):
+        return self.membership or self.person or self.organization
+
+    @property
     def person_or_organization(self):
         return self.person or self.organization
 
@@ -40,7 +44,7 @@ class KuBEntityDocPropertyProvider(object):
         return properties
 
     def get_contact_properties(self, prefix):
-        provider = KuBContactDocPropertyProvider(self.person_or_organization)
+        provider = KuBContactDocPropertyProvider(self.membership_person_or_organization)
         return provider.get_properties(prefix)
 
     def get_person_properties(self, prefix):


### PR DESCRIPTION
We were using the description and text of the person for the contact docproperties of a membership, when the membership itself also has a description and should have a text (not implemented yet in KuB).

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-2452]

## Checklist
- [ ] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-2452]: https://4teamwork.atlassian.net/browse/CA-2452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ