### PR TITLE
Add new customfield type date.

### DIFF
--- a/changes/CA-2794.feature
+++ b/changes/CA-2794.feature
@@ -1,0 +1,1 @@
+Add new customfield type date.

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -15,6 +15,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- Propertysheets: ``date`` fields are now supported.
 - ``@listing-custom-fields`` endpoint contains now also the widget information.
 - ``@solrsearch``: The results can now be filtered by its ``@id``.
 - ``@solrsearch``: Allow POST requests against the endpoint. This allows us to get around the length-limit of GET requests.

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -15,6 +15,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- ``@listing-custom-fields`` endpoint contains now also the widget information.
 - ``@solrsearch``: The results can now be filtered by its ``@id``.
 - ``@solrsearch``: Allow POST requests against the endpoint. This allows us to get around the length-limit of GET requests.
 - ``@config``: Add ``is_propertysheets_manager`` key to indicate whether user is allowed to manage property sheets.

--- a/docs/public/dev-manual/api/listings.rst
+++ b/docs/public/dev-manual/api/listings.rst
@@ -280,22 +280,32 @@ Endpoints verwendet werden.
                 "buul_custom_field_boolean": {
                     "name": "buul_custom_field_boolean",
                     "title": "J/N",
-                    "type": "boolean"
+                    "type": "boolean",
+                    "widget": null
                 },
                 "choice_custom_field_string": {
                     "name": "choice_custom_field_string",
                     "title": "Auswahl",
-                    "type": "string"
+                    "type": "string",
+                    "widget": null
                 },
                 "num_custom_field_int": {
                     "name": "num_custom_field_int",
                     "title": "Zahl",
-                    "type": "integer"
+                    "type": "integer",
+                    "widget": null
                 },
                 "textline_custom_field_string": {
                     "name": "textline_custom_field_string",
                     "title": "Zeile Text",
-                    "type": "string"
+                    "type": "string",
+                    "widget": null
+                },
+                "date_custom_field_date": {
+                    "name": "date_custom_field_date",
+                    "title": "Datum",
+                    "type": "string",
+                    "widget": "date"
                 }
             }
         }

--- a/docs/public/dev-manual/api/propertysheets.rst
+++ b/docs/public/dev-manual/api/propertysheets.rst
@@ -72,6 +72,7 @@ Einzelne Felder werden in folgendem Format erwartet:
 
   - ``bool``
   - ``choice``
+  - ``date``
   - ``multiple_choice``
   - ``int``
   - ``text``

--- a/opengever/api/tests/test_listing_custom_fields.py
+++ b/opengever/api/tests/test_listing_custom_fields.py
@@ -30,31 +30,43 @@ class TestListingCustomFieldsGet(IntegrationTestCase):
                         u"choose_custom_field_string": {
                             u"name": u"choose_custom_field_string",
                             u"title": u"Choose",
+                            u'widget': None,
                             u"type": u"string"
                         },
                         u'choosemulti_custom_field_strings': {
                             u'name': u'choosemulti_custom_field_strings',
                             u'title': u'Choose multi',
+                            u'widget': None,
                             u'type': u'array'
                         },
                         u"f1_custom_field_string": {
                             u"name": u"f1_custom_field_string",
                             u"title": u"Field 1",
+                            u'widget': None,
                             u"type": u"string"
+                        },
+                        u'date_custom_field_date': {
+                            u'name': u'date_custom_field_date',
+                            u'title': u'Choose a date',
+                            u'widget': u'date',
+                            u'type': u'string'
                         },
                         u"num_custom_field_int": {
                             u"name": u"num_custom_field_int",
                             u"title": u"Number",
+                            u'widget': None,
                             u"type": u"integer"
                         },
                         u"textline_custom_field_string": {
                             u"name": u"textline_custom_field_string",
                             u"title": u"A line of text",
+                            u'widget': None,
                             u"type": u"string"
                         },
                         u"yesorno_custom_field_boolean": {
                             u"name": u"yesorno_custom_field_boolean",
                             u"title": u"Yes or no",
+                            u'widget': None,
                             u"type": u"boolean"
                         }
                     }
@@ -64,11 +76,13 @@ class TestListingCustomFieldsGet(IntegrationTestCase):
                         u"additional_title_custom_field_string": {
                             u"name": u"additional_title_custom_field_string",
                             u"title": u"Additional dossier title",
+                            u'widget': None,
                             u"type": u"string"
                         },
                         u'location_custom_field_string': {
                             u'name': u'location_custom_field_string',
                             u'title': u'Location',
+                            u'widget': None,
                             u'type': u'string'
                         },
                     }
@@ -106,7 +120,8 @@ class TestListingCustomFieldsGet(IntegrationTestCase):
                         u"yesorno_custom_field_boolean": {
                             u"name": u"yesorno_custom_field_boolean",
                             u"title": u"Y/N (regulations)",
-                            u"type": u"boolean"
+                            u"type": u"boolean",
+                            u"widget": None
                         }
                     }
                 }

--- a/opengever/document/tests/test_indexers.py
+++ b/opengever/document/tests/test_indexers.py
@@ -1,3 +1,4 @@
+from datetime import date
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.solr.interfaces import ISolrSearch
@@ -263,6 +264,7 @@ class TestDocumentIndexers(FunctionalTestCase):
             .with_field("int", u"num", u"Number", u"", True)
             .with_field("text", u"text", u"Some lines of text", u"", True)
             .with_field("textline", u"textline", u"A line of text", u"", True)
+            .with_field("date", u"date", u"Date", u"", True)
         )
         doc = create(Builder("document").having(document_type=u"question"))
         IDocumentCustomProperties(doc).custom_properties = {
@@ -273,6 +275,7 @@ class TestDocumentIndexers(FunctionalTestCase):
                 "num": 122333,
                 "text": u"K\xe4fer\nJ\xe4ger",
                 "textline": u"Kr\xe4he",
+                "date": date(2021, 12, 21)
             },
         }
         indexed_value = metadata(doc)().decode('utf8')
@@ -283,6 +286,7 @@ class TestDocumentIndexers(FunctionalTestCase):
         self.assertIn(u"Kr\xe4he", indexed_value)
         self.assertIn(u"rot", indexed_value)
         self.assertIn(u"blau", indexed_value)
+        self.assertIn(u"2021-12-21", indexed_value)
 
 
 class SolrDocumentIndexer(SolrIntegrationTestCase):

--- a/opengever/propertysheets/annotation.py
+++ b/opengever/propertysheets/annotation.py
@@ -46,6 +46,9 @@ class CustomPropertiesStorageImpl(AnnotationsFactoryImpl):
             super(CustomPropertiesStorageImpl, self).__getattr__(name)
         )
 
+    def get_plain_values(self, name):
+        return super(CustomPropertiesStorageImpl, self).__getattr__(name)
+
     def __setattr__(self, name, value):
         if name not in self.__dict__['schema']:
             super(CustomPropertiesStorageImpl, self).__setattr__(name, value)

--- a/opengever/propertysheets/definition.py
+++ b/opengever/propertysheets/definition.py
@@ -22,6 +22,7 @@ from zope.dottedname.resolve import resolve
 from zope.globalrequest import getRequest
 from zope.schema import Bool
 from zope.schema import Choice
+from zope.schema import Date
 from zope.schema import getFieldNamesInOrder
 from zope.schema import getFieldsInOrder
 from zope.schema import Int
@@ -49,7 +50,8 @@ class SolrDynamicField(object):
         Int: 'int',
         TextLine: 'string',
         # We currently only support multiple_choice for string values
-        Set: 'strings'
+        Set: 'strings',
+        Date: 'date'
     }
     DYNAMIC_FIELD_IDENT = '_custom_field_'
 
@@ -96,6 +98,7 @@ class PropertySheetSchemaDefinition(object):
     FACTORIES = {
         'bool': fields.BoolFactory,
         'choice': fields.ChoiceFactory,
+        'date': fields.DateFactory,
         'multiple_choice': fields.MultiChoiceFactory,
         'int': fields.IntFactory,
         'text': fields.TextFactory,

--- a/opengever/propertysheets/definition.py
+++ b/opengever/propertysheets/definition.py
@@ -84,6 +84,7 @@ class SolrDynamicField(object):
             'title': schema['title'],
             'name': self.solr_field_name,
             'type': schema['type'],
+            'widget': schema.get('widget'),
         }
 
 

--- a/opengever/propertysheets/solr.py
+++ b/opengever/propertysheets/solr.py
@@ -24,7 +24,7 @@ class CustomPropertiesIndexHandler(DefaultIndexHandler):
         if not adapted:
             return data
 
-        custom_properties = adapted.custom_properties
+        custom_properties = adapted.get_plain_values('custom_properties')
         if not custom_properties:
             return data
 
@@ -41,9 +41,8 @@ class CustomPropertiesIndexHandler(DefaultIndexHandler):
             for solr_field in definition.get_solr_dynamic_fields():
                 name = solr_field.name
                 if name in custom_properties[slot]:
-                    value = custom_properties[slot][name]
+                    value = solr_field.convert_value(custom_properties[slot][name])
                     data[solr_field.solr_field_name] = value
-
         return data
 
 

--- a/opengever/propertysheets/tests/test_definition.py
+++ b/opengever/propertysheets/tests/test_definition.py
@@ -120,6 +120,7 @@ class TestSchemaDefinitionSolrFields(FunctionalTestCase):
                     'name': 'yesorno_custom_field_boolean',
                     'title': u'y/n',
                     'type': u'boolean',
+                    'widget': None
                 }
             },
             definition.get_solr_dynamic_field_schema()
@@ -138,6 +139,7 @@ class TestSchemaDefinitionSolrFields(FunctionalTestCase):
                     'name': 'chooseone_custom_field_string',
                     'title': u'choose',
                     'type': u'string',
+                    'widget': None
                 }
             },
             definition.get_solr_dynamic_field_schema()
@@ -155,6 +157,7 @@ class TestSchemaDefinitionSolrFields(FunctionalTestCase):
                     'name': 'num_custom_field_int',
                     'title': u'A number',
                     'type': u'integer',
+                    'widget': None
                 }
             },
             definition.get_solr_dynamic_field_schema()
@@ -180,6 +183,23 @@ class TestSchemaDefinitionSolrFields(FunctionalTestCase):
                     'name': 'bla_custom_field_string',
                     'title': u'Textline',
                     'type': u'string',
+                    'widget': None
+                }
+            },
+            definition.get_solr_dynamic_field_schema()
+        )
+
+    def test_date_field_solr_dynamic_field_info(self):
+        definition = PropertySheetSchemaDefinition.create("foo")
+        definition.add_field("date", u"bla", u"Date field", u"", True)
+
+        self.assertEqual(
+            {
+                'bla_custom_field_date': {
+                    'name': 'bla_custom_field_date',
+                    'title': u'Date field',
+                    'type': u'string',
+                    'widget': u'date',
                 }
             },
             definition.get_solr_dynamic_field_schema()

--- a/opengever/propertysheets/tests/test_solr.py
+++ b/opengever/propertysheets/tests/test_solr.py
@@ -1,3 +1,4 @@
+from datetime import date
 from ftw.builder import Builder
 from ftw.builder import create
 from opengever.document.behaviors.customproperties import IDocumentCustomProperties
@@ -46,6 +47,7 @@ class TestCustomPropertiesIndexHandler(SolrIntegrationTestCase):
                 "num": 122333,
                 "text": u"K\xe4fer\nJ\xe4ger",
                 "textline": u"Kr\xe4he",
+                "date": date(2021, 12, 21),
             }
         }
         self.document.reindexObject()
@@ -63,6 +65,8 @@ class TestCustomPropertiesIndexHandler(SolrIntegrationTestCase):
         self.assertNotIn(u'text_custom_field_string', solr_doc)
         self.assertEqual(
             solr_doc.get(u'textline_custom_field_string'), u"Kr\xe4he")
+        self.assertEqual(
+            solr_doc.get(u'date_custom_field_date'), u'2021-12-21T00:00:00Z')
 
     def test_index_custom_properties_of_dossiers(self):
         self.login(self.manager)

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -516,6 +516,7 @@ class OpengeverContentFixture(object):
             .with_field("int", u"num", u"Number", u"", True)
             .with_field("text", u"text", u"Some lines of text", u"", True)
             .with_field("textline", u"textline", u"A line of text", u"", True)
+            .with_field("date", u"date", u"Choose a date", u"", True)
         )
         create(
             Builder("property_sheet_schema")

--- a/solr-conf/managed-schema
+++ b/solr-conf/managed-schema
@@ -189,6 +189,7 @@
     <dynamicField name="*_custom_field_int" type="pint" indexed="true" stored="false"/>
     <dynamicField name="*_custom_field_boolean" type="boolean" indexed="true" stored="false"/>
     <dynamicField name="*_custom_field_strings" type="string" indexed="true" stored="false" multiValued="true"/>
+    <dynamicField name="*_custom_field_date" type="pdate" indexed="true" stored="false"/>
 
     <dynamicField name="ignored_*" type="ignored"/>
 


### PR DESCRIPTION
Two general adjustments were necessary for correct display and indexing:
 - The `@listing-custom-fields` endpoint contains now also the widget information
 - Don't use `json_compatible` and ftw.solr `to_iso8601` instead when passing in date values to the solr index handler 

For [CA-2794]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [x] api-change label added
    - (not necessary IMHO) #delivery channel notified about breaking change
    - _(not necessary IMHO)_ Scrum master is informed 

[CA-2794]: https://4teamwork.atlassian.net/browse/CA-2794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ