### PR TITLE
Fix save PDF under for workspace documents.

### DIFF
--- a/changes/CA-3389.bugfix
+++ b/changes/CA-3389.bugfix
@@ -1,0 +1,1 @@
+Fix save PDF under for workspace documents. [njohner]

--- a/opengever/api/tests/test_save_document_as_pdf.py
+++ b/opengever/api/tests/test_save_document_as_pdf.py
@@ -193,3 +193,15 @@ class TestSaveDocumentAsPdfPost(IntegrationTestCase):
         self.assertEqual(len(children["added"]), 1)
         created_document = children["added"].pop()
         self.assertEqual(0, IAnnotations(created_document).get(PDF_SAVE_SOURCE_VERSION_KEY))
+
+    @browsing
+    def test_save_document_as_pdf_post_does_not_set_shadow_state_for_workspace_documents(self, browser):
+        self.login(self.workspace_member, browser)
+        with self.observe_children(self.workspace) as children:
+            browser.open(self.workspace, view='@save-document-as-pdf', method='POST',
+                         headers=self.api_headers,
+                         data=json.dumps({"document_uid": self.workspace_document.UID()}))
+
+        self.assertEqual(len(children["added"]), 1)
+        created_document = children["added"].pop()
+        self.assertFalse(created_document.is_shadow_document())

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -216,6 +216,8 @@ class Document(Item, BaseDocumentMixin):
     restore_transition = 'document-transition-restore'
     initialize_transition = 'document-transition-initialize'
 
+    workspace_workflow_id = 'opengever_workspace_document'
+
     # disable file preview creation when modifying or creating document
     buildPreview = False
 
@@ -335,6 +337,9 @@ class Document(Item, BaseDocumentMixin):
         wftool = api.portal.get_tool('portal_workflow')
         chain = wftool.getChainFor(self)
         workflow_id = chain[0]
+        if workflow_id == self.workspace_workflow_id:
+            # There is no shadow state for workspace documents.
+            return self
         wftool.setStatusOf(workflow_id, self, {
             'review_state': self.shadow_state,
             'action': '',


### PR DESCRIPTION
Workspace documents have their own workflow, which has only a single state. This breaks save PDF under, as the function sets the document to shadow state and then transitions it back to active state when the PDF has been posted back by bumblebee. This transition did not exist and led to the function failing.


Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-3389]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- New functionality:
  - [ ] for `document` also works for `mail`: 👎  not available for mails

[CA-3389]: https://4teamwork.atlassian.net/browse/CA-3389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ