### PR TITLE
Make sure customproperty default values are initalized, when content is created.

### DIFF
--- a/changes/CA-2851.feature
+++ b/changes/CA-2851.feature
@@ -1,0 +1,1 @@
+Make sure customproperty default values are initialized, when content is created. [phgross]

--- a/opengever/api/deserializer.py
+++ b/opengever/api/deserializer.py
@@ -2,6 +2,7 @@ from Acquisition import aq_inner
 from Acquisition import aq_parent
 from opengever.base.default_values import set_default_values
 from opengever.base.interfaces import IOpengeverBaseLayer
+from opengever.propertysheets.creation_defaults import initialize_customproperties_defaults
 from plone.dexterity.interfaces import IDexterityContent
 from plone.restapi.deserializer import json_body
 from plone.restapi.deserializer.dxcontent import DeserializeFromJson
@@ -35,6 +36,7 @@ class GeverDeserializeFromJson(DeserializeFromJson):
         if create:
             container = aq_parent(aq_inner(self.context))
             set_default_values(self.context, container, data)
+            initialize_customproperties_defaults(self.context)
 
         schema_data, errors = self.get_schema_data(data, validate_all)
 

--- a/opengever/api/tus.py
+++ b/opengever/api/tus.py
@@ -53,8 +53,7 @@ class GeverUploadPatch(UploadPatch):
                 'for %r. Got: %r' % (self.request, exc))
 
         if created_doc:
-            initialize_customproperties_defaults(
-                created_doc, IDocumentCustomProperties)
+            initialize_customproperties_defaults(created_doc)
         return result
 
 

--- a/opengever/base/monkey/patches/default_values.py
+++ b/opengever/base/monkey/patches/default_values.py
@@ -475,6 +475,8 @@ class PatchTransmogrifyDXSchemaUpdater(MonkeyPatch):
         from opengever.base import default_values
         from opengever.base.default_values import get_persisted_value_for_field
         from opengever.base.default_values import NO_DEFAULT_MARKER
+        from opengever.propertysheets.creation_defaults import get_customproperties_defaults
+        from opengever.propertysheets.field import IPropertySheetField
         from transmogrify.dexterity.schemaupdater import _marker as _tm_marker
         from z3c.form.interfaces import NO_VALUE
 
@@ -482,6 +484,10 @@ class PatchTransmogrifyDXSchemaUpdater(MonkeyPatch):
             """Determine the default to be set for a field that didn't receive
             a value from the pipeline.
             """
+
+            if IPropertySheetField.providedBy(field):
+                return get_customproperties_defaults(field)
+
             default = default_values.determine_default_value(
                 field, obj.aq_parent)
             if default is NO_DEFAULT_MARKER:

--- a/opengever/base/monkey/patches/default_values.py
+++ b/opengever/base/monkey/patches/default_values.py
@@ -118,6 +118,7 @@ class PatchDXCreateContentInContainer(MonkeyPatch):
         from zope.component import getUtility
         from zope.event import notify
         from zope.lifecycleevent import ObjectCreatedEvent
+        from opengever.propertysheets.creation_defaults import initialize_customproperties_defaults
 
         def createContentWithDefaults(portal_type, container, **kw):
             fti = getUtility(IDexterityFTI, name=portal_type)
@@ -160,6 +161,9 @@ class PatchDXCreateContentInContainer(MonkeyPatch):
             content = createContentWithDefaults(portal_type, container, **kw)
             if interfaces is not None:
                 alsoProvides(content, *interfaces)
+
+            initialize_customproperties_defaults(content)
+
             result = addContentToContainer(
                 container, content, checkConstraints=checkConstraints)
             noLongerProvides(container.REQUEST, IDuringContentCreation)
@@ -181,6 +185,7 @@ class PatchInvokeFactory(MonkeyPatch):
     def __call__(self):
         from opengever.base.default_values import inject_title_and_description_defaults  # noqa
         from opengever.base.default_values import set_default_values
+        from opengever.propertysheets.creation_defaults import initialize_customproperties_defaults
         from Products.CMFCore.utils import getToolByName
 
         def invokeFactory(self, type_name, id, RESPONSE=None, *args, **kw):
@@ -203,6 +208,7 @@ class PatchInvokeFactory(MonkeyPatch):
 
             # Set default values
             set_default_values(content, self, kw)
+            initialize_customproperties_defaults(content)
 
             noLongerProvides(self.REQUEST, IDuringContentCreation)
             return new_id

--- a/opengever/base/quickupload.py
+++ b/opengever/base/quickupload.py
@@ -112,7 +112,7 @@ class OGQuickUploadCapableFileFactory(object):
                     'success': None}
 
         # Initialize custom properties with default values
-        initialize_customproperties_defaults(obj, IDocumentCustomProperties)
+        initialize_customproperties_defaults(obj)
 
         result = {'success': obj}
         return result

--- a/opengever/base/tests/test_command.py
+++ b/opengever/base/tests/test_command.py
@@ -1,6 +1,9 @@
+from ftw.builder import Builder
+from ftw.builder import create
 from opengever.base.command import CreateDocumentCommand
 from opengever.base.command import CreateEmailCommand
 from opengever.document.behaviors.related_docs import IRelatedDocuments
+from opengever.propertysheets.utils import get_custom_properties
 from opengever.testing import IntegrationTestCase
 from z3c.relationfield.relation import RelationValue
 from zope.annotation.interfaces import IAnnotations
@@ -55,3 +58,17 @@ class TestCreateDocumentCommand(IntegrationTestCase):
             'opengever.document.behaviors.related_docs.IRelatedDocuments.relatedItems',
             IAnnotations(document))
         self.assertIn(relation, IRelatedDocuments(document).relatedItems)
+
+    def test_create_document_from_command_initialize_customproperty_defaults(self):
+        self.login(self.regular_user)
+
+        create(Builder("property_sheet_schema")
+               .named("documentdefault_schema")
+               .assigned_to_slots(u"IDocument.default")
+               .with_field("textline", u"portal", u"Portal", u"",
+                           False, default_expression='portal/getId'))
+
+        command = CreateDocumentCommand(self.dossier, 'testm\xc3\xa4il.txt', 'buh!')
+        document = command.execute()
+
+        self.assertEqual({'portal': u'plone'}, get_custom_properties(document))

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from datetime import date
 from datetime import timedelta
 from ftw.builder import Builder
@@ -112,7 +113,7 @@ DOSSIER_DEFAULTS = {
     'reading_and_writing': [],
     'dossier_manager': None,
     'touched': FROZEN_TODAY,
-    'custom_properties': None,
+    'custom_properties': {'IDossier.default': {'location': u'B\xfcren an der Aare'}},
     'dossier_type': None,
 }
 DOSSIER_FORM_DEFAULTS = {
@@ -814,10 +815,10 @@ class TestDossierDefaults(TestDefaultsBase):
         dossier = browser.context
 
         persisted_values = get_persisted_values_for_obj(dossier)
-        expected = self.get_z3c_form_defaults()
+        expected = deepcopy(self.get_z3c_form_defaults())
 
-        # ignore custom_properties
-        persisted_values['custom_properties'] = None
+        # Add customproperties form missing values
+        expected['custom_properties']['IDossier.default']['additional_title'] = None
 
         self.assert_default_values_equal(expected, persisted_values)
 
@@ -871,10 +872,10 @@ class TestDossierDefaults(TestDefaultsBase):
         dossier = browser.context
 
         persisted_values = get_persisted_values_for_obj(dossier)
-        expected = self.get_z3c_form_defaults()
+        expected = deepcopy(self.get_z3c_form_defaults())
 
-        # ignore custom_properties
-        persisted_values['custom_properties'] = None
+        # Add customproperties form missing values
+        expected['custom_properties']['IDossier.default']['additional_title'] = None
 
         self.assert_default_values_equal(expected, persisted_values)
 

--- a/opengever/base/transport.py
+++ b/opengever/base/transport.py
@@ -4,6 +4,7 @@ from opengever.base.request import dispatch_json_request
 from opengever.base.security import elevated_privileges
 from opengever.ogds.base.utils import decode_for_json
 from opengever.ogds.base.utils import encode_after_json
+from opengever.propertysheets.creation_defaults import initialize_customproperties_defaults
 from opengever.task.reminder import Reminder
 from opengever.task.task import ITask
 from plone.dexterity.interfaces import IDexterityContent
@@ -157,6 +158,7 @@ class DexterityObjectCreator(object):
     # XXX use plone.api
     def create_in(self, container):
         obj = createContent(self.portal_type, title=self.title)
+        initialize_customproperties_defaults(obj)
         notify(ObjectCreatedEvent(obj))
 
         # insert data from collectors

--- a/opengever/bundle/tests/test_oggbundle_pipeline.py
+++ b/opengever/bundle/tests/test_oggbundle_pipeline.py
@@ -2,6 +2,8 @@ from collective.transmogrifier.transmogrifier import Transmogrifier
 from datetime import date
 from datetime import datetime
 from DateTime import DateTime
+from ftw.builder import Builder
+from ftw.builder import create
 from ftw.testing import freeze
 from opengever.base.behaviors.classification import IClassification
 from opengever.base.behaviors.lifecycle import ILifeCycle
@@ -14,6 +16,7 @@ from opengever.bundle.sections.bundlesource import BUNDLE_KEY
 from opengever.bundle.sections.bundlesource import BUNDLE_PATH_KEY
 from opengever.bundle.sections.constructor import BUNDLE_GUID_KEY
 from opengever.dossier.behaviors.dossier import IDossier
+from opengever.propertysheets.utils import get_custom_properties
 from opengever.repository.behaviors.referenceprefix import IReferenceNumberPrefix  # noqa
 from opengever.testing import index_data_for
 from opengever.testing import IntegrationTestCase
@@ -101,6 +104,13 @@ class TestOggBundlePipeline(IntegrationTestCase):
         # test its data.
 
         self.login(self.manager)
+
+        # Add custom field with default values
+        create(Builder("property_sheet_schema")
+               .named("documentdefault_schema")
+               .assigned_to_slots(u"IDocument.default")
+               .with_field("textline", u"portal", u"Portal", u"",
+                           False, default_expression='portal/getId'))
 
         # Create the 'bundle_guid' index. In production, this will be done
         # by the "bin/instance import" command in opengever.bundle.console
@@ -512,6 +522,10 @@ class TestOggBundlePipeline(IntegrationTestCase):
         self.assertEqual(
             IAnnotations(document1)[BUNDLE_GUID_KEY],
             index_data_for(document1)[GUID_INDEX_NAME])
+
+        # customproperty with default
+        self.assertEqual(
+            {'portal': u'plone'}, get_custom_properties(document1))
 
     def assert_document2_created(self, parent):
         document2 = self.find_by_title(parent, u'Entlassung Hanspeter M\xfcller')

--- a/opengever/ech0147/tests/test_import.py
+++ b/opengever/ech0147/tests/test_import.py
@@ -2,6 +2,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from opengever.ech0147.interfaces import IECH0147Settings
+from opengever.propertysheets.field import IPropertySheetField
 from opengever.testing import FunctionalTestCase
 from opengever.testing import IntegrationTestCase
 from opengever.testing.helpers import obj2brain
@@ -9,7 +10,6 @@ from plone import api
 from plone.dexterity.utils import iterSchemata
 from zope.schema import getFieldsInOrder
 import os.path
-
 
 def get_path(name):
     return os.path.join(os.path.dirname(__file__), 'data', name)
@@ -105,6 +105,9 @@ class TestImport(IntegrationTestCase):
                 value = getattr(field.interface(dossier), name, None)
                 # Allow empty values on non-required fields
                 if not field.required and value is not None:
+                    if IPropertySheetField.providedBy(field):
+                        continue
+
                     self.assertEqual(field._type, type(value), 'Wrong type for value of field: {}'.format(name))
 
     @browsing

--- a/opengever/mail/create.py
+++ b/opengever/mail/create.py
@@ -32,7 +32,7 @@ class OGCreateMailInContainer(CreateMailInContainer):
         obj = command.execute()
 
         # Initialize custom properties with default values
-        initialize_customproperties_defaults(obj, IDocumentCustomProperties)
+        initialize_customproperties_defaults(obj)
 
         return obj
 

--- a/opengever/mail/mail.py
+++ b/opengever/mail/mail.py
@@ -266,8 +266,7 @@ class OGMail(Mail, BaseDocumentMixin):
             alsoProvides(doc, IExtractedFromMail)
 
             # Initialize custom properties with default values
-            initialize_customproperties_defaults(
-                doc, IDocumentCustomProperties, reindex=False)
+            initialize_customproperties_defaults(doc, reindex=False)
 
             doc.reindexObject()
 

--- a/opengever/propertysheets/creation_defaults.py
+++ b/opengever/propertysheets/creation_defaults.py
@@ -1,9 +1,23 @@
 from copy import copy
+from opengever.document.behaviors import IBaseDocument
+from opengever.document.behaviors.customproperties import IDocumentCustomProperties
+from opengever.dossier.behaviors.customproperties import IDossierCustomProperties
+from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.propertysheets.storage import PropertySheetSchemaStorage
 from zope.component import queryAdapter
 
 
-def initialize_customproperties_defaults(obj, behavior_iface, reindex=True):
+def get_customproperties_behavior(obj):
+    if IDossierMarker.providedBy(obj):
+        return IDossierCustomProperties
+    elif IBaseDocument.providedBy(obj):
+        return IDocumentCustomProperties
+
+    return
+
+
+def initialize_customproperties_defaults(obj, reindex=True):
+    behavior_iface = get_customproperties_behavior(obj)
     behavior = queryAdapter(obj, behavior_iface)
     if behavior:
         custom_prop_defaults = get_customproperties_defaults(

--- a/opengever/propertysheets/creation_defaults.py
+++ b/opengever/propertysheets/creation_defaults.py
@@ -25,6 +25,9 @@ def initialize_customproperties_defaults(obj, reindex=True):
         custom_prop_defaults = get_customproperties_defaults(
             behavior_iface['custom_properties'])
 
+        if not custom_prop_defaults:
+            return
+
         # Only attempt to set defaults if no actual custom properties exist yet
         if not behavior.custom_properties:
             behavior.custom_properties = custom_prop_defaults

--- a/opengever/propertysheets/creation_defaults.py
+++ b/opengever/propertysheets/creation_defaults.py
@@ -1,13 +1,15 @@
 from copy import copy
 from opengever.document.behaviors import IBaseDocument
-from opengever.document.behaviors.customproperties import IDocumentCustomProperties
-from opengever.dossier.behaviors.customproperties import IDossierCustomProperties
-from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.propertysheets.storage import PropertySheetSchemaStorage
 from zope.component import queryAdapter
 
 
 def get_customproperties_behavior(obj):
+    # Avoid import problems when importing a bundle
+    from opengever.document.behaviors.customproperties import IDocumentCustomProperties
+    from opengever.dossier.behaviors.customproperties import IDossierCustomProperties
+    from opengever.dossier.behaviors.dossier import IDossierMarker
+
     if IDossierMarker.providedBy(obj):
         return IDossierCustomProperties
     elif IBaseDocument.providedBy(obj):

--- a/opengever/propertysheets/tests/test_dossier_custom_properties.py
+++ b/opengever/propertysheets/tests/test_dossier_custom_properties.py
@@ -148,6 +148,9 @@ class TestDossierCustomPropertiesPost(IntegrationTestCase):
 
         self.login(self.regular_user, browser)
         property_data = {
+            u'IDossier.default': {
+                u'location': u'B\xfcren an der Aare'
+            },
             "IDossier.dossier_type.businesscase": {
                 "foo": u"f\xfc"
             }


### PR DESCRIPTION
This PR makes sure that custom properties are initialized correctly with default values, if they're provide one. 

The following content creation are handled:

_already ensured, implemented_
 - content creation via form (old and new UI)
 - mail creation via Inbound Mail
 - document creation via Drag&Drop TUS upload (neues UI)
 - document creation via Drag&Drop QuickUpload (old UI)
 - document creation Dokument via Mail-Attachment extraction (old and new UI)

_newly ensured_
 - content creation via API
 - dossier creation via Drag&Drop folder upload
 - content creation via OGGBundle import
 - content creation via `Transporter` (used in multi adminunit communication)
 - document creation from template (old and new UI)
 - dossier creation from template (old and new UI)
 
The concerns about dynamic defaults which lead to errors in content creation could be defused. Because we will only allow "Managers" to define dynamic defaults. This is already being ensured.

For [CA-2851]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- New functionality:
  - [x] for `document` also works for `mail`


[CA-2851]: https://4teamwork.atlassian.net/browse/CA-2851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ