### PR TITLE
Introduce PropertySheetsManager role and custom permission 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -626,6 +626,7 @@ Users
 - ``self.manager``: ``admin``
 - ``self.meeting_user``: ``herbert.jager``
 - ``self.member_admin``: ``david.meier``
+- ``self.propertysheets_manager``: ``propertysheets.manager``
 - ``self.reader_user``: ``lucklicher.laser``
 - ``self.records_manager``: ``ramon.flucht``
 - ``self.regular_user``: ``kathi.barfuss``

--- a/changes/CA-2953.other
+++ b/changes/CA-2953.other
@@ -1,0 +1,1 @@
+Add PropertySheetsManager role and custom permission. [lgraf]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -15,6 +15,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- ``@config``: Add ``is_propertysheets_manager`` key to indicate whether user is allowed to manage property sheets.
 - ``@propertysheets``: Management of property sheets is now also allowed for ``PropertySheetsManager`` role.
 - ``@solrsearch``: Now supports facetting custom property fields.
 - Add new endpoint ``@external-activities`` (see :ref:`docs <external-activities>`)

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -15,6 +15,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- ``@propertysheets``: Management of property sheets is now also allowed for ``PropertySheetsManager`` role.
 - ``@solrsearch``: Now supports facetting custom property fields.
 - Add new endpoint ``@external-activities`` (see :ref:`docs <external-activities>`)
 - Include sip_delivery_status in the disposition serialization.

--- a/docs/public/dev-manual/api/config.rst
+++ b/docs/public/dev-manual/api/config.rst
@@ -99,6 +99,7 @@ GEVER-Mandanten abgefragt werden.
           "inbox_folder_url": "https://dev.onegovgever.ch/fd/eingangskorb/eingangskorb_afi",
           "is_admin": false,
           "is_inbox_user": false,
+          "is_propertysheets_manager": false,
           "is_emm_environment": false,
           "max_dossier_levels": 5,
           "max_repositoryfolder_levels": 3,

--- a/docs/public/dev-manual/api/propertysheets.rst
+++ b/docs/public/dev-manual/api/propertysheets.rst
@@ -21,9 +21,9 @@ Mittels Property Sheets ist es möglich benutzerdefinierte Schemata mit einem
 oder mehreren Feldern zu definieren damit zusätzliche Properties in GEVER
 strukturiert erfasst werden können.
 
-Im Moment ist das Definieren der zusätzlichen Property Sheets einem ``Manager``
-vorbehalten. Hierzu steht der Service-Endpoint ``@propertysheets`` zur
-Verfügung. Folgende Aufrufe sind möglich:
+Das Erstellen, Bearbeiten oder Löschen von Property Sheets über die API benötigt die Rolle ``PropertySheetsManager``. Das Auflisten / Anzeigen (GET) ist Benutzern mit Leseberechtigung erlaubt.
+
+Zur Verwaltung von Property Sheets steht der Service-Endpoint ``@propertysheets`` zur Verfügung. Folgende Aufrufe sind möglich:
 
 Eine Liste aller bestehender Property Sheets:
 
@@ -164,7 +164,7 @@ immer nur eine dieser Optionen angegeben werden
 - ``default_from_member``: Bestimmen des Defaults mittels eines Properties auf dem Member / User
 
 Optionen für dynamische Default-Werte (alle Optionen ausser ``default``)
-können nur von Benutzern mit Manager-Berechtigungen gesetzt werden.
+können aus Sicherheitsgründen nur von Benutzern mit der Rolle ``Manager`` gesetzt werden - die Rolle ``PropertySheetsManager`` reicht nicht.
 
 
 ``default``
@@ -214,7 +214,7 @@ enthält, welche dynamisch ausgewertet wird um einen Default-Wert zu bestimmen.
 Der ExpressionContext in dem die Expression ausgewertet wird, enthält die
 üblichen Namen. Allerdings sind aufgrund einer Limitierung zur Zeit der
 aktuelle Kontext und der enthaltende Folder nicht verfügbar. ``here`` und
-``object`` sind daher ``None``, und der ``folder`` ist auf das Portal gesetzt.  
+``object`` sind daher ``None``, und der ``folder`` ist auf das Portal gesetzt.
 
 **Beispiel**:
 

--- a/docs/public/dev-manual/api/schemas/opengever.workspace.workspace.inc
+++ b/docs/public/dev-manual/api/schemas/opengever.workspace.workspace.inc
@@ -4,6 +4,16 @@
 
 
 
+   .. py:attribute:: responsible
+
+       :Feldname: :field-title:`Besitzer`
+       :Datentyp: ``Choice``
+       
+       
+       
+       :Wertebereich: <Gültige ID eines Teamraum Teilnehmers>
+
+
    .. py:attribute:: videoconferencing_url
 
        :Feldname: :field-title:`Videokonferenz URL`

--- a/opengever/api/config.py
+++ b/opengever/api/config.py
@@ -9,6 +9,7 @@ from opengever.ogds.base.utils import get_current_org_unit
 from opengever.ogds.models.service import ogds_service
 from opengever.private import get_private_folder_url
 from opengever.repository.browser.primary_repository_root import PrimaryRepositoryRoot
+from plone import api
 from plone.restapi.interfaces import ISerializeToJsonSummary
 from plone.restapi.services import Service
 from zope.component import queryMultiAdapter
@@ -50,6 +51,8 @@ class ConfigGet(Service):
         ogds_inbox = get_current_org_unit().inbox()
         current_user = ogds_service().fetch_current_user()
         config['is_inbox_user'] = current_user in ogds_inbox.assigned_users()
+        config['is_propertysheets_manager'] = api.user.has_permission(
+            'opengever.propertysheets: Manage PropertySheets')
 
         try:
             primary_root = PrimaryRepositoryRoot(

--- a/opengever/api/tests/test_assigned_users.py
+++ b/opengever/api/tests/test_assigned_users.py
@@ -29,5 +29,5 @@ class TestAssignedUsers(IntegrationTestCase):
         browser.open(url, method='GET', headers=self.api_headers)
 
         self.assertEqual(5, len(browser.json.get('items')))
-        self.assertEqual(18, browser.json.get('items_total'))
+        self.assertEqual(19, browser.json.get('items_total'))
         self.assertIn('batching', browser.json)

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -246,6 +246,20 @@ class TestConfig(IntegrationTestCase):
         self.assertFalse(browser.json.get(u'is_inbox_user'))
 
     @browsing
+    def test_is_propertysheets_manager_is_true_for_users_with_manage_propertysheets_permission(self, browser):
+        self.login(self.propertysheets_manager, browser)
+        browser.open(self.config_url, headers=self.api_headers)
+        self.assertEqual(browser.status_code, 200)
+        self.assertTrue(browser.json.get(u'is_propertysheets_manager'))
+
+    @browsing
+    def test_is_propertysheets_manager_is_false_for_regular_user(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.config_url, headers=self.api_headers)
+        self.assertEqual(browser.status_code, 200)
+        self.assertFalse(browser.json.get(u'is_propertysheets_manager'))
+
+    @browsing
     def test_config_contains_bumblebee_app_id(self, browser):
         self.login(self.regular_user, browser)
         browser.open(self.config_url, headers=self.api_headers)

--- a/opengever/api/tests/test_dossier_participations.py
+++ b/opengever/api/tests/test_dossier_participations.py
@@ -741,7 +741,7 @@ class TestPossibleParticipantsGet(SolrIntegrationTestCase):
         browser.open(url, method='GET', headers=self.api_headers)
 
         self.assertEqual(5, len(browser.json.get('items')))
-        self.assertEqual(22, browser.json.get('items_total'))
+        self.assertEqual(23, browser.json.get('items_total'))
         self.assertIn('batching', browser.json)
 
 
@@ -772,7 +772,7 @@ class TestPossibleParticipantsGetWithContactFeatureEnabled(SolrIntegrationTestCa
 
         browser.open(url, method='GET', headers=self.api_headers)
         self.assertEqual(5, len(browser.json.get('items')))
-        self.assertEqual(21, browser.json.get('items_total'))
+        self.assertEqual(22, browser.json.get('items_total'))
         self.assertIn('batching', browser.json)
 
 

--- a/opengever/api/tests/test_local_roles.py
+++ b/opengever/api/tests/test_local_roles.py
@@ -19,7 +19,7 @@ class TestLocalRolesSerializer(IntegrationTestCase):
         with disabled_permission_check():
             result = serializer(search="A")
 
-        self.assertEqual(21, result['items_total'])
+        self.assertEqual(22, result['items_total'])
         self.assertEqual(3, len(result['items']))
         self.assertIn('batching', result)
 

--- a/opengever/api/tests/test_ogdsuserlisting.py
+++ b/opengever/api/tests/test_ogdsuserlisting.py
@@ -46,7 +46,7 @@ class TestOGDSUserListingGet(IntegrationTestCase):
              u'title': u'B\xf6nd James',
              u'userid': u'james.bond'}],
             browser.json.get('items')[:2])
-        self.assertEqual(19, browser.json['items_total'])
+        self.assertEqual(20, browser.json['items_total'])
 
     @browsing
     def test_last_login_is_visible_in_ogds_user_listing(self, browser):
@@ -73,7 +73,7 @@ class TestOGDSUserListingGet(IntegrationTestCase):
              u'jurgen.konig',
              u'lucklicher.laser'],
             [each['userid'] for each in browser.json['items']])
-        self.assertEqual(19, browser.json['items_total'])
+        self.assertEqual(20, browser.json['items_total'])
 
     @browsing
     def test_batch_large_offset_returns_empty_items(self, browser):
@@ -85,7 +85,7 @@ class TestOGDSUserListingGet(IntegrationTestCase):
         self.assertEqual(200, browser.status_code)
 
         self.assertEqual(0, len(browser.json['items']))
-        self.assertEqual(19, browser.json['items_total'])
+        self.assertEqual(20, browser.json['items_total'])
 
     @browsing
     def test_batch_disallows_negative_size(self, browser):
@@ -128,8 +128,8 @@ class TestOGDSUserListingGet(IntegrationTestCase):
                      view='@ogds-user-listing?filters.state:record:list=active',
                      headers=self.api_headers)
 
-        self.assertEqual(18, len(browser.json['items']))
-        self.assertEqual(18, browser.json['items_total'])
+        self.assertEqual(19, len(browser.json['items']))
+        self.assertEqual(19, browser.json['items_total'])
 
     @browsing
     def test_state_filter_active_and_inactive(self, browser):
@@ -143,8 +143,8 @@ class TestOGDSUserListingGet(IntegrationTestCase):
                           '&filters.state:record:list=active',
                      headers=self.api_headers)
 
-        self.assertEqual(19, len(browser.json['items']))
-        self.assertEqual(19, browser.json['items_total'])
+        self.assertEqual(20, len(browser.json['items']))
+        self.assertEqual(20, browser.json['items_total'])
 
     @browsing
     def test_last_login_filter(self, browser):
@@ -238,11 +238,11 @@ class TestOGDSUserListingGet(IntegrationTestCase):
                      view=u'@ogds-user-listing?sort_on=firstname',
                      headers=self.api_headers)
 
-        self.assertEqual(19, len(browser.json['items']))
+        self.assertEqual(20, len(browser.json['items']))
         self.assertEqual(
             [u'B\xe9atrice', u'C\xf6mmittee', u'David', u'Fridolin'],
             [each['firstname'] for each in browser.json['items'][:4]])
-        self.assertEqual(19, browser.json['items_total'])
+        self.assertEqual(20, browser.json['items_total'])
 
     @browsing
     def test_listing_always_has_a_secondary_sort_by_userid(self, browser):
@@ -253,8 +253,8 @@ class TestOGDSUserListingGet(IntegrationTestCase):
 
         subset = [item['userid'] for item in browser.json['items']
                   if item['department'] is None]
-        self.assertEqual(18, len(subset))
-        self.assertEqual(19, browser.json['items_total'])
+        self.assertEqual(19, len(subset))
+        self.assertEqual(20, browser.json['items_total'])
 
         expected = sorted([item.userid for item in User.query.all()
                            if item.department is None])
@@ -270,8 +270,8 @@ class TestOGDSUserListingGet(IntegrationTestCase):
 
         subset = [item['userid'] for item in browser.json['items']
                   if item['department'] is None]
-        self.assertEqual(18, len(subset))
-        self.assertEqual(19, browser.json['items_total'])
+        self.assertEqual(19, len(subset))
+        self.assertEqual(20, browser.json['items_total'])
 
         expected = sorted(
             [item.userid for item in User.query.all() if item.department is None],
@@ -285,11 +285,11 @@ class TestOGDSUserListingGet(IntegrationTestCase):
                      view=u'@ogds-user-listing?sort_order=descending',
                      headers=self.api_headers)
 
-        self.assertEqual(19, len(browser.json['items']))
+        self.assertEqual(20, len(browser.json['items']))
         self.assertEqual(
             [u'Ziegler', u'User', u'Secretary', u'Schr\xf6dinger'],
             [each['lastname'] for each in browser.json['items'][:4]])
-        self.assertEqual(19, browser.json['items_total'])
+        self.assertEqual(20, browser.json['items_total'])
 
     @browsing
     def test_handles_non_ascii_userids(self, browser):

--- a/opengever/api/tests/test_serializer.py
+++ b/opengever/api/tests/test_serializer.py
@@ -320,7 +320,6 @@ class TestGroupSerializer(IntegrationTestCase):
 
         response = browser.json
         del response.get('users')['batching']
-
         self.assertEqual(
             {u'@id': u'http://nohost/plone/@groups/fa_users',
              u'@type': u'virtual.plone.group',
@@ -335,7 +334,7 @@ class TestGroupSerializer(IntegrationTestCase):
                                     u'@type': u'virtual.plone.user',
                                     u'title': u'User Service (service.user)',
                                     u'token': u'service.user'}],
-                        u'items_total': 17}},
+                        u'items_total': 18}},
             response)
 
 

--- a/opengever/api/tests/test_users.py
+++ b/opengever/api/tests/test_users.py
@@ -14,14 +14,16 @@ class TestUsersGet(IntegrationTestCase):
         browser.open('{}/@users'.format(self.portal.absolute_url()),
                      headers=self.api_headers)
 
-        self.assertEquals(19, len(browser.json))
+        self.assertEqual(20, len(browser.json))
 
     @browsing
     def test_enumarating_users_unauthorized_raises(self, browser):
         with browser.expect_http_error(code=401, reason='Unauthorized'):
             browser.open('{}/@users'.format(self.portal.absolute_url()),
                          headers=self.api_headers)
-            self.assertEquals(19, len(browser.json))
+        self.assertEqual(
+            {u'message': u'Unauthorized()', u'type': u'Unauthorized'},
+            browser.json)
 
     @browsing
     def test_accessing_an_other_user_is_possible_for_regular_user(self, browser):

--- a/opengever/api/tests/test_watchers.py
+++ b/opengever/api/tests/test_watchers.py
@@ -776,5 +776,5 @@ class TestPossibleWatchers(IntegrationTestCase):
         browser.open(url, method='GET', headers=self.api_headers)
 
         self.assertEqual(5, len(browser.json.get('items')))
-        self.assertEqual(16, browser.json.get('items_total'))
+        self.assertEqual(17, browser.json.get('items_total'))
         self.assertIn('batching', browser.json)

--- a/opengever/base/monkey/patches/readonly.py
+++ b/opengever/base/monkey/patches/readonly.py
@@ -124,10 +124,11 @@ class PatchMembershipToolCreateMemberarea(MonkeyPatch):
 WRITER_ROLES = [
     'Contributor',
     'Editor',
-    'Reviewer',
+    'PropertySheetsManager',
     'Publisher',
-    'WorkspacesCreator',
+    'Reviewer',
     'Role Manager',
+    'WorkspacesCreator',
 ]
 
 
@@ -213,6 +214,7 @@ WRITE_PERMISSIONS = [
     'opengever.private: Add private dossier',
     'opengever.private: Add private folder',
     'opengever.private: Add private root',
+    'opengever.propertysheets: Manage PropertySheets',
     'opengever.repository: Add repositoryfolder',
     'opengever.repository: Add repositoryroot',
     'opengever.task: Add task',

--- a/opengever/core/lawgiver.zcml
+++ b/opengever/core/lawgiver.zcml
@@ -227,6 +227,7 @@
                    opengever.meeting: Add Meeting Template,
                    opengever.meeting: Add Paragraph Template,
                    opengever.meeting: Add Proposal Comment,
+                   opengever.propertysheets: Manage PropertySheets,
                    opengever.repository: Export repository,
                    opengever.sharing: List Protected Objects,
                    opengever.webactions: Manage own WebActions,

--- a/opengever/core/profiles/default/rolemap.xml
+++ b/opengever/core/profiles/default/rolemap.xml
@@ -9,6 +9,7 @@
     <role name="DossierManager" />
     <role name="Impersonator" />
     <role name="MeetingUser" />
+    <role name="PropertySheetsManager" />
     <role name="Publisher" />
     <role name="Records Manager" />
     <role name="Role Manager" />
@@ -228,6 +229,13 @@
     <permission name="opengever.private: Add private folder" acquire="True">
       <role name="Manager" />
     </permission>
+
+    <!-- PROPERTYSHEETS -->
+    <permission name="opengever.propertysheets: Manage PropertySheets" acquire="False">
+      <role name="Manager" />
+      <role name="PropertySheetsManager" />
+    </permission>
+
 
     <!-- REPOSITORY -->
     <permission name="opengever.repository: Add repositoryfolder" acquire="True">

--- a/opengever/core/upgrades/20211220121109_add_property_sheets_manager_role/rolemap.xml
+++ b/opengever/core/upgrades/20211220121109_add_property_sheets_manager_role/rolemap.xml
@@ -1,0 +1,14 @@
+<rolemap>
+
+  <roles>
+    <role name="PropertySheetsManager" />
+  </roles>
+
+  <permissions>
+    <permission name="opengever.propertysheets: Manage PropertySheets" acquire="False">
+      <role name="Manager" />
+      <role name="PropertySheetsManager" />
+    </permission>
+  </permissions>
+
+</rolemap>

--- a/opengever/core/upgrades/20211220121109_add_property_sheets_manager_role/upgrade.py
+++ b/opengever/core/upgrades/20211220121109_add_property_sheets_manager_role/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddPropertySheetsManagerRole(UpgradeStep):
+    """Add PropertySheetsManager role.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/propertysheets/api/configure.zcml
+++ b/opengever/propertysheets/api/configure.zcml
@@ -23,7 +23,7 @@
       factory=".post.PropertySheetsPost"
       name="@propertysheets"
       layer="opengever.base.interfaces.IOpengeverBaseLayer"
-      permission="cmf.ManagePortal"
+      permission="opengever.propertysheets.ManagePropertySheets"
       />
 
   <plone:service
@@ -32,7 +32,7 @@
       factory=".delete.PropertySheetsDelete"
       name="@propertysheets"
       layer="opengever.base.interfaces.IOpengeverBaseLayer"
-      permission="cmf.ManagePortal"
+      permission="opengever.propertysheets.ManagePropertySheets"
       />
 
 </configure>

--- a/opengever/propertysheets/configure.zcml
+++ b/opengever/propertysheets/configure.zcml
@@ -7,6 +7,7 @@
     xmlns:z3c="http://namespaces.zope.org/z3c"
     i18n_domain="opengever.propertysheets">
 
+  <include file="permissions.zcml" />
   <i18n:registerTranslations directory="locales" />
 
   <include package=".api" />

--- a/opengever/propertysheets/permissions.zcml
+++ b/opengever/propertysheets/permissions.zcml
@@ -1,0 +1,7 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    i18n_domain="opengever.propertysheets">
+
+  <permission id="opengever.propertysheets.ManagePropertySheets" title="opengever.propertysheets: Manage PropertySheets" />
+
+</configure>

--- a/opengever/propertysheets/tests/test_schema_definition_post.py
+++ b/opengever/propertysheets/tests/test_schema_definition_post.py
@@ -21,7 +21,7 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
 
     @browsing
     def test_property_sheet_schema_definition_post_defaults(self, browser):
-        self.login(self.manager, browser)
+        self.login(self.propertysheets_manager, browser)
 
         data = {"fields": [{"name": "foo", "field_type": "text"}]}
         browser.open(
@@ -48,7 +48,7 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
 
     @browsing
     def test_property_sheet_schema_definition_post(self, browser):
-        self.login(self.manager, browser)
+        self.login(self.propertysheets_manager, browser)
 
         data = {
             "fields": [
@@ -117,7 +117,7 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
 
     @browsing
     def test_property_sheet_schema_definition_post_supports_all_field_types(self, browser):
-        self.login(self.manager, browser)
+        self.login(self.propertysheets_manager, browser)
 
         data = {
             "fields": [
@@ -175,7 +175,7 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
 
     @browsing
     def test_property_sheet_schema_definition_post_supports_setting_static_defaults(self, browser):
-        self.login(self.manager, browser)
+        self.login(self.propertysheets_manager, browser)
 
         data = {
             "fields": [
@@ -241,6 +241,7 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
 
     @browsing
     def test_property_sheet_schema_definition_post_supports_setting_default_factories(self, browser):
+        # PropertySheetsManager is not allowed to modify dynamic defaults
         self.login(self.manager, browser)
 
         data = {
@@ -324,6 +325,7 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
 
     @browsing
     def test_property_sheet_schema_definition_post_supports_setting_default_expressions(self, browser):
+        # PropertySheetsManager is not allowed to modify dynamic defaults
         self.login(self.manager, browser)
 
         data = {
@@ -454,6 +456,7 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
             "assignments": ["IDocumentMetadata.document_type.question"],
         }
 
+        # PropertySheetsManager is not allowed to modify dynamic defaults
         self.login(self.manager, browser)
         browser.open(
             view="@propertysheets/meinschema",
@@ -489,7 +492,7 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
 
     @browsing
     def test_property_sheet_schema_definition_post_reject_invalid_choices(self, browser):
-        self.login(self.manager, browser)
+        self.login(self.propertysheets_manager, browser)
 
         data = {
             "fields": [
@@ -523,7 +526,7 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
 
     @browsing
     def test_property_sheet_schema_definition_post_replaces_existing_schema(self, browser):
-        self.login(self.manager, browser)
+        self.login(self.propertysheets_manager, browser)
         create(Builder("property_sheet_schema").named("question"))
 
         data = {
@@ -555,7 +558,7 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
     def test_property_sheet_schema_definition_post_requires_valid_assignment(
         self, browser
     ):
-        self.login(self.manager, browser)
+        self.login(self.propertysheets_manager, browser)
 
         data = {
             "fields": [{"name": "foo", "field_type": "bool"}],
@@ -584,7 +587,7 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
     def test_property_sheet_schema_definition_post_requires_unique_assignment(
         self, browser
     ):
-        self.login(self.manager, browser)
+        self.login(self.propertysheets_manager, browser)
         create(
             Builder("property_sheet_schema")
             .named("fixture")
@@ -618,7 +621,7 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
     def test_property_sheet_schema_definition_post_requires_name(
         self, browser
     ):
-        self.login(self.manager, browser)
+        self.login(self.propertysheets_manager, browser)
 
         data = {"fields": [{"name": "foo", "field_type": "bool"}]}
         with browser.expect_http_error(400):
@@ -644,7 +647,7 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
     def test_property_sheet_schema_definition_post_requires_valid_name(
         self, browser
     ):
-        self.login(self.manager, browser)
+        self.login(self.propertysheets_manager, browser)
 
         data = {"fields": [{"name": "foo", "field_type": "bool"}]}
         with browser.expect_http_error(400):
@@ -670,7 +673,7 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
     def test_property_sheet_schema_definition_post_requires_fields(
         self, browser
     ):
-        self.login(self.manager, browser)
+        self.login(self.propertysheets_manager, browser)
 
         data = {"fields": []}
         with browser.expect_http_error(400):
@@ -696,7 +699,7 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
     def test_property_sheet_schema_definition_post_requires_valid_fields_type(
         self, browser
     ):
-        self.login(self.manager, browser)
+        self.login(self.propertysheets_manager, browser)
 
         data = {"fields": {"foo": None}}
         with browser.expect_http_error(400):
@@ -722,7 +725,7 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
     def test_property_sheet_schema_definition_post_prevents_duplicate_field_name(
         self, browser
     ):
-        self.login(self.manager, browser)
+        self.login(self.propertysheets_manager, browser)
 
         dupe1 = {"name": "dupe", "field_type": "text"}
         dupe2 = {"name": "foo", "field_type": "text"}
@@ -748,7 +751,7 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
 
     @browsing
     def test_property_sheet_schema_definition_post_invalid_type(self, browser):
-        self.login(self.manager, browser)
+        self.login(self.propertysheets_manager, browser)
 
         data = {"fields": [{"name": "foo", "field_type": "invalid"}]}
         with browser.expect_http_error(400):
@@ -768,7 +771,7 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
         self.assertEqual(3, len(storage))
 
     @browsing
-    def test_non_managers_cannot_post(self, browser):
+    def test_non_propertysheets_managers_cannot_post(self, browser):
         self.login(self.administrator, browser)
 
         data = {"fields": [{"name": "foo", "field_type": "text"}]}
@@ -782,12 +785,7 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
 
     @browsing
     def test_dynamic_defaults_require_manager_role(self, browser):
-        """This test would not *currently* fail if the protection for dynamic
-        defaults wasn't in place, because the entire @propertysheets POST
-        endpoint is restricted to managers anyway. It *would* however fail if
-        that API endpoint was ever opened up (tested manually).
-        """
-        self.login(self.regular_user, browser)
+        self.login(self.propertysheets_manager, browser)
 
         with browser.expect_unauthorized():
             browser.open(

--- a/opengever/sharing/tests/test_sharing.py
+++ b/opengever/sharing/tests/test_sharing.py
@@ -391,7 +391,7 @@ class TestOpengeverSharing(IntegrationTestCase):
                      method='Get', headers={'Accept': 'application/json'})
 
         result = browser.json
-        self.assertEqual(19, result['items_total'])
+        self.assertEqual(20, result['items_total'])
         self.assertEqual(3, len(result['items']))
         self.assertIn('batching', result)
 

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -384,6 +384,13 @@ class OpengeverContentFixture(object):
             user_settings={'_seen_tours': '["*"]'},
         )
 
+        self.propertysheets_manager = self.create_user(
+            'propertysheets_manager',
+            u'PropertySheets',
+            u'Manager',
+            ['PropertySheetsManager'],
+        )
+
         # This user is intended to be used in situations where you need a user
         # which has only the 'Reader' role on some context and one has to build
         # the granting of that themselves


### PR DESCRIPTION
This introduces a new permission `opengever.propertysheets: Manage PropertySheets` that is used to protect `POST` and `DELETE` to the `@propertysheets` endpoint. This permission is assigned to the `Manager` and a new `PropertySheetsManager` role.

Therefore, the `PropertySheetsManager` role can be assigned to a group of users that should be able to manage propertysheets (setting dynamic defaults is still only allowed for the `Manager` role though).

The `@config` endpoint also includes a new key `is_propertysheets_manager` to indicate whether the user is allowed to manage property sheets _(and the respective functionality should be displayed in the frontend)_.

For [CA-2953](https://4teamwork.atlassian.net/browse/CA-2953)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry

