### PR TITLE
Correctly handle error when trying to move proposal document.

### DIFF
--- a/changes/CA-3476.bugfix
+++ b/changes/CA-3476.bugfix
@@ -1,0 +1,1 @@
+Correctly handle error when trying to move proposal document. [njohner]

--- a/opengever/dossier/move_items.py
+++ b/opengever/dossier/move_items.py
@@ -126,7 +126,7 @@ class MoveItemsForm(form.Form):
                                     u'therefore not movable. Move the task '
                                     u'instead',
                             mapping=dict(name=obj.title))
-                    elif exc.message == u'msg_doc_inside_task_cant_be_moved':
+                    elif exc.message == u'msg_doc_inside_proposal_cant_be_moved':
                         msg = _(
                             'label_not_movable_since_inside_proposal',
                             default=u'Document ${name} is inside a proposal '

--- a/opengever/dossier/tests/test_move_items.py
+++ b/opengever/dossier/tests/test_move_items.py
@@ -1082,6 +1082,20 @@ class TestMoveItemsWithTestbrowser(IntegrationTestCase):
         self.assertNotIn(mail, self.empty_dossier.objectValues())
 
     @browsing
+    def test_document_inside_a_proposal_is_not_movable(self, browser):
+        self.login(self.regular_user, browser)
+        self.activate_feature('meeting')
+        self.move_items(
+            browser, src=self.proposal,
+            obj=self.proposaldocument, target=self.empty_dossier)
+
+        self.assertEqual(
+            'Document {} is inside a proposal and therefore not movable. Please move the proposal instead.'.format(self.proposaldocument.title),
+            error_messages()[0])
+        self.assertIn(self.proposaldocument, self.proposal.objectValues())
+        self.assertNotIn(self.proposaldocument, self.empty_dossier.objectValues())
+
+    @browsing
     def test_document_inside_closed_dossier_is_not_movable(self, browser):
         self.login(self.dossier_manager, browser)
         self.move_items(


### PR DESCRIPTION
Trying to move a proposal document was not handled correctly anymore in the classic UI and led to an error.

For [CA-3476]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-3476]: https://4teamwork.atlassian.net/browse/CA-3476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ