### PR TITLE
Implement @solrsearch filtering by @id through a POST request

### DIFF
--- a/changes/CA-3044-2.feature
+++ b/changes/CA-3044-2.feature
@@ -1,0 +1,1 @@
+- The @solrsearch results can now be filtered by its ``@id``. [elioschmutz]

--- a/changes/CA-3044.feature
+++ b/changes/CA-3044.feature
@@ -1,0 +1,1 @@
+- Allow POST requests against the @solrsearch endpoint. [elioschmutz]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -15,6 +15,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- ``@solrsearch``: Allow POST requests against the endpoint. This allows us to get around the length-limit of GET requests.
 - ``@config``: Add ``is_propertysheets_manager`` key to indicate whether user is allowed to manage property sheets.
 - ``@propertysheets``: Management of property sheets is now also allowed for ``PropertySheetsManager`` role.
 - ``@solrsearch``: Now supports facetting custom property fields.

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -15,6 +15,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- ``@solrsearch``: The results can now be filtered by its ``@id``.
 - ``@solrsearch``: Allow POST requests against the endpoint. This allows us to get around the length-limit of GET requests.
 - ``@config``: Add ``is_propertysheets_manager`` key to indicate whether user is allowed to manage property sheets.
 - ``@propertysheets``: Management of property sheets is now also allowed for ``PropertySheetsManager`` role.

--- a/docs/public/dev-manual/api/searching.rst
+++ b/docs/public/dev-manual/api/searching.rst
@@ -108,10 +108,13 @@ darzustellen, kann ``metadata_fields=_all`` verwendet werden.
    handelt, zur Verfügung.
 
 
-Solr Suche
-----------
+.. _solr-search-get:
+
+Solr Suche GET
+--------------
 Um direkt eine Suchabfrage an den Solr Service abzusetzen, steht der ``@solrsearch`` Endpoint zur Verfügung. Für die Abfrage kann SOLR API Syntax und dessen Parameter verwendet werden. Der Endpoint liefert ein Liste von Treffern zurück mit den im Parameter ``fl`` definierten Felder. Die folgende Parameter sind zurzeit vom Endpoint unterstützt:
 
+Achtung: Eine URL hat je nach Client/Server/Proxy eine maximale länge. Für grössere Queries muss der Endpoint als POST-Request abgefragt werden.
 
 Query
 ~~~~~
@@ -270,6 +273,34 @@ Der Endpoint stellt die Standard-Paginierung gem :ref:`Kapitel Paginierung <batc
 Breadcrumbs
 ~~~~~~~~~~~
 Wird eine ``@solrsearch`` Anfrage mit ``breadcrumbs=1`` Parameter ergänzt, so werden die einzelnen Suchtreffer unter dem Key ``breadcrumbs`` mit den Breadcrumb Informationen ergänzt. Diese Ergänzung ist nur bei kleinen Batchsizes (maximal 50) erlaubt.
+
+
+Solr Suche POST
+---------------
+Eine Suche kann auch über einen POST-Request an den ``@solrsearch`` Endpoint abgesetzt werden. Der Hauptvorteil eines POST-Requests ist, dass es keine Limitierung beim Payload gibt. Bei einem GET-Request wird die Länge der URL je nach Client/Server/Proxy limitiert.
+
+Grundsätzlich funktioniert der POST-Endpoint gleich wie der GET-Endpoint. Der Body vom Reqeust wird in JSON geschrieben.
+
+Query
+~~~~~
+Beispiel für eine Suche mit diversen Kriterien als Übersicht für die Verwendung des POST-Endpoints. Genauere Details zu den jeweiligen Parametern finden Sie unter :ref:`Solr Suche GET <solr-search-get>`
+
+.. sourcecode:: http
+
+  POST /plone/@solrsearch HTTP/1.1
+  Content-Type: application/json
+  Accept: application/json
+
+  {
+    "q": "Kurz",
+    "fl": "UID,Title",
+    "fq": [
+      "portal_type:opengever.document.document",
+      "path_parent:/fd/os/dossier-1"
+    ],
+    "facet": true,
+    "facet.field": "responsible"
+  }
 
 
 Teamraum Solr Suche

--- a/docs/public/dev-manual/api/searching.rst
+++ b/docs/public/dev-manual/api/searching.rst
@@ -138,11 +138,20 @@ Filters
 ~~~~~~~
 ``fq``: Filtern nach einem bestimmten Wert eines Feldes.
 
-Beispiel für ein Suchabfrage gefiltert nach portal_type nur für Dokumente und Dossiers
+Beispiele für gefilterte Suchabfragen
+
+**Filtern nach ``portal_type`` nur für Dokumente und Dossiers**
 
 .. sourcecode:: http
 
   GET /plone/@solrsearch?fq=portal_type:(opengever.document.document%20OR%20opengever.dossier.businesscasedossier) HTTP/1.1
+
+**Filtern nach ``url`` (alias ``@id``)**
+
+.. sourcecode:: http
+
+  GET /plone/@solrsearch?fq:list=url:http://example.com/dossier-1&fq:list=url:@id:http://example.com/dossier-2 HTTP/1.1
+
 
 
 Fields

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -603,6 +603,14 @@
       />
 
   <plone:service
+      method="POST"
+      for="zope.interface.Interface"
+      factory=".solrsearch.SolrSearchGet"
+      name="@solrsearch"
+      permission="zope2.View"
+      />
+
+  <plone:service
       method="GET"
       for="zope.interface.Interface"
       factory=".solrsearch.TeamraumSolrSearchGet"

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -139,6 +139,25 @@ def relative_path(brain):
     return to_relative_path(brain.getPath())
 
 
+def relative_to_physical_path(relative_path):
+    """A frontend usualy only knows the relative path to the plone site,
+    not the real physical path of an object.
+    But the solr index value contains the physical path of
+    the object. Thus, we need to replace the relative paths with the physical
+    path of an object.
+    """
+    physical_path = api.portal.get().getPhysicalPath()
+    if relative_path:
+        physical_path += (relative_path, )
+
+    return '/'.join(physical_path)
+
+
+def url_to_physical_path(value):
+    portal_url = api.portal.get().absolute_url()
+    return relative_to_physical_path(value.replace(portal_url, '').strip('/'))
+
+
 class SimpleListingField(object):
     """Mapping between a requested field_name, the corresponding index
     in solr, the accessor on the ContentListingObject, and an index used

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -4,6 +4,7 @@ from DateTime.interfaces import DateTimeError
 from ftw.solr.converters import to_iso8601
 from ftw.solr.interfaces import ISolrSearch
 from ftw.solr.query import escape
+from opengever.api.utils import recursive_encode
 from opengever.base.behaviors.translated_title import ITranslatedTitleSupport
 from opengever.base.behaviors.translated_title import TRANSLATED_TITLE_PORTAL_TYPES
 from opengever.base.helpers import display_name
@@ -18,7 +19,9 @@ from opengever.propertysheets.storage import PropertySheetSchemaStorage
 from opengever.task.helper import task_type_helper
 from opengever.tasktemplates.content.templatefoldersschema import sequence_type_vocabulary
 from plone import api
+from plone.memoize.view import memoize
 from plone.restapi.batching import HypermediaBatch
+from plone.restapi.deserializer import json_body
 from plone.restapi.serializer.converters import json_compatible
 from plone.restapi.services import Service
 from plone.rfc822.interfaces import IPrimaryFieldInfo
@@ -29,6 +32,7 @@ from zope.component import getUtility
 from zope.component.hooks import getSite
 from zope.globalrequest import getRequest
 from zope.i18n import translate
+import json
 import Missing
 
 
@@ -391,10 +395,22 @@ class SolrQueryBaseService(Service):
         self.response_fields = None
         self.facets = []
 
+    @property
+    @memoize
+    def request_payload(self):
+        """Returns the request payload depending on the http request method.
+        """
+        if self.request.method == 'GET':
+            return self.request.form
+        elif self.request.method == 'POST':
+            # JSON always returns unicode strings. We need to encode the values
+            # to utf-8 to get the same encoding as with a GET reqeust.
+            return recursive_encode(json_body(self.request))
+
     def prepare_solr_query(self):
         """ Extract the requested parameters and prepare the solr query
         """
-        params = self.request.form.copy()
+        params = self.request_payload.copy()
         query = self.extract_query(params)
         filters = self.extract_filters(params)
         start = self.extract_start(params)

--- a/opengever/api/solrsearch.py
+++ b/opengever/api/solrsearch.py
@@ -34,9 +34,9 @@ class SolrSearchGet(SolrQueryBaseService):
         """Extract breadcrumbs flag and checks if the batchsize is
         not higher than 50 when enabled."""
 
-        show_breadcrumbs = bool(self.request.form.get('breadcrumbs', False))
+        show_breadcrumbs = bool(self.request_payload.get('breadcrumbs', False))
         if show_breadcrumbs:
-            if self.request.form.get('b_size', 0) > 50:
+            if self.request_payload.get('b_size', 0) > 50:
                 raise BadRequest('Breadcrumb flag is only allowed for '
                                  'small batch sizes (max. 50).')
         return show_breadcrumbs

--- a/opengever/api/tests/test_solrsearch.py
+++ b/opengever/api/tests/test_solrsearch.py
@@ -993,6 +993,22 @@ class TestSolrSearchGet(SolrIntegrationTestCase):
 
         self.assertIsNone(browser.json.get('stats'))
 
+    @browsing
+    def test_fq_with_urls(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        url = u'{}/@solrsearch?{}'.format(
+            self.portal.absolute_url(),
+            '&'.join([
+                'fq:list=@id:{}'.format(self.document.absolute_url()),
+                'fq:list=url:{}'.format(self.task.absolute_url())
+            ]))
+
+        browser.open(url, method='GET', headers=self.api_headers)
+        search_on_context = browser.json
+
+        self.assertEqual(2, search_on_context['items_total'])
+
 
 class TestSolrSearchPost(SolrIntegrationTestCase):
     """The POST endpoint should behave exactly the same as the GET endpoint. We do not
@@ -1105,3 +1121,19 @@ class TestSolrSearchPost(SolrIntegrationTestCase):
 
         self.assertItemsEqual([u'UID', u'Title'],
                               browser.json['items'][0].keys())
+
+    @browsing
+    def test_fq_with_urls(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        url = u'{}/@solrsearch'.format(self.dossier.absolute_url())
+        payload = {
+            'fq': [
+                '@id:{}'.format(self.document.absolute_url()),
+                'url:{}'.format(self.task.absolute_url())
+            ]
+        }
+        browser.open(url, method='POST', data=json.dumps(payload), headers=self.api_headers)
+        search_on_context = browser.json
+
+        self.assertEqual(2, search_on_context['items_total'])

--- a/opengever/api/tests/test_utils.py
+++ b/opengever/api/tests/test_utils.py
@@ -1,0 +1,48 @@
+from opengever.api.utils import recursive_encode
+import unittest
+
+
+class TestRecursiveEncode(unittest.TestCase):
+    """
+    """
+
+    def equals(self, input, output):
+        self.assertEqual(recursive_encode(input), output)
+
+    def test_unicode(self):
+        self.equals(u'foo', 'foo')
+        self.equals(u'b\xe4r', 'b\xc3\xa4r')
+        self.equals('b\xc3\xa4r', 'b\xc3\xa4r')
+
+    def test_dicts(self):
+        self.equals({u'b\xe4r': u'b\xe4r'},
+                    {'b\xc3\xa4r': 'b\xc3\xa4r'})
+
+    def test_lists(self):
+        self.equals([u'b\xe4r'], ['b\xc3\xa4r'])
+
+    def test_other_types(self):
+        self.equals([1, 2.2, True, False, None],
+                    [1, 2.2, True, False, None])
+
+        self.equals(1, 1)
+        self.equals(None, None)
+
+    def test_nesting(self):
+        input = {
+            u'b\xe4r': {
+                u'b\xe4r': [
+                    u'b\xe4r',
+                    1,
+                    True]},
+            'blubb': [{u'b\xe4r': 3}]}
+
+        output = {
+            'b\xc3\xa4r': {
+                'b\xc3\xa4r': [
+                    'b\xc3\xa4r',
+                    1,
+                    True]},
+            'blubb': [{'b\xc3\xa4r': 3}]}
+
+        self.equals(input, output)

--- a/opengever/api/utils.py
+++ b/opengever/api/utils.py
@@ -121,3 +121,35 @@ def create_proxy_request_error_handler(
         return handler
 
     return request_error_handler
+
+
+def recursive_encode(data):
+    """Encodes unicodes (from json) to utf-8 strings recursively.
+
+    Credits: https://github.com/4teamwork/ftw.inflator/blob/1.12.1/ftw/inflator/creation/sections/utils.py
+    """
+    if isinstance(data, unicode):
+        return data.encode('utf-8')
+
+    elif isinstance(data, str):
+        return data
+
+    elif isinstance(data, dict):
+        for key, value in data.items():
+            del data[key]
+            data[recursive_encode(key)] = recursive_encode(value)
+        return data
+
+    elif isinstance(data, list):
+        new_data = []
+        for item in data:
+            new_data.append(recursive_encode(item))
+        return new_data
+
+    elif hasattr(data, '__iter__'):
+        for item in data:
+            recursive_encode(item)
+        return data
+
+    else:
+        return data


### PR DESCRIPTION
This PR extends the `@solrsearch` endpoint with a new `fq`: `url` (or you can also use `@id` as an alias).

This allows us to directly filter objects by its `@id`. 

Since queries can be very long and an url is limited by the client, server or proxy, we now allow `POST` requests against the `@solrsearch` endpoint. This allows us to use the request-body instead the query-string to pass arguments.

The `POST` endpoint is an alias for the `GET` endpoint. So it behaves exactly the same with exactly the same feature-set. The only difference is, that we pass JSON with the `POST` endpoint.

Here is a practical example of how to use the `POST` endpoint in combination with the `@id` filter:

**Request**
```http
POST /plone/@solrsearch HTTP/1.1
Content-Type: application/json
Accept: application/json

{
    "fl":"Title",
    "fq": [
        "@id:http://localhost:8080/fd/sitzungen/committee-1/submitted-proposal-419/document-36",
        "@id:http://localhost:8080/fd/sitzungen/committee-1/submitted-proposal-419/document-34"
        ]
}
```

**Response**
```json
{
    "@id": "http://localhost:8080/fd/@solrsearch",
    "facet_counts": {},
    "items": [
        {
            "@id": "http://localhost:8080/fd/sitzungen/committee-1/submitted-proposal-419/document-36",
            "UID": "5829913fdab744adb3f5838312ce01bd"
        },
        {
            "@id": "http://localhost:8080/fd/sitzungen/committee-1/submitted-proposal-419/document-34",
            "UID": "cac0830361404d9c82ecd730a9337bd0"
        }
    ],
    "items_total": 2,
    "rows": 25,
    "start": 0
}
````

For [CA-3044]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-3044]: https://4teamwork.atlassian.net/browse/CA-3044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ