### PR TITLE
Extend KuBContactSource with ogds users.

### DIFF
--- a/changes/CA-3350.feature
+++ b/changes/CA-3350.feature
@@ -1,0 +1,1 @@
+Extend KuBContactSource with ogds users. [njohner]

--- a/opengever/dossier/tests/test_participation.py
+++ b/opengever/dossier/tests/test_participation.py
@@ -185,6 +185,12 @@ class TestSQLParticipationHanlder(TestPloneParticipationHanlder):
     valid_id = 'ogds_user:kathi.barfuss'
 
 
+class TestKuBParticipationHanlderWithOgdsUser(KuBIntegrationTestCase, TestPloneParticipationHanlder):
+
+    handler_class = KuBParticipationHandler
+    valid_id = 'kathi.barfuss'
+
+
 @requests_mock.Mocker()
 class TestKuBParticipationHanlder(KuBIntegrationTestCase, TestPloneParticipationHanlder):
 

--- a/opengever/kub/sources.py
+++ b/opengever/kub/sources.py
@@ -1,4 +1,7 @@
 from opengever.kub.client import KuBClient
+from opengever.ogds.base.actor import ActorLookup
+from opengever.ogds.models.exceptions import RecordNotFound
+from opengever.ogds.models.service import ogds_service
 from z3c.formwidget.query.interfaces import IQuerySource
 from zope.interface import implementer
 from zope.interface import implements
@@ -9,24 +12,46 @@ from zope.schema.vocabulary import SimpleTerm
 
 @implementer(IQuerySource)
 class KuBContactsSource(object):
+    """This source supports KuB contacts and OGDS Users.
+    """
 
     def __init__(self, context):
         self.context = context
         self.terms = []
         self.client = KuBClient()
 
+    @staticmethod
+    def _kub_term(item):
+        return SimpleTerm(value=item['typedId'], title=item['text'])
+
+    @staticmethod
+    def _ogds_user_term(user):
+        return SimpleTerm(value=user,
+                          token=user.userid,
+                          title=user.label(with_principal=True))
+
     def getTermByToken(self, token):
         if not token:
-            raise LookupError
+            raise LookupError()
 
-        item = self.client.get_by_id(token)
-        return SimpleTerm(value=item['typedId'], title=item['text'])
+        if ActorLookup(token).is_kub_contact():
+            item = self.client.get_by_id(token)
+            return self._kub_term(item)
+
+        # it's an ogds user
+        try:
+            user = ogds_service().find_user(token)
+        except RecordNotFound:
+            raise LookupError()
+        return self._ogds_user_term(user)
 
     def search(self, query_string):
         items = self.client.query(query_string)
-        self.terms = [
-            SimpleTerm(value=item['typedId'], title=item['text'])
-            for item in items]
+        self.terms = [self._kub_term(item) for item in items]
+
+        text_filters = query_string.split()
+        for ogds_user in ogds_service().filter_users(text_filters):
+            self.terms.append(self._ogds_user_term(ogds_user))
 
         return self.terms
 

--- a/opengever/kub/tests/test_kub_contact_source.py
+++ b/opengever/kub/tests/test_kub_contact_source.py
@@ -1,5 +1,6 @@
 from opengever.kub.sources import KuBContactsSource
 from opengever.kub.testing import KuBIntegrationTestCase
+from opengever.ogds.models.service import ogds_service
 import requests_mock
 
 
@@ -34,6 +35,20 @@ class TestKubContactSource(KuBIntegrationTestCase):
         self.assertItemsEqual(["Dupont Jean - 4Teamwork (CEO)", "4Teamwork"],
                               [term.title for term in terms])
 
+    def test_search_returns_ogds_users(self, mocker):
+        query_str = "Barfuss"
+        url = u'{}search?q={}'.format(self.client.kub_api_url, query_str)
+        mocker.get(url, json=[])
+        ogds_user = ogds_service().fetch_user(self.regular_user.getId())
+
+        terms = self.source.search(query_str)
+        self.assertItemsEqual(['kathi.barfuss'],
+                              [term.token for term in terms])
+        self.assertItemsEqual([ogds_user],
+                              [term.value for term in terms])
+        self.assertItemsEqual([u'B\xe4rfuss K\xe4thi (kathi.barfuss)'],
+                              [term.title for term in terms])
+
     def test_get_term_by_token_handles_persons(self, mocker):
         self.mock_get_by_id(mocker, self.person_jean)
         term = self.source.getTermByToken(self.person_jean)
@@ -54,6 +69,13 @@ class TestKubContactSource(KuBIntegrationTestCase):
         self.assertEqual(self.memb_jean_ftw, term.token)
         self.assertEqual(self.memb_jean_ftw, term.value)
         self.assertEqual('Dupont Jean - 4Teamwork (CEO)', term.title)
+
+    def test_get_by_id_handles_ogds_users(self, mocker):
+        term = self.source.getTermByToken(self.regular_user.getId())
+        ogds_user = ogds_service().fetch_user(self.regular_user.getId())
+        self.assertEqual(self.regular_user.getId(), term.token)
+        self.assertEqual(ogds_user, term.value)
+        self.assertEqual(u'B\xe4rfuss K\xe4thi (kathi.barfuss)', term.title)
 
     def test_get_by_id_raises_lookup_error_for_invalid_token(self, mocker):
         contact_id = "invalid-id"


### PR DESCRIPTION
For both dossier participations and recipients ogds users should be available when KuB feature is enabled. This was already the case for SQL contacts and needs to also be supported with KuB contacts.

Note that when creating a document from template, after selecting a recipient from the OGDS, you could select an address, phone number, url and mail address when using SQL contacts. This is not possible anymore, as we have decided not to implement that form in the new UI, and instead use default address, phone number, URL and mail for KuB contacts. For OGDS users there is no default for these fields, so I simply chose to take the first on of each...

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-3350]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-3350]: https://4teamwork.atlassian.net/browse/CA-3350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ