### PR TITLE
`@propertysheets` GET: Return same format as POST, instead of JSON schema

### DIFF
--- a/changes/CA-2954-1.feature
+++ b/changes/CA-2954-1.feature
@@ -1,0 +1,1 @@
+Expose propertysheet JSON schemas under `@schema` endpoint. [lgraf]

--- a/changes/CA-2954-2.feature
+++ b/changes/CA-2954-2.feature
@@ -1,0 +1,1 @@
+GET @propertysheets: Return same format as POST, instead of JSON schema. [lgraf]

--- a/changes/CA-2954-3.feature
+++ b/changes/CA-2954-3.feature
@@ -1,0 +1,1 @@
+Add some extra info to `@propertysheets` listing. [lgraf]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -5,8 +5,10 @@ API Changelog
 
 2022.2.0 (unreleased)
 ----------------------
+
 Breaking Changes
 ^^^^^^^^^^^^^^^^
+- ``@propertysheets/<sheet_id>``: GET and POST responses now return the same JSON format as accepted by POST as input, not the JSON schemas anymore. The JSON schemas can now be retrieved from the ``@schema`` endpoint (see change below).
 
 
 Other Changes

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -13,6 +13,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- ``@propertysheets``: Add ``id`` and ``@type`` to sheet listing.
 - ``@schema``: JSON Schemas for propertysheets can now be retrieved with ``GET /@schema/virtual.propertysheet.<sheet_id>``
 - ``@propertysheet-metaschema``: New endpoint to retrieve schema for propertysheet definitions.
 

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,6 +11,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- ``@schema``: JSON Schemas for propertysheets can now be retrieved with ``GET /@schema/virtual.propertysheet.<sheet_id>``
 - ``@propertysheet-metaschema``: New endpoint to retrieve schema for propertysheet definitions.
 
 

--- a/docs/public/dev-manual/api/propertysheets.rst
+++ b/docs/public/dev-manual/api/propertysheets.rst
@@ -356,6 +356,48 @@ Slots nicht überschrieben.
     HTTP/1.1 204 No content
     Content-Type: application/json
 
+
+Schemas für Propertysheets
+--------------------------
+
+JSON Schemas für existierende Propertysheets können über den ``@schema`` Endpoint abgerufen werden. Dazu wird ein ``GET`` Request auf ``@schema/virtual.propertysheet.<sheet_id>`` ausgeführt, wobei ``sheet_id`` die ID / der Name des entsprechenden Sheets ist.
+
+Beispiel (für ein Sheet mit der ID ``question``)
+
+.. sourcecode:: http
+
+  GET /@schema/virtual.propertysheet.question HTTP/1.1
+  Accept: application/json
+
+.. sourcecode:: http
+
+  HTTP/1.1 200 OK
+  Content-Type: application/json+schema
+
+  {
+      "assignments": ["IDocumentMetadata.document_type.question"],
+      "fieldsets": [
+          {
+              "behavior": "plone",
+              "fields": ["yesorno"],
+              "id": "default",
+              "title": "Default"
+          }
+      ],
+      "properties": {
+          "yesorno": {
+              "description": "yes or no",
+              "factory": "Yes/No",
+              "title": "Y/N",
+              "type": "boolean"
+          }
+      },
+      "required": ["yesorno"],
+      "title": "question",
+      "type": "object"
+  }
+
+
 Schema für Propertysheet-Definitionen
 -------------------------------------
 

--- a/docs/public/dev-manual/api/propertysheets.rst
+++ b/docs/public/dev-manual/api/propertysheets.rst
@@ -32,7 +32,7 @@ Eine Liste aller bestehender Property Sheets:
   GET /@propertysheets HTTP/1.1
 
 
-Schema eines Property Sheets:
+Auslesen der Definition eines Property Sheets:
 
 .. sourcecode:: http
 
@@ -128,26 +128,19 @@ ist im Moment nicht unterstützt.
   Location: /@propertysheets/question
 
   {
-      "assignments": ["IDocumentMetadata.document_type.question"],
-      "fieldsets": [
+      "assignments": [
+          "IDocumentMetadata.document_type.question"
+      ],
+      "fields": [
           {
-              "behavior": "plone",
-              "fields": ["yesorno"],
-              "id": "default",
-              "title": "Default"
+              "description": "yes or no",
+              "field_type": "bool",
+              "name": "yesorno",
+              "required": true,
+              "title": "Y/N"
           }
       ],
-      "properties": {
-          "yesorno": {
-              "description": "yes or no",
-              "factory": "Yes/No",
-              "title": "Y/N",
-              "type": "boolean"
-          }
-      },
-      "required": ["yesorno"],
-      "title": "question",
-      "type": "object"
+      "id": "question"
   }
 
 .. _propertysheet-default-values:

--- a/opengever/api/schema/schema.py
+++ b/opengever/api/schema/schema.py
@@ -1,3 +1,4 @@
+from opengever.propertysheets.schema import get_jsonschema_for_propertysheet
 from plone.restapi.services import Service
 from plone.restapi.services.types.get import check_security
 from plone.restapi.types.utils import get_jsonschema_for_portal_type
@@ -44,7 +45,12 @@ class GEVERSchemaGet(Service):
 
         check_security(self.context)
         self.content_type = "application/json+schema"
+
         try:
+            if portal_type.startswith('virtual.'):
+                return self.get_jsonschema_for_virtal_type(
+                    portal_type, self.context, self.request)
+
             return get_jsonschema_for_portal_type(
                 portal_type, self.context, self.request
             )
@@ -55,3 +61,10 @@ class GEVERSchemaGet(Service):
                 "type": "NotFound",
                 "message": 'Type "{}" could not be found.'.format(portal_type),
             }
+
+    def get_jsonschema_for_virtal_type(self, portal_type, context, request):
+        if portal_type.startswith('virtual.propertysheet.'):
+            sheet_id = portal_type.split('virtual.propertysheet.')[-1]
+            return get_jsonschema_for_propertysheet(sheet_id)
+
+        raise KeyError(portal_type)

--- a/opengever/propertysheets/api/configure.zcml
+++ b/opengever/propertysheets/api/configure.zcml
@@ -45,4 +45,6 @@
       permission="opengever.propertysheets.ManagePropertySheets"
       />
 
+  <adapter factory=".definition_serializer.SerializePropertySheetSchemaDefinitionToJson" />
+
 </configure>

--- a/opengever/propertysheets/api/definition_serializer.py
+++ b/opengever/propertysheets/api/definition_serializer.py
@@ -1,0 +1,93 @@
+from opengever.propertysheets.definition import PropertySheetSchemaDefinition
+from opengever.propertysheets.exportimport import dottedname
+from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.serializer.converters import json_compatible
+from zope.component import adapter
+from zope.interface import implementer
+from zope.interface import Interface
+from zope.schema import Choice
+from zope.schema import getFieldsInOrder
+import json
+
+
+@implementer(ISerializeToJson)
+@adapter(PropertySheetSchemaDefinition, Interface)
+class SerializePropertySheetSchemaDefinitionToJson(object):
+
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+
+    def __call__(self, *args, **kwargs):
+        definition = self.context
+
+        serialized_definition = {
+            'id': definition.name,
+            'fields': [],
+            'assignments': definition.assignments,
+        }
+
+        for name, field in getFieldsInOrder(definition.schema_class):
+            ps_field = {
+                'name': name,
+                'field_type': self.get_field_type(field),
+                'title': field.title,
+                'description': field.description,
+                'required': field.required,
+            }
+
+            ps_field.update(self.get_values(field))
+            ps_field.update(self.get_defaults(field))
+
+            serialized_definition['fields'].append(ps_field)
+
+        return json_compatible(serialized_definition)
+
+    def get_field_type(self, field):
+        """Return propertysheet field_type name given a zope.schema field.
+        """
+        type_map = {
+            v.fieldcls.__name__: k for k, v
+            in PropertySheetSchemaDefinition.FACTORIES.items()
+        }
+        return type_map[field.__class__.__name__]
+
+    def get_values(self, field):
+        values = {}
+        vocab = getattr(field, 'vocabulary', None)
+
+        value_type = getattr(field, 'value_type', None)
+        if isinstance(value_type, Choice):
+            vocab = value_type.vocabulary
+
+        if vocab:
+            values['values'] = [t.value for t in vocab]
+
+        return values
+
+    def get_defaults(self, field):
+        """Determine static or dynamic defaults.
+        """
+        defaults = {}
+
+        # Order is important here.
+        # default_from_member is internally turned into a default_expression,
+        # which in turn is implemented as a default-factory-factory.
+        # Therefore these must be checked in exactly this order.
+        if getattr(field, 'default_from_member', None) is not None:
+            defaults['default_from_member'] = json.loads(field.default_from_member)
+        elif getattr(field, 'default_expression', None) is not None:
+            defaults['default_expression'] = field.default_expression
+        elif getattr(field, 'defaultFactory', None) is not None:
+            defaults['default_factory'] = dottedname(field.defaultFactory)
+
+        else:
+            # Only check for a default if none of the dynamic defaults
+            # above are present. Otherwise .default might be a property
+            # that invokes a factory, and we would then accidentally
+            # materialize that dynamic default and serialize is as a
+            # static one.
+            if field.default is not None:
+                defaults['default'] = field.default
+
+        return defaults

--- a/opengever/propertysheets/api/get.py
+++ b/opengever/propertysheets/api/get.py
@@ -1,6 +1,8 @@
 from opengever.propertysheets.storage import PropertySheetSchemaStorage
+from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.services import Service
 from zExceptions import BadRequest
+from zope.component import getMultiAdapter
 from zope.interface import implementer
 from zope.publisher.interfaces import IPublishTraverse
 
@@ -61,6 +63,8 @@ class PropertySheetsGet(Service):
                 "message": u"Sheet '{}' not found.".format(sheet_name),
             }
 
-        json_schema = schema_definition.get_json_schema()
-        self.content_type = "application/json+schema"
-        return json_schema
+        serializer = getMultiAdapter(
+            (schema_definition, self.request),
+            ISerializeToJson,
+        )
+        return serializer()

--- a/opengever/propertysheets/api/get.py
+++ b/opengever/propertysheets/api/get.py
@@ -46,7 +46,9 @@ class PropertySheetsGet(Service):
         result = {"@id": base_url, "items": []}
         for schema_definition in storage.list():
             sheet_definition = {
-                "@id": "{}/{}".format(base_url, schema_definition.name)
+                "@id": "{}/{}".format(base_url, schema_definition.name),
+                "@type": "virtual.propertysheet",
+                "id": schema_definition.name,
             }
             result["items"].append(sheet_definition)
         return result

--- a/opengever/propertysheets/api/post.py
+++ b/opengever/propertysheets/api/post.py
@@ -8,9 +8,11 @@ from opengever.propertysheets.storage import PropertySheetSchemaStorage
 from plone import api
 from plone.protect.interfaces import IDisableCSRFProtection
 from plone.restapi.deserializer import json_body
+from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.services import Service
 from zExceptions import BadRequest
 from zExceptions import Unauthorized
+from zope.component import getMultiAdapter
 from zope.interface import alsoProvides
 from zope.interface import implementer
 from zope.publisher.interfaces import IPublishTraverse
@@ -80,10 +82,12 @@ class PropertySheetsPost(Service):
         except InvalidSchemaAssignment as exc:
             raise BadRequest(exc.message)
 
-        json_schema = schema_definition.get_json_schema()
         self.request.response.setStatus(201)
-        self.content_type = "application/json+schema"
-        return json_schema
+        serializer = getMultiAdapter(
+            (schema_definition, self.request),
+            ISerializeToJson,
+        )
+        return serializer()
 
     def validate_fields(self, fields):
         errors = []

--- a/opengever/propertysheets/schema.py
+++ b/opengever/propertysheets/schema.py
@@ -8,6 +8,18 @@ from zope.globalrequest import getRequest
 import json
 
 
+def get_jsonschema_for_propertysheet(sheet_id):
+    # Avoid circular import
+    from opengever.propertysheets.storage import PropertySheetSchemaStorage
+    storage = PropertySheetSchemaStorage()
+
+    schema_definition = storage.get(sheet_id)
+    if schema_definition is None:
+        raise KeyError(sheet_id)
+
+    return schema_definition.get_json_schema()
+
+
 def get_property_sheet_schema(schema_class):
     context = None
     request = getRequest()

--- a/opengever/propertysheets/tests/test_definition_serializer.py
+++ b/opengever/propertysheets/tests/test_definition_serializer.py
@@ -1,0 +1,244 @@
+from ftw.testbrowser import browsing
+from opengever.propertysheets.exportimport import dottedname
+from opengever.propertysheets.storage import PropertySheetSchemaStorage
+from opengever.propertysheets.testing import dummy_default_factory_fr
+from opengever.testing import IntegrationTestCase
+from plone.restapi.interfaces import ISerializeToJson
+from zope.component import getMultiAdapter
+import json
+
+
+class TestPropertySheetSchemaDefinitionSerializer(IntegrationTestCase):
+
+    maxDiff = None
+
+    def serialize(self, definition):
+        serializer = getMultiAdapter(
+            (definition, self.request), ISerializeToJson)
+        return serializer()
+
+    @browsing
+    def test_serializes_all_field_types(self, browser):
+        self.login(self.propertysheets_manager, browser)
+
+        data = {
+            "fields": [
+                {
+                    "name": "active",
+                    "field_type": u"bool",
+                    "title": u"Active",
+                    "default": True,
+                },
+                {
+                    "name": "language",
+                    "field_type": u"choice",
+                    "title": u"Language",
+                    "values": [u"de", u"fr", u"en"],
+                    "default": u"fr",
+                },
+                {
+                    "name": "colors",
+                    "field_type": u"multiple_choice",
+                    "title": u"Colors",
+                    "description": "A selection of colors",
+                    "values": [u"Rot", u"Gr\xfcn", "Blau"],
+                    "default": [u"Gr\xfcn"],
+                },
+                {
+                    "name": "number",
+                    "field_type": u"int",
+                    "title": u"Number",
+                    "default": 42,
+                },
+                {
+                    "name": "text",
+                    "field_type": u"text",
+                    "title": u"Text",
+                    "required": True,
+                    "default": u"some text",
+                },
+                {
+                    "name": "lineoftext",
+                    "field_type": u"textline",
+                    "title": u"Line of text",
+                    "default": u"some text line",
+                },
+                {
+                    "name": "birthday",
+                    "field_type": u"date",
+                    "title": u"Birthday",
+                },
+            ],
+            "assignments": ["IDocumentMetadata.document_type.question"],
+        }
+        browser.open(
+            view="@propertysheets/meinschema",
+            method="POST",
+            data=json.dumps(data),
+            headers=self.api_headers,
+        )
+
+        storage = PropertySheetSchemaStorage()
+        definition = storage.get("meinschema")
+
+        serialized = self.serialize(definition)
+        self.assertEqual('meinschema', serialized['id'])
+        self.assertEqual(data['assignments'], serialized['assignments'])
+        self.assertEqual(len(data['fields']), len(serialized['fields']))
+
+        for input_field, serialized_field in zip(data['fields'], serialized['fields']):
+            # Fill in any implied defaults in the input fields so they
+            # actually match the equivalent serialized field
+            if 'description' not in input_field:
+                input_field['description'] = ''
+            if 'required' not in input_field:
+                input_field['required'] = False
+
+            self.assertEqual(input_field, serialized_field)
+
+    @browsing
+    def test_serializes_default_factory(self, browser):
+        self.login(self.manager, browser)
+
+        data = {
+            "fields": [
+                {
+                    "name": "language",
+                    "field_type": u"choice",
+                    "title": u"Language",
+                    "values": [u"de", u"fr", u"en"],
+                    "default_factory": dottedname(dummy_default_factory_fr),
+                },
+            ],
+            "assignments": ["IDocument.default"],
+        }
+        browser.open(
+            view="@propertysheets/meinschema",
+            method="POST",
+            data=json.dumps(data),
+            headers=self.api_headers,
+        )
+
+        storage = PropertySheetSchemaStorage()
+        definition = storage.get("meinschema")
+
+        serialized = self.serialize(definition)
+        self.assertEqual(
+            {
+                u'id': u'meinschema',
+                u'assignments': [u'IDocument.default'],
+                u'fields': [
+                    {
+                        u'name': u'language',
+                        u'field_type': u'choice',
+                        u'title': u'Language',
+                        u'description': u'',
+                        u'required': False,
+                        u'values': [u'de', u'fr', u'en'],
+                        u'default_factory': dottedname(dummy_default_factory_fr),
+                    },
+                ],
+            },
+            serialized,
+        )
+
+    @browsing
+    def test_serializes_default_expression(self, browser):
+        self.login(self.manager, browser)
+
+        data = {
+            "fields": [
+                {
+                    "name": "language",
+                    "field_type": u"choice",
+                    "title": u"Language",
+                    "values": [u"de", u"fr", u"en"],
+                    "default_expression": "python: 'fr'",
+                },
+            ],
+            "assignments": ["IDocument.default"],
+        }
+        browser.open(
+            view="@propertysheets/meinschema",
+            method="POST",
+            data=json.dumps(data),
+            headers=self.api_headers,
+        )
+
+        storage = PropertySheetSchemaStorage()
+        definition = storage.get("meinschema")
+
+        serialized = self.serialize(definition)
+        self.assertEqual(
+            {
+                u'id': u'meinschema',
+                u'assignments': [u'IDocument.default'],
+                u'fields': [
+                    {
+                        u'name': u'language',
+                        u'field_type': u'choice',
+                        u'title': u'Language',
+                        u'description': u'',
+                        u'required': False,
+                        u'values': [u'de', u'fr', u'en'],
+                        u'default_expression': u"python: 'fr'",
+                    },
+                ],
+            },
+            serialized,
+        )
+
+    @browsing
+    def test_serializes_default_from_member(self, browser):
+        self.login(self.manager, browser)
+
+        default_from_member = {
+            'property': 'location',
+            'mapping': {
+                'Switzerland': 'CH',
+                'Germany': 'DE',
+                'United States': 'US',
+            }
+        }
+
+        data = {
+            "fields": [
+                {
+                    "name": "language",
+                    "field_type": u"choice",
+                    "title": u"Language",
+                    "values": [u"de", u"fr", u"en"],
+                    "default_from_member": default_from_member,
+                },
+            ],
+            "assignments": ["IDocument.default"],
+        }
+        browser.open(
+            view="@propertysheets/meinschema",
+            method="POST",
+            data=json.dumps(data),
+            headers=self.api_headers,
+        )
+
+        storage = PropertySheetSchemaStorage()
+        definition = storage.get("meinschema")
+
+        serialized = self.serialize(definition)
+        self.assertEqual(
+            {
+                u'id': u'meinschema',
+                u'assignments': [u'IDocument.default'],
+                u'fields': [
+                    {
+                        u'name': u'language',
+                        u'field_type': u'choice',
+                        u'title': u'Language',
+                        u'description': u'',
+                        u'required': False,
+                        u'values': [u'de', u'fr', u'en'],
+                        u'default_from_member': default_from_member,
+                    },
+                ],
+            },
+            serialized,
+        )

--- a/opengever/propertysheets/tests/test_schema_definition_get.py
+++ b/opengever/propertysheets/tests/test_schema_definition_get.py
@@ -1,7 +1,6 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
-from jsonschema import Draft4Validator
 from opengever.propertysheets.exportimport import dottedname
 from opengever.propertysheets.storage import PropertySheetSchemaStorage
 from opengever.propertysheets.testing import dummy_default_factory_fr
@@ -72,42 +71,28 @@ class TestSchemaDefinitionGet(IntegrationTestCase):
         self.assertEqual(
             {
                 u"assignments": [u"IDocumentMetadata.document_type.question"],
-                u"fieldsets": [
+                u"fields": [
                     {
-                        u"behavior": u"plone",
-                        u"fields": [u"yesorno", u"chooseone"],
-                        u"id": u"default",
-                        u"title": u"Default",
-                    }
-                ],
-                u"properties": {
-                    u"chooseone": {
-                        u"choices": [
-                            [u"one", u"one"],
-                            [u"two", u"two"],
-                            [u"three", u"three"],
-                        ],
                         u"description": u"",
-                        u"enum": [u"one", u"two", u"three"],
-                        u"enumNames": [u"one", u"two", u"three"],
-                        u"factory": u"Choice",
-                        u"title": u"choose",
-                        u"type": u"string",
-                    },
-                    u"yesorno": {
-                        u"description": u"",
-                        u"factory": u"Yes/No",
+                        u"field_type": u"bool",
+                        u"name": u"yesorno",
+                        u"required": False,
                         u"title": u"y/n",
-                        u"type": u"boolean",
                     },
-                },
-                u"title": u"schema",
-                u"type": u"object",
+                    {
+                        u"description": u"",
+                        u"field_type": u"choice",
+                        u"name": u"chooseone",
+                        u"required": False,
+                        u"title": u"choose",
+                        u"values": [u"one", u"two", u"three"],
+                    },
+                ],
+                u"id": u"schema",
             },
             browser.json,
         )
-        self.assertEqual("application/json+schema", browser.mimetype)
-        Draft4Validator.check_schema(browser.json)
+        self.assertEqual("application/json", browser.mimetype)
 
     @browsing
     def test_property_sheet_schema_definition_get_field_with_static_default(self, browser):
@@ -128,8 +113,8 @@ class TestSchemaDefinitionGet(IntegrationTestCase):
             headers=self.api_headers,
         )
 
-        prop = browser.json['properties']['language']
-        self.assertEqual(u'fr', prop['default'])
+        field = browser.json['fields'][0]
+        self.assertEqual(u'fr', field['default'])
 
     @browsing
     def test_property_sheet_schema_definition_get_field_with_default_factory(self, browser):
@@ -151,11 +136,11 @@ class TestSchemaDefinitionGet(IntegrationTestCase):
             headers=self.api_headers,
         )
 
-        prop = browser.json['properties']['language']
-        self.assertEqual(u'fr', prop['default'])
+        field = browser.json['fields'][0]
+        self.assertNotIn('default', field)
         self.assertEqual(
             dottedname(dummy_default_factory_fr),
-            prop['default_factory'])
+            field['default_factory'])
 
     @browsing
     def test_property_sheet_schema_definition_get_field_with_default_expression(self, browser):
@@ -177,11 +162,11 @@ class TestSchemaDefinitionGet(IntegrationTestCase):
             headers=self.api_headers,
         )
 
-        prop = browser.json['properties']['language']
-        self.assertEqual(u'en', prop['default'])
+        field = browser.json['fields'][0]
+        self.assertNotIn('default', field)
         self.assertEqual(
             'portal/language',
-            prop['default_expression'])
+            field['default_expression'])
 
     @browsing
     def test_property_sheet_schema_definition_get_field_with_default_from_member(self, browser):
@@ -206,11 +191,11 @@ class TestSchemaDefinitionGet(IntegrationTestCase):
             headers=self.api_headers,
         )
 
-        prop = browser.json['properties']['location']
-        self.assertEqual(u'CH', prop['default'])
+        field = browser.json['fields'][0]
+        self.assertNotIn('default', field)
         self.assertEqual(
             {'property': 'location'},
-            prop['default_from_member'])
+            field['default_from_member'])
 
     @browsing
     def test_property_sheet_schema_definition_get_404(self, browser):

--- a/opengever/propertysheets/tests/test_schema_definition_get.py
+++ b/opengever/propertysheets/tests/test_schema_definition_get.py
@@ -39,9 +39,21 @@ class TestSchemaDefinitionGet(IntegrationTestCase):
             {
                 u"@id": u"http://nohost/plone/@propertysheets",
                 u"items": [
-                    {u"@id": u"http://nohost/plone/@propertysheets/schema2"},
-                    {u"@id": u"http://nohost/plone/@propertysheets/schema1"},
-                    {u"@id": u"http://nohost/plone/@propertysheets/dossier_default"},
+                    {
+                        u"@id": u"http://nohost/plone/@propertysheets/schema2",
+                        u"@type": "virtual.propertysheet",
+                        u"id": "schema2",
+                    },
+                    {
+                        u"@id": u"http://nohost/plone/@propertysheets/schema1",
+                        u"@type": "virtual.propertysheet",
+                        u"id": "schema1",
+                    },
+                    {
+                        u"@id": u"http://nohost/plone/@propertysheets/dossier_default",
+                        u"@type": "virtual.propertysheet",
+                        u"id": "dossier_default",
+                    },
                 ],
             },
             browser.json,

--- a/opengever/propertysheets/tests/test_schema_definition_post.py
+++ b/opengever/propertysheets/tests/test_schema_definition_post.py
@@ -71,30 +71,21 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
 
         self.assertEqual(
             {
-                u"assignments": [u"IDocumentMetadata.document_type.question"],
-                u"fieldsets": [
+                u"id": u"question",
+                u"fields": [
                     {
-                        u"behavior": u"plone",
-                        u"fields": [u"foo"],
-                        u"id": u"default",
-                        u"title": u"Default",
-                    }
-                ],
-                u"properties": {
-                    u"foo": {
                         u"description": u"yes or no",
-                        u"factory": u"Yes/No",
+                        u"field_type": u"bool",
+                        u"name": u"foo",
+                        u"required": True,
                         u"title": u"Y/N",
-                        u"type": u"boolean",
                     },
-                },
-                u"required": [u"foo"],
-                u"title": u"question",
-                u"type": u"object",
+                ],
+                u"assignments": [u"IDocumentMetadata.document_type.question"],
             },
             browser.json,
         )
-        self.assertEqual("application/json+schema", browser.mimetype)
+        self.assertEqual("application/json", browser.mimetype)
 
         storage = PropertySheetSchemaStorage()
         self.assertEqual(4, len(storage))


### PR DESCRIPTION
Use the same custom format that POST requests accept as input for GET responses (and the POST response upon successful creation).

This format, unlike the serialization to a JSON schema, is much more compact, and more importantly, **information-preserving**. For example:

In propertysheet definitions, we distinguish between `texline` and `multiple_choice` (of textline) fields on the field type level. In JSON schema, these both get serialized to a field with a `type` of `string`, but the second has a vocabulary.

Also, by using the same JSON format for serialization and deserialization with the `@propertysheets` endpoint, it will finally follow the behavior that any response it gives, will
- result in the creation of a equivalent sheet if POSTed
- not result in a meaningful modification if sent as a PATCH payload

The JSON schema serialization of a specific propertysheet is instead moved to `@schema/virtual.propertysheet.<sheet_id>`.


For [CA-2954](https://4teamwork.atlassian.net/browse/CA-2954)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry
  - If breaking:
    - [x] api-change label added
    - [ ] #delivery channel notified about breaking change 
        _(deemed unnecessary, propertysheets API was only used internally so far)_
    - [ ] Scrum master is informed _(same)_
