### PR TITLE
Expose dossier_type_label column in @listing endpoint.

### DIFF
--- a/changes/CA-2791-4.feature
+++ b/changes/CA-2791-4.feature
@@ -1,0 +1,1 @@
+- Expose dossier_type_label column in @listing endpoint. [elioschmutz]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -36,7 +36,7 @@ Other Changes
 - A new endpoint ``@substitutions`` is added (see :ref:`get-substitutions`).
 - Include email address in workspace and workspace folder serialization.
 - ``@listing``: Add document_type_label column.
-
+- ``@listing``: Add dossier_type_label column.
 
 2021.24.0 (2021-11-30)
 ----------------------

--- a/docs/public/dev-manual/api/listings.rst
+++ b/docs/public/dev-manual/api/listings.rst
@@ -89,6 +89,7 @@ werden. Folgende Felder stehen zur Verfügung:
 - ``document_type``: Dokumenttyp
 - ``document_type_label``: Dokumenttyp (Anzeigewert)
 - ``dossier_type``: Dossiertyp
+- ``dossier_type_label``: Dossiertyp (Anzeigewert)
 - ``email``: E-Mail Adresse
 - ``end``: Enddatum des Dossiers
 - ``external_reference``: Externe Referenz für Dossiers oder Fremdzeichen für Dokumente

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -142,6 +142,18 @@ def translated_document_type_label(obj):
     return term.title
 
 
+def translated_dossier_type_label(obj):
+    portal = getSite()
+    voc = wrap_vocabulary(
+        'opengever.dossier.dossier_types',
+        hidden_terms_from_registry='opengever.dossier.interfaces.IDossierType.hidden_dossier_types')(portal)
+    try:
+        term = voc.getTerm(obj.get("dossier_type"))
+    except LookupError:
+        return None
+    return term.title
+
+
 def translated_public_trial(obj):
     try:
         return translate(obj.public_trial, context=getRequest(), domain="opengever.base")
@@ -357,6 +369,7 @@ FIELDS_WITH_MAPPING = [
     ListingField('document_type', 'document_type', transform=translate_document_type),
     ListingField('document_type_label', 'document_type', accessor=translated_document_type_label),
     ListingField('dossier_type', 'dossier_type', transform=translate_dossier_type),
+    ListingField('dossier_type_label', 'dossier_type', accessor=translated_dossier_type_label),
     ListingField('filename', 'filename', filename),
     ListingField('filesize', 'filesize', filesize),
     ListingField('issuer', 'issuer', transform=display_name),

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -231,6 +231,11 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
     def test_dossier_listing(self, browser):
         self.enable_languages()
         self.login(self.regular_user, browser=browser)
+
+        IDossier(self.dossier).dossier_type = "businesscase"
+        self.dossier.reindexObject()
+        self.commit_solr()
+
         query_string = '&'.join((
             'name=dossiers',
             'columns=blocked_local_roles',
@@ -239,6 +244,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
             'columns=reference',
             'columns=title',
             'columns=retention_expiration',
+            'columns=dossier_type_label',
             'columns=review_state',
             'columns=relative_path',
             'columns=UID',
@@ -265,6 +271,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
              u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1',
              u'UID': IUUID(self.dossier),
              u'blocked_local_roles': False,
+             u'dossier_type_label':u'Gesch\xe4ftsfall',
              u'external_reference': u'qpr-900-9001-\xf7',
              u'public_trial': u'Nicht gepr\xfcft',
              u'trashed': False,


### PR DESCRIPTION
Exposes the `dossier_type_label` column in the `@listing` endpoint according to https://github.com/4teamwork/opengever.core/pull/7316 which does the same with the `document_type_label`.

For [CA-2791]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-2791]: https://4teamwork.atlassian.net/browse/CA-2791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ