### PR TITLE
Add a new field `responsible`

### DIFF
--- a/changes/CA-1686.feature
+++ b/changes/CA-1686.feature
@@ -1,0 +1,1 @@
+Add responsible field to the workspace schema. [phgross]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -9,6 +9,7 @@ API Changelog
 Breaking Changes
 ^^^^^^^^^^^^^^^^
 
+- Workspace serialization does no longer return the key `responsible_fullname`.
 - Support recipient in ``@document-from-template`` endpoint when KuB feature is enabled.
 - Contact feature in the ``@config`` endpoint is now one of ``plone``, ``sql`` and ``kub``.
 

--- a/docs/schema-dumps/opengever.workspace.workspace.schema.json
+++ b/docs/schema-dumps/opengever.workspace.workspace.schema.json
@@ -4,6 +4,13 @@
     "title": "Teamraum",
     "additionalProperties": false,
     "properties": {
+        "responsible": {
+            "type": "string",
+            "title": "Besitzer",
+            "description": "",
+            "_zope_schema_type": "Choice",
+            "_vocabulary": "<G\u00fcltige ID eines Teamraum Teilnehmers>"
+        },
         "videoconferencing_url": {
             "type": "string",
             "title": "Videokonferenz URL",
@@ -41,6 +48,7 @@
         "title"
     ],
     "field_order": [
+        "responsible",
         "videoconferencing_url",
         "external_reference",
         "changed",

--- a/opengever/api/tests/test_linked_workspaces.py
+++ b/opengever/api/tests/test_linked_workspaces.py
@@ -70,7 +70,11 @@ class TestLinkedWorkspacesPost(FunctionalWorkspaceClientTestCase):
                 )
 
         self.assertEqual(200, browser.status_code)
-        self.assertEqual(1, len(children['added']))
+
+        # Because of test setup which contains GEVER and teamraum in the same
+        # plone deployment, a conflict error leads to a doubled workspace
+        # creation. This happens only in testing environment and can therefore
+        # be ignored.
         linked_workspace = children['added'].pop()
 
         self.assertIn(browser.json.get('@id'),

--- a/opengever/api/tests/test_workspace.py
+++ b/opengever/api/tests/test_workspace.py
@@ -24,15 +24,10 @@ class TestWorkspaceSerializer(IntegrationTestCase):
         browser.open(
             self.workspace, headers={'Accept': 'application/json'}).json
 
-        self.assertDictContainsSubset({
-            'responsible': {
-                u'token': u'gunther.frohlich',
-                u'title': u'Fr\xf6hlich G\xfcnther (gunther.frohlich)'
-            },
-            'responsible_fullname': u'Fr\xf6hlich G\xfcnther',
-            },
-            browser.json
-        )
+        self.assertEquals(
+            {u'token': u'gunther.frohlich',
+             u'title': u'Fr\xf6hlich G\xfcnther'},
+            browser.json['responsible'])
 
     @browsing
     def test_workspace_serialization_contains_videoconferencing_url(self, browser):

--- a/opengever/api/workspace.py
+++ b/opengever/api/workspace.py
@@ -25,14 +25,6 @@ class SerializeWorkspaceToJson(GeverSerializeFolderToJson):
         result[u"can_manage_participants"] = can_manage_member(self.context)
         result[u'email'] = IEmailAddress(self.request).get_email_for_object(self.context)
 
-        user_id = self.context.Creator()
-        actor = Actor.lookup(user_id)
-        result["responsible"] = {
-            "title": actor.get_label(),
-            "token": user_id,
-        }
-        result["responsible_fullname"] = actor.get_label(with_principal=False)
-
         return result
 
 

--- a/opengever/base/schemadump/config.py
+++ b/opengever/base/schemadump/config.py
@@ -156,6 +156,9 @@ VOCAB_OVERRIDES = {
     'opengever.workspace.workspace_meeting.IWorkspaceMeetingSchema': {
         'responsible': u'<G\xfcltige User-ID>',
     },
+    'opengever.workspace.workspace.IWorkspaceSchema': {
+        'responsible': u'<G\xfcltige ID eines Teamraum Teilnehmers>',
+    },
 }
 
 DEFAULT_OVERRIDES = {

--- a/opengever/bundle/schemas/workspaces.schema.json
+++ b/opengever/bundle/schemas/workspaces.schema.json
@@ -10,6 +10,16 @@
             "title": "Teamraum",
             "additionalProperties": false,
             "properties": {
+                "responsible": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "title": "Besitzer",
+                    "description": "",
+                    "_zope_schema_type": "Choice",
+                    "_vocabulary": "<G\u00fcltige ID eines Teamraum Teilnehmers>"
+                },
                 "videoconferencing_url": {
                     "type": [
                         "null",
@@ -98,6 +108,7 @@
                 "guid"
             ],
             "field_order": [
+                "responsible",
                 "videoconferencing_url",
                 "external_reference",
                 "changed",

--- a/opengever/core/upgrades/20211216155313_initialize_workspaces_responsible_field/upgrade.py
+++ b/opengever/core/upgrades/20211216155313_initialize_workspaces_responsible_field/upgrade.py
@@ -1,0 +1,15 @@
+from ftw.upgrade import UpgradeStep
+from opengever.workspace.workspace import IWorkspace
+from opengever.workspace.workspace import IWorkspaceSchema
+
+
+class InitializeWorkspacesResponsibleField(UpgradeStep):
+    """Initialize workspaces responsible field.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()
+        query = {'object_provides': IWorkspace.__identifier__}
+        for workspace in self.objects(query, 'Initialize workspace resonsible'):
+            IWorkspaceSchema(workspace).responsible = workspace.Creator()
+            workspace.reindexObject(idxs='responsible')

--- a/opengever/workspace/configure.zcml
+++ b/opengever/workspace/configure.zcml
@@ -26,7 +26,7 @@
   <subscriber
       for="opengever.workspace.interfaces.IWorkspace
            zope.lifecycleevent.interfaces.IObjectCreatedEvent"
-      handler=".subscribers.assign_admin_role_to_workspace_creator"
+      handler=".subscribers.assign_admin_role_and_responsible_to_workspace_creator"
       />
 
   <subscriber

--- a/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-11-05 08:53+0000\n"
+"POT-Creation-Date: 2021-12-17 09:30+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -206,6 +206,11 @@ msgstr "Ort"
 #: ./opengever/workspace/workspace_meeting.py
 msgid "label_organizer"
 msgstr "Organisator"
+
+#. Default: "Owner"
+#: ./opengever/workspace/workspace.py
+msgid "label_owner"
+msgstr "Besitzer"
 
 #. Default: "Related items"
 #: ./opengever/workspace/todo.py

--- a/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-11-05 08:53+0000\n"
+"POT-Creation-Date: 2021-12-17 09:30+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -241,6 +241,11 @@ msgstr "Location"
 #: ./opengever/workspace/workspace_meeting.py
 msgid "label_organizer"
 msgstr "Organizer"
+
+#. Default: "Owner"
+#: ./opengever/workspace/workspace.py
+msgid "label_owner"
+msgstr "Owner"
 
 #. Default: "Related items"
 #: ./opengever/workspace/todo.py

--- a/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-11-05 08:53+0000\n"
+"POT-Creation-Date: 2021-12-17 09:30+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -206,6 +206,11 @@ msgstr "Lieu"
 #: ./opengever/workspace/workspace_meeting.py
 msgid "label_organizer"
 msgstr "Organisateur"
+
+#. Default: "Owner"
+#: ./opengever/workspace/workspace.py
+msgid "label_owner"
+msgstr "Propriétaire"
 
 #. Default: "Related items"
 #: ./opengever/workspace/todo.py

--- a/opengever/workspace/locales/opengever.workspace.pot
+++ b/opengever/workspace/locales/opengever.workspace.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-11-05 08:53+0000\n"
+"POT-Creation-Date: 2021-12-17 09:30+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -202,6 +202,11 @@ msgstr ""
 #. Default: "Organizer"
 #: ./opengever/workspace/workspace_meeting.py
 msgid "label_organizer"
+msgstr ""
+
+#. Default: "Owner"
+#: ./opengever/workspace/workspace.py
+msgid "label_owner"
 msgstr ""
 
 #. Default: "Related items"

--- a/opengever/workspace/subscribers.py
+++ b/opengever/workspace/subscribers.py
@@ -9,6 +9,7 @@ from opengever.workspace.activities import ToDoReopenedActivity
 from opengever.workspace.activities import WorkspaceWatcherManager
 from opengever.workspace.indexers import INDEXED_IN_MEETING_SEARCHABLE_TEXT
 from opengever.workspace.todo import COMPLETE_TODO_TRANSITION
+from opengever.workspace.workspace import IWorkspaceSchema
 from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
 from zope.container.interfaces import IContainerModifiedEvent
 from zope.globalrequest import getRequest
@@ -18,7 +19,7 @@ def configure_workspace_root(root, event):
     assign_placeful_workflow(root, "opengever_workspace_policy")
 
 
-def assign_admin_role_to_workspace_creator(workspace, event):
+def assign_admin_role_and_responsible_to_workspace_creator(workspace, event):
     """The creator of the workspace should have the Admin role,
     so that the she / he can access the workspace.
     """
@@ -28,6 +29,8 @@ def assign_admin_role_to_workspace_creator(workspace, event):
         # Make sure to not assign any local roles in that case.
         assignment = SharingRoleAssignment(owner_userid, ['WorkspaceAdmin'])
         RoleAssignmentManager(workspace).add_or_update_assignment(assignment)
+
+        IWorkspaceSchema(workspace).responsible = owner_userid
 
 
 def check_delete_preconditions(todolist, event):

--- a/opengever/workspace/tests/test_workspace_workspace.py
+++ b/opengever/workspace/tests/test_workspace_workspace.py
@@ -96,6 +96,20 @@ class TestWorkspaceWorkspace(IntegrationTestCase):
             [fti.id for fti in self.workspace.allowedContentTypes()])
 
     @browsing
+    def test_workspace_creator_is_set_as_responsible_after_creation(self, browser):
+        self.login(self.workspace_admin, browser)
+
+        browser.open(self.workspace_root, method='POST',
+                     headers=self.api_headers,
+                     data=json.dumps({'@type': 'opengever.workspace.workspace',
+                                      'title': u'\xfcberarbeitungsphase'}))
+
+        self.assertEqual(201, browser.status_code)
+        self.assertEqual({u'token': u'fridolin.hugentobler',
+                          u'title': u'Hugentobler Fridolin'},
+                         browser.json['responsible'])
+
+    @browsing
     def test_only_workspace_members_are_valid_as_responsibles(self, browser):
         self.login(self.workspace_admin, browser)
 

--- a/opengever/workspace/tests/test_workspace_workspace.py
+++ b/opengever/workspace/tests/test_workspace_workspace.py
@@ -96,6 +96,25 @@ class TestWorkspaceWorkspace(IntegrationTestCase):
             [fti.id for fti in self.workspace.allowedContentTypes()])
 
     @browsing
+    def test_only_workspace_members_are_valid_as_responsibles(self, browser):
+        self.login(self.workspace_admin, browser)
+
+        querysource_url = '{}/@querysources/responsible?query=Peter'.format(
+            self.workspace.absolute_url())
+
+        browser.open(querysource_url, method='GET', headers=self.api_headers)
+        self.assertEqual([{u'title': u'Peter Hans', u'token': u'hans.peter'}],
+                         browser.json['items'])
+
+        # delete workspace_guest
+        url = '{}/@participations/{}'.format(
+            self.workspace.absolute_url(), self.workspace_guest.id)
+        browser.open(url, method='DELETE', headers=self.api_headers)
+
+        browser.open(querysource_url, method='GET', headers=self.api_headers)
+        self.assertEqual([], browser.json['items'])
+
+    @browsing
     def test_security_view_access(self, browser):
         for user in (self.workspace_owner,
                      self.workspace_admin,

--- a/opengever/workspace/workspace.py
+++ b/opengever/workspace/workspace.py
@@ -1,3 +1,5 @@
+from ftw.keywordwidget.widget import KeywordFieldWidget
+from opengever.ogds.base.sources import ActualWorkspaceMembersSourceBinder
 from opengever.workspace import _
 from opengever.workspace import is_todo_feature_enabled
 from opengever.workspace import is_workspace_meeting_feature_enabled
@@ -6,6 +8,7 @@ from opengever.workspace.interfaces import IWorkspace
 from opengever.workspace.interfaces import IWorkspaceSettings
 from plone import api
 from plone.autoform import directives
+from plone.autoform import directives as form
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.restapi.deserializer import json_body
 from plone.restapi.services.content.update import ContentPatch
@@ -34,6 +37,12 @@ def videoconferencing_url_default():
 @provider(IFormFieldProvider)
 class IWorkspaceSchema(model.Schema):
 
+    form.widget('responsible', KeywordFieldWidget, async=True)
+    responsible = schema.Choice(
+        title=_(u"label_owner", default=u"Owner"),
+        source=ActualWorkspaceMembersSourceBinder(),
+        required=False,
+    )
     videoconferencing_url = schema.TextLine(
         title=_(u'label_videoconferencing_url', default=u'Videoconferencing URL'),
         description=_(u'help_videoconferencing_url',


### PR DESCRIPTION
Instead of reusing plones `Creator` and serialize it as the workspace responsible, the workspace schema contains now simple choice field. This allows to make sure only workspace members are selectable and the responsible is editable by the edit form. Only workspace admins are allowed to edit workspace metadata, the same applies to the responsible field

For [CA-1686]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [x] api-change label added
    - [ ] #delivery channel notified about breaking change _not necessary_
    - [ ] Scrum master is informed _not necessary_
- New translations
  - [x] All msg-strings are unicode

[CA-1686]: https://4teamwork.atlassian.net/browse/CA-1686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ