### PR TITLE
Use custom Solr distribution containing Log4j 2.17.0

### DIFF
--- a/changes/CA-3339.bugfix
+++ b/changes/CA-3339.bugfix
@@ -1,1 +1,1 @@
-Bump ftw.recipe.solr to version 1.3.5. Mitigation for CVE-2021-44228 (log4j vulnerability). [buchi]
+Bump ftw.recipe.solr to version 1.3.6 and use custom Solr distribution containing Log4j 2.17.0. Mitigation for CVE-2021-44228, CVE-2021-45046 and CVE-2021-45105. [buchi]

--- a/versions.cfg
+++ b/versions.cfg
@@ -90,7 +90,7 @@ ftw.pdfgenerator = 1.6.4
 ftw.profilehook = 1.2.1
 ftw.raven = 1.2.0
 ftw.recipe.deployment = 1.4.3
-ftw.recipe.solr = 1.3.5
+ftw.recipe.solr = 1.3.6
 ftw.recipe.translations = 1.2.6
 ftw.showroom = 1.5.1
 ftw.slacker = 1.0.2
@@ -216,5 +216,5 @@ zope.testrunner = 4.8.1
 zptlint = 0.2.4
 
 [solr]
-url = https://archive.apache.org/dist/lucene/solr/8.4.0/solr-8.4.0.tgz
-md5sum = cb0baee135be316c0beb6f70244d7677
+url = https://sos-ch-dk-2.exo.io/ftw-dist/solr-8.4.0-log4j-2.17.0.tgz
+md5sum = c113831c62bd1b6f57d29952f9f5febc


### PR DESCRIPTION
Currently there's no official Solr distribution that contains the latest security fixes for Log4j. Thus we use our own for now.

For [CA-3339](https://4teamwork.atlassian.net/browse/CA-3339)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

