### PR TITLE
Fix copy document from workspace as new version when gever document is trashed.

### DIFF
--- a/changes/CA-3323.bugfix
+++ b/changes/CA-3323.bugfix
@@ -1,0 +1,1 @@
+Fix copy document from workspace as new version when gever document is trashed. [njohner]


### PR DESCRIPTION
Sometimes the document on the Gever side cannot be found, for example because it has been trashed, or maybe moved to a dossier where the current user does not have access. In such cases, when copying a document back from a workspace as a new version, we will instead create a new document.

For [CA-3323]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-3323]: https://4teamwork.atlassian.net/browse/CA-3323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ