### PR TITLE
Add dossier type index

### DIFF
--- a/changes/CA-2791-2.feature
+++ b/changes/CA-2791-2.feature
@@ -1,0 +1,1 @@
+-  Allow 'dossier_type' in the '@listing' endpoint [elioschmutz]

--- a/changes/CA-2791.feature
+++ b/changes/CA-2791.feature
@@ -1,0 +1,1 @@
+-  Add 'dossier_type' index to solr [elioschmutz]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -15,6 +15,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- ``@solrsearch`` and ``@listing``: ``dossier_type`` is added as a new solr index and whitelisted in the ``@listing`` endpoint.
 - Propertysheets: ``date`` fields are now supported.
 - ``@listing-custom-fields`` endpoint contains now also the widget information.
 - ``@solrsearch``: The results can now be filtered by its ``@id``.

--- a/docs/public/dev-manual/api/listings.rst
+++ b/docs/public/dev-manual/api/listings.rst
@@ -87,6 +87,7 @@ werden. Folgende Felder stehen zur Verfügung:
 - ``document_author``: Dokumentauthor
 - ``document_date``: Dokumentdatum
 - ``document_type``: Dokumenttyp
+- ``dossier_type``: Dossiertyp
 - ``email``: E-Mail Adresse
 - ``end``: Enddatum des Dossiers
 - ``external_reference``: Externe Referenz für Dossiers oder Fremdzeichen für Dokumente
@@ -178,6 +179,8 @@ siehe Tabelle:
     |``document_date``         |    ja    |   nein  |     nein     |        nein        |  nein   |  nein   |  nein   |   nein   |       nein      |       nein       |       nein      |   nein   |       nein       |      nein      |   nein   |
     +--------------------------+----------+---------+--------------+--------------------+---------+---------+---------+----------+-----------------+------------------+-----------------+----------+------------------+----------------+----------+
     |``document_type``         |    ja    |   nein  |     nein     |        nein        |  nein   |  nein   |  nein   |   nein   |       nein      |       nein       |       nein      |   nein   |       nein       |      nein      |   nein   |
+    +--------------------------+----------+---------+--------------+--------------------+---------+---------+---------+----------+-----------------+------------------+-----------------+----------+------------------+----------------+----------+
+    |``dossier_type``          |    nein  |   ja    |     nein     |        nein        |  nein   |  nein   |  nein   |   nein   |       nein      |       nein       |       ja        |   nein   |       nein       |      nein      |   nein   |
     +--------------------------+----------+---------+--------------+--------------------+---------+---------+---------+----------+-----------------+------------------+-----------------+----------+------------------+----------------+----------+
     |``end``                   |   nein   |    ja   |     nein     |        nein        |  nein   |  nein   |  nein   |   nein   |       nein      |       nein       |       nein      |    ja    |       nein       |      nein      |   nein   |
     +--------------------------+----------+---------+--------------+--------------------+---------+---------+---------+----------+-----------------+------------------+-----------------+----------+------------------+----------------+----------+

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -26,6 +26,7 @@ OTHER_ALLOWED_FIELDS = set([
     'document_author',
     'document_date',
     'document_type',
+    'dossier_type',
     'email',
     'end',
     'external_reference',

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -65,6 +65,19 @@ def translate_document_type(document_type):
         return term.title
 
 
+def translate_dossier_type(dossier_type):
+    portal = getSite()
+    voc = wrap_vocabulary(
+        'opengever.dossier.dossier_types',
+        hidden_terms_from_registry='opengever.dossier.interfaces.IDossierType.hidden_dossier_types')(portal)
+    try:
+        term = voc.getTerm(dossier_type)
+    except LookupError:
+        return dossier_type
+    else:
+        return term.title
+
+
 def translate_sequence_type(sequence_type):
     return translate(sequence_type_vocabulary.getTerm(sequence_type).title,
                      context=getRequest(),
@@ -331,6 +344,7 @@ FIELDS_WITH_MAPPING = [
     ListingField('creator_fullname', 'Creator', 'creator_fullname'),
     ListingField('description', 'Description'),
     ListingField('document_type', 'document_type', transform=translate_document_type),
+    ListingField('dossier_type', 'dossier_type', transform=translate_dossier_type),
     ListingField('filename', 'filename', filename),
     ListingField('filesize', 'filesize', filesize),
     ListingField('issuer', 'issuer', transform=display_name),

--- a/opengever/core/upgrades/20211221135724_add_dossier_type_index/upgrade.py
+++ b/opengever/core/upgrades/20211221135724_add_dossier_type_index/upgrade.py
@@ -1,0 +1,24 @@
+from ftw.upgrade import UpgradeStep
+from opengever.core.upgrade import NightlyIndexer
+from opengever.dossier.behaviors.dossier import IDossierMarker
+from opengever.dossier.dossiertemplate.behaviors import IDossierTemplateMarker
+
+
+class AddDossierTypeIndex(UpgradeStep):
+    """Add dossier type index.
+    """
+
+    deferrable = True
+
+    def __call__(self):
+        self.install_upgrade_profile()
+
+        query = {'object_provides': [
+            IDossierMarker.__identifier__,
+            IDossierTemplateMarker.__identifier__,
+        ]}
+
+        with NightlyIndexer(idxs=["dossier_type"],
+                            index_in_solr_only=True) as indexer:
+            for obj in self.objects(query, 'Index dossier_type in Solr'):
+                indexer.add_by_obj(obj)

--- a/opengever/dossier/configure.zcml
+++ b/opengever/dossier/configure.zcml
@@ -188,6 +188,11 @@
       name="participations"
       />
 
+  <adapter
+      factory=".indexers.dossier_type"
+      name="dossier_type"
+      />
+
   <subscriber
       for="plone.dexterity.interfaces.IDexterityContent
            zope.lifecycleevent.interfaces.IObjectModifiedEvent"

--- a/opengever/dossier/dossiertemplate/configure.zcml
+++ b/opengever/dossier/dossiertemplate/configure.zcml
@@ -14,6 +14,11 @@
       />
 
   <adapter
+      factory=".indexers.dossier_type"
+      name="dossier_type"
+      />
+
+  <adapter
       factory=".indexers.DossierTemplateSearchableTextExtender"
       name="IDossierTemplate"
       />

--- a/opengever/dossier/dossiertemplate/indexers.py
+++ b/opengever/dossier/dossiertemplate/indexers.py
@@ -14,6 +14,11 @@ def DossierTemplateSubjectIndexer(obj):
     return aobj.keywords
 
 
+@indexer(IDossierTemplateMarker)
+def dossier_type(obj):
+    return IDossierTemplate(obj).dossier_type
+
+
 @implementer(dexteritytextindexer.IDynamicTextIndexExtender)
 @adapter(IDossierTemplateMarker)
 class DossierTemplateSearchableTextExtender(object):

--- a/opengever/dossier/indexers.py
+++ b/opengever/dossier/indexers.py
@@ -108,6 +108,11 @@ def has_sametype_children(obj):
     return False
 
 
+@indexer(IDossierMarker)
+def dossier_type(obj):
+    return IDossier(obj).dossier_type
+
+
 TYPES_WITH_CONTAINING_DOSSIER_INDEX = set(('opengever.dossier.businesscasedossier',
                                            'opengever.meeting.proposal',
                                            'opengever.workspace.folder',

--- a/opengever/dossier/tests/test_indexer.py
+++ b/opengever/dossier/tests/test_indexer.py
@@ -6,6 +6,7 @@ from opengever.dossier.behaviors.customproperties import IDossierCustomPropertie
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.behaviors.filing import IFilingNumber
 from opengever.dossier.behaviors.participation import IParticipationAware
+from opengever.dossier.dossiertemplate.behaviors import IDossierTemplate
 from opengever.dossier.indexers import ParticipationIndexHelper
 from opengever.dossier.interfaces import IDossierArchiver
 from opengever.kub.testing import KuBIntegrationTestCase
@@ -283,6 +284,34 @@ class TestDossierIndexers(SolrIntegrationTestCase):
         notify(LocalRolesAcquisitionBlocked(self.dossier, ))
 
         self.assert_index_value(True, 'blocked_local_roles', self.dossier)
+
+    def test_dossier_type_indexer(self):
+        self.login(self.regular_user)
+
+        IDossier(self.dossier).dossier_type = None
+        self.dossier.reindexObject()
+        self.commit_solr()
+
+        self.assertEqual(solr_data_for(self.dossier, 'dossier_type'), None)
+
+        IDossier(self.dossier).dossier_type = "businesscase"
+        self.dossier.reindexObject()
+        self.commit_solr()
+        self.assertEqual(solr_data_for(self.dossier, 'dossier_type'), "businesscase")
+
+    def test_dossiertemplate_dossier_type_indexer(self):
+        self.login(self.regular_user)
+
+        IDossierTemplate(self.dossiertemplate).dossier_type = None
+        self.dossiertemplate.reindexObject()
+        self.commit_solr()
+
+        self.assertEqual(solr_data_for(self.dossiertemplate, 'dossier_type'), None)
+
+        IDossierTemplate(self.dossiertemplate).dossier_type = "businesscase"
+        self.dossiertemplate.reindexObject()
+        self.commit_solr()
+        self.assertEqual(solr_data_for(self.dossiertemplate, 'dossier_type'), "businesscase")
 
 
 class TestDossierFilingNumberIndexer(SolrIntegrationTestCase):

--- a/solr-conf/managed-schema
+++ b/solr-conf/managed-schema
@@ -143,6 +143,7 @@
     <field name="document_date" type="pdate" indexed="true" stored="false" />
     <field name="document_type" type="string" indexed="true" stored="false" />
     <field name="dossier_review_state" type="string" indexed="true" stored="false" />
+    <field name="dossier_type" type="string" indexed="true" stored="false" />
     <field name="touched" type="pdate" indexed="true" stored="false" />
     <field name="email" type="string" indexed="true" stored="false" />
     <field name="email2" type="string" indexed="true" stored="false" />


### PR DESCRIPTION
This PR adds a new solr index `dossier_type` according to the `document_type` index.

The `dossier_type` is also added as a `ListingFiled` for the `@listing` endpoint.

For [CA-2791]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-2791]: https://4teamwork.atlassian.net/browse/CA-2791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ