### PR TITLE
Handle int field customproperties when extending for ech0160 export.

### DIFF
--- a/opengever/disposition/ech0160/model/additional_data.py
+++ b/opengever/disposition/ech0160/model/additional_data.py
@@ -23,6 +23,9 @@ def get_additional_data(obj):
                 value = translate(
                     _(u'label_no', default=u'No'), context=getRequest())
 
+        if isinstance(value, int):
+            value = str(value)
+
         zusatzdaten.merkmal.append(value)
         zusatzdaten.merkmal[-1].name = key
 

--- a/opengever/disposition/tests/test_model.py
+++ b/opengever/disposition/tests/test_model.py
@@ -353,21 +353,23 @@ class TestDocumentModel(IntegrationTestCase):
                .with_field("textline", u"f1", u"Field 1", u"", False)
                .with_field("multiple_choice", u"f2", u"Field 2", u"", False,
                            values=["one", "two", "three"])
-               .with_field("bool", u"f3", u"Field 3", u"", False))
+               .with_field("bool", u"f3", u"Field 3", u"", False)
+               .with_field("int", u"f4", u"Field 4", u"", False))
 
         IDocumentCustomProperties(self.document).custom_properties = {
             "IDocument.default": {"f1": "custom field text",
                                   "f2": ["one", "three"],
-                                  "f3": False},
+                                  "f3": False,
+                                  "f4": 1234},
         }
 
         binding = Document(self.document).binding()
 
         self.assertEquals(
-            [u'f1', u'f2', u'f3'],
+            [u'f1', u'f2', u'f3', u'f4'],
             [prop.name for prop in binding.zusatzDaten.merkmal])
         self.assertEquals(
-            [u'custom field text', u'one, three', u'No'],
+            [u'custom field text', u'one, three', u'No', u'1234'],
             [prop.value() for prop in binding.zusatzDaten.merkmal])
 
 


### PR DESCRIPTION
Small fix for #7295.

For [CA-2612]

## Checklist

- [x] Changelog entry _not necessary_ 
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-2612]: https://4teamwork.atlassian.net/browse/CA-2612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ