### PR TITLE
Drop related items when copying document to workspace.

### DIFF
--- a/changes/CA-3382.bugfix
+++ b/changes/CA-3382.bugfix
@@ -1,0 +1,1 @@
+Drop related items when copying document to workspace. [njohner]

--- a/opengever/workspaceclient/linked_workspaces.py
+++ b/opengever/workspaceclient/linked_workspaces.py
@@ -502,7 +502,7 @@ class LinkedWorkspaces(object):
         """
         return self._blacklisted_dict(
             serialized_document,
-            ['file', 'archival_file', 'message', 'original_message'])
+            ['file', 'archival_file', 'message', 'original_message', 'relatedItems'])
 
     def _whitelisted_dict(self, dict_obj, whitelist):
         whitelisted_dict = {}


### PR DESCRIPTION
Copying a document with a related document to a workspace will fail, as the related item does not exist on the teamraum deployment (and we pass the serialized object, which will lead to errors on the other side). So as this does anyway not make sense, we simply drop that field before copying the document to the workspace.

For [CA-3382]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-3382]: https://4teamwork.atlassian.net/browse/CA-3382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ