### PR TITLE
Add support for custom property facets to `@solrsearch` endpoint

### DIFF
--- a/changes/CA-2613.feature
+++ b/changes/CA-2613.feature
@@ -1,0 +1,1 @@
+Add support for custom property facets to `@solrsearch` endpoint. [lgraf]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -15,6 +15,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- ``@solrsearch``: Now supports facetting custom property fields.
 - Add new endpoint ``@external-activities`` (see :ref:`docs <external-activities>`)
 - Include sip_delivery_status in the disposition serialization.
 - Disposition serialization contains now responses.

--- a/docs/public/dev-manual/api/searching.rst
+++ b/docs/public/dev-manual/api/searching.rst
@@ -214,6 +214,8 @@ Beispiel für ein Suchabfrage mit Facetten für ``responsible`` und ``portal_typ
       "start": 0
     }
 
+Facetten können auch für :ref:`benutzerdefinierte Felder <propertysheets>` abgefragt werden (Ausnahme: Felder vom Typ ``text``). Die Schreibweise der Solr-Felder für Custom Properties, und in welchen Listings sie aufgeführt werden sollen, kann dem ``@listing-custom-fields`` Endpoint entnommen werden.
+
 
 Statistiken
 ~~~~~~~~~~~


### PR DESCRIPTION
Custom property fields can now be faceted as well using the `@solrsearch` endpoint (except ones of type `text`).

The names for the Solr fields of custom properties, and in which listings they should appear, can be retrieved using the existing `@listing-custom-fields` endpoint.

For [CA-2613](https://4teamwork.atlassian.net/browse/CA-2613)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry
