### PR TITLE
Drop workspace administrator group from policy templates and setup.

### DIFF
--- a/changes/CA-2989.other
+++ b/changes/CA-2989.other
@@ -1,0 +1,1 @@
+Drop workspace administrator group from policy templates and setup. [njohner]

--- a/opengever/policytemplates/hooks.py
+++ b/opengever/policytemplates/hooks.py
@@ -45,7 +45,6 @@ IGNORED_QUESTIONS = {
         'setup.bumblebee_auto_refresh',
         ],
     'gever': [
-        'deployment.workspace_administrators_group',
         'deployment.workspace_creators_group',
         'deployment.workspace_users_group',
         'setup.invitation_group_dn',

--- a/opengever/policytemplates/policy_template/.mrbob.ini
+++ b/opengever/policytemplates/policy_template/.mrbob.ini
@@ -208,10 +208,6 @@ setup.repositoryfolder_proposals_tab.required = True
 setup.repositoryfolder_proposals_tab.default = true
 setup.repositoryfolder_proposals_tab.post_ask_question = mrbob.hooks:to_boolean
 
-deployment.workspace_administrators_group.question = Workspace administrators group
-deployment.workspace_administrators_group.default = tr_administrators
-deployment.workspace_administrators_group.required = False
-
 deployment.workspace_creators_group.question = Workspace creators group
 deployment.workspace_creators_group.default = tr_creators
 deployment.workspace_creators_group.required = False

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/configure.zcml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/configure.zcml.bob
@@ -94,7 +94,6 @@
                           "
       admin_unit_id="{{{adminunit.id}}}"
       administrator_group="{{{deployment.administrator_group}}}"
-      workspace_administrator_group="{{{deployment.workspace_administrators_group}}}"
       workspace_creator_group="{{{deployment.workspace_creators_group}}}"
       workspace_user_group="{{{deployment.workspace_users_group}}}"
       mail_domain="{{{deployment.mail_domain}}}"

--- a/opengever/setup/deploy.py
+++ b/opengever/setup/deploy.py
@@ -227,8 +227,6 @@ class GeverDeployment(object):
                                   'workspace_user_group', 'WorkspacesUser')
         self.assign_group_to_role(self.site, self.config,
                                   'workspace_creator_group', 'WorkspacesCreator')
-        self.assign_group_to_role(self.site, self.config,
-                                  'workspace_administrator_group', 'WorkspaceAdmin')
 
         # REALLY set the language - the plone4 addPloneSite is really
         # buggy with languages.

--- a/opengever/setup/meta.py
+++ b/opengever/setup/meta.py
@@ -107,11 +107,6 @@ class IDeploymentDirective(Interface):
         required=False,
         max_length=GROUP_ID_LENGTH)
 
-    workspace_administrator_group = TextLine(
-        title=u'Workspace administrator group',
-        required=False,
-        max_length=GROUP_ID_LENGTH)
-
     workspace_creator_group = TextLine(
         title=u'Workspace creator group',
         required=False,


### PR DESCRIPTION
We do not need a specific workspace administrator group, instead we give the Administrator role to the `tr_administrators` group (which will be the default for teamraum deployments).

For [CA-2989]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-2989]: https://4teamwork.atlassian.net/browse/CA-2989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ