### PR TITLE
Disallow edit with office online for trashed documents.

### DIFF
--- a/changes/CA-3437.bugfix
+++ b/changes/CA-3437.bugfix
@@ -1,0 +1,1 @@
+Disallow edit with office online for trashed documents. [njohner]

--- a/opengever/document/fileactions.py
+++ b/opengever/document/fileactions.py
@@ -8,6 +8,7 @@ from opengever.document.interfaces import IFileActions
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.officeconnector.helpers import is_officeconnector_attach_feature_enabled  # noqa
 from opengever.officeconnector.helpers import is_officeconnector_checkout_feature_enabled  # noqa
+from opengever.trash.trash import ITrashed
 from opengever.trash.trash import ITrasher
 from opengever.wopi import is_wopi_feature_enabled
 from opengever.workspace.interfaces import IDeleter
@@ -271,6 +272,9 @@ class DocumentFileActions(BaseDocumentFileActions):
         # Office Online allows collaborative editing
         # Thus a document is editable by Office Online if it's not checked out and not locked
         # or if it's collaboratively checked out.
+        # If the document is trashed, then it's not editable.
+        if ITrashed.providedBy(self.context):
+            return False
         if self.context.checked_out_by():
             return self.context.is_collaborative_checkout()
         if self.context.is_locked():

--- a/opengever/document/tests/test_fileactions.py
+++ b/opengever/document/tests/test_fileactions.py
@@ -6,6 +6,7 @@ from opengever.document.interfaces import IFileActions
 from opengever.officeconnector.interfaces import IOfficeConnectorSettings
 from opengever.testing import IntegrationTestCase
 from opengever.testing.test_case import TestCase
+from opengever.trash.trash import ITrasher
 from opengever.wopi.lock import create_lock
 from opengever.wopi.testing import mock_wopi_discovery
 from plone import api
@@ -102,6 +103,13 @@ class TestOfficeOnlineEditable(IntegrationTestCase):
         manager.checkout(True)
         actions = getMultiAdapter((self.document, self.request), IFileActions)
         self.assertTrue(actions.is_office_online_edit_action_available())
+
+    def test_not_editable_if_document_is_trashed(self):
+        mock_wopi_discovery()
+        self.login(self.regular_user)
+        ITrasher(self.document).trash()
+        actions = getMultiAdapter((self.document, self.request), IFileActions)
+        self.assertFalse(actions.is_office_online_edit_action_available())
 
 
 class TestOfficeConnectorActions(IntegrationTestCase):


### PR DESCRIPTION
Trashed documents should not be editable in office online.

For [CA-3437]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-3437]: https://4teamwork.atlassian.net/browse/CA-3437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ