### PR TITLE
Fix @groups patch endpoint.

### DIFF
--- a/changes/CA-1675.bugfix
+++ b/changes/CA-1675.bugfix
@@ -1,0 +1,1 @@
+Fix @groups patch endpoint. [tinagerber]

--- a/opengever/api/group.py
+++ b/opengever/api/group.py
@@ -167,11 +167,9 @@ class GeverGroupsPatch(Service):
             raise BadRequest('Can only modify local groups.')
         raise_for_unassignable_roles(self.roles)
 
-    def update_ogds_group(self, title, description, users):
+    def update_ogds_group(self, title, users):
         if title:
             self.ogds_group.title = title
-        if description:
-            self.ogds_group.description = description
         if users:
             self.ogds_group.users = map(get_sql_user, users)
 
@@ -220,7 +218,7 @@ class GeverGroupsPatch(Service):
                     with elevated_privileges():
                         self.group.removeMember(userid)
 
-        self.update_ogds_group(title, description, self.group.getGroupMemberIds() if users.items() else None)
+        self.update_ogds_group(title, self.group.getGroupMemberIds() if users.items() else None)
 
         return self.reply_no_content()
 

--- a/opengever/api/group.py
+++ b/opengever/api/group.py
@@ -170,7 +170,7 @@ class GeverGroupsPatch(Service):
     def update_ogds_group(self, title, users):
         if title:
             self.ogds_group.title = title
-        if users:
+        if users is not None:
             self.ogds_group.users = map(get_sql_user, users)
 
     def reply(self):

--- a/opengever/api/group.py
+++ b/opengever/api/group.py
@@ -177,8 +177,12 @@ class GeverGroupsPatch(Service):
         data = json_body(self.request)
         self.group = self._get_group(self._get_group_id)
 
-        title = data.get("title", None)
-        description = data.get("description", None)
+        arguments = {}
+        if 'title' in data:
+            arguments['title'] = data['title']
+        if 'description' in data:
+            arguments['description'] = data['description']
+
         self.roles = data.get("roles", None)
         groups = data.get("groups", None)
         users = data.get("users", {})
@@ -195,8 +199,7 @@ class GeverGroupsPatch(Service):
             self._get_group_id,
             roles=self.roles,
             groups=groups,
-            title=title,
-            description=description,
+            **arguments
         )
 
         properties = {}
@@ -218,7 +221,8 @@ class GeverGroupsPatch(Service):
                     with elevated_privileges():
                         self.group.removeMember(userid)
 
-        self.update_ogds_group(title, self.group.getGroupMemberIds() if users.items() else None)
+        self.update_ogds_group(data.get("title", None), self.group.getGroupMemberIds()
+                               if users.items() else None)
 
         return self.reply_no_content()
 

--- a/opengever/api/tests/test_group.py
+++ b/opengever/api/tests/test_group.py
@@ -447,6 +447,21 @@ class TestGeverGroupsPatch(IntegrationTestCase):
             [user.userid for user in self.ogds_group.users])
 
     @browsing
+    def test_does_not_override_title_when_no_title_and_no_description_are_set(self, browser):
+        self.login(self.administrator, browser)
+
+        portal_groups = getToolByName(self.portal, "portal_groups")
+        group_data = portal_groups.getGroupById(self.groupid)
+        self.assertEqual(u'Gruppe Rechnungspr\xfcfungskommission', group_data.getProperty('title'))
+
+        payload = {'users': {self.workspace_guest.getId(): True}}
+        browser.open("{}/@groups/{}".format(self.portal.absolute_url(), self.groupid),
+                     data=json.dumps(payload), method='PATCH', headers=self.api_headers)
+
+        group_data = portal_groups.getGroupById(self.groupid)
+        self.assertEqual(u'Gruppe Rechnungspr\xfcfungskommission', group_data.getProperty('title'))
+
+    @browsing
     def test_only_local_groups_can_be_updated(self, browser):
         self.login(self.administrator, browser)
         self.ogds_group.is_local = False

--- a/opengever/api/tests/test_group.py
+++ b/opengever/api/tests/test_group.py
@@ -447,6 +447,26 @@ class TestGeverGroupsPatch(IntegrationTestCase):
             [user.userid for user in self.ogds_group.users])
 
     @browsing
+    def test_all_users_can_be_removed_from_ogds_group(self, browser):
+        self.login(self.administrator, browser)
+
+        self.assertItemsEqual(
+            [self.committee_responsible.id, self.administrator.id],
+            [user.userid for user in self.ogds_group.users])
+
+        payload = {u'users': {self.committee_responsible.id: False,
+                              self.administrator.id: False}}
+
+        response = browser.open(
+            "{}/@groups/{}".format(self.portal.absolute_url(), self.groupid),
+            data=json.dumps(payload),
+            method='PATCH',
+            headers=self.api_headers)
+
+        self.assertEqual(204, response.status_code)
+        self.assertEqual([], self.ogds_group.users)
+
+    @browsing
     def test_does_not_override_title_when_no_title_and_no_description_are_set(self, browser):
         self.login(self.administrator, browser)
 


### PR DESCRIPTION
 There were several problems with the endpoint:
- Not all users could be deleted from the OGDS group
- If the payload did not contain the title and description, the title and description were set to None
- A description was set for the ogds_group, although we don't have a column for the description in the SQL database for groups

For [CA-1675]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-1675]: https://4teamwork.atlassian.net/browse/CA-1675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ