### PR TITLE
Expose document_type_label column in @listing endpoint

### DIFF
--- a/changes/CA-2792.feature
+++ b/changes/CA-2792.feature
@@ -1,0 +1,1 @@
+Expose document_type_label column in @listing endpoint. [tinagerber]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -34,6 +34,7 @@ Other Changes
 - Include is_absent in actors serialization.
 - A new endpoint ``@substitutions`` is added (see :ref:`get-substitutions`).
 - Include email address in workspace and workspace folder serialization.
+- ``@listing``: Add document_type_label column.
 
 
 2021.24.0 (2021-11-30)

--- a/docs/public/dev-manual/api/listings.rst
+++ b/docs/public/dev-manual/api/listings.rst
@@ -87,6 +87,7 @@ werden. Folgende Felder stehen zur Verfügung:
 - ``document_author``: Dokumentauthor
 - ``document_date``: Dokumentdatum
 - ``document_type``: Dokumenttyp
+- ``document_type_label``: Dokumenttyp (Anzeigewert)
 - ``dossier_type``: Dossiertyp
 - ``email``: E-Mail Adresse
 - ``end``: Enddatum des Dossiers

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -129,6 +129,19 @@ def translated_task_type(obj):
     return task_type_helper(obj, obj.get("task_type"))
 
 
+def translated_document_type_label(obj):
+    portal = getSite()
+    voc = wrap_vocabulary(
+            'opengever.document.document_types',
+            visible_terms_from_registry='opengever.document.interfaces.'
+                                        'IDocumentType.document_types')(portal)
+    try:
+        term = voc.getTerm(obj.get("document_type"))
+    except LookupError:
+        return None
+    return term.title
+
+
 def translated_public_trial(obj):
     try:
         return translate(obj.public_trial, context=getRequest(), domain="opengever.base")
@@ -342,6 +355,7 @@ FIELDS_WITH_MAPPING = [
     ListingField('creator_fullname', 'Creator', 'creator_fullname'),
     ListingField('description', 'Description'),
     ListingField('document_type', 'document_type', transform=translate_document_type),
+    ListingField('document_type_label', 'document_type', accessor=translated_document_type_label),
     ListingField('dossier_type', 'dossier_type', transform=translate_dossier_type),
     ListingField('filename', 'filename', filename),
     ListingField('filesize', 'filesize', filesize),

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -5,7 +5,6 @@ from ftw.solr.converters import to_iso8601
 from ftw.solr.interfaces import ISolrSearch
 from ftw.solr.query import escape
 from opengever.api.utils import recursive_encode
-from opengever.base.behaviors.translated_title import ITranslatedTitleSupport
 from opengever.base.behaviors.translated_title import TRANSLATED_TITLE_PORTAL_TYPES
 from opengever.base.helpers import display_name
 from opengever.base.solr import OGSolrContentListing
@@ -32,7 +31,6 @@ from zope.component import getUtility
 from zope.component.hooks import getSite
 from zope.globalrequest import getRequest
 from zope.i18n import translate
-import json
 import Missing
 
 

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -366,6 +366,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
             'columns=title',
             'columns=modified',
             'columns=document_author',
+            'columns=document_type_label',
             'columns=containing_dossier',
             'columns=bumblebee_checksum',
             'columns=relative_path',
@@ -375,11 +376,14 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
             'sort_on=created',
         ))
         view = '?'.join(('@listing', query_string))
-        browser.open(self.dossier, view=view, headers=self.api_headers)
+        browser.open(self.dossier, view=view,
+                     headers={'Accept': 'application/json', 'Accept-Language': 'de-ch'})
+
         self.assertEqual(
             {u'reference': u'Client1 1.1 / 1 / 14',
              u'title': u'Vertr\xe4gsentwurf',
              u'document_author': u'test_user_1_',
+             u'document_type_label': u'Vertrag',
              u'external_reference': None,
              u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-14',
              u'UID': IUUID(self.document),


### PR DESCRIPTION
Since in the new UI the document type should be available as a column in the table, the document type must be translated.

For [CA-2792]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))

[CA-2792]: https://4teamwork.atlassian.net/browse/CA-2792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ