### PR TITLE
Add a new feature to the '@config' endpiont: 'multiple_dossier_types'

### DIFF
--- a/changes/CA-2791-3.feature
+++ b/changes/CA-2791-3.feature
@@ -1,0 +1,1 @@
+- Add a new property 'multiple_dossier_types' to the '@config' endpoint. [elioschmutz]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -15,6 +15,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- ``@config``: added new property ``multiple_dossier_types`` which will be set to true if there is more than one dossier type available.
 - ``@solrsearch`` and ``@listing``: ``dossier_type`` is added as a new solr index and whitelisted in the ``@listing`` endpoint.
 - Propertysheets: ``date`` fields are now supported.
 - ``@listing-custom-fields`` endpoint contains now also the widget information.

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -2,6 +2,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.casauth.plugin import CASAuthenticationPlugin
 from ftw.testbrowser import browsing
+from mock import patch
 from opengever.base.interfaces import IUserSnapSettings
 from opengever.private import enable_opengever_private
 from opengever.testing import IntegrationTestCase
@@ -74,6 +75,7 @@ class TestConfig(IntegrationTestCase):
                 u'hubspot': False,
                 u'journal_pdf': False,
                 u'meetings': False,
+                u'multiple_dossier_types': False,
                 u'officeatwork': False,
                 u'officeconnector_attach': True,
                 u'officeconnector_checkout': True,
@@ -351,6 +353,17 @@ class TestConfig(IntegrationTestCase):
 
         browser.open(self.config_url, headers=self.api_headers)
         self.assertTrue(browser.json['features']['filing_number'])
+
+    @browsing
+    def test_feature_multiple_dossier_types(self, browser):
+        self.login(self.regular_user, browser)
+
+        browser.open(self.config_url, headers=self.api_headers)
+        self.assertFalse(browser.json['features']['multiple_dossier_types'])
+
+        with patch('opengever.base.configuration.count_available_dossier_types', return_value=2):
+            browser.open(self.config_url, headers=self.api_headers)
+            self.assertTrue(browser.json['features']['multiple_dossier_types'])
 
     @browsing
     def test_contains_the_current_admin_unit(self, browser):

--- a/opengever/base/configuration.py
+++ b/opengever/base/configuration.py
@@ -24,6 +24,7 @@ from opengever.dossier.filing.interfaces import IFilingNumberActivatedLayer
 from opengever.dossier.interfaces import IDossierContainerTypes
 from opengever.dossier.interfaces import IDossierResolveProperties
 from opengever.dossier.interfaces import ITemplateFolderProperties
+from opengever.dossier.vocabularies import count_available_dossier_types
 from opengever.ech0147.interfaces import IECH0147Settings
 from opengever.kub import is_kub_feature_enabled
 from opengever.mail.interfaces import IMailDownloadSettings
@@ -175,6 +176,8 @@ class GeverSettingsAdpaterV1(object):
         features['workspace_todo'] = api.portal.get_registry_record('is_feature_enabled', interface=IToDoSettings)
         features['private_tasks'] = api.portal.get_registry_record('private_task_feature_enabled', interface=ITaskSettings)
         features['optional_task_permissions_revoking'] = api.portal.get_registry_record('optional_task_permissions_revoking_enabled', interface=ITaskSettings)  # noqa
+        features['multiple_dossier_types'] = count_available_dossier_types() > 1
+
         return features
 
     def is_filing_number_feature_installed(self):

--- a/opengever/base/tests/test_configuration_adapter.py
+++ b/opengever/base/tests/test_configuration_adapter.py
@@ -102,6 +102,7 @@ class TestConfigurationAdapter(IntegrationTestCase):
                 ('workspace_todo', True),
                 ('private_tasks', True),
                 ('optional_task_permissions_revoking', False),
+                ('multiple_dossier_types', False),
                 ])),
             ('root_url', 'http://nohost/plone'),
             ('portal_url', 'http://nohost/portal'),

--- a/opengever/dossier/vocabularies.py
+++ b/opengever/dossier/vocabularies.py
@@ -3,6 +3,8 @@ from ftw.keywordwidget.vocabularies import KeywordWidgetAddableSourceWrapper
 from zope.interface import implementer
 from zope.interface import Interface
 from zope.schema.interfaces import IContextSourceBinder
+from zope.component import getUtility
+from zope.schema.interfaces import IVocabularyFactory
 
 
 class IRestrictKeywords(Interface):
@@ -39,3 +41,9 @@ class KeywordAddableRestrictableSourceBinder(object):
             KeywordSearchableSource(context),
             restricted,
             allowed_terms)
+
+
+def count_available_dossier_types():
+    """Returns the number of dossier_types available for the current deployment
+    """
+    return len(getUtility(IVocabularyFactory, name="opengever.dossier.dossier_types")(None))


### PR DESCRIPTION
This PR adds a new `feature` to the `@config` endpoint called: `multiple_dossier_types`

It also patches the available dossier-types for the testserver. This allows us to write better e2e tests with dossier-types.
Changing the dossier-types for the whole dev-deployment seems to be a big deal since we would change the default for production as well.

For [CA-2791]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-2791]: https://4teamwork.atlassian.net/browse/CA-2791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ