### PR TITLE
WOPI check_file_info(): Fall back to document owner if creator isn't set.

### DIFF
--- a/opengever/wopi/browser/wopi.py
+++ b/opengever/wopi/browser/wopi.py
@@ -147,7 +147,7 @@ class WOPIView(BrowserView):
             self.obj.file._blob.committed(), algorithm=u'SHA256')
         data = {
             'BaseFileName': self.obj.file.filename,
-            'OwnerId': self.obj.Creator(),
+            'OwnerId': self.obj.Creator() or self.obj.getOwner().getId(),
             'Size': self.obj.file.size,
             'UserId': member.getId(),
             'Version': self._file_version(),

--- a/opengever/wopi/tests/test_wopi.py
+++ b/opengever/wopi/tests/test_wopi.py
@@ -87,3 +87,11 @@ class TestWOPIView(IntegrationTestCase):
     def test_breadcrumbBrandName_is_portal_title(self):
         self.assertIn(u'BreadcrumbBrandName', self.check_file_info())
         self.assertEqual('Plone site', self.check_file_info()[u'BreadcrumbBrandName'])
+
+    def test_owner_id_falls_back_to_owner_if_creator_is_missing(self):
+        with self.login(self.regular_user):
+            self.document.setCreators('')
+            assert self.document.Creator() == ''
+
+        self.assertIn('OwnerId', self.check_file_info())
+        self.assertEqual('robert.ziegler', self.check_file_info()['OwnerId'])


### PR DESCRIPTION
The `Creator` for documents imported via OGGBundle may not be set (`Creator()` returns empty string).

This fix makes `OwnerId` fall back to `getOwner().getId()` in such a case, in order to make OfficeOnline happy.

For [CA-3318](https://4teamwork.atlassian.net/browse/CA-3318)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

