### PR TITLE
Correctly handle missing excerpt suffix template when creating excerpt.

### DIFF
--- a/changes/CA-3455.bugfix
+++ b/changes/CA-3455.bugfix
@@ -1,0 +1,1 @@
+Correctly handle missing excerpt suffix template when creating protocol excerpt. [njohner]

--- a/opengever/meeting/command.py
+++ b/opengever/meeting/command.py
@@ -64,7 +64,8 @@ class MergeDocxExcerptCommand(CreateDocumentCommand):
 
         has_header_template = header_template is not None
 
-        if has_header_template and suffix_template is None:
+        if not has_header_template and suffix_template is None:
+            # No header and no suffix, so no need to merge anything...
             return agenda_item_document.file.data
 
         if has_header_template:


### PR DESCRIPTION
It seems the condition introduced in https://github.com/4teamwork/opengever.core/commit/cf5c7401c926e2247963dd9622d30ce9688a4416 was wrong. When creating a proposal excerpt we skip merging only if both the head and suffix templates are missing. Otherwise we need to merge with the agendaitem file.

This cannot be easily tested, hence no test...

For [CA-3455]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-3455]: https://4teamwork.atlassian.net/browse/CA-3455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ