### PR TITLE
Add browser view and zopectl command to show nightly jobs stats.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1457,7 +1457,7 @@ Example configuration:
 Nightly Jobs
 ------------
 
-Gever offers a whole infrastructure to execute certain jobs overnight, to avoid excessive load of the instances during working hours. Nightly jobs are executed via a cronjob calling the ``NightlyJobRunner``, which will try to execute all jobs provided by the registered nightly job providers (named multiadapters of INightlyJobProvider).
+Gever offers a whole infrastructure to execute certain jobs overnight, to avoid excessive load of the instances during working hours. Nightly jobs are executed via a cronjob calling the ``NightlyJobRunner``, which will try to execute all jobs provided by the registered nightly job providers (named multiadapters of INightlyJobProvider). The ``nightly-jobs-stats`` view provides information about the status of the nightly job queue.
 
 Reindexing operations as nightly maintenance jobs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/changes/CA-3290.feature
+++ b/changes/CA-3290.feature
@@ -1,0 +1,1 @@
+Add browser view and zopectl command to show nightly jobs stats. [tinagerber]

--- a/opengever/nightlyjobs/browser/configure.zcml
+++ b/opengever/nightlyjobs/browser/configure.zcml
@@ -1,0 +1,12 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser">
+
+  <browser:page
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      name="nightly-jobs-stats"
+      class=".nightly_jobs_stats.NightlyJobsStatsView"
+      permission="cmf.ManagePortal"
+      />
+
+</configure>

--- a/opengever/nightlyjobs/browser/nightly_jobs_stats.py
+++ b/opengever/nightlyjobs/browser/nightly_jobs_stats.py
@@ -1,0 +1,22 @@
+from Products.Five.browser import BrowserView
+from opengever.nightlyjobs.runner import get_job_counts
+from opengever.nightlyjobs.runner import get_nightly_run_timestamp
+from opengever.nightlyjobs.runner import nightly_run_within_24h
+
+
+def get_nightly_job_stats():
+    job_counts = "\n".join(['{}: {}'.format(name, count)
+                            for name, count in get_job_counts().items()])
+    nightly_status = 'Nightly status: {}'.format(
+        'healthy' if nightly_run_within_24h() else 'unhealthy')
+    timestamp = get_nightly_run_timestamp()
+    last_nightly_run = 'Last nightly run: {}'.format(
+        timestamp.isoformat() if timestamp else 'never')
+
+    return '\n'.join([nightly_status, last_nightly_run, '\nNightly job counts:', job_counts])
+
+
+class NightlyJobsStatsView(BrowserView):
+
+    def __call__(self):
+        return get_nightly_job_stats()

--- a/opengever/nightlyjobs/configure.zcml
+++ b/opengever/nightlyjobs/configure.zcml
@@ -1,5 +1,7 @@
 <configure xmlns="http://namespaces.zope.org/zope">
 
+  <include package=".browser" />
+
   <adapter
       factory=".maintenance_jobs.NightlyMaintenanceJobsProvider"
       name="maintenance-jobs"

--- a/opengever/nightlyjobs/cronjobs.py
+++ b/opengever/nightlyjobs/cronjobs.py
@@ -2,7 +2,9 @@ from logging.handlers import TimedRotatingFileHandler
 from opengever.base.pathfinder import PathFinder
 from opengever.base.sentry import maybe_report_exception
 from opengever.core.debughelpers import all_plone_sites
+from opengever.core.debughelpers import get_first_plone_site
 from opengever.core.debughelpers import setup_plone
+from opengever.nightlyjobs.browser.nightly_jobs_stats import get_nightly_job_stats
 from opengever.nightlyjobs.runner import nightly_jobs_feature_enabled
 from opengever.nightlyjobs.runner import NightlyJobRunner
 from plone import api
@@ -47,6 +49,12 @@ def setup_logger():
     logger.addHandler(file_handler)
 
     return logger
+
+
+def log_nightly_jobs_stats(app, args):
+    logger = setup_logger()
+    setup_plone(get_first_plone_site(app))
+    logger.info(get_nightly_job_stats())
 
 
 def run_nightly_jobs_handler(app, args):

--- a/opengever/nightlyjobs/tests/test_nightly_jobs_stats.py
+++ b/opengever/nightlyjobs/tests/test_nightly_jobs_stats.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+from ftw.testbrowser import browsing
+from ftw.testing import freeze
+from opengever.core.upgrade import NightlyWorkflowSecurityUpdater
+from opengever.nightlyjobs.runner import NightlyJobRunner
+from opengever.testing import IntegrationTestCase
+
+
+class TestNightlyJobsStats(IntegrationTestCase):
+
+    @browsing
+    def test_nightly_jobs_stats(self, browser):
+        self.login(self.manager, browser)
+
+        with NightlyWorkflowSecurityUpdater(reindex_security=False) as updater:
+            updater.update(['opengever_mail_workflow', 'opengever_repositoryroot_workflow'])
+        browser.open(self.portal, view='nightly-jobs-stats')
+
+        self.assertEqual('Nightly status: unhealthy\n'
+                         'Last nightly run: never\n\n'
+                         'Nightly job counts:\n'
+                         'maintenance-jobs: 4\n'
+                         'deliver-sip-packages: 0\n'
+                         'create-dossier-journal-pdf: 0\n'
+                         'complete-role-assignment-reports: 1\n'
+                         'execute-after-resolve-jobs: 0', browser.contents)
+
+        with freeze(datetime(2019, 12, 31, 17, 45)) as clock:
+            runner = NightlyJobRunner(force_execution=True)
+            runner.execute_pending_jobs()
+            clock.forward(hours=5)
+            browser.open(self.portal, view='nightly-jobs-stats')
+
+        self.assertEqual('Nightly status: healthy\n'
+                         'Last nightly run: 2019-12-31T17:45:00\n\n'
+                         'Nightly job counts:\n'
+                         'maintenance-jobs: 0\n'
+                         'deliver-sip-packages: 0\n'
+                         'create-dossier-journal-pdf: 0\n'
+                         'complete-role-assignment-reports: 0\n'
+                         'execute-after-resolve-jobs: 0', browser.contents)

--- a/setup.py
+++ b/setup.py
@@ -208,6 +208,7 @@ setup(name='opengever.core',
       generate_remind_notifications = opengever.task.reminder.cronjobs:generate_remind_notifications_zopectl_handler
       import = opengever.bundle.console:import_oggbundle
       run_nightly_jobs = opengever.nightlyjobs.cronjobs:run_nightly_jobs_handler
+      nightly_jobs_stats = opengever.nightlyjobs.cronjobs:log_nightly_jobs_stats
       send_digest = opengever.activity:send_digest_zopectl_handler
       sync_ogds = opengever.ogds.base:sync_ogds_zopectl_handler
 


### PR DESCRIPTION
The BrowserView is accessible only for managers.

<img width="411" alt="Bildschirmfoto 2022-01-17 um 15 38 25" src="https://user-images.githubusercontent.com/50165195/149789509-94a25e82-b781-440d-a411-d8d40d99d45b.png">


For [CA-3290]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-3290]: https://4teamwork.atlassian.net/browse/CA-3290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ