### PR TITLE
Add PATCH support for `@propertysheets` endpoint

### DIFF
--- a/changes/CA-2954-4.feature
+++ b/changes/CA-2954-4.feature
@@ -1,0 +1,1 @@
+Add PATCH support for `@propertysheets` endpoint. [lgraf]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -13,6 +13,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- ``@propertysheets``: Add PATCH support.
 - ``@propertysheets``: Add ``id`` and ``@type`` to sheet listing.
 - ``@schema``: JSON Schemas for propertysheets can now be retrieved with ``GET /@schema/virtual.propertysheet.<sheet_id>``
 - ``@propertysheet-metaschema``: New endpoint to retrieve schema for propertysheet definitions.

--- a/docs/public/dev-manual/api/propertysheets.rst
+++ b/docs/public/dev-manual/api/propertysheets.rst
@@ -39,12 +39,18 @@ Auslesen der Definition eines Property Sheets:
   GET /@propertysheets/<property_sheet_name> HTTP/1.1
 
 
-Hinzufügen eines neuen Property Sheets oder Überschreiben eines bestehenden
-Property Sheets:
+Hinzufügen eines neuen Property Sheets:
 
 .. sourcecode:: http
 
   POST /@propertysheets/<property_sheet_name> HTTP/1.1
+
+
+Mutieren eines bestehenden Property Sheets:
+
+.. sourcecode:: http
+
+  PATCH /@propertysheets/<property_sheet_name> HTTP/1.1
 
 
 Löschen eines bestehenden Property Sheets:
@@ -260,6 +266,60 @@ gesteuert werden, ob Rückgabewerte erlaubt sind, die nicht im Mapping vorkommen
       }
     }
 
+
+Existierende Property Sheets mutieren (PATCH)
+---------------------------------------------
+
+Existierende Property Sheets können über einen ``PATCH`` request mutiert werden. Die PATCH-Semantik besagt grundsätzlich, dass Feldwerte, welche im Request nicht mitgeschickt werden, so belassen werden wie sie sind. Für Propertysheets gilt dies für die äusserste Ebene, nicht aber für verschachtelte Ebenen.
+
+Das heisst, wenn entweder der ``assignments`` Key oder der ``fields`` Key weggelassen werden, behalten diese den vorherigen Wert. Wird aber ein ``fields`` Key mitgeschickt, und enthält weniger Felder als zuvor, werden diese fehlenden Felder *gelöscht*.
+
+Beim Aktualisieren von einzelnen Feldern muss vom Client daher immer die komplette Feld-Liste, wie sie neu aussehen soll, mitgeschickt werden.
+
+Es ist dementsprechend auch nicht möglich, ein Feld umzubenennen. Das Feld kann aber entfernt , und unter einem anderen Namen hinzugefügt werden. Dies führt aber dazu, dass Daten, welche auf Dossiers oder Dokumenten unter dem alten Feldnamen bereits erfasst wurden, verloren gehen und nicht dem neuen Feld zugeordnet sind.
+
+Beispiel für einen PATCH-Request:
+
+
+**Beispiel-Request**:
+
+.. sourcecode:: http
+
+  PATCH http://localhost:8080/fd/@propertysheets/question HTTP/1.1
+  Accept: application/json
+  Content-Type: application/json
+
+  {
+    "assignments": ["IDocument.default"]
+  }
+
+(Ändert die Assignments auf `["IDocument.default"]`. Die Felder werden so belassen wie zuvor.)
+
+
+**Beispiel-Response**:
+
+.. sourcecode:: http
+
+  HTTP/1.1 200 OK
+  Content-Type: application/json
+
+  {
+      "assignments": [
+          "IDocument.default"
+      ],
+      "fields": [
+          {
+              "description": "yes or no",
+              "field_type": "bool",
+              "name": "yesorno",
+              "required": true,
+              "title": "Y/N"
+          }
+      ],
+      "id": "question"
+  }
+
+(Die Response auf PATCH Requests enthält die komplette, neue Definition des Propertysheets.)
 
 
 Serialisierung/Deserialisierung von Custom Properties

--- a/docs/public/dev-manual/api/propertysheets.rst
+++ b/docs/public/dev-manual/api/propertysheets.rst
@@ -63,8 +63,7 @@ Löschen eines bestehenden Property Sheets:
 Neue Property Sheets erstellen
 ------------------------------
 
-Neue Property Sheets können mittels POST Request hinzugefügt werden. Im Moment
-sind keine Inkrementellen Updates der Sheets mittels ``PATCH`` unterstützt.
+Neue Property Sheets können mittels POST Request hinzugefügt werden.
 Ein Sheet kann immer nur als gesamte Einheit gespeichert werden. Existiert
 schon ein Sheet mit dem verwendeten Namen, so wird dieses überschrieben.
 
@@ -320,6 +319,8 @@ Beispiel für einen PATCH-Request:
   }
 
 (Die Response auf PATCH Requests enthält die komplette, neue Definition des Propertysheets.)
+
+Das Ändern von :ref:`dynamischen Defaults <propertysheet-default-values>` ist nur für Benutzer mit der ``Manager``-Rolle erlaubt. Wenn jedoch ein dynamischer default für ein Feld bereits existiert, dann kann dieser in einem PATCH request auch von einem Benutzer mit der Rolle ``PropertySheetsManager`` mitgeschickt werden (um ihn zu erhalten), sofern der dynamische Default nicht geändert wird.
 
 
 Serialisierung/Deserialisierung von Custom Properties

--- a/opengever/propertysheets/api/base.py
+++ b/opengever/propertysheets/api/base.py
@@ -1,0 +1,75 @@
+from opengever.propertysheets.metaschema import IPropertySheetDefinition
+from opengever.propertysheets.storage import PropertySheetSchemaStorage
+from plone.restapi.services import Service
+from zExceptions import BadRequest
+from zExceptions import NotFound
+from zope.interface import implementer
+from zope.publisher.interfaces import IPublishTraverse
+
+
+@implementer(IPublishTraverse)
+class PropertySheetLocator(Service):
+    """Locates a propertysheet definition by its sheet_id.
+
+    This is a Service base class for all services that need to look up a
+    propertysheet definition via a /@propertysheets/{sheet_id} style URL.
+
+    It handles
+    - extraction of the {sheet_id} path parameter
+    - error response for incorrect number of path parameters
+    - validation of {sheet_id}
+    - return of a 404 Not Found response if that sheet doesn't exist
+    - retrieval of the respective sheet
+    in a single place so that not every service has to implement this again,
+    and we ensure consistent behavior across all services.
+
+    Because the GET service supports both individual retrieval as well as
+    listing, this needs to be handled here as well.
+    """
+
+    def __init__(self, context, request):
+        super(PropertySheetLocator, self).__init__(context, request)
+        self.params = []
+
+    def publishTraverse(self, request, sheet_id):
+        # Consume any path segments after /@propertysheets as parameters
+        self.params.append(sheet_id)
+        return self
+
+    def get_sheet_id(self):
+        sheet_id_required = getattr(self, 'sheet_id_required')
+
+        if sheet_id_required:
+            if len(self.params) != 1:
+                raise BadRequest(
+                    'Must supply exactly one {sheet_id} path parameter.')
+        else:
+            # We'll accept zero (listing) or one (get by id) params, but not more
+            if len(self.params) > 1:
+                raise BadRequest(
+                    'Must supply either exactly one {sheet_id} path parameter '
+                    'to fetch a specific property sheet, or no parameter for a '
+                    'listing of all property sheets.')
+
+        # We have a valid number of parameters for the given endpoint
+        if len(self.params) == 1:
+            sheet_id = self.params[0]
+            id_field = IPropertySheetDefinition['id']
+            try:
+                id_field.bind(sheet_id).validate(sheet_id)
+            except Exception:
+                raise BadRequest(u"The name '{}' is invalid.".format(sheet_id))
+
+            return sheet_id
+
+    def locate_sheet(self):
+        sheet_id = self.get_sheet_id()
+
+        if sheet_id is not None:
+            storage = PropertySheetSchemaStorage()
+            definition = storage.get(sheet_id)
+
+            if not definition:
+                raise NotFound
+
+            return definition

--- a/opengever/propertysheets/api/base.py
+++ b/opengever/propertysheets/api/base.py
@@ -1,14 +1,32 @@
 from opengever.propertysheets.metaschema import IPropertySheetDefinition
 from opengever.propertysheets.storage import PropertySheetSchemaStorage
+from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.services import Service
 from zExceptions import BadRequest
 from zExceptions import NotFound
+from zope.component import getMultiAdapter
 from zope.interface import implementer
 from zope.publisher.interfaces import IPublishTraverse
 
 
+class PropertySheetAPIBase(object):
+    """Base class for @propertysheets API endpoints.
+    """
+
+    @property
+    def storage(self):
+        return PropertySheetSchemaStorage()
+
+    def serialize(self, sheet_definition):
+        serializer = getMultiAdapter(
+            (sheet_definition, self.request),
+            ISerializeToJson,
+        )
+        return serializer()
+
+
 @implementer(IPublishTraverse)
-class PropertySheetLocator(Service):
+class PropertySheetLocator(PropertySheetAPIBase, Service):
     """Locates a propertysheet definition by its sheet_id.
 
     This is a Service base class for all services that need to look up a

--- a/opengever/propertysheets/api/configure.zcml
+++ b/opengever/propertysheets/api/configure.zcml
@@ -45,6 +45,15 @@
       permission="opengever.propertysheets.ManagePropertySheets"
       />
 
+  <plone:service
+      method="PATCH"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      factory=".patch.PropertySheetsPatch"
+      name="@propertysheets"
+      layer="opengever.base.interfaces.IOpengeverBaseLayer"
+      permission="opengever.propertysheets.ManagePropertySheets"
+      />
+
   <adapter factory=".definition_serializer.SerializePropertySheetSchemaDefinitionToJson" />
 
 </configure>

--- a/opengever/propertysheets/api/get.py
+++ b/opengever/propertysheets/api/get.py
@@ -1,7 +1,4 @@
 from opengever.propertysheets.api.base import PropertySheetLocator
-from opengever.propertysheets.storage import PropertySheetSchemaStorage
-from plone.restapi.interfaces import ISerializeToJson
-from zope.component import getMultiAdapter
 
 
 class PropertySheetsGet(PropertySheetLocator):
@@ -25,22 +22,15 @@ class PropertySheetsGet(PropertySheetLocator):
 
         if sheet_definition is not None:
             # Get sheet by id
-            serializer = getMultiAdapter(
-                (sheet_definition, self.request),
-                ISerializeToJson,
-            )
-            return serializer()
-
+            return self.serialize(sheet_definition)
         else:
             # List all sheets
             return self.list()
 
     def list(self):
-        storage = PropertySheetSchemaStorage()
-
         base_url = "{}/@propertysheets".format(self.context.absolute_url())
         result = {"@id": base_url, "items": []}
-        for schema_definition in storage.list():
+        for schema_definition in self.storage.list():
             sheet_definition = {
                 "@id": "{}/{}".format(base_url, schema_definition.name),
                 "@type": "virtual.propertysheet",

--- a/opengever/propertysheets/api/patch.py
+++ b/opengever/propertysheets/api/patch.py
@@ -1,0 +1,87 @@
+from opengever.propertysheets.api.base import PropertySheetWriter
+from opengever.propertysheets.exceptions import InvalidSchemaAssignment
+from plone.protect.interfaces import IDisableCSRFProtection
+from plone.restapi.deserializer import json_body
+from zExceptions import BadRequest
+from zope.interface import alsoProvides
+
+
+class PropertySheetsPatch(PropertySheetWriter):
+    """
+    Modify an existing property sheet.
+
+    PATCH semantics only apply to the topmost level (assignments and fields) -
+    if either of those keys is omitted, it will be preserved as-is.
+
+    Omitting a field from the list of fields however will delete it. The field
+    list as a whole therefore needs to be modified by the caller, and always
+    be sent in its entirety.
+
+    Syntax:
+
+    PATCH /@propertysheets/question HTTP/1.1
+    {
+        "fields": [{"name": "foo", field_type": "text", "required": true}],
+    }
+    """
+
+    sheet_id_required = False
+
+    def reply(self):
+        alsoProvides(self.request, IDisableCSRFProtection)
+
+        sheet_definition = self.locate_sheet()
+        sheet_id = sheet_definition.name
+        data = json_body(self.request)
+
+        if 'id' in data and data['id'] != sheet_id:
+            raise BadRequest("The 'id' of an existing sheet must not be changed.")
+
+        fields = data.get("fields")
+
+        if fields:
+            errors = self.validate_fields(fields)
+            if errors:
+                raise BadRequest(errors)
+
+            seen = set()
+            duplicates = []
+            for name in [each["name"] for each in fields]:
+                if name in seen:
+                    duplicates.append(name)
+                seen.add(name)
+            if duplicates:
+                raise BadRequest(
+                    u"Duplicate fields '{}'.".format("', '".join(duplicates))
+                )
+
+        assignments = data.get("assignments")
+        if assignments is not None:
+            assignments = tuple(assignments)
+
+        # Get existing sheet definition
+        serialized_existing_definition = self.serialize(sheet_definition)
+
+        # Update it
+        new_definition_data = serialized_existing_definition.copy()
+        if fields is not None:
+            new_definition_data.update({'fields': fields})
+
+        if assignments is not None:
+            new_definition_data.update({'assignments': assignments})
+
+        # Delete old one
+        self.storage.remove(sheet_id)
+
+        # Recreate the updated one
+        try:
+            new_definition = self.create_property_sheet(
+                sheet_id,
+                new_definition_data['assignments'],
+                new_definition_data['fields'],
+            )
+        except InvalidSchemaAssignment as exc:
+            raise BadRequest(exc.message)
+
+        self.request.response.setStatus(200)
+        return self.serialize(new_definition)

--- a/opengever/propertysheets/api/post.py
+++ b/opengever/propertysheets/api/post.py
@@ -4,14 +4,11 @@ from opengever.propertysheets.api.base import PropertySheetLocator
 from opengever.propertysheets.definition import PropertySheetSchemaDefinition
 from opengever.propertysheets.exceptions import InvalidSchemaAssignment
 from opengever.propertysheets.metaschema import IFieldDefinition
-from opengever.propertysheets.storage import PropertySheetSchemaStorage
 from plone import api
 from plone.protect.interfaces import IDisableCSRFProtection
 from plone.restapi.deserializer import json_body
-from plone.restapi.interfaces import ISerializeToJson
 from zExceptions import BadRequest
 from zExceptions import Unauthorized
-from zope.component import getMultiAdapter
 from zope.interface import alsoProvides
 
 
@@ -27,11 +24,6 @@ class PropertySheetsPost(PropertySheetLocator):
     """
 
     sheet_id_required = True
-
-    def __init__(self, context, request):
-        super(PropertySheetsPost, self).__init__(context, request)
-        self.params = []
-        self.storage = PropertySheetSchemaStorage()
 
     def reply(self):
         alsoProvides(self.request, IDisableCSRFProtection)
@@ -70,11 +62,7 @@ class PropertySheetsPost(PropertySheetLocator):
             raise BadRequest(exc.message)
 
         self.request.response.setStatus(201)
-        serializer = getMultiAdapter(
-            (schema_definition, self.request),
-            ISerializeToJson,
-        )
-        return serializer()
+        return self.serialize(schema_definition)
 
     def validate_fields(self, fields):
         errors = []

--- a/opengever/propertysheets/tests/test_api_error_formatting.py
+++ b/opengever/propertysheets/tests/test_api_error_formatting.py
@@ -53,7 +53,7 @@ class TestPropertysheetsAPIErrorFormatting(IntegrationTestCase):
 
         self.assertDictContainsSubset(
             {
-                u"message": u'Missing parameter sheet_name.',
+                u"message": u"Must supply exactly one {sheet_id} path parameter.",
                 u"type": u"BadRequest",
             },
             browser.json,

--- a/opengever/propertysheets/tests/test_schema_definition_get.py
+++ b/opengever/propertysheets/tests/test_schema_definition_get.py
@@ -222,7 +222,7 @@ class TestSchemaDefinitionGet(IntegrationTestCase):
 
         self.assertDictContainsSubset(
             {
-                u"message": u"Sheet 'idonotexist' not found.",
+                u"message": u"Resource not found: http://nohost/plone/@propertysheets/idonotexist",
                 "type": "NotFound",
             },
             browser.json,
@@ -241,7 +241,9 @@ class TestSchemaDefinitionGet(IntegrationTestCase):
 
         self.assertDictContainsSubset(
             {
-                u"message": u"Must supply either zero or one parameters.",
+                u"message": u"Must supply either exactly one {sheet_id} path "
+                            u"parameter to fetch a specific property sheet, "
+                            u"or no parameter for a listing of all property sheets.",
                 "type": "BadRequest",
             },
             browser.json,

--- a/opengever/propertysheets/tests/test_schema_definition_patch.py
+++ b/opengever/propertysheets/tests/test_schema_definition_patch.py
@@ -1,0 +1,313 @@
+from copy import deepcopy
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+import json
+import transaction
+import unittest
+
+
+class TestSchemaDefinitionPatch(IntegrationTestCase):
+
+    maxDiff = None
+
+    @browsing
+    def test_patch_assignments(self, browser):
+        self.login(self.propertysheets_manager, browser)
+
+        # Create a sheet definition
+        data = {
+            "fields": [
+                {
+                    "name": "foo",
+                    "field_type": "bool",
+                    "title": u"Y/N",
+                    "description": u"yes or no",
+                    "required": True,
+                }
+            ],
+            "assignments": [u"IDocumentMetadata.document_type.question"],
+        }
+        browser.open(
+            view="@propertysheets/question",
+            method="POST",
+            data=json.dumps(data),
+            headers=self.api_headers,
+        )
+
+        patch_data = {
+            "assignments": [u"IDocumentMetadata.document_type.report"],
+        }
+
+        # Patch it
+        browser.open(
+            view="@propertysheets/question",
+            method="PATCH",
+            data=json.dumps(patch_data),
+            headers=self.api_headers,
+        )
+
+        expected = deepcopy(data)
+        expected['id'] = 'question'
+        expected.update(patch_data)
+
+        self.assertEqual(expected, browser.json)
+
+    @browsing
+    def test_patch_fields(self, browser):
+        self.login(self.propertysheets_manager, browser)
+
+        # Create a sheet definition
+        data = {
+            "fields": [
+                {
+                    "name": "yn",
+                    "field_type": u"bool",
+                    "title": u"ja oder nein"
+                },
+            ],
+            "assignments": ["IDocumentMetadata.document_type.question"],
+        }
+        browser.open(
+            view="@propertysheets/question",
+            method="POST",
+            data=json.dumps(data),
+            headers=self.api_headers,
+        )
+
+        patch_data = {
+            "fields": [
+                {
+                    "name": "colors",
+                    "field_type": u"multiple_choice",
+                    "title": u"Some colors",
+                    "values": [u"Rot", u"Gr\xfcn", u"Blau"],
+                    "description": "Select one or more",
+                    "required": False,
+                },
+            ],
+        }
+
+        # Patch it
+        browser.open(
+            view="@propertysheets/question",
+            method="PATCH",
+            data=json.dumps(patch_data),
+            headers=self.api_headers,
+        )
+
+        expected = deepcopy(data)
+        expected['id'] = 'question'
+        expected.update(patch_data)
+
+        self.assertEqual(expected, browser.json)
+
+    @browsing
+    def test_patching_id_is_not_allowed(self, browser):
+        self.login(self.propertysheets_manager, browser)
+
+        # Create a sheet definition
+        data = {
+            "fields": [
+                {
+                    "name": "yn",
+                    "field_type": u"bool",
+                    "title": u"ja oder nein"
+                },
+            ],
+            "assignments": ["IDocumentMetadata.document_type.question"],
+        }
+
+        browser.open(
+            view="@propertysheets/question",
+            method="POST",
+            data=json.dumps(data),
+            headers=self.api_headers,
+        )
+
+        patch_data = {
+            "id": "some_new_id",
+        }
+
+        # Patch it
+        with browser.expect_http_error(400):
+            browser.open(
+                view="@propertysheets/question",
+                method="PATCH",
+                data=json.dumps(patch_data),
+                headers=self.api_headers,
+            )
+        self.assertDictContainsSubset(
+            {
+                u"message": u"The 'id' of an existing sheet must not be changed.",
+                u"type": u"BadRequest",
+            },
+            browser.json,
+        )
+
+    @unittest.expectedFailure
+    @browsing
+    def test_existing_data_preserved_after_patch(self, browser):
+        """Test that existing propertysheet field data is preserved after
+        "renaming" (deleting and re-adding) a propertysheet field from the
+        definition, and manipulating content in between.
+        """
+        self.login(self.propertysheets_manager, browser)
+
+        # Create an initial sheet definition
+        data = {
+            "fields": [
+                {
+                    "name": "color",
+                    "field_type": u"choice",
+                    "title": u"A color",
+                    "values": [u"Rot", u"Gr\xfcn", u"Blau"],
+                    "description": "Select one",
+                    "default": u"Rot",
+                    "required": False,
+                },
+            ],
+            "assignments": ["IDocument.default"],
+        }
+
+        browser.open(
+            view="@propertysheets/question",
+            method="POST",
+            data=json.dumps(data),
+            headers=self.api_headers,
+        )
+        transaction.commit()
+
+        # Create a document
+        with self.observe_children(self.dossier) as children:
+            browser.open(
+                self.dossier,
+                method="POST",
+                data=json.dumps({
+                    '@type': 'opengever.document.document',
+                    'title': 'My document',
+                    'custom_properties': {
+                        'IDocument.default': {
+                            'color': u'Gr\xfcn',
+                        }
+                    }
+                }),
+                headers=self.api_headers,
+            )
+        document = list(children['added'])[0]
+        transaction.commit()
+
+        # Verify custom property field data has been written
+        browser.open(
+            document.absolute_url(),
+            headers=self.api_headers,
+        )
+        self.assertEqual({
+            u'IDocument.default': {
+                u'color': {
+                    u'title': u'Gr\xfcn',
+                    u'token': u'Gr\\xfcn',
+                },
+            }}, browser.json['custom_properties'])
+
+        # "Rename" the field in the definition
+        patch_data = {
+            "fields": [
+                {
+                    "name": "temporary_color_field_name",    # <---
+                    "field_type": u"choice",
+                    "title": u"A color",
+                    "values": [u"Rot", u"Gr\xfcn", u"Blau"],
+                    "description": "Select one",
+                    "default": u"Rot",
+                    "required": False,
+                },
+            ],
+        }
+        browser.open(
+            view="@propertysheets/question",
+            method="PATCH",
+            data=json.dumps(patch_data),
+            headers=self.api_headers,
+        )
+
+        transaction.commit()
+
+        # Old data is still there and getting serialized
+        # (no token/title any more though, because schema definition is gone)
+        browser.open(
+            document.absolute_url(),
+            headers=self.api_headers,
+        )
+        self.assertEqual({
+            u'IDocument.default': {
+                u'color': u'Gr\xfcn'}
+            }, browser.json['custom_properties'])
+
+        # Patch the document and write something to the temporary field
+        browser.open(
+            document.absolute_url(),
+            method="PATCH",
+            data=json.dumps({
+                'custom_properties': {
+                    'IDocument.default': {
+                        'temporary_color_field_name': u'Blau',
+                        }
+                    }
+                },
+            ),
+            headers=self.api_headers,
+        )
+        transaction.commit()
+
+        # Both the old and new field data should still be there
+        browser.open(
+            document.absolute_url(),
+            headers=self.api_headers,
+        )
+        self.assertEqual({
+            u'IDocument.default': {
+                u'color': u'Gr\xfcn',
+                u'temporary_color_field_name': {
+                    u'title': u'Blau',
+                    u'token': u'Blau',
+                },
+            }}, browser.json['custom_properties'])
+
+        transaction.commit()
+
+        # "Rename" the field back to its old name
+        patch_data = {
+            "fields": [
+                {
+                    "name": "color",    # <---
+                    "field_type": u"choice",
+                    "title": u"A color",
+                    "values": [u"Rot", u"Gr\xfcn", u"Blau"],
+                    "description": "Select one",
+                    "default": u"Rot",
+                    "required": False,
+                },
+            ],
+        }
+        browser.open(
+            view="@propertysheets/question",
+            method="PATCH",
+            data=json.dumps(patch_data),
+            headers=self.api_headers,
+        )
+        transaction.commit()
+
+        # The original field data should now be serialized again, with the
+        # temporary field that also being preserved
+        browser.open(
+            document.absolute_url(),
+            headers=self.api_headers,
+        )
+        self.assertEqual({
+            u'IDocument.default': {
+                u'color': {
+                    u'title': u'Gr\xfcn',
+                    u'token': u'Gr\\xfcn',
+                },
+                u'temporary_color_field_name': u'Blau',
+            }}, browser.json['custom_properties'])

--- a/opengever/propertysheets/tests/test_schema_definition_post.py
+++ b/opengever/propertysheets/tests/test_schema_definition_post.py
@@ -625,7 +625,7 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
 
         self.assertDictContainsSubset(
             {
-                u"message": u"Missing parameter sheet_name.",
+                u"message": u"Must supply exactly one {sheet_id} path parameter.",
                 "type": "BadRequest",
             },
             browser.json,


### PR DESCRIPTION
This implements PATCH support for the `@propertysheets` endpoint.

PATCH semantics only apply to the topmost level (assignments and fields) - if either of those keys is omitted, it will be preserved as-is. Omitting a field from the list of fields however will **delete** it. The field list as a whole therefore needs to be modified by the caller, and always be sent in its entirety.

Dynamic defaults also need some special handling for PATCH:

We also allow non-Managers to PATCH propertysheets that contain dynamic defaults (which otherwise may only be set by managers), if those dynamic defaults already existed before and don't get modified by the PATCH request.

This is necessary to allow regular PropertySheetsManagers to allow saving the form with modifications to other things that don't concern the dynamic defaults.

For [CA-2954](https://4teamwork.atlassian.net/browse/CA-2954)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry
