### PR TITLE
Inbound mail: Add support for sender address aliases

### DIFF
--- a/changes/CA-2598.feature
+++ b/changes/CA-2598.feature
@@ -1,0 +1,1 @@
+Inbound mail: Add support for sender address aliases [lgraf]

--- a/opengever/core/profiles/default/registry.xml
+++ b/opengever/core/profiles/default/registry.xml
@@ -99,6 +99,7 @@
   <records interface="opengever.mail.interfaces.ISendDocumentConf" />
   <records interface="opengever.mail.interfaces.IMailTabbedviewSettings" />
   <records interface="opengever.mail.interfaces.IMailDownloadSettings" />
+  <records interface="opengever.mail.interfaces.IInboundMailSettings" />
 
   <!-- MEETING -->
   <records interface="opengever.meeting.interfaces.IMeetingSettings" />

--- a/opengever/core/upgrades/20211223165356_add_i_inbound_mail_settings_registry_record/registry.xml
+++ b/opengever/core/upgrades/20211223165356_add_i_inbound_mail_settings_registry_record/registry.xml
@@ -1,0 +1,5 @@
+<registry>
+
+  <records interface="opengever.mail.interfaces.IInboundMailSettings" />
+
+</registry>

--- a/opengever/core/upgrades/20211223165356_add_i_inbound_mail_settings_registry_record/upgrade.py
+++ b/opengever/core/upgrades/20211223165356_add_i_inbound_mail_settings_registry_record/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddIInboundMailSettingsRegistryRecord(UpgradeStep):
+    """Add IInboundMailSettings registry record.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/mail/browser/inbound.py
+++ b/opengever/mail/browser/inbound.py
@@ -1,8 +1,17 @@
+from ftw.mail.exceptions import NoSenderFound
+from ftw.mail.exceptions import UnknownSender
 from ftw.mail.inbound import MailInbound
 from opengever.mail.exceptions import MessageContainsVirus
+from opengever.mail.interfaces import IInboundMailSettings
 from opengever.virusscan.validator import validateUploadForFieldIfNecessary
+from plone import api
 from six import BytesIO
+from zope.component import getMultiAdapter
 from zope.interface import Invalid
+import logging
+
+
+log = logging.getLogger(__name__)
 
 
 class GeverMailInbound(MailInbound):
@@ -21,3 +30,45 @@ class GeverMailInbound(MailInbound):
         except Invalid as e:
             raise MessageContainsVirus(e.message)
         return msg
+
+    def get_sender_aliases(self):
+        sender_aliases = api.portal.get_registry_record(
+            'sender_aliases', interface=IInboundMailSettings)
+
+        if not sender_aliases:
+            # Dict records in p.a.registry may be returned as `None`
+            sender_aliases = {}
+
+        sender_aliases = {
+            key.lower(): value for key, value in sender_aliases.items()
+        }
+        return sender_aliases
+
+    def get_user(self):
+        sender_email = self.sender()
+        if not sender_email:
+            log.warn("No sender found in 'Resent-From' or 'From' headers")
+            raise NoSenderFound(self.msg())
+
+        sender_aliases = self.get_sender_aliases()
+        acl_users = api.portal.get_tool('acl_users')
+        pas_search = getMultiAdapter((self.context, self.request),
+                                     name='pas_search')
+        users = pas_search.searchUsers(email=sender_email)
+        if len(users) > 0:
+            user = acl_users.getUserById(users[0].get('userid'))
+            if not hasattr(user, 'aq_base'):
+                user = user.__of__(acl_users)
+            return user
+
+        elif sender_email.lower() in sender_aliases:
+            target_userid = sender_aliases[sender_email.lower()]
+            log.info('Sender address %r is an alias for userid %r' % (
+                sender_email, target_userid))
+            user = acl_users.getUserById(target_userid)
+            if user:
+                return user
+
+        log.warn('Sender address: %r' % sender_email)
+        log.warn('No users found in %r for that address.' % acl_users)
+        raise UnknownSender(self.msg())

--- a/opengever/mail/interfaces.py
+++ b/opengever/mail/interfaces.py
@@ -6,6 +6,18 @@ from zope.interface import Interface, Attribute
 DEFAULT_MAIL_MAX_SIZE = 5
 
 
+class IInboundMailSettings(Interface):
+
+    sender_aliases = schema.Dict(
+        title=u'Sender address aliases',
+        description=u'Maps sender addresses to GEVER users. '
+                    u'Inbound mails from those addresses will '
+                    u'be created with the respective user.',
+        key_type=schema.TextLine(title=u'Aliased from (email)'),
+        value_type=schema.TextLine(title=u'Aliased to (userid)'),
+    )
+
+
 class ISendDocumentConf(Interface):
     max_size = schema.Int(
         title=u'max_size',


### PR DESCRIPTION
This adds a new registry setting `IInboundMailSettings.sender_aliases` of type dict that can be used to alias sender addresses for incoming mails to a GEVER user. Mails coming from those senders will then be created with the respective user instead of getting rejected as unknown sender.

The lookup for an alias in the `email address -> userid` mapping is **case-insensitive** (because users might easily have a irregular casing configured in their MUA). The lookup of a user based on the `userid` however is **case-sensitive** (`getUserById()`) - but since we control that aspect, this shouldn't be an issue. 

The regular user lookup via sender email address has precedence - if the sender address can be resolved to a user, any potential entries in alias table will be ignored.

The PR to configure the aliases for RefBl is at 4teamwork/opengever.refbl#7

For [CA-2598](https://4teamwork.atlassian.net/browse/CA-2598)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
