### PR TITLE
Testserver: auto-isolate on startup.

### DIFF
--- a/changes/testserver-auto-isolate.feature
+++ b/changes/testserver-auto-isolate.feature
@@ -1,0 +1,1 @@
+Testserver now automatically isolates on startup. [jone]

--- a/opengever/core/testserver_zope2server.py
+++ b/opengever/core/testserver_zope2server.py
@@ -151,6 +151,9 @@ def start(zope_layer_dotted_name):
     listener.register_function(zsl.isolate, 'isolate')  # PATCH
     listener.register_function(lambda: None, 'connectiontest')
 
+    print('Setting up isolation (zodb_setup).')
+    zsl.isolate()
+
     robotframework_server.print_urls(zsl.zope_layer, listener)
 
     try:


### PR DESCRIPTION
The testserver now automatically runs the initial isolation setup on startup before starting the XMLRPC server.

That means that users and tests no longer have to run a `zodb_setup` or `isolation` after starting up.
This makes the usage easier and more convenient when the app is doing requests on startup before the first test.

The testserver prints the line `Setting up isolation (zodb_setup).` when it is doing the isolation on startup; making it easier for devs to figure out whether their installed version is doing that already.

<img width="858" alt="Bildschirmfoto 2022-01-20 um 08 49 13" src="https://user-images.githubusercontent.com/7469/150295703-d65b4ad1-8f6d-466b-8345-526c5b2f1c0e.png">

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [HG-2189]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [X] Changelog entry
- [X] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


/CC @bierik @RychenerLorenz 

[HG-2189]: https://4teamwork.atlassian.net/browse/HG-2189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ