### PR TITLE
Exclude exceptions that happen in normal usage from sentry.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1467,3 +1467,9 @@ which can be used in upgrade steps:
             indexer.add_by_obj(obj)
 
 This will register the corresponding jobs to the ``NightlyMaintenanceJobsProvider``.
+
+
+API Error handling
+------------------
+
+Errors, especially client errors, are a normal part of the API. ZPublisher's ``HTTPResponse`` will set the proper error codes while ``Plone.rest`` will serialize these errors back to the client. This allows to simply raise errors such as ``BadRequest`` in the API Services, and the rest will happen automatically. This does not prevent the error from being raised and therefore be handled by ``ftw.raven`` and logged to sentry. Specific exceptions that we know will happen in normal Gever operations should not be reported to sentry, which can be easily achieved by raising an exception inheriting from ``NotReportedException``.

--- a/changes/CA-2755.other
+++ b/changes/CA-2755.other
@@ -1,0 +1,1 @@
+Avoid reporting normal API exceptions in sentry. [njohner]

--- a/opengever/api/not_reported_exceptions.py
+++ b/opengever/api/not_reported_exceptions.py
@@ -1,5 +1,6 @@
 from zExceptions import BadRequest as _BadRequest
 from zExceptions import Forbidden as _Forbidden
+from OFS.CopySupport import ResourceLockedError as _ResourceLockedError
 
 
 class NotReportedException(Exception):
@@ -22,4 +23,9 @@ class Forbidden(_Forbidden, NotReportedException):
     This class needs to be named Forbidden so that ZPublisher's HTTPResponse
     will set the status code to 403, and so that the API will return BadRequest
     as error type.
+    """
+
+
+class ResourceLockedError(_ResourceLockedError, NotReportedException):
+    """ResourceLockedError that is not reported in sentry.
     """

--- a/opengever/api/not_reported_exceptions.py
+++ b/opengever/api/not_reported_exceptions.py
@@ -1,4 +1,5 @@
 from zExceptions import BadRequest as _BadRequest
+from zExceptions import Forbidden as _Forbidden
 
 
 class NotReportedException(Exception):
@@ -11,5 +12,14 @@ class BadRequest(_BadRequest, NotReportedException):
 
     This class needs to be named BadRequest so that ZPublisher's HTTPResponse
     will set the status code to 400, and so that the API will return BadRequest
+    as error type.
+    """
+
+
+class Forbidden(_Forbidden, NotReportedException):
+    """Forbidden that is not reported in sentry.
+
+    This class needs to be named Forbidden so that ZPublisher's HTTPResponse
+    will set the status code to 403, and so that the API will return BadRequest
     as error type.
     """

--- a/opengever/api/not_reported_exceptions.py
+++ b/opengever/api/not_reported_exceptions.py
@@ -1,6 +1,7 @@
 from zExceptions import BadRequest as _BadRequest
 from zExceptions import Forbidden as _Forbidden
 from OFS.CopySupport import ResourceLockedError as _ResourceLockedError
+from OFS.CopySupport import CopyError as _CopyError
 
 
 class NotReportedException(Exception):
@@ -28,4 +29,9 @@ class Forbidden(_Forbidden, NotReportedException):
 
 class ResourceLockedError(_ResourceLockedError, NotReportedException):
     """ResourceLockedError that is not reported in sentry.
+    """
+
+
+class CopyError(_CopyError, NotReportedException):
+    """CopyError that is not reported in sentry.
     """

--- a/opengever/api/not_reported_exceptions.py
+++ b/opengever/api/not_reported_exceptions.py
@@ -1,0 +1,3 @@
+class NotReportedException(Exception):
+    """An exception that is not reported in sentry
+    """

--- a/opengever/api/not_reported_exceptions.py
+++ b/opengever/api/not_reported_exceptions.py
@@ -1,3 +1,15 @@
+from zExceptions import BadRequest as _BadRequest
+
+
 class NotReportedException(Exception):
     """An exception that is not reported in sentry
+    """
+
+
+class BadRequest(_BadRequest, NotReportedException):
+    """BadRequest that is not reported in sentry.
+
+    This class needs to be named BadRequest so that ZPublisher's HTTPResponse
+    will set the status code to 400, and so that the API will return BadRequest
+    as error type.
     """

--- a/opengever/api/trash.py
+++ b/opengever/api/trash.py
@@ -1,4 +1,5 @@
 from opengever.api import _
+from opengever.api.not_reported_exceptions import BadRequest as NotReportedBadRequest
 from opengever.trash.trash import ITrasher
 from opengever.trash.trash import TrashError
 from plone.restapi.services import Service
@@ -21,17 +22,17 @@ class TrashPost(Service):
             trasher.trash()
         except TrashError as exc:
             if exc.message == 'Already trashed':
-                raise BadRequest(
+                raise NotReportedBadRequest(
                     _(u'msg_already_trashed', default=u'Already trashed'))
             elif exc.message == 'Document checked out':
-                raise BadRequest(
+                raise NotReportedBadRequest(
                     _(u'msg_trash_checked_out_doc',
                       default=u'Cannot trash a checked-out document'))
             elif exc.message == 'The document is locked':
-                raise BadRequest(
+                raise NotReportedBadRequest(
                     _(u'msg_trash_locked_doc', default=u'Cannot trash a locked document'))
             elif exc.message == 'The document has been returned as excerpt':
-                raise BadRequest(
+                raise NotReportedBadRequest(
                     _(u'msg_trash_doc_returned_as_excerpt',
                       default=u'Cannot trash a document that has been returned as excerpt'))
             elif exc.message == 'Not trashable':

--- a/opengever/api/tus.py
+++ b/opengever/api/tus.py
@@ -1,6 +1,6 @@
+from opengever.api.not_reported_exceptions import BadRequest as NotReportedBadRequest
 from opengever.base.interfaces import IDuringContentCreation
 from opengever.document import _
-from opengever.document.behaviors.customproperties import IDocumentCustomProperties
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.meeting.proposaltemplate import IProposalTemplate
 from opengever.propertysheets.creation_defaults import initialize_customproperties_defaults
@@ -92,7 +92,7 @@ class UploadPatch(GeverUploadPatch):
                     default=u"It's not possible to have non-.docx documents as"
                             " proposal documents.",
                 ), context=self.request),
-                raise BadRequest(msg)
+                raise NotReportedBadRequest(msg)
 
     def is_proposal_upload(self):
         """The upload form context can be, for example, a Dossier."""

--- a/opengever/api/upload_structure.py
+++ b/opengever/api/upload_structure.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from ftw.solr.interfaces import ISolrSearch
 from ftw.solr.query import make_path_filter
 from opengever.api import _
+from opengever.api.not_reported_exceptions import BadRequest as NotReportedBadRequest
 from opengever.document.document import is_email_upload
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.interfaces import IDossierContainerTypes
@@ -290,7 +291,6 @@ class UploadStructurePost(Service):
                     _(u'msg_filename_required',
                       default=u"Empty filename not supported"))
 
-                raise BadRequest("")
         return files
 
     def reply(self):
@@ -301,5 +301,5 @@ class UploadStructurePost(Service):
         try:
             upload_checker(files)
         except (MaximalDepthExceeded, TypeNotAddable) as exc:
-            raise BadRequest(exc.message)
+            raise NotReportedBadRequest(exc.message)
         return json_compatible(upload_checker.structure)

--- a/opengever/api/upload_structure.py
+++ b/opengever/api/upload_structure.py
@@ -3,6 +3,7 @@ from ftw.solr.interfaces import ISolrSearch
 from ftw.solr.query import make_path_filter
 from opengever.api import _
 from opengever.api.not_reported_exceptions import BadRequest as NotReportedBadRequest
+from opengever.api.not_reported_exceptions import Forbidden as NotReportedForbidden
 from opengever.document.document import is_email_upload
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.interfaces import IDossierContainerTypes
@@ -21,7 +22,6 @@ from plone.restapi.deserializer import json_body
 from plone.restapi.serializer.converters import json_compatible
 from plone.restapi.services import Service
 from zExceptions import BadRequest
-from zExceptions import Forbidden
 from zope.component import adapter
 from zope.component import getUtility
 from zope.interface import implementer
@@ -128,7 +128,7 @@ class DefaultUploadStructureAnalyser(object):
 
     def check_permission(self):
         if not api.user.has_permission('Add portal content', obj=self.context):
-            raise Forbidden("User is not allowed to add objects here")
+            raise NotReportedForbidden("User is not allowed to add objects here")
 
     def extract_structure(self, files):
         root = {'items': {}}

--- a/opengever/base/monkey/patches/__init__.py
+++ b/opengever/base/monkey/patches/__init__.py
@@ -17,6 +17,7 @@ from .filter_trashed_from_catalog import PatchCatalogToFilterTrashedDocs
 from .history_handler_tool import PatchCMFEditonsHistoryHandlerTool
 from .jsonschema_for_portal_type import PatchGetJsonschemaForPortalType
 from .language_tool import PatchLanguageToolCall
+from .maybe_report_exception import PatchMaybeReportException
 from .namedfile_data_converter import PatchNamedfileNamedDataConverter
 from .paste_permission import PatchDXContainerPastePermission
 from .plone_43rc1_upgrade import PatchPlone43RC1Upgrade
@@ -60,6 +61,8 @@ PatchExtendedPathIndex()()
 PatchFullHistory()()
 PatchGetJsonschemaForPortalType()()
 PatchInvokeFactory()()
+PatchLanguageToolCall()()
+PatchMaybeReportException()()
 PatchMembershipToolCreateMemberarea()()
 PatchMembershipToolSetLoginTimes()()
 PatchNamedfileNamedDataConverter()()
@@ -76,7 +79,6 @@ PatchZ2LogTimezone()()
 PatchZ3CFormChangedField()()
 PatchZ3CFormWidgetUpdate()()
 ScrubBoboExceptions()()
-PatchLanguageToolCall()()
 
 # These three patches implement role and permission filtering during RO mode.
 # We only apply these conditionally when RO mode actually is active.

--- a/opengever/base/monkey/patches/maybe_report_exception.py
+++ b/opengever/base/monkey/patches/maybe_report_exception.py
@@ -1,0 +1,24 @@
+from opengever.base.monkey.patching import MonkeyPatch
+
+
+class PatchMaybeReportException(MonkeyPatch):
+    """Monkeypatch for ftw.raven.reporter.maybe_report_exception
+
+    This allows to skip reporting of exceptions that inherit NotReportedException
+    """
+
+    def __call__(self):
+        from opengever.base.sentry import FTW_RAVEN_AVAILABLE
+        if not FTW_RAVEN_AVAILABLE:
+            return
+
+        from ftw.raven.reporter import maybe_report_exception as original_maybe_report_exception
+        from opengever.api.not_reported_exceptions import NotReportedException
+
+        def maybe_report_exception(context, request, exc_type, exc, traceback):
+            if isinstance(exc, NotReportedException):
+                return
+            return original_maybe_report_exception(context, request, exc_type, exc, traceback)
+
+        from ftw.raven import reporter
+        self.patch_refs(reporter, 'maybe_report_exception', maybe_report_exception)

--- a/opengever/base/monkey/patches/verify_object_paste.py
+++ b/opengever/base/monkey/patches/verify_object_paste.py
@@ -15,6 +15,7 @@ class PatchCopyContainerVerifyObjectPaste(MonkeyPatch):
         from cgi import escape
         from OFS.CopySupport import absattr
         from OFS.CopySupport import CopyError
+        from opengever.api.not_reported_exceptions import CopyError as NotReportedCopyError
         from opengever.document.behaviors import IBaseDocument
         from ZODB.POSException import ConflictError
 
@@ -36,7 +37,7 @@ class PatchCopyContainerVerifyObjectPaste(MonkeyPatch):
             # We also make sure that we are not pasting a checked-out document
 
             if IBaseDocument.providedBy(object) and object.is_checked_out():
-                raise CopyError('Checked out documents cannot be copied.')
+                raise NotReportedCopyError('Checked out documents cannot be copied.')
 
             if not hasattr(object, 'meta_type'):
                 raise CopyError(MessageDialog(

--- a/opengever/document/move.py
+++ b/opengever/document/move.py
@@ -1,5 +1,5 @@
-from OFS.CopySupport import ResourceLockedError
 from opengever.api.not_reported_exceptions import Forbidden as NotReportedForbidden
+from opengever.api.not_reported_exceptions import ResourceLockedError as NotReportedResourceLockedError
 from opengever.base.adapters import DefaultMovabilityChecker
 from opengever.document import _
 from opengever.document.behaviors import IBaseDocument
@@ -29,7 +29,7 @@ class DocumentMovabiliyChecker(DefaultMovabilityChecker):
                 _(u'msg_doc_inside_closed_dossier',
                   default=u'Documents inside a closed dossier cannot be moved.'))
         if ILockable(self.context).locked():
-            raise ResourceLockedError(
+            raise NotReportedResourceLockedError(
                 _('msg_locked_doc_cant_be_moved',
                   default=u'Locked documents cannot be moved.'))
 

--- a/opengever/document/move.py
+++ b/opengever/document/move.py
@@ -1,4 +1,5 @@
 from OFS.CopySupport import ResourceLockedError
+from opengever.api.not_reported_exceptions import Forbidden as NotReportedForbidden
 from opengever.base.adapters import DefaultMovabilityChecker
 from opengever.document import _
 from opengever.document.behaviors import IBaseDocument
@@ -16,15 +17,15 @@ class DocumentMovabiliyChecker(DefaultMovabilityChecker):
 
     def validate_movement(self, target):
         if self.context.is_inside_a_task():
-            raise Forbidden(
+            raise NotReportedForbidden(
                 _(u'msg_doc_inside_task_cant_be_moved',
                   u'Documents inside a task cannot be moved.'))
         if self.context.is_inside_a_proposal():
-            raise Forbidden(
+            raise NotReportedForbidden(
                 _(u'msg_doc_inside_proposal_cant_be_moved',
                   u'Documents inside a proposal cannot be moved.'))
         if self.context.is_inside_a_closed_dossier():
-            raise Forbidden(
+            raise NotReportedForbidden(
                 _(u'msg_doc_inside_closed_dossier',
                   default=u'Documents inside a closed dossier cannot be moved.'))
         if ILockable(self.context).locked():

--- a/opengever/dossier/move_items.py
+++ b/opengever/dossier/move_items.py
@@ -2,6 +2,7 @@ from Acquisition import aq_chain
 from Acquisition import aq_inner
 from Acquisition import aq_parent
 from OFS.CopySupport import CopyError, ResourceLockedError
+from opengever.api.not_reported_exceptions import Forbidden as NotReportedForbidden
 from opengever.base.adapters import DefaultMovabilityChecker
 from opengever.base.interfaces import IMovabilityChecker
 from opengever.base.source import RepositoryPathSourceBinder
@@ -383,7 +384,7 @@ class DossierMovabiliyChecker(DefaultMovabilityChecker):
         substructure_depth = self.dossier_structure_depth()
 
         if not target.is_dossier_structure_addable(substructure_depth):
-            raise Forbidden(
+            raise NotReportedForbidden(
                 _(u'msg_would_exceed_max_dossier_level',
                   u'This would exceed maximally allowed dossier depth.'))
 

--- a/opengever/workspace/participation/browser/manage_participants.py
+++ b/opengever/workspace/participation/browser/manage_participants.py
@@ -1,3 +1,4 @@
+from opengever.api.not_reported_exceptions import BadRequest as NotReportedBadRequest
 from opengever.base.role_assignments import ASSIGNMENT_VIA_SHARING
 from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.base.role_assignments import SharingRoleAssignment
@@ -177,7 +178,7 @@ class ManageParticipants(BrowserView):
             if ADMIN_ROLE in assignment.get('roles', []):
                 return
 
-        raise BadRequest(
+        raise NotReportedBadRequest(
             _(u'msg_one_must_remain_admin',
               default=u'At least one principal must remain admin.'))
 


### PR DESCRIPTION
I did not like the idea of excluding errors using the `RAVEN_DISABLE_EXCEPTIONS` environment variable from `ftw.raven`, notably because it only allows to exclude whole classes of exceptions and because it is not easily visible in the code. Also this did not seem like a very future proof solution for when we move away from ftw.raven. 

Instead I chose to not report to sentry all exceptions inheriting from a newly introduced `NotReportedException` class. This allows to specifically disregard certain exceptions in sentry, while still returning the correct error codes and types over the API.

I went over all sentry issues and checked which ones should be disregarded. For a few of them, notably validation errors which are all handled generically (https://github.com/4teamwork/opengever.core/blob/master/opengever/api/deserializer.py#L51-L57), it was not easily possible to avoid reporting them to sentry, so I left it as is. There are also some that I decided not to disregard, because I actually think they should not happen in normal circumstances, and should be avoided in the gever-ui (for example adding twice the same participant on a dossier). As I've gone over the issues I've made a list of a few that we should really look at (see [CA-2755]).

Here the sentry issues that will get resolved with this PR:
- https://sentry.4teamwork.ch/organizations/sentry/issues/75285
- https://sentry.4teamwork.ch/organizations/sentry/issues/79698
- https://sentry.4teamwork.ch/organizations/sentry/issues/80604
- https://sentry.4teamwork.ch/organizations/sentry/issues/75589
- https://sentry.4teamwork.ch/organizations/sentry/issues/76770
- https://sentry.4teamwork.ch/organizations/sentry/issues/72929
- https://sentry.4teamwork.ch/organizations/sentry/issues/68672
- https://sentry.4teamwork.ch/organizations/sentry/issues/73541
- https://sentry.4teamwork.ch/organizations/sentry/issues/77707
- https://sentry.4teamwork.ch/organizations/sentry/issues/79565
- https://sentry.4teamwork.ch/organizations/sentry/issues/80091
- https://sentry.4teamwork.ch/organizations/sentry/issues/80346
- https://sentry.4teamwork.ch/organizations/sentry/issues/79564

For [CA-2755]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed

[CA-2755]: https://4teamwork.atlassian.net/browse/CA-2755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ