### PR TITLE
Serialize `@propertysheet` errors in a frontend-friendly way

### DIFF
--- a/changes/CA-2954-5.other
+++ b/changes/CA-2954-5.other
@@ -1,0 +1,1 @@
+Make error serialization for `@propertysheets` more frontend-friendly. [lgraf]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -19,6 +19,7 @@ Other Changes
 
 Breaking Changes
 ^^^^^^^^^^^^^^^^
+- ``@propertysheets``: Change error serialization format for PATCH and POST (to be more frontend-friendly).
 - ``@propertysheets/<sheet_id>``: GET and POST responses now return the same JSON format as accepted by POST as input, not the JSON schemas anymore. The JSON schemas can now be retrieved from the ``@schema`` endpoint (see change below).
 
 

--- a/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-01-16 21:27+0000\n"
+"POT-Creation-Date: 2022-01-17 21:25+0000\n"
 "PO-Revision-Date: 2014-09-04 01:03+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -29,6 +29,10 @@ msgstr "Wollen Sie diese Inhalte wirklich löschen?"
 #: ./opengever/base/browser/reporting_view.py
 msgid "Could not generate the report."
 msgstr "Report konnte nicht generiert werden."
+
+#: ./opengever/base/schema.py
+msgid "Invalid identifier"
+msgstr "Ungültiger Bezeichner"
 
 #: ./opengever/base/browser/folder_delete_confirmation.py
 msgid "Items successfully deleted."

--- a/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-02-16 11:20+0000\n"
+"POT-Creation-Date: 2022-01-16 21:27+0000\n"
 "PO-Revision-Date: 2014-09-04 01:03+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -399,7 +399,7 @@ msgstr "Fehler"
 #. Default: "Title"
 #: ./opengever/base/behaviors/base.py
 #: ./opengever/base/browser/favorites.py
-#: ./opengever/base/browser/translated_title.py
+#: ./opengever/base/browser/role_assignment_excel_report.py
 msgid "label_title"
 msgstr "Titel"
 

--- a/opengever/base/locales/en/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/en/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-02-16 11:20+0000\n"
+"POT-Creation-Date: 2022-01-16 21:27+0000\n"
 "PO-Revision-Date: 2014-09-04 01:03+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -482,7 +482,7 @@ msgstr "Error"
 #. Default: "Title"
 #: ./opengever/base/behaviors/base.py
 #: ./opengever/base/browser/favorites.py
-#: ./opengever/base/browser/translated_title.py
+#: ./opengever/base/browser/role_assignment_excel_report.py
 msgid "label_title"
 msgstr "Title"
 

--- a/opengever/base/locales/en/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/en/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-01-16 21:27+0000\n"
+"POT-Creation-Date: 2022-01-17 21:25+0000\n"
 "PO-Revision-Date: 2014-09-04 01:03+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -32,6 +32,10 @@ msgstr "Are you sure you want to delete these items?"
 #: ./opengever/base/browser/reporting_view.py
 msgid "Could not generate the report."
 msgstr "Could not generate report."
+
+#: ./opengever/base/schema.py
+msgid "Invalid identifier"
+msgstr ""
 
 #. German translation: Inhalte wurden erfolgreich gelöscht.
 #: ./opengever/base/browser/folder_delete_confirmation.py

--- a/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-02-16 11:20+0000\n"
+"POT-Creation-Date: 2022-01-16 21:27+0000\n"
 "PO-Revision-Date: 2017-11-29 10:53+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-base/fr/>\n"
@@ -398,7 +398,7 @@ msgstr "Erreur"
 #. Default: "Title"
 #: ./opengever/base/behaviors/base.py
 #: ./opengever/base/browser/favorites.py
-#: ./opengever/base/browser/translated_title.py
+#: ./opengever/base/browser/role_assignment_excel_report.py
 msgid "label_title"
 msgstr "Titre"
 

--- a/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-01-16 21:27+0000\n"
+"POT-Creation-Date: 2022-01-17 21:25+0000\n"
 "PO-Revision-Date: 2017-11-29 10:53+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-base/fr/>\n"
@@ -30,6 +30,10 @@ msgstr "Êtes-vous sûr de vouloir supprimer ces contenus?"
 #: ./opengever/base/browser/reporting_view.py
 msgid "Could not generate the report."
 msgstr "Impossible de générer l'affichage."
+
+#: ./opengever/base/schema.py
+msgid "Invalid identifier"
+msgstr ""
 
 #: ./opengever/base/browser/folder_delete_confirmation.py
 msgid "Items successfully deleted."

--- a/opengever/base/locales/opengever.base.pot
+++ b/opengever/base/locales/opengever.base.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-01-16 21:27+0000\n"
+"POT-Creation-Date: 2022-01-17 21:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -27,6 +27,10 @@ msgstr ""
 
 #: ./opengever/base/browser/reporting_view.py
 msgid "Could not generate the report."
+msgstr ""
+
+#: ./opengever/base/schema.py
+msgid "Invalid identifier"
 msgstr ""
 
 #: ./opengever/base/browser/folder_delete_confirmation.py

--- a/opengever/base/locales/opengever.base.pot
+++ b/opengever/base/locales/opengever.base.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-02-16 11:20+0000\n"
+"POT-Creation-Date: 2022-01-16 21:27+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -396,7 +396,7 @@ msgstr ""
 #. Default: "Title"
 #: ./opengever/base/behaviors/base.py
 #: ./opengever/base/browser/favorites.py
-#: ./opengever/base/browser/translated_title.py
+#: ./opengever/base/browser/role_assignment_excel_report.py
 msgid "label_title"
 msgstr ""
 

--- a/opengever/base/schema.py
+++ b/opengever/base/schema.py
@@ -1,5 +1,6 @@
 from collective.z3cform.datetimewidget.interfaces import DatetimeValidationError
 from ftw.datepicker.converter import DateTimeDataConverter
+from opengever.base import _
 from opengever.base.date_time import as_utc
 from tzlocal import get_localzone
 from zope import schema
@@ -103,7 +104,7 @@ class MultiTypeField(schema.Field):
 
         if type(value) not in self.allowed_pytypes:
             raise WrongType(
-                'Default value %r of type %r not allowed for its '
+                'Value %r of type %r not allowed for this '
                 'field' % (value, type(value).__name__))
 
         super(MultiTypeField, self)._validate(value)
@@ -114,7 +115,7 @@ class IIdentifier(schema.interfaces.IASCIILine):
 
 
 class InvalidIdentifier(InvalidValue):
-    pass
+    __doc__ = _("""Invalid identifier""")
 
 
 class Identifier(schema.ASCIILine):

--- a/opengever/propertysheets/api/base.py
+++ b/opengever/propertysheets/api/base.py
@@ -173,6 +173,9 @@ class PropertySheetWriter(PropertySheetLocator):
         """Require Manager role for any kind of dynamic defaults, unless
         it's a PATCH request and they already existed and didn't get modified.
         """
+        if api.user.has_permission('cmf.ManagePortal'):
+            return
+
         dynamic_default_types = PSDefinition.DYNAMIC_DEFAULT_PROPERTIES
 
         for name, value in field_data.items():
@@ -181,11 +184,10 @@ class PropertySheetWriter(PropertySheetLocator):
             if (field_data['name'], name, value) in existing_dynamic_defaults:
                 # Existing dynamic default that is left unchanged - allowed
                 continue
-            else:
-                # New or modified dynamic default - managers only
-                if not api.user.has_permission('cmf.ManagePortal'):
-                    raise Unauthorized(
-                        'Setting any dynamic defaults requires Manager role')
+
+            # New or modified dynamic default - managers only
+            raise Unauthorized(
+                'Setting any dynamic defaults requires Manager role')
 
     def get_assignments(self, data, sheet=None):
         assignments = data.get("assignments")

--- a/opengever/propertysheets/api/base.py
+++ b/opengever/propertysheets/api/base.py
@@ -3,6 +3,7 @@ from opengever.api.validation import scrub_json_payload
 from opengever.propertysheets.api.error_serialization import ErrorSerializer
 from opengever.propertysheets.definition import PropertySheetSchemaDefinition as PSDefinition
 from opengever.propertysheets.exceptions import AssignmentAlreadyInUse
+from opengever.propertysheets.exceptions import AssignmentValidationError
 from opengever.propertysheets.exceptions import SheetValidationError
 from opengever.propertysheets.metaschema import IFieldDefinition
 from opengever.propertysheets.metaschema import IPropertySheetDefinition
@@ -154,6 +155,17 @@ class PropertySheetWriter(PropertySheetLocator):
                 if not api.user.has_permission('cmf.ManagePortal'):
                     raise Unauthorized(
                         'Setting any dynamic defaults requires Manager role')
+
+    def get_assignments(self, data, sheet=None):
+        assignments = data.get("assignments")
+        assignment_errors = self.validate_assignments(assignments, sheet=sheet)
+        if assignment_errors:
+            raise AssignmentValidationError(assignment_errors)
+
+        if assignments is not None:
+            assignments = tuple(assignments)
+
+        return assignments
 
     def validate_assignments(self, assignments_data, sheet=None):
         if not assignments_data:

--- a/opengever/propertysheets/api/base.py
+++ b/opengever/propertysheets/api/base.py
@@ -155,7 +155,7 @@ class PropertySheetWriter(PropertySheetLocator):
                     raise Unauthorized(
                         'Setting any dynamic defaults requires Manager role')
 
-    def validate_assignments(self, assignments_data):
+    def validate_assignments(self, assignments_data, sheet=None):
         if not assignments_data:
             return
 
@@ -171,6 +171,12 @@ class PropertySheetWriter(PropertySheetLocator):
         # Validate that assignment isn't already in use
         storage = IAnnotations(self.storage.context).get(
             self.storage.ANNOTATIONS_KEY, {})
+
+        already_existing = []
+        if sheet is not None:
+            # PATCH - allow assignments that already existed
+            already_existing = sheet.assignments
+
         used_assignments = {}
         for sheet_id, definition_data in storage.items():
             for assignment in definition_data['assignments']:
@@ -178,7 +184,7 @@ class PropertySheetWriter(PropertySheetLocator):
 
         for new_assignment in assignments_data:
             in_use_by = used_assignments.get(new_assignment)
-            if in_use_by:
+            if in_use_by and new_assignment not in already_existing:
                 exc = AssignmentAlreadyInUse({
                     'assignment': new_assignment,
                     'in_use_by': in_use_by,

--- a/opengever/propertysheets/api/configure.zcml
+++ b/opengever/propertysheets/api/configure.zcml
@@ -55,5 +55,8 @@
       />
 
   <adapter factory=".definition_serializer.SerializePropertySheetSchemaDefinitionToJson" />
+  <adapter factory=".error_serialization.FieldValidationErrorInfos" />
+  <adapter factory=".error_serialization.AssignmentValidationErrorInfos" />
+  <adapter factory=".error_serialization.SheetValidationErrorInfos" />
 
 </configure>

--- a/opengever/propertysheets/api/error_serialization.py
+++ b/opengever/propertysheets/api/error_serialization.py
@@ -1,0 +1,274 @@
+from opengever.propertysheets import _
+from opengever.propertysheets.exceptions import AssignmentAlreadyInUse
+from opengever.propertysheets.exceptions import AssignmentValidationError
+from opengever.propertysheets.exceptions import FieldValidationError
+from opengever.propertysheets.exceptions import SheetValidationError
+from opengever.propertysheets.metaschema import IPropertySheetDefinition
+from zExceptions import BadRequest
+from zope.component import adapter
+from zope.component import queryMultiAdapter
+from zope.i18n import translate
+from zope.interface import implementer
+from zope.interface import Interface
+from zope.publisher.interfaces.browser import IBrowserRequest
+from zope.schema.interfaces import InvalidValue
+from zope.schema.interfaces import TooLong
+from zope.schema.interfaces import ValidationError
+
+
+class IErrorInfos(Interface):
+    pass
+
+
+class ErrorSerializer(object):
+    """Serialize exceptions for @propertysheets API responses in a
+    frontend-friendly way.
+
+    This mainly involves creating a multi-line string for 'translated_message'
+    that contains enough context to be displayed at the top of the form,
+    without any highlighting of the error field taking place. This message
+    must therefore contain enough context to stand on its own, and allow
+    the user to find and fix the error.
+
+    Example:
+
+    The form contains errors:
+    Field 3 ('location'):
+    Parameter 'title': Value is too long
+    (Max: 128 characters, Actual length: 135 characters)
+    """
+
+    def __init__(self, exc, request):
+        self.exc = exc
+        self.request = request
+
+    def __call__(self):
+        error_adapter = queryMultiAdapter((self.exc, self.request), IErrorInfos)
+        if not error_adapter:
+            # No propertysheets specific error handling
+            raise
+
+        error_infos = error_adapter()
+
+        # Prevent ZPublisher from setting wrong status code
+        if isinstance(self.exc, BadRequest):
+            self.request.response.setStatus(400, lock=1)
+
+        serialized_error = {
+            "message": str(self.exc).decode('utf-8'),
+            "type": type(self.exc).__name__.decode('utf-8'),
+            "translated_message": self.get_translated_message(**error_infos),
+        }
+        return serialized_error
+
+    def get_translated_message(self, error_location, error_description, error_extras):
+        error_string = '\n'.join([
+            error_location,
+            error_description,
+            error_extras,
+        ]).strip()
+
+        message = _(
+            u'msg_propertysheet_has_errors',
+            default=u"The form contains errors:\n"
+                    u"${error_string}",
+            mapping={'error_string': error_string})
+
+        return translate(message, context=self.request)
+
+
+@implementer(IErrorInfos)
+class ErrorInfosBase(object):
+
+    def __init__(self, exc, request):
+        self.exc = exc
+        self.request = request
+
+        self.validation_error = None
+        self.unpack_error(exc)
+
+    def __call__(self):
+        error_infos = {
+            'error_location': self.get_error_location(),
+            'error_description': self.get_error_description(),
+            'error_extras': self.get_error_extras(),
+        }
+        return error_infos
+
+    def unpack_error(self, exc):
+        """Unpack the given exception's data into a more standardized form.
+
+        Subclasses must implement this, and know how their adapted exception's
+        data is structured / nested.
+        """
+        raise NotImplementedError
+
+    def get_error_location(self):
+        """One-line summary of the error's location.
+        """
+        return u''
+
+    def get_error_description(self):
+        """One-line description of the error, with optional prefix for context.
+        """
+        short_text = self.get_error_short_text()
+        prefix = self.get_error_description_prefix()
+        return prefix + short_text
+
+    def get_error_short_text(self):
+        """Concise message describing only the error.
+
+        For example, "Value too long".
+        Defaults to extracting it from the zope.schema ValidationError.
+        """
+        validation_error = self.get_validation_error()
+        return self.extract_error_description(validation_error)
+
+    def get_error_description_prefix(self):
+        """Short prefix providing context for the error description (optional).
+        """
+        return u''
+
+    def get_error_extras(self):
+        """One line of extra details about the error (optional).
+        """
+        return u''
+
+    def get_first_error(self):
+        return self.exc.message[0]
+
+    def get_validation_error(self):
+        return self.validation_error
+
+    def extract_error_description(self, validation_error):
+        """Get a translated, short description of the error from the inner
+        exception (usually a zope.schema ValidationError).
+
+        All subclasses of ValidationError have a .doc() method that returns a
+        concise, translated error description, like "Value is too long".
+        """
+
+        if isinstance(validation_error, ValidationError):
+            desc = validation_error.doc()
+        else:
+            # Otherwise default to the generic "Invalid value"
+            desc = InvalidValue().doc()
+
+        return translate(desc, context=self.request)
+
+    def extract_extra_info(self, validation_error):
+        """Return one line of extra info about a ValidationError, if more
+        context is needed for the user to properly understand and fix the
+        error.
+
+        ValidationErrors usually contain information about the offending
+        value and the failed constraint in a semi-structed way in exc.args.
+        """
+        extra_info = u''
+
+        if isinstance(validation_error, TooLong):
+            value, max_length = validation_error.args
+            extra_info = translate(
+                _(u'extra_info_max_length',
+                  default=u'(Max: ${max_length} characters. '
+                          u'Actual length: ${actual_length} characters)',
+                  mapping={
+                    'max_length': max_length,
+                    'actual_length': len(value),
+                  }),
+                context=self.request,
+            )
+
+        return extra_info
+
+
+@adapter(FieldValidationError, IBrowserRequest)
+class FieldValidationErrorInfos(ErrorInfosBase):
+
+    def unpack_error(self, exc):
+        ps_field_no, ps_field_name, field_error = self.get_first_error()
+        field_key, validation_error = field_error
+        self.validation_error = validation_error
+        self.field_key = field_key
+        self.propertysheet_field_no = ps_field_no
+        self.propertysheet_field_name = ps_field_name
+
+    def get_error_location(self):
+        """Location line with propertysheet field number and name.
+        """
+        error_location = _(
+            u'msg_propertysheet_field_location',
+            default=u"Field ${field_no} ('${field_name}'):",
+            mapping={
+                'field_no': self.propertysheet_field_no + 1,
+                'field_name': self.propertysheet_field_name,
+            })
+        return translate(error_location, context=self.request)
+
+    def get_error_description_prefix(self):
+        """Prefix with the offending key of the propertysheet field dict.
+        """
+        if self.field_key is not None:
+            prefix = _(
+                u'msg_propertysheet_field_error_prefix',
+                default=u"Parameter '${field_key}': ",
+                mapping={
+                    'field_key': self.field_key,
+                })
+            return translate(prefix, context=self.request)
+
+        return u''
+
+    def get_error_extras(self):
+        return self.extract_extra_info(self.get_validation_error())
+
+
+@adapter(AssignmentValidationError, IBrowserRequest)
+class AssignmentValidationErrorInfos(ErrorInfosBase):
+
+    def unpack_error(self, exc):
+        self.validation_error = self.get_first_error()
+
+    def get_error_location(self):
+        field = IPropertySheetDefinition['assignments']
+        error_location = translate(
+            field.title,
+            context=self.request,
+        ) + u':'
+        return error_location
+
+    def get_error_short_text(self):
+        validation_exc = self.get_validation_error()
+        error_description = self.extract_error_description(validation_exc)
+
+        if isinstance(validation_exc, AssignmentAlreadyInUse):
+            # Provide a custom, more helpful error message for this
+            error_description = translate(
+                _(u'msg_assignment_already_in_use',
+                  default=u"Assignment '${assignment}' is already in use.",
+                  mapping={'assignment': validation_exc.message['assignment']}),
+                context=self.request,
+            )
+
+        return error_description
+
+
+@adapter(SheetValidationError, IBrowserRequest)
+class SheetValidationErrorInfos(ErrorInfosBase):
+
+    def unpack_error(self, exc):
+        field_name, validation_error = self.get_first_error()
+        self.validation_error = validation_error
+        self.field_name = field_name
+
+    def get_error_location(self):
+        # We currently only raise SheetValidationError for ID field errors.
+        field = IPropertySheetDefinition['id']
+        error_location = translate(
+            field.title,
+            context=self.request,
+        ) + u':'
+        return error_location
+
+    def get_error_extras(self):
+        return self.extract_extra_info(self.get_validation_error())

--- a/opengever/propertysheets/api/patch.py
+++ b/opengever/propertysheets/api/patch.py
@@ -1,6 +1,5 @@
 from opengever.propertysheets.api.base import PropertySheetWriter
 from opengever.propertysheets.definition import PropertySheetSchemaDefinition as PSDefinition
-from opengever.propertysheets.exceptions import AssignmentValidationError
 from opengever.propertysheets.exceptions import FieldValidationError
 from opengever.propertysheets.exceptions import InvalidSchemaAssignment
 from plone.protect.interfaces import IDisableCSRFProtection
@@ -46,13 +45,7 @@ class PropertySheetsPatch(PropertySheetWriter):
         if 'id' in data and data['id'] != sheet_id:
             raise BadRequest("The 'id' of an existing sheet must not be changed.")
 
-        assignments = data.get("assignments")
-        assignment_errors = self.validate_assignments(assignments, sheet=sheet_definition)
-        if assignment_errors:
-            raise AssignmentValidationError(assignment_errors)
-
-        if assignments is not None:
-            assignments = tuple(assignments)
+        assignments = self.get_assignments(data, sheet_definition)
 
         existing_dynamic_defaults = self.get_existing_dynamic_defaults(
             sheet_definition)

--- a/opengever/propertysheets/api/patch.py
+++ b/opengever/propertysheets/api/patch.py
@@ -26,7 +26,7 @@ class PropertySheetsPatch(PropertySheetWriter):
     }
     """
 
-    sheet_id_required = False
+    sheet_id_required = True
 
     def reply(self):
         alsoProvides(self.request, IDisableCSRFProtection)

--- a/opengever/propertysheets/api/patch.py
+++ b/opengever/propertysheets/api/patch.py
@@ -1,6 +1,5 @@
 from opengever.propertysheets.api.base import PropertySheetWriter
 from opengever.propertysheets.definition import PropertySheetSchemaDefinition as PSDefinition
-from opengever.propertysheets.exceptions import FieldValidationError
 from opengever.propertysheets.exceptions import InvalidSchemaAssignment
 from plone.protect.interfaces import IDisableCSRFProtection
 from plone.restapi.deserializer import json_body
@@ -50,23 +49,7 @@ class PropertySheetsPatch(PropertySheetWriter):
         existing_dynamic_defaults = self.get_existing_dynamic_defaults(
             sheet_definition)
 
-        fields = data.get("fields")
-
-        if fields:
-            errors = self.validate_fields(fields, existing_dynamic_defaults)
-            if errors:
-                raise FieldValidationError(errors)
-
-            seen = set()
-            duplicates = []
-            for name in [each["name"] for each in fields]:
-                if name in seen:
-                    duplicates.append(name)
-                seen.add(name)
-            if duplicates:
-                raise BadRequest(
-                    u"Duplicate fields '{}'.".format("', '".join(duplicates))
-                )
+        fields = self.get_fields(data, existing_dynamic_defaults)
 
         # Get existing sheet definition
         serialized_existing_definition = self.serialize(sheet_definition)

--- a/opengever/propertysheets/api/post.py
+++ b/opengever/propertysheets/api/post.py
@@ -34,24 +34,9 @@ class PropertySheetsPost(PropertySheetWriter):
 
         assignments = self.get_assignments(data)
 
-        fields = data.get("fields")
-        if not fields or not isinstance(fields, list):
+        fields = self.get_fields(data)
+        if not fields:
             raise BadRequest(u"Missing or invalid field definitions.")
-
-        errors = self.validate_fields(fields)
-        if errors:
-            raise FieldValidationError(errors)
-
-        seen = set()
-        duplicates = []
-        for name in [each["name"] for each in fields]:
-            if name in seen:
-                duplicates.append(name)
-            seen.add(name)
-        if duplicates:
-            raise BadRequest(
-                u"Duplicate fields '{}'.".format("', '".join(duplicates))
-            )
 
         try:
             schema_definition = self.create_property_sheet(

--- a/opengever/propertysheets/api/post.py
+++ b/opengever/propertysheets/api/post.py
@@ -1,9 +1,6 @@
-from opengever.propertysheets import _
 from opengever.propertysheets.api.base import PropertySheetWriter
-from opengever.propertysheets.exceptions import AssignmentValidationError
 from opengever.propertysheets.exceptions import FieldValidationError
 from opengever.propertysheets.exceptions import InvalidSchemaAssignment
-from opengever.propertysheets.exceptions import SheetValidationError
 from plone.protect.interfaces import IDisableCSRFProtection
 from plone.restapi.deserializer import json_body
 from zExceptions import BadRequest
@@ -35,13 +32,7 @@ class PropertySheetsPost(PropertySheetWriter):
         sheet_id = self.get_sheet_id()
         data = json_body(self.request)
 
-        assignments = data.get("assignments")
-        assignment_errors = self.validate_assignments(assignments)
-        if assignment_errors:
-            raise AssignmentValidationError(assignment_errors)
-
-        if assignments is not None:
-            assignments = tuple(assignments)
+        assignments = self.get_assignments(data)
 
         fields = data.get("fields")
         if not fields or not isinstance(fields, list):

--- a/opengever/propertysheets/exceptions.py
+++ b/opengever/propertysheets/exceptions.py
@@ -1,5 +1,6 @@
 from opengever.propertysheets import _
 from zExceptions import BadRequest
+from zope.schema.interfaces import InvalidValue
 from zope.schema.interfaces import ValidationError
 
 
@@ -37,3 +38,7 @@ class AssignmentAlreadyInUse(BadRequest):
 
 class DuplicateField(ValidationError):
     __doc__ = _("""Duplicate field with this name""")
+
+
+class InvalidDefaultValue(InvalidValue):
+    __doc__ = _("""Invalid default value""")

--- a/opengever/propertysheets/exceptions.py
+++ b/opengever/propertysheets/exceptions.py
@@ -1,4 +1,6 @@
+from opengever.propertysheets import _
 from zExceptions import BadRequest
+from zope.schema.interfaces import ValidationError
 
 
 class InvalidFieldType(Exception):
@@ -31,3 +33,7 @@ class AssignmentValidationError(BadRequest):
 
 class AssignmentAlreadyInUse(BadRequest):
     pass
+
+
+class DuplicateField(ValidationError):
+    __doc__ = _("""Duplicate field with this name""")

--- a/opengever/propertysheets/exceptions.py
+++ b/opengever/propertysheets/exceptions.py
@@ -1,3 +1,6 @@
+from zExceptions import BadRequest
+
+
 class InvalidFieldType(Exception):
     pass
 
@@ -11,4 +14,20 @@ class InvalidSchemaAssignment(Exception):
 
 
 class BadCustomPropertiesFactoryConfiguration(Exception):
+    pass
+
+
+class SheetValidationError(BadRequest):
+    pass
+
+
+class FieldValidationError(BadRequest):
+    pass
+
+
+class AssignmentValidationError(BadRequest):
+    pass
+
+
+class AssignmentAlreadyInUse(BadRequest):
     pass

--- a/opengever/propertysheets/locales/de/LC_MESSAGES/opengever.propertysheets.po
+++ b/opengever/propertysheets/locales/de/LC_MESSAGES/opengever.propertysheets.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-01-17 23:41+0000\n"
+"POT-Creation-Date: 2022-01-17 23:50+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -85,15 +85,15 @@ msgstr "Datentyp für dieses Feld"
 msgid "help_fields"
 msgstr "Felder"
 
-#. Default: "ID of this property sheet"
+#. Default: "ID of this property sheet (alphanumeric, lowercase, no special characters)"
 #: ./opengever/propertysheets/metaschema.py
 msgid "help_id"
-msgstr "ID dieses Property Sheets"
+msgstr "ID dieses Property Sheets (Alphanumerisch, nur Kleinbuchstaben, keine Sonderzeichen)"
 
-#. Default: "Field name (alphanumeric, lowercase)"
+#. Default: "Field name (alphanumeric, lowercase, no special characters)"
 #: ./opengever/propertysheets/metaschema.py
 msgid "help_name"
-msgstr "Name (Alphanumerisch, nur Kleinbuchstaben)"
+msgstr "Name (Alphanumerisch, nur Kleinbuchstaben, keine Sonderzeichen)"
 
 #. Default: "Whether or not the field is required"
 #: ./opengever/propertysheets/metaschema.py

--- a/opengever/propertysheets/locales/de/LC_MESSAGES/opengever.propertysheets.po
+++ b/opengever/propertysheets/locales/de/LC_MESSAGES/opengever.propertysheets.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-01-17 23:50+0000\n"
+"POT-Creation-Date: 2022-01-18 10:39+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -105,10 +105,10 @@ msgstr "Angabe, ob Benutzer dieses Feld zwingend ausfüllen müssen"
 msgid "help_title"
 msgstr "Titel"
 
-#. Default: "List of values that are allowed for this field"
+#. Default: "List of values that are allowed for this field (one per line)"
 #: ./opengever/propertysheets/metaschema.py
 msgid "help_values"
-msgstr "Liste der erlaubten Werte für das Feld"
+msgstr "Liste der erlaubten Werte für das Feld (ein Wert pro Zeile)"
 
 #. Default: "Assignments"
 #: ./opengever/propertysheets/metaschema.py

--- a/opengever/propertysheets/locales/de/LC_MESSAGES/opengever.propertysheets.po
+++ b/opengever/propertysheets/locales/de/LC_MESSAGES/opengever.propertysheets.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-01-06 14:16+0000\n"
+"POT-Creation-Date: 2022-01-17 21:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -48,101 +48,101 @@ msgid "No custom properties are available."
 msgstr "Es sind keine benutzerdefinierten Felder verfügbar."
 
 #. Default: "What type of content this property sheet will be available for"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_assignments"
 msgstr "Für welche Arten von Inhalten dieses Property Sheet verfügbar sein soll"
 
 #. Default: "Default value for this field"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_default"
 msgstr "Default-Wert für dieses Feld"
 
 #. Default: "Description"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_description"
 msgstr "Beschreibung"
 
 #. Default: "Data type of this field"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_field_type"
 msgstr "Datentyp für dieses Feld"
 
 #. Default: "Fields"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_fields"
 msgstr "Felder"
 
 #. Default: "ID of this property sheet"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_id"
 msgstr "ID dieses Property Sheets"
 
 #. Default: "Field name (alphanumeric, lowercase)"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_name"
 msgstr "Name (Alphanumerisch, nur Kleinbuchstaben)"
 
 #. Default: "Whether or not the field is required"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_required"
 msgstr "Angabe, ob Benutzer dieses Feld zwingend ausfüllen müssen"
 
 #. Default: "Title"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_title"
 msgstr "Titel"
 
 #. Default: "List of values that are allowed for this field"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_values"
 msgstr "Liste der erlaubten Werte für das Feld"
 
 #. Default: "Assignments"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_assignments"
 msgstr "Slots"
 
 #. Default: "Default"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_default"
 msgstr "Default"
 
 #. Default: "Description"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_description"
 msgstr "Beschreibung"
 
 #. Default: "Field type"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_field_type"
 msgstr "Feld-Typ"
 
 #. Default: "Fields"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_fields"
 msgstr "Felder"
 
 #. Default: "ID"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_id"
 msgstr "ID"
 
 #. Default: "Name"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_name"
 msgstr "Name"
 
 #. Default: "Required"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_required"
 msgstr "Pflichtfeld"
 
 #. Default: "Title"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_title"
 msgstr "Titel"
 
 #. Default: "Allowed values"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_values"
 msgstr "Wertebereich"

--- a/opengever/propertysheets/locales/de/LC_MESSAGES/opengever.propertysheets.po
+++ b/opengever/propertysheets/locales/de/LC_MESSAGES/opengever.propertysheets.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-01-17 21:25+0000\n"
+"POT-Creation-Date: 2022-01-17 23:24+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -41,6 +41,10 @@ msgstr "Dossier"
 #: ./opengever/propertysheets/assignment.py
 msgid "Dossier (Type: ${dossier_type})"
 msgstr "Dossier (Typ: ${dossier_type})"
+
+#: ./opengever/propertysheets/exceptions.py
+msgid "Duplicate field with this name"
+msgstr "Doppeltes Feld mit diesem Namen"
 
 #: ./opengever/propertysheets/templates/propertysheet.pt
 #: ./opengever/propertysheets/templates/propertysheet_display.pt

--- a/opengever/propertysheets/locales/de/LC_MESSAGES/opengever.propertysheets.po
+++ b/opengever/propertysheets/locales/de/LC_MESSAGES/opengever.propertysheets.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-01-17 21:02+0000\n"
+"POT-Creation-Date: 2022-01-17 21:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -46,6 +46,11 @@ msgstr "Dossier (Typ: ${dossier_type})"
 #: ./opengever/propertysheets/templates/propertysheet_display.pt
 msgid "No custom properties are available."
 msgstr "Es sind keine benutzerdefinierten Felder verfügbar."
+
+#. Default: "(Max: ${max_length} characters. Actual length: ${actual_length} characters)"
+#: ./opengever/propertysheets/api/error_serialization.py
+msgid "extra_info_max_length"
+msgstr "(Maximum: ${max_length} Zeichen. Tatsächliche Länge: ${actual_length} Zeichen)"
 
 #. Default: "What type of content this property sheet will be available for"
 #: ./opengever/propertysheets/metaschema.py
@@ -146,3 +151,25 @@ msgstr "Titel"
 #: ./opengever/propertysheets/metaschema.py
 msgid "label_values"
 msgstr "Wertebereich"
+
+#. Default: "Assignment '${assignment}' is already in use."
+#: ./opengever/propertysheets/api/error_serialization.py
+msgid "msg_assignment_already_in_use"
+msgstr "Der Slot '${assignment}' ist bereits belegt."
+
+#. Default: "Parameter '${field_key}': "
+#: ./opengever/propertysheets/api/error_serialization.py
+msgid "msg_propertysheet_field_error_prefix"
+msgstr "Parameter '${field_key}': "
+
+#. Default: "Field ${field_no} ('${field_name}'):"
+#: ./opengever/propertysheets/api/error_serialization.py
+msgid "msg_propertysheet_field_location"
+msgstr "Feld ${field_no} ('${field_name}'):"
+
+#. Default: "The form contains errors:\n${error_string}"
+#: ./opengever/propertysheets/api/error_serialization.py
+msgid "msg_propertysheet_has_errors"
+msgstr ""
+"Das Formular enthält Fehler:\n"
+"${error_string}"

--- a/opengever/propertysheets/locales/de/LC_MESSAGES/opengever.propertysheets.po
+++ b/opengever/propertysheets/locales/de/LC_MESSAGES/opengever.propertysheets.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-01-17 23:24+0000\n"
+"POT-Creation-Date: 2022-01-17 23:41+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -45,6 +45,10 @@ msgstr "Dossier (Typ: ${dossier_type})"
 #: ./opengever/propertysheets/exceptions.py
 msgid "Duplicate field with this name"
 msgstr "Doppeltes Feld mit diesem Namen"
+
+#: ./opengever/propertysheets/exceptions.py
+msgid "Invalid default value"
+msgstr "Ungültiger Default-Wert"
 
 #: ./opengever/propertysheets/templates/propertysheet.pt
 #: ./opengever/propertysheets/templates/propertysheet_display.pt

--- a/opengever/propertysheets/locales/en/LC_MESSAGES/opengever.propertysheets.po
+++ b/opengever/propertysheets/locales/en/LC_MESSAGES/opengever.propertysheets.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-01-06 14:16+0000\n"
+"POT-Creation-Date: 2022-01-17 21:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -48,101 +48,101 @@ msgid "No custom properties are available."
 msgstr "No custom properties are available."
 
 #. Default: "What type of content this property sheet will be available for"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_assignments"
 msgstr "What type of content this property sheet will be available for"
 
 #. Default: "Default value for this field"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_default"
 msgstr "Default value for this field"
 
 #. Default: "Description"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_description"
 msgstr "Description"
 
 #. Default: "Data type of this field"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_field_type"
 msgstr "Data type of this field"
 
 #. Default: "Fields"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_fields"
 msgstr "Fields"
 
 #. Default: "ID of this property sheet"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_id"
 msgstr "ID of this property sheet"
 
 #. Default: "Field name (alphanumeric, lowercase)"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_name"
 msgstr "Field name (alphanumeric, lowercase)"
 
 #. Default: "Whether or not the field is required"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_required"
 msgstr "Whether or not the field is required"
 
 #. Default: "Title"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_title"
 msgstr "Title"
 
 #. Default: "List of values that are allowed for this field"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_values"
 msgstr "List of values that are allowed for this field"
 
 #. Default: "Assignments"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_assignments"
 msgstr "Assignments"
 
 #. Default: "Default"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_default"
 msgstr "Default"
 
 #. Default: "Description"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_description"
 msgstr "Description"
 
 #. Default: "Field type"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_field_type"
 msgstr "Field type"
 
 #. Default: "Fields"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_fields"
 msgstr "Fields"
 
 #. Default: "ID"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_id"
 msgstr "ID"
 
 #. Default: "Name"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_name"
 msgstr "Name"
 
 #. Default: "Required"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_required"
 msgstr "Required"
 
 #. Default: "Title"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_title"
 msgstr "Title"
 
 #. Default: "Allowed values"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_values"
 msgstr "Allowed values"

--- a/opengever/propertysheets/locales/en/LC_MESSAGES/opengever.propertysheets.po
+++ b/opengever/propertysheets/locales/en/LC_MESSAGES/opengever.propertysheets.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-01-17 21:02+0000\n"
+"POT-Creation-Date: 2022-01-17 21:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -46,6 +46,11 @@ msgstr "Dossier (Type: ${dossier_type})"
 #: ./opengever/propertysheets/templates/propertysheet_display.pt
 msgid "No custom properties are available."
 msgstr "No custom properties are available."
+
+#. Default: "(Max: ${max_length} characters. Actual length: ${actual_length} characters)"
+#: ./opengever/propertysheets/api/error_serialization.py
+msgid "extra_info_max_length"
+msgstr ""
 
 #. Default: "What type of content this property sheet will be available for"
 #: ./opengever/propertysheets/metaschema.py
@@ -146,3 +151,23 @@ msgstr "Title"
 #: ./opengever/propertysheets/metaschema.py
 msgid "label_values"
 msgstr "Allowed values"
+
+#. Default: "Assignment '${assignment}' is already in use."
+#: ./opengever/propertysheets/api/error_serialization.py
+msgid "msg_assignment_already_in_use"
+msgstr ""
+
+#. Default: "Parameter '${field_key}': "
+#: ./opengever/propertysheets/api/error_serialization.py
+msgid "msg_propertysheet_field_error_prefix"
+msgstr ""
+
+#. Default: "Field ${field_no} ('${field_name}'):"
+#: ./opengever/propertysheets/api/error_serialization.py
+msgid "msg_propertysheet_field_location"
+msgstr ""
+
+#. Default: "The form contains errors:\n${error_string}"
+#: ./opengever/propertysheets/api/error_serialization.py
+msgid "msg_propertysheet_has_errors"
+msgstr ""

--- a/opengever/propertysheets/locales/en/LC_MESSAGES/opengever.propertysheets.po
+++ b/opengever/propertysheets/locales/en/LC_MESSAGES/opengever.propertysheets.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-01-17 23:24+0000\n"
+"POT-Creation-Date: 2022-01-17 23:41+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -44,6 +44,10 @@ msgstr "Dossier (Type: ${dossier_type})"
 
 #: ./opengever/propertysheets/exceptions.py
 msgid "Duplicate field with this name"
+msgstr ""
+
+#: ./opengever/propertysheets/exceptions.py
+msgid "Invalid default value"
 msgstr ""
 
 #: ./opengever/propertysheets/templates/propertysheet.pt

--- a/opengever/propertysheets/locales/en/LC_MESSAGES/opengever.propertysheets.po
+++ b/opengever/propertysheets/locales/en/LC_MESSAGES/opengever.propertysheets.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-01-17 23:50+0000\n"
+"POT-Creation-Date: 2022-01-18 10:39+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -105,10 +105,10 @@ msgstr "Whether or not the field is required"
 msgid "help_title"
 msgstr "Title"
 
-#. Default: "List of values that are allowed for this field"
+#. Default: "List of values that are allowed for this field (one per line)"
 #: ./opengever/propertysheets/metaschema.py
 msgid "help_values"
-msgstr "List of values that are allowed for this field"
+msgstr "List of values that are allowed for this field (one per line)"
 
 #. Default: "Assignments"
 #: ./opengever/propertysheets/metaschema.py

--- a/opengever/propertysheets/locales/en/LC_MESSAGES/opengever.propertysheets.po
+++ b/opengever/propertysheets/locales/en/LC_MESSAGES/opengever.propertysheets.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-01-17 23:41+0000\n"
+"POT-Creation-Date: 2022-01-17 23:50+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -85,15 +85,15 @@ msgstr "Data type of this field"
 msgid "help_fields"
 msgstr "Fields"
 
-#. Default: "ID of this property sheet"
+#. Default: "ID of this property sheet (alphanumeric, lowercase, no special characters)"
 #: ./opengever/propertysheets/metaschema.py
 msgid "help_id"
-msgstr "ID of this property sheet"
+msgstr "ID of this property sheet (alphanumeric, lowercase, no special characters)"
 
-#. Default: "Field name (alphanumeric, lowercase)"
+#. Default: "Field name (alphanumeric, lowercase, no special characters)"
 #: ./opengever/propertysheets/metaschema.py
 msgid "help_name"
-msgstr "Field name (alphanumeric, lowercase)"
+msgstr "Field name (alphanumeric, lowercase, no special characters)"
 
 #. Default: "Whether or not the field is required"
 #: ./opengever/propertysheets/metaschema.py

--- a/opengever/propertysheets/locales/en/LC_MESSAGES/opengever.propertysheets.po
+++ b/opengever/propertysheets/locales/en/LC_MESSAGES/opengever.propertysheets.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-01-17 21:25+0000\n"
+"POT-Creation-Date: 2022-01-17 23:24+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -41,6 +41,10 @@ msgstr "Dossier"
 #: ./opengever/propertysheets/assignment.py
 msgid "Dossier (Type: ${dossier_type})"
 msgstr "Dossier (Type: ${dossier_type})"
+
+#: ./opengever/propertysheets/exceptions.py
+msgid "Duplicate field with this name"
+msgstr ""
 
 #: ./opengever/propertysheets/templates/propertysheet.pt
 #: ./opengever/propertysheets/templates/propertysheet_display.pt

--- a/opengever/propertysheets/locales/fr/LC_MESSAGES/opengever.propertysheets.po
+++ b/opengever/propertysheets/locales/fr/LC_MESSAGES/opengever.propertysheets.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-01-17 23:50+0000\n"
+"POT-Creation-Date: 2022-01-18 10:39+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -105,10 +105,10 @@ msgstr "S'agit-il d'un champ obligatoire?"
 msgid "help_title"
 msgstr "Titre"
 
-#. Default: "List of values that are allowed for this field"
+#. Default: "List of values that are allowed for this field (one per line)"
 #: ./opengever/propertysheets/metaschema.py
 msgid "help_values"
-msgstr "Liste des valeurs valides pour ce champ"
+msgstr "Liste des valeurs valides pour ce champ (une valeur par ligne)"
 
 #. Default: "Assignments"
 #: ./opengever/propertysheets/metaschema.py

--- a/opengever/propertysheets/locales/fr/LC_MESSAGES/opengever.propertysheets.po
+++ b/opengever/propertysheets/locales/fr/LC_MESSAGES/opengever.propertysheets.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-01-06 14:16+0000\n"
+"POT-Creation-Date: 2022-01-17 21:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -48,101 +48,101 @@ msgid "No custom properties are available."
 msgstr "Aucun champ personnalisé disponible."
 
 #. Default: "What type of content this property sheet will be available for"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_assignments"
 msgstr "Type de contenu pour lequel cette Property Sheet sera disponible"
 
 #. Default: "Default value for this field"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_default"
 msgstr "Valeur par défaut de ce champ"
 
 #. Default: "Description"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_description"
 msgstr "Description"
 
 #. Default: "Data type of this field"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_field_type"
 msgstr "Type de donnée de ce champ"
 
 #. Default: "Fields"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_fields"
 msgstr "Champs"
 
 #. Default: "ID of this property sheet"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_id"
 msgstr "ID de cette Property Sheet"
 
 #. Default: "Field name (alphanumeric, lowercase)"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_name"
 msgstr "Nom du champ (alphanumérique, minuscule)"
 
 #. Default: "Whether or not the field is required"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_required"
 msgstr "S'agit-il d'un champ obligatoire?"
 
 #. Default: "Title"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_title"
 msgstr "Titre"
 
 #. Default: "List of values that are allowed for this field"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_values"
 msgstr "Liste des valeurs valides pour ce champ"
 
 #. Default: "Assignments"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_assignments"
 msgstr "Assignations"
 
 #. Default: "Default"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_default"
 msgstr "Valeur par défaut"
 
 #. Default: "Description"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_description"
 msgstr "Description"
 
 #. Default: "Field type"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_field_type"
 msgstr "Type"
 
 #. Default: "Fields"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_fields"
 msgstr "Champs"
 
 #. Default: "ID"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_id"
 msgstr "ID"
 
 #. Default: "Name"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_name"
 msgstr "Nom"
 
 #. Default: "Required"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_required"
 msgstr "Requis"
 
 #. Default: "Title"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_title"
 msgstr "Titre"
 
 #. Default: "Allowed values"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_values"
 msgstr "Valeurs admises"

--- a/opengever/propertysheets/locales/fr/LC_MESSAGES/opengever.propertysheets.po
+++ b/opengever/propertysheets/locales/fr/LC_MESSAGES/opengever.propertysheets.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-01-17 23:24+0000\n"
+"POT-Creation-Date: 2022-01-17 23:41+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -44,6 +44,10 @@ msgstr "Dossier (Type: ${dossier_type})"
 
 #: ./opengever/propertysheets/exceptions.py
 msgid "Duplicate field with this name"
+msgstr ""
+
+#: ./opengever/propertysheets/exceptions.py
+msgid "Invalid default value"
 msgstr ""
 
 #: ./opengever/propertysheets/templates/propertysheet.pt

--- a/opengever/propertysheets/locales/fr/LC_MESSAGES/opengever.propertysheets.po
+++ b/opengever/propertysheets/locales/fr/LC_MESSAGES/opengever.propertysheets.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-01-17 23:41+0000\n"
+"POT-Creation-Date: 2022-01-17 23:50+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -85,15 +85,15 @@ msgstr "Type de donnée de ce champ"
 msgid "help_fields"
 msgstr "Champs"
 
-#. Default: "ID of this property sheet"
+#. Default: "ID of this property sheet (alphanumeric, lowercase, no special characters)"
 #: ./opengever/propertysheets/metaschema.py
 msgid "help_id"
-msgstr "ID de cette Property Sheet"
+msgstr "ID de cette Property Sheet (alphanumérique, minuscule, pas de caractères spéciaux)"
 
-#. Default: "Field name (alphanumeric, lowercase)"
+#. Default: "Field name (alphanumeric, lowercase, no special characters)"
 #: ./opengever/propertysheets/metaschema.py
 msgid "help_name"
-msgstr "Nom du champ (alphanumérique, minuscule)"
+msgstr "Nom du champ (alphanumérique, minuscule, pas de caractères spéciaux)"
 
 #. Default: "Whether or not the field is required"
 #: ./opengever/propertysheets/metaschema.py

--- a/opengever/propertysheets/locales/fr/LC_MESSAGES/opengever.propertysheets.po
+++ b/opengever/propertysheets/locales/fr/LC_MESSAGES/opengever.propertysheets.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-01-17 21:02+0000\n"
+"POT-Creation-Date: 2022-01-17 21:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -46,6 +46,11 @@ msgstr "Dossier (Type: ${dossier_type})"
 #: ./opengever/propertysheets/templates/propertysheet_display.pt
 msgid "No custom properties are available."
 msgstr "Aucun champ personnalisé disponible."
+
+#. Default: "(Max: ${max_length} characters. Actual length: ${actual_length} characters)"
+#: ./opengever/propertysheets/api/error_serialization.py
+msgid "extra_info_max_length"
+msgstr ""
 
 #. Default: "What type of content this property sheet will be available for"
 #: ./opengever/propertysheets/metaschema.py
@@ -146,3 +151,23 @@ msgstr "Titre"
 #: ./opengever/propertysheets/metaschema.py
 msgid "label_values"
 msgstr "Valeurs admises"
+
+#. Default: "Assignment '${assignment}' is already in use."
+#: ./opengever/propertysheets/api/error_serialization.py
+msgid "msg_assignment_already_in_use"
+msgstr ""
+
+#. Default: "Parameter '${field_key}': "
+#: ./opengever/propertysheets/api/error_serialization.py
+msgid "msg_propertysheet_field_error_prefix"
+msgstr ""
+
+#. Default: "Field ${field_no} ('${field_name}'):"
+#: ./opengever/propertysheets/api/error_serialization.py
+msgid "msg_propertysheet_field_location"
+msgstr ""
+
+#. Default: "The form contains errors:\n${error_string}"
+#: ./opengever/propertysheets/api/error_serialization.py
+msgid "msg_propertysheet_has_errors"
+msgstr ""

--- a/opengever/propertysheets/locales/fr/LC_MESSAGES/opengever.propertysheets.po
+++ b/opengever/propertysheets/locales/fr/LC_MESSAGES/opengever.propertysheets.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-01-17 21:25+0000\n"
+"POT-Creation-Date: 2022-01-17 23:24+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -41,6 +41,10 @@ msgstr "Dossier"
 #: ./opengever/propertysheets/assignment.py
 msgid "Dossier (Type: ${dossier_type})"
 msgstr "Dossier (Type: ${dossier_type})"
+
+#: ./opengever/propertysheets/exceptions.py
+msgid "Duplicate field with this name"
+msgstr ""
 
 #: ./opengever/propertysheets/templates/propertysheet.pt
 #: ./opengever/propertysheets/templates/propertysheet_display.pt

--- a/opengever/propertysheets/locales/opengever.propertysheets.pot
+++ b/opengever/propertysheets/locales/opengever.propertysheets.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-01-17 23:41+0000\n"
+"POT-Creation-Date: 2022-01-17 23:50+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -88,12 +88,12 @@ msgstr ""
 msgid "help_fields"
 msgstr ""
 
-#. Default: "ID of this property sheet"
+#. Default: "ID of this property sheet (alphanumeric, lowercase, no special characters)"
 #: ./opengever/propertysheets/metaschema.py
 msgid "help_id"
 msgstr ""
 
-#. Default: "Field name (alphanumeric, lowercase)"
+#. Default: "Field name (alphanumeric, lowercase, no special characters)"
 #: ./opengever/propertysheets/metaschema.py
 msgid "help_name"
 msgstr ""

--- a/opengever/propertysheets/locales/opengever.propertysheets.pot
+++ b/opengever/propertysheets/locales/opengever.propertysheets.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-01-17 21:02+0000\n"
+"POT-Creation-Date: 2022-01-17 21:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -48,6 +48,11 @@ msgstr ""
 #: ./opengever/propertysheets/templates/propertysheet.pt
 #: ./opengever/propertysheets/templates/propertysheet_display.pt
 msgid "No custom properties are available."
+msgstr ""
+
+#. Default: "(Max: ${max_length} characters. Actual length: ${actual_length} characters)"
+#: ./opengever/propertysheets/api/error_serialization.py
+msgid "extra_info_max_length"
 msgstr ""
 
 #. Default: "What type of content this property sheet will be available for"
@@ -148,4 +153,24 @@ msgstr ""
 #. Default: "Allowed values"
 #: ./opengever/propertysheets/metaschema.py
 msgid "label_values"
+msgstr ""
+
+#. Default: "Assignment '${assignment}' is already in use."
+#: ./opengever/propertysheets/api/error_serialization.py
+msgid "msg_assignment_already_in_use"
+msgstr ""
+
+#. Default: "Parameter '${field_key}': "
+#: ./opengever/propertysheets/api/error_serialization.py
+msgid "msg_propertysheet_field_error_prefix"
+msgstr ""
+
+#. Default: "Field ${field_no} ('${field_name}'):"
+#: ./opengever/propertysheets/api/error_serialization.py
+msgid "msg_propertysheet_field_location"
+msgstr ""
+
+#. Default: "The form contains errors:\n${error_string}"
+#: ./opengever/propertysheets/api/error_serialization.py
+msgid "msg_propertysheet_has_errors"
 msgstr ""

--- a/opengever/propertysheets/locales/opengever.propertysheets.pot
+++ b/opengever/propertysheets/locales/opengever.propertysheets.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-01-17 23:24+0000\n"
+"POT-Creation-Date: 2022-01-17 23:41+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -47,6 +47,10 @@ msgstr ""
 
 #: ./opengever/propertysheets/exceptions.py
 msgid "Duplicate field with this name"
+msgstr ""
+
+#: ./opengever/propertysheets/exceptions.py
+msgid "Invalid default value"
 msgstr ""
 
 #: ./opengever/propertysheets/templates/propertysheet.pt

--- a/opengever/propertysheets/locales/opengever.propertysheets.pot
+++ b/opengever/propertysheets/locales/opengever.propertysheets.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-01-06 14:16+0000\n"
+"POT-Creation-Date: 2022-01-17 21:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -51,101 +51,101 @@ msgid "No custom properties are available."
 msgstr ""
 
 #. Default: "What type of content this property sheet will be available for"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_assignments"
 msgstr ""
 
 #. Default: "Default value for this field"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_default"
 msgstr ""
 
 #. Default: "Description"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_description"
 msgstr ""
 
 #. Default: "Data type of this field"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_field_type"
 msgstr ""
 
 #. Default: "Fields"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_fields"
 msgstr ""
 
 #. Default: "ID of this property sheet"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_id"
 msgstr ""
 
 #. Default: "Field name (alphanumeric, lowercase)"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_name"
 msgstr ""
 
 #. Default: "Whether or not the field is required"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_required"
 msgstr ""
 
 #. Default: "Title"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_title"
 msgstr ""
 
 #. Default: "List of values that are allowed for this field"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "help_values"
 msgstr ""
 
 #. Default: "Assignments"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_assignments"
 msgstr ""
 
 #. Default: "Default"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_default"
 msgstr ""
 
 #. Default: "Description"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_description"
 msgstr ""
 
 #. Default: "Field type"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_field_type"
 msgstr ""
 
 #. Default: "Fields"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_fields"
 msgstr ""
 
 #. Default: "ID"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_id"
 msgstr ""
 
 #. Default: "Name"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_name"
 msgstr ""
 
 #. Default: "Required"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_required"
 msgstr ""
 
 #. Default: "Title"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_title"
 msgstr ""
 
 #. Default: "Allowed values"
-#: ./opengever/propertysheets/api/post.py
+#: ./opengever/propertysheets/metaschema.py
 msgid "label_values"
 msgstr ""

--- a/opengever/propertysheets/locales/opengever.propertysheets.pot
+++ b/opengever/propertysheets/locales/opengever.propertysheets.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-01-17 23:50+0000\n"
+"POT-Creation-Date: 2022-01-18 10:39+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -108,7 +108,7 @@ msgstr ""
 msgid "help_title"
 msgstr ""
 
-#. Default: "List of values that are allowed for this field"
+#. Default: "List of values that are allowed for this field (one per line)"
 #: ./opengever/propertysheets/metaschema.py
 msgid "help_values"
 msgstr ""

--- a/opengever/propertysheets/locales/opengever.propertysheets.pot
+++ b/opengever/propertysheets/locales/opengever.propertysheets.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-01-17 21:25+0000\n"
+"POT-Creation-Date: 2022-01-17 23:24+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -43,6 +43,10 @@ msgstr ""
 
 #: ./opengever/propertysheets/assignment.py
 msgid "Dossier (Type: ${dossier_type})"
+msgstr ""
+
+#: ./opengever/propertysheets/exceptions.py
+msgid "Duplicate field with this name"
 msgstr ""
 
 #: ./opengever/propertysheets/templates/propertysheet.pt

--- a/opengever/propertysheets/metaschema.py
+++ b/opengever/propertysheets/metaschema.py
@@ -82,7 +82,7 @@ class IFieldDefinition(model.Schema):
     values = schema.List(
         title=_(u'label_values', default=u'Allowed values'),
         description=_(u'help_values',
-                      default=u'List of values that are allowed for this field'),
+                      default=u'List of values that are allowed for this field (one per line)'),
         required=False,
         default=None,
         value_type=schema.TextLine(),

--- a/opengever/propertysheets/metaschema.py
+++ b/opengever/propertysheets/metaschema.py
@@ -4,11 +4,11 @@ from opengever.propertysheets import _
 from opengever.propertysheets.assignment import PropertySheetAssignmentVocabulary
 from opengever.propertysheets.definition import isidentifier
 from opengever.propertysheets.definition import PropertySheetSchemaDefinition
+from opengever.propertysheets.exceptions import InvalidDefaultValue
 from plone.supermodel import model
 from zope import schema
 from zope.globalrequest import getRequest
 from zope.i18n import translate
-from zope.interface import Invalid
 from zope.interface import invariant
 from zope.interface import provider
 from zope.schema import Choice
@@ -117,7 +117,7 @@ class IFieldDefinition(model.Schema):
         try:
             field.validate(default)
         except Exception:
-            raise Invalid('Invalid default value: %r' % default)
+            raise InvalidDefaultValue(default)
 
 
 class IPropertySheetDefinition(model.Schema):

--- a/opengever/propertysheets/metaschema.py
+++ b/opengever/propertysheets/metaschema.py
@@ -35,7 +35,8 @@ class IFieldDefinition(model.Schema):
 
     name = Identifier(
         title=_(u'label_name', default=u'Name'),
-        description=_(u'help_name', default=u'Field name (alphanumeric, lowercase)'),
+        description=_(u'help_name', default=u'Field name (alphanumeric, lowercase, '
+                                            u'no special characters)'),
         required=True,
         max_length=32,
         pattern='^[a-z_0-9]*$',
@@ -124,7 +125,8 @@ class IPropertySheetDefinition(model.Schema):
 
     id = Identifier(
         title=_(u'label_id', default=u'ID'),
-        description=_(u'help_id', default=u'ID of this property sheet'),
+        description=_(u'help_id', default=u'ID of this property sheet (alphanumeric, '
+                                          u'lowercase, no special characters)'),
         required=False,
         max_length=32,
         pattern='^[a-z_0-9]*$',

--- a/opengever/propertysheets/tests/test_api_error_formatting.py
+++ b/opengever/propertysheets/tests/test_api_error_formatting.py
@@ -486,7 +486,7 @@ class TestPropertysheetsAPIErrorFormatting(IntegrationTestCase):
                 u"translated_message": "\n".join([
                     u"Das Formular enth\xe4lt Fehler:",
                     u"Feld 1 ('myfield'):",
-                    u"Ung\xfcltiger Wert",
+                    u"Ung\xfcltiger Default-Wert",
                 ]),
             },
             browser.json,
@@ -515,7 +515,7 @@ class TestPropertysheetsAPIErrorFormatting(IntegrationTestCase):
                 u"translated_message": "\n".join([
                     u"Das Formular enth\xe4lt Fehler:",
                     u"Feld 1 ('myfield'):",
-                    u"Ung\xfcltiger Wert",
+                    u"Ung\xfcltiger Default-Wert",
                 ]),
             },
             browser.json,
@@ -544,7 +544,7 @@ class TestPropertysheetsAPIErrorFormatting(IntegrationTestCase):
                 u"translated_message": "\n".join([
                     u"Das Formular enth\xe4lt Fehler:",
                     u"Feld 1 ('myfield'):",
-                    u"Ung\xfcltiger Wert",
+                    u"Ung\xfcltiger Default-Wert",
                 ]),
             },
             browser.json,
@@ -573,7 +573,7 @@ class TestPropertysheetsAPIErrorFormatting(IntegrationTestCase):
                 u"translated_message": "\n".join([
                     u"Das Formular enth\xe4lt Fehler:",
                     u"Feld 1 ('myfield'):",
-                    u"Ung\xfcltiger Wert",
+                    u"Ung\xfcltiger Default-Wert",
                 ]),
             },
             browser.json,
@@ -1142,7 +1142,7 @@ class TestPropertysheetsAPIErrorFormattingPatch(IntegrationTestCase):
                 u"translated_message": "\n".join([
                     u"Das Formular enth\xe4lt Fehler:",
                     u"Feld 1 ('myfield'):",
-                    u"Ung\xfcltiger Wert",
+                    u"Ung\xfcltiger Default-Wert",
                 ]),
             },
             browser.json,
@@ -1171,7 +1171,7 @@ class TestPropertysheetsAPIErrorFormattingPatch(IntegrationTestCase):
                 u"translated_message": "\n".join([
                     u"Das Formular enth\xe4lt Fehler:",
                     u"Feld 1 ('myfield'):",
-                    u"Ung\xfcltiger Wert",
+                    u"Ung\xfcltiger Default-Wert",
                 ]),
             },
             browser.json,
@@ -1200,7 +1200,7 @@ class TestPropertysheetsAPIErrorFormattingPatch(IntegrationTestCase):
                 u"translated_message": "\n".join([
                     u"Das Formular enth\xe4lt Fehler:",
                     u"Feld 1 ('myfield'):",
-                    u"Ung\xfcltiger Wert",
+                    u"Ung\xfcltiger Default-Wert",
                 ]),
             },
             browser.json,
@@ -1229,7 +1229,7 @@ class TestPropertysheetsAPIErrorFormattingPatch(IntegrationTestCase):
                 u"translated_message": "\n".join([
                     u"Das Formular enth\xe4lt Fehler:",
                     u"Feld 1 ('myfield'):",
-                    u"Ung\xfcltiger Wert",
+                    u"Ung\xfcltiger Default-Wert",
                 ]),
             },
             browser.json,

--- a/opengever/propertysheets/tests/test_api_error_formatting.py
+++ b/opengever/propertysheets/tests/test_api_error_formatting.py
@@ -336,8 +336,12 @@ class TestPropertysheetsAPIErrorFormatting(IntegrationTestCase):
 
         self.assertDictContainsSubset(
             {
-                u"message": u"Duplicate fields 'myfield'.",
-                u"type": u"BadRequest",
+                u"type": u"FieldValidationError",
+                u"translated_message": "\n".join([
+                    u"Das Formular enth\xe4lt Fehler:",
+                    u"Feld 2 ('myfield'):",
+                    u"Parameter 'name': Doppeltes Feld mit diesem Namen",
+                ]),
             },
             browser.json,
         )
@@ -988,8 +992,12 @@ class TestPropertysheetsAPIErrorFormattingPatch(IntegrationTestCase):
 
         self.assertDictContainsSubset(
             {
-                u"message": u"Duplicate fields 'myfield'.",
-                u"type": u"BadRequest",
+                u"type": u"FieldValidationError",
+                u"translated_message": "\n".join([
+                    u"Das Formular enth\xe4lt Fehler:",
+                    u"Feld 2 ('myfield'):",
+                    u"Parameter 'name': Doppeltes Feld mit diesem Namen",
+                ]),
             },
             browser.json,
         )

--- a/opengever/propertysheets/tests/test_api_error_formatting.py
+++ b/opengever/propertysheets/tests/test_api_error_formatting.py
@@ -654,3 +654,655 @@ class TestPropertysheetsAPIErrorFormatting(IntegrationTestCase):
             },
             browser.json,
         )
+
+
+class TestPropertysheetsAPIErrorFormattingPatch(IntegrationTestCase):
+    """Same as above, but for PATCH
+    """
+
+    VALID_SAMPLE_PAYLOAD = {
+        "fields": [
+            {
+                "name": "foo",
+                "field_type": "bool",
+                "title": u"Y/N",
+                "description": u"yes or no",
+                "required": True,
+            }
+        ],
+        "assignments": [u"IDocumentMetadata.document_type.report"],
+    }
+
+    api_headers = {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+        'Accept-Language': 'de-ch',
+    }
+
+    def patch_sheet(self, browser, data, sheet_id='sheet_to_patch', post_first=True):
+        if post_first:
+            # First create a sheet
+            browser.open(
+                view="@propertysheets/%s" % sheet_id,
+                method="POST",
+                data=json.dumps(self.VALID_SAMPLE_PAYLOAD),
+                headers=self.api_headers,
+            )
+
+        # Then attempt to patch it
+        browser.open(
+            view="@propertysheets/%s" % sheet_id,
+            method="PATCH",
+            data=json.dumps(data),
+            headers=self.api_headers,
+        )
+
+    @browsing
+    def test_rejects_missing_sheet_id(self, browser):
+        self.login(self.propertysheets_manager, browser)
+
+        data = deepcopy(self.VALID_SAMPLE_PAYLOAD)
+
+        with browser.expect_http_error(400):
+            browser.open(
+                view="@propertysheets/",
+                method="PATCH",
+                data=json.dumps(data),
+                headers=self.api_headers,
+            )
+
+        self.assertDictContainsSubset(
+            {
+                u"message": u"Must supply exactly one {sheet_id} path parameter.",
+                u"type": u"BadRequest",
+            },
+            browser.json,
+        )
+
+    @browsing
+    def test_rejects_sheet_id_not_matching_pattern(self, browser):
+        self.login(self.propertysheets_manager, browser)
+
+        data = deepcopy(self.VALID_SAMPLE_PAYLOAD)
+
+        with browser.expect_http_error(400):
+            self.patch_sheet(
+                browser,
+                data,
+                sheet_id='invalid-sheet-id-$$$-xyz',
+                post_first=False,
+            )
+
+        self.assertDictContainsSubset(
+            {
+                u"type": u"SheetValidationError",
+                u"translated_message": "\n".join([
+                    u"Das Formular enth\xe4lt Fehler:",
+                    u"ID:",
+                    u"Ung\xfcltiger Bezeichner",
+                ]),
+            },
+            browser.json,
+        )
+
+    @browsing
+    def test_rejects_sheet_id_that_is_too_long(self, browser):
+        self.login(self.propertysheets_manager, browser)
+
+        data = deepcopy(self.VALID_SAMPLE_PAYLOAD)
+
+        with browser.expect_http_error(400):
+            self.patch_sheet(browser, data, sheet_id='x' * 34, post_first=False)
+
+        self.assertDictContainsSubset(
+            {
+                u"type": u"SheetValidationError",
+                u"translated_message": "\n".join([
+                    u"Das Formular enth\xe4lt Fehler:",
+                    u"ID:",
+                    u"Wert ist zu lang.",
+                    u"(Maximum: 32 Zeichen. Tats\xe4chliche L\xe4nge: 34 Zeichen)",
+                ]),
+            },
+            browser.json,
+        )
+
+    @browsing
+    def test_rejects_sheet_id_that_is_a_python_keyword(self, browser):
+        self.login(self.propertysheets_manager, browser)
+
+        data = deepcopy(self.VALID_SAMPLE_PAYLOAD)
+
+        with browser.expect_http_error(400):
+            self.patch_sheet(browser, data, sheet_id='import', post_first=False)
+
+        self.assertDictContainsSubset(
+            {
+                u"type": u"SheetValidationError",
+                u"translated_message": "\n".join([
+                    u"Das Formular enth\xe4lt Fehler:",
+                    u"ID:",
+                    u"Einschr\xe4nkung ist nicht erf\xfcllt",
+                ]),
+            },
+            browser.json,
+        )
+
+    @browsing
+    def test_rejects_invalid_assignments(self, browser):
+        self.login(self.propertysheets_manager, browser)
+
+        data = deepcopy(self.VALID_SAMPLE_PAYLOAD)
+        data['assignments'] = [u"slot-that-doesnt-exist"]
+
+        with browser.expect_http_error(400):
+            self.patch_sheet(browser, data)
+
+        self.assertDictContainsSubset(
+            {
+                u"type": u"AssignmentValidationError",
+                u"translated_message": "\n".join([
+                    u"Das Formular enth\xe4lt Fehler:",
+                    u"Slots:",
+                    u"Falscher Typ f\xfcr Beh\xe4lterinhalt",
+                ]),
+            },
+            browser.json,
+        )
+
+    @browsing
+    def test_rejects_invalid_assignment_value_type(self, browser):
+        self.login(self.propertysheets_manager, browser)
+
+        data = deepcopy(self.VALID_SAMPLE_PAYLOAD)
+        data['assignments'] = [42]
+
+        with browser.expect_http_error(400):
+            self.patch_sheet(browser, data)
+
+        self.assertDictContainsSubset(
+            {
+                u"type": u"AssignmentValidationError",
+                u"translated_message": "\n".join([
+                    u"Das Formular enth\xe4lt Fehler:",
+                    u"Slots:",
+                    u"Falscher Typ f\xfcr Beh\xe4lterinhalt",
+                ]),
+            },
+            browser.json,
+        )
+
+    @browsing
+    def test_rejects_assignments_already_in_use(self, browser):
+        self.login(self.propertysheets_manager, browser)
+
+        data = deepcopy(self.VALID_SAMPLE_PAYLOAD)
+
+        # IDossier.default is already used by a fixture object
+        data['assignments'] = [u"IDossier.default"]
+
+        with browser.expect_http_error(400):
+            self.patch_sheet(browser, data)
+
+        self.assertDictContainsSubset(
+            {
+                u"type": u"AssignmentValidationError",
+                u"translated_message": "\n".join([
+                    u"Das Formular enth\xe4lt Fehler:",
+                    u"Slots:",
+                    u"Der Slot 'IDossier.default' ist bereits belegt.",
+                ]),
+            },
+            browser.json,
+        )
+
+    @browsing
+    def test_allows_missing_fields(self, browser):
+        """Rejecting missing fields makes sense for POST,
+        but not so much for PATCH.
+        """
+        self.login(self.propertysheets_manager, browser)
+
+        data = {"assignments": ["IDocument.default"]}
+
+        self.patch_sheet(browser, data)
+        self.assertEqual(200, browser.status_code)
+
+    @browsing
+    def test_allows_empty_fields(self, browser):
+        """Rejecting empty fields makes sense for POST,
+        but not so much for PATCH.
+        """
+        self.login(self.propertysheets_manager, browser)
+
+        data = {"assignments": ["IDocument.default"], "fields": []}
+
+        self.patch_sheet(browser, data)
+        self.assertEqual(200, browser.status_code)
+
+    @browsing
+    def test_rejects_field_name_not_matching_pattern(self, browser):
+        self.login(self.propertysheets_manager, browser)
+
+        data = {
+            "fields": [
+                {
+                    "name": "foo-.$$$",
+                    "field_type": "bool",
+                    "title": u"Y/N",
+                }
+            ],
+        }
+        with browser.expect_http_error(400):
+            self.patch_sheet(browser, data)
+
+        self.assertDictContainsSubset(
+            {
+                u"type": u"FieldValidationError",
+                u"translated_message": "\n".join([
+                    u"Das Formular enth\xe4lt Fehler:",
+                    u"Feld 1 ('foo-.$$$'):",
+                    u"Parameter 'name': Ung\xfcltiger Bezeichner",
+                ]),
+            },
+            browser.json,
+        )
+
+    @browsing
+    def test_rejects_field_name_that_is_a_python_keyword(self, browser):
+        self.login(self.propertysheets_manager, browser)
+
+        data = {
+            "fields": [
+                {
+                    "name": "import",
+                    "field_type": "bool",
+                    "title": u"Y/N",
+                }
+            ],
+        }
+        with browser.expect_http_error(400):
+            self.patch_sheet(browser, data)
+
+        self.assertDictContainsSubset(
+            {
+                u"type": u"FieldValidationError",
+                u"translated_message": "\n".join([
+                    u"Das Formular enth\xe4lt Fehler:",
+                    u"Feld 1 ('import'):",
+                    u"Parameter 'name': Einschr\xe4nkung ist nicht erf\xfcllt",
+                ]),
+            },
+            browser.json,
+        )
+
+    @browsing
+    def test_rejects_field_names_that_are_too_long(self, browser):
+        self.login(self.propertysheets_manager, browser)
+
+        data = {
+            "fields": [
+                {
+                    "name": "x" * 34,
+                    "field_type": "bool",
+                    "title": u"Y/N",
+                }
+            ],
+        }
+        with browser.expect_http_error(400):
+            self.patch_sheet(browser, data)
+
+        self.assertDictContainsSubset(
+            {
+                u"type": u"FieldValidationError",
+                u"translated_message": "\n".join([
+                    u"Das Formular enth\xe4lt Fehler:",
+                    u"Feld 1 ('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'):",
+                    u"Parameter 'name': Wert ist zu lang.",
+                    u"(Maximum: 32 Zeichen. Tats\xe4chliche L\xe4nge: 34 Zeichen)",
+                ]),
+            },
+            browser.json,
+        )
+
+    @browsing
+    def test_rejects_field_name_duplicates(self, browser):
+        self.login(self.propertysheets_manager, browser)
+
+        data = {
+            "fields": [
+                {
+                    "name": "myfield",
+                    "field_type": "bool",
+                    "title": u"Y/N",
+                },
+                {
+                    "name": "myfield",
+                    "field_type": "int",
+                    "title": u"Number",
+                },
+            ],
+        }
+        with browser.expect_http_error(400):
+            self.patch_sheet(browser, data)
+
+        self.assertDictContainsSubset(
+            {
+                u"message": u"Duplicate fields 'myfield'.",
+                u"type": u"BadRequest",
+            },
+            browser.json,
+        )
+
+    @browsing
+    def test_rejects_field_type_not_in_vocabulary(self, browser):
+        self.login(self.propertysheets_manager, browser)
+
+        data = {
+            "fields": [
+                {
+                    "name": "myfield",
+                    "field_type": "not-a-field-type",
+                    "title": u"My title",
+                },
+            ],
+        }
+        with browser.expect_http_error(400):
+            self.patch_sheet(browser, data)
+
+        self.assertDictContainsSubset(
+            {
+                u"type": u"FieldValidationError",
+                u"translated_message": "\n".join([
+                    u"Das Formular enth\xe4lt Fehler:",
+                    u"Feld 1 ('myfield'):",
+                    u"Parameter 'field_type': Einschr\xe4nkung ist nicht erf\xfcllt",
+                ]),
+            },
+            browser.json,
+        )
+
+    @browsing
+    def test_rejects_title_that_is_too_long(self, browser):
+        self.login(self.propertysheets_manager, browser)
+
+        data = {
+            "fields": [
+                {
+                    "name": "myfield",
+                    "field_type": "bool",
+                    "title": u"X" * 50,
+                },
+            ],
+        }
+        with browser.expect_http_error(400):
+            self.patch_sheet(browser, data)
+
+        self.assertDictContainsSubset(
+            {
+                u"type": u"FieldValidationError",
+                u"translated_message": "\n".join([
+                    u"Das Formular enth\xe4lt Fehler:",
+                    u"Feld 1 ('myfield'):",
+                    u"Parameter 'title': Wert ist zu lang.",
+                    u"(Maximum: 48 Zeichen. Tats\xe4chliche L\xe4nge: 50 Zeichen)",
+                ]),
+            },
+            browser.json,
+        )
+
+    @browsing
+    def test_rejects_description_that_is_too_long(self, browser):
+        self.login(self.propertysheets_manager, browser)
+
+        data = {
+            "fields": [
+                {
+                    "name": "myfield",
+                    "field_type": "bool",
+                    "title": u"My title",
+                    "description": u"X" * 130,
+                },
+            ],
+        }
+        with browser.expect_http_error(400):
+            self.patch_sheet(browser, data)
+
+        self.assertDictContainsSubset(
+            {
+                u"type": u"FieldValidationError",
+                u"translated_message": "\n".join([
+                    u"Das Formular enth\xe4lt Fehler:",
+                    u"Feld 1 ('myfield'):",
+                    u"Parameter 'description': Wert ist zu lang.",
+                    u"(Maximum: 128 Zeichen. Tats\xe4chliche L\xe4nge: 130 Zeichen)",
+                ]),
+            },
+            browser.json,
+        )
+
+    @browsing
+    def test_rejects_unsupported_types_for_default(self, browser):
+        self.login(self.propertysheets_manager, browser)
+
+        data = {
+            "fields": [
+                {
+                    "name": "myfield",
+                    "field_type": "bool",
+                    "title": u"My title",
+                    "default": 5.5,
+                },
+            ],
+        }
+        with browser.expect_http_error(400):
+            self.patch_sheet(browser, data)
+
+        self.assertDictContainsSubset(
+            {
+                u"type": u"FieldValidationError",
+                u"translated_message": "\n".join([
+                    u"Das Formular enth\xe4lt Fehler:",
+                    u"Feld 1 ('myfield'):",
+                    u"Parameter 'default': Objekttyp ist falsch.",
+                ]),
+            },
+            browser.json,
+        )
+
+    @browsing
+    def test_rejects_invalid_default_value_for_choice(self, browser):
+        self.login(self.propertysheets_manager, browser)
+
+        data = {
+            "fields": [
+                {
+                    "name": "myfield",
+                    "field_type": "choice",
+                    "title": u"My title",
+                    "values": ["alpha", "beta"],
+                    "default": "not-in-vocab",
+                },
+            ],
+        }
+        with browser.expect_http_error(400):
+            self.patch_sheet(browser, data)
+
+        self.assertDictContainsSubset(
+            {
+                u"type": u"FieldValidationError",
+                u"translated_message": "\n".join([
+                    u"Das Formular enth\xe4lt Fehler:",
+                    u"Feld 1 ('myfield'):",
+                    u"Ung\xfcltiger Wert",
+                ]),
+            },
+            browser.json,
+        )
+
+    @browsing
+    def test_rejects_invalid_default_value_for_int(self, browser):
+        self.login(self.propertysheets_manager, browser)
+
+        data = {
+            "fields": [
+                {
+                    "name": "myfield",
+                    "field_type": "int",
+                    "title": u"A number",
+                    "default": "not-a-number",
+                },
+            ],
+        }
+        with browser.expect_http_error(400):
+            self.patch_sheet(browser, data)
+
+        self.assertDictContainsSubset(
+            {
+                u"type": u"FieldValidationError",
+                u"translated_message": "\n".join([
+                    u"Das Formular enth\xe4lt Fehler:",
+                    u"Feld 1 ('myfield'):",
+                    u"Ung\xfcltiger Wert",
+                ]),
+            },
+            browser.json,
+        )
+
+    @browsing
+    def test_rejects_invalid_default_value_for_textline(self, browser):
+        self.login(self.propertysheets_manager, browser)
+
+        data = {
+            "fields": [
+                {
+                    "name": "myfield",
+                    "field_type": "textline",
+                    "title": u"A line of text",
+                    "default": 42,
+                },
+            ],
+        }
+        with browser.expect_http_error(400):
+            self.patch_sheet(browser, data)
+
+        self.assertDictContainsSubset(
+            {
+                u"type": u"FieldValidationError",
+                u"translated_message": "\n".join([
+                    u"Das Formular enth\xe4lt Fehler:",
+                    u"Feld 1 ('myfield'):",
+                    u"Ung\xfcltiger Wert",
+                ]),
+            },
+            browser.json,
+        )
+
+    @browsing
+    def test_rejects_invalid_default_value_for_date(self, browser):
+        self.login(self.propertysheets_manager, browser)
+
+        data = {
+            "fields": [
+                {
+                    "name": "myfield",
+                    "field_type": "date",
+                    "title": u"A date",
+                    "default": "not-a-date",
+                },
+            ],
+        }
+        with browser.expect_http_error(400):
+            self.patch_sheet(browser, data)
+
+        self.assertDictContainsSubset(
+            {
+                u"type": u"FieldValidationError",
+                u"translated_message": "\n".join([
+                    u"Das Formular enth\xe4lt Fehler:",
+                    u"Feld 1 ('myfield'):",
+                    u"Ung\xfcltiger Wert",
+                ]),
+            },
+            browser.json,
+        )
+
+    @browsing
+    def test_rejects_missing_values_for_choice(self, browser):
+        self.login(self.propertysheets_manager, browser)
+
+        data = {
+            "fields": [
+                {
+                    "name": "myfield",
+                    "field_type": "choice",
+                    "title": u"A choice",
+                },
+            ],
+        }
+        with browser.expect_http_error(500):
+            self.patch_sheet(browser, data)
+
+        self.assertDictContainsSubset(
+            {
+                u"message": u"For 'choice' or 'multiple_choice' fields types "
+                            u"values are required.",
+                u"type": u"InvalidFieldTypeDefinition",
+            },
+            browser.json,
+        )
+
+    @browsing
+    def test_rejects_empty_values_for_choice(self, browser):
+        self.login(self.propertysheets_manager, browser)
+
+        data = {
+            "fields": [
+                {
+                    "name": "myfield",
+                    "field_type": "choice",
+                    "title": u"A choice",
+                    "values": [],
+                },
+            ],
+        }
+        with browser.expect_http_error(500):
+            self.patch_sheet(browser, data)
+
+        self.assertDictContainsSubset(
+            {
+                u"message": u"For 'choice' or 'multiple_choice' fields types "
+                            u"values are required.",
+                u"type": u"InvalidFieldTypeDefinition",
+            },
+            browser.json,
+        )
+
+    @browsing
+    def test_rejects_non_string_term_type_for_values(self, browser):
+        self.login(self.propertysheets_manager, browser)
+
+        data = {
+            "fields": [
+                {
+                    "name": "myfield",
+                    "field_type": "choice",
+                    "title": u"A choice",
+                    "values": [42],
+                },
+            ],
+        }
+        with browser.expect_http_error(400):
+            self.patch_sheet(browser, data)
+
+        self.assertDictContainsSubset(
+            {
+                u"type": u"FieldValidationError",
+                u"translated_message": "\n".join([
+                    u"Das Formular enth\xe4lt Fehler:",
+                    u"Feld 1 ('myfield'):",
+                    u"Parameter 'values': Falscher Typ f\xfcr Beh\xe4lterinhalt",
+                ]),
+            },
+            browser.json,
+        )

--- a/opengever/propertysheets/tests/test_propertysheet_metaschema.py
+++ b/opengever/propertysheets/tests/test_propertysheet_metaschema.py
@@ -107,7 +107,7 @@ class TestPropertysheetMetaschemaEndpoint(IntegrationTestCase):
                     },
                     u"values": {
                         u"description": u"List of values that are allowed for "
-                                        u"this field",
+                                        u"this field (one per line)",
                         u"items": {
                             u"description": u"",
                             u"factory": u"Text line (String)",
@@ -398,7 +398,7 @@ class TestPropertysheetMetaschemaEndpoint(IntegrationTestCase):
                 u'Beschreibung',
                 u'Angabe, ob Benutzer dieses Feld zwingend ausf\xfcllen m\xfcssen',
                 u'Default-Wert f\xfcr dieses Feld',
-                u'Liste der erlaubten Werte f\xfcr das Feld',
+                u'Liste der erlaubten Werte f\xfcr das Feld (ein Wert pro Zeile)',
             ],
             [prop['description'] for prop in field_properties.values()]
         )

--- a/opengever/propertysheets/tests/test_propertysheet_metaschema.py
+++ b/opengever/propertysheets/tests/test_propertysheet_metaschema.py
@@ -30,7 +30,8 @@ class TestPropertysheetMetaschemaEndpoint(IntegrationTestCase):
 
         id_schema = {
             u"additionalProperties": False,
-            u"description": u"ID of this property sheet",
+            u"description": u"ID of this property sheet (alphanumeric, "
+                            u"lowercase, no special characters)",
             u'maxLength': 32,
             u"pattern": u"^[a-z_0-9]*$",
             u"title": u"ID",
@@ -86,7 +87,8 @@ class TestPropertysheetMetaschemaEndpoint(IntegrationTestCase):
                         u"type": u"string",
                     },
                     u"name": {
-                        u"description": u"Field name (alphanumeric, lowercase)",
+                        u"description": u"Field name (alphanumeric, lowercase, "
+                                        u"no special characters)",
                         u'maxLength': 32,
                         u"pattern": u"^[a-z_0-9]*$",
                         u"title": u"Name",
@@ -380,7 +382,7 @@ class TestPropertysheetMetaschemaEndpoint(IntegrationTestCase):
 
         self.assertItemsEqual(
             [
-                u'ID dieses Property Sheets',
+                u'ID dieses Property Sheets (Alphanumerisch, nur Kleinbuchstaben, keine Sonderzeichen)',
                 u'Felder',
                 u'F\xfcr welche Arten von Inhalten dieses Property Sheet verf\xfcgbar sein soll',
             ],
@@ -390,7 +392,7 @@ class TestPropertysheetMetaschemaEndpoint(IntegrationTestCase):
         field_properties = properties['fields']['items']['properties']
         self.assertItemsEqual(
             [
-                u'Name (Alphanumerisch, nur Kleinbuchstaben)',
+                u'Name (Alphanumerisch, nur Kleinbuchstaben, keine Sonderzeichen)',
                 u'Datentyp f\xfcr dieses Feld',
                 u'Titel',
                 u'Beschreibung',

--- a/opengever/propertysheets/tests/test_schema_definition_patch.py
+++ b/opengever/propertysheets/tests/test_schema_definition_patch.py
@@ -14,6 +14,27 @@ class TestSchemaDefinitionPatch(IntegrationTestCase):
     maxDiff = None
 
     @browsing
+    def test_patch_requires_sheet_id(self, browser):
+        self.login(self.propertysheets_manager, browser)
+
+        patch_data = {
+            "assignments": [u"IDocumentMetadata.document_type.report"],
+        }
+
+        with browser.expect_http_error(400):
+            browser.open(
+                view="@propertysheets/",
+                method="PATCH",
+                data=json.dumps(patch_data),
+                headers=self.api_headers,
+            )
+
+        self.assertEqual({
+            u'type': u'BadRequest',
+            u'message': u'Must supply exactly one {sheet_id} path parameter.',
+            }, browser.json)
+
+    @browsing
     def test_patch_assignments(self, browser):
         self.login(self.propertysheets_manager, browser)
 

--- a/opengever/propertysheets/tests/test_schema_definition_post.py
+++ b/opengever/propertysheets/tests/test_schema_definition_post.py
@@ -507,7 +507,7 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
 
         self.assertDictContainsSubset(
             {
-                "type": "BadRequest",
+                "type": "FieldValidationError",
             },
             browser.json,
         )
@@ -565,8 +565,12 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
 
         self.assertDictContainsSubset(
             {
-                u"message": u"The assignment 'fail' is invalid.",
-                "type": "BadRequest",
+                "type": "AssignmentValidationError",
+                u"translated_message": "\n".join([
+                    u"The form contains errors:",
+                    u"Assignments:",
+                    u"Wrong contained type",
+                ]),
             },
             browser.json,
         )
@@ -599,9 +603,12 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
 
         self.assertDictContainsSubset(
             {
-                u"message": u"The assignment 'IDocumentMetadata.document_type."
-                            "question' is already in use.",
-                "type": "BadRequest",
+                u"type": u"AssignmentValidationError",
+                u"translated_message": "\n".join([
+                    u"The form contains errors:",
+                    u"Assignments:",
+                    u"Assignment 'IDocumentMetadata.document_type.question' is already in use.",
+                ]),
             },
             browser.json,
         )
@@ -651,8 +658,12 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
 
         self.assertDictContainsSubset(
             {
-                u"message": u"The name 'in-val.id' is invalid.",
-                "type": "BadRequest",
+                u"type": u"SheetValidationError",
+                u"translated_message": "\n".join([
+                    u"The form contains errors:",
+                    u"ID:",
+                    u"Invalid identifier",
+                ]),
             },
             browser.json,
         )
@@ -754,7 +765,7 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
             )
         self.assertDictContainsSubset(
             {
-                "type": "BadRequest",
+                "type": "FieldValidationError",
             },
             browser.json,
         )

--- a/opengever/propertysheets/tests/test_schema_definition_post.py
+++ b/opengever/propertysheets/tests/test_schema_definition_post.py
@@ -742,8 +742,12 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
 
         self.assertDictContainsSubset(
             {
-                u"message": u"Duplicate fields 'dupe', 'foo'.",
-                "type": "BadRequest",
+                u"type": u"FieldValidationError",
+                u"translated_message": "\n".join([
+                    u"The form contains errors:",
+                    u"Field 2 ('dupe'):",
+                    u"Parameter 'name': Duplicate field with this name",
+                ]),
             },
             browser.json,
         )


### PR DESCRIPTION
This overhauls the error handling in the `@propertysheets` APIs in a way that the client-side errors get serialized in a way where they contain a deliberately crafted `translated_message`.

We do this to enable the frontend to just display this one message at the top of the form, without any further processing of the response or highlighting of the offending widget.

The message must therefore contain enough context so that the user can identify where the error is, and what he needs to change to fix it.

This generated `translated_message` is a multi-line string (three, sometimes four lines), where each line gets progressively more specific / local.

Example:
```
    The form contains errors:
    Field 3 ('location'):
    Parameter 'title': Value is too long
    (Max: 128 characters, Actual length: 135 characters)
```

In order to achieve this, we wrap certain validation errors in some custom higher level exceptions, to which we attach the necessary context info to build a rich `translated_message` later:

- `FieldValidationError` (for errors in the `fields` key)
- `AssignmentValidationError` ((for errors in the `assignments` key)
- `SheetValidationError` (everything else)

These then get processed by adapters that know how the data attached to these exceptions is structured, and they extract the necessary context information from them.

For [CA-2954](https://4teamwork.atlassian.net/browse/CA-2954)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry
  - If breaking:
    - [x] api-change label added
    - [ ] #delivery channel notified about breaking change _(deemed unnecessary)_
    - [ ] Scrum master is informed _(deemed unnecessary)_
- New translations
  - [x] All msg-strings are unicode
