### PR TITLE
Add parameter to include full representation in @actors endpoint

### DIFF
--- a/changes/CA-2616.feature
+++ b/changes/CA-2616.feature
@@ -1,0 +1,1 @@
+Add parameter to include full representation in @actors endpoint. [tinagerber]

--- a/docs/public/dev-manual/api/actors.rst
+++ b/docs/public/dev-manual/api/actors.rst
@@ -46,6 +46,43 @@ Ein actor ist kein Plone Inhaltstyp, deshalb beinhaltet die Response weniger Inf
         }
       }
 
+Mit dem Parameter ``full_representation`` werden im represents-Feld nicht nur eine URL, sondern alle Details des Aktors zurückgegeben.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+      GET /@actors?full_representation=true HTTP/1.1
+      Accept: application/json
+
+
+**Beispiel-Response**:
+
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+        "@id": "http://example.org/@actors/peter.mueller",
+        "...": "",
+        "represents": {
+            "@id": "http://example.org/@ogds-users/peter.mueller"
+            "@type": "virtual.ogds.user",
+             "absent": false,
+             "active": true,
+             "city": "Thun",
+             "country": "Schweiz",
+             "department": "Finanzdirektion",
+             "department_abbr": "fd",
+             "email": "peter.mueller@4teamwork.ch",
+             "firstname": "Peter",
+             "...":"..."
+        }
+      }
+
+
 Via POST können die Daten von mehreren actors mit einem Request abgefragt werden. Im Request-body wird die Liste von actor ID angegeben:
 
 **Beispiel-Request**:

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -12,6 +12,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- ``@actors``: Add ``full_representation`` parameter. (see :ref:`docs <actors>`)
 
 
 2022.2.0 (2022-01-19)

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -49,6 +49,7 @@
   <adapter factory=".dossier.SerializeDossierToJson" />
   <adapter factory=".workspace_folder.SerializeWorkspaceFolderToJson" />
   <adapter factory=".document.SerializeDocumentToJson" />
+  <adapter factory=".kub.SerializeKuBEntityToJson" />
   <adapter factory=".mail.SerializeMailToJson" />
   <adapter factory=".workspace.SerializeWorkspaceToJson" />
   <adapter factory=".response.ResponseDefaultFieldSerializer" />

--- a/opengever/api/tests/test_actors.py
+++ b/opengever/api/tests/test_actors.py
@@ -71,6 +71,19 @@ class TestActorsGet(IntegrationTestCase):
         )
 
     @browsing
+    def test_full_representation_for_team(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        actor_id = 'team:1'
+        url = "{}/{}?full_representation=true".format(self.actors_url, actor_id)
+        browser.open(url, headers=self.api_headers)
+        self.assertEqual(200, browser.status_code)
+        self.assertDictContainsSubset({
+            u'@id': u'http://nohost/plone/@teams/1',
+            u'@type': u'virtual.ogds.team',
+            u'title': u'Projekt \xdcberbaung Dorfmatte'}, browser.json['represents'])
+
+    @browsing
     def test_actors_response_for_inbox(self, browser):
         self.login(self.secretariat_user, browser=browser)
 
@@ -103,6 +116,19 @@ class TestActorsGet(IntegrationTestCase):
         )
 
     @browsing
+    def test_full_representation_for_inbox(self, browser):
+        self.login(self.secretariat_user, browser=browser)
+
+        actor_id = 'inbox:fa'
+        url = "{}/{}?full_representation=true".format(self.actors_url, actor_id)
+        browser.open(url, headers=self.api_headers)
+        self.assertEqual(200, browser.status_code)
+        self.assertDictContainsSubset({
+            u'@id': u'http://nohost/plone/eingangskorb/eingangskorb_fa',
+            u'@type': u'opengever.inbox.inbox',
+            u'email': u'1011033300@example.org'}, browser.json['represents'])
+
+    @browsing
     def test_actors_response_for_contact(self, browser):
         self.login(self.regular_user, browser=browser)
 
@@ -128,6 +154,17 @@ class TestActorsGet(IntegrationTestCase):
             },
             browser.json
         )
+
+    @browsing
+    def test_full_representation_for_contact(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        actor_id = 'contact:{}'.format(self.franz_meier.id)
+        url = "{}/{}?full_representation=true".format(self.actors_url, actor_id)
+        browser.open(url, headers=self.api_headers)
+        self.assertEqual(200, browser.status_code)
+        self.assertEqual({u'@id': u'http://nohost/plone/kontakte/meier-franz'},
+                         browser.json['represents'])
 
     @browsing
     def test_actors_response_for_committee(self, browser):
@@ -165,6 +202,18 @@ class TestActorsGet(IntegrationTestCase):
             browser.json)
 
     @browsing
+    def test_full_representation_for_committee(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        actor_id = 'committee:1'
+        url = "{}/{}?full_representation=true".format(self.actors_url, actor_id)
+        browser.open(url, headers=self.api_headers)
+        self.assertEqual(200, browser.status_code)
+        self.assertEqual(
+            {u'@id': u'http://nohost/plone/opengever-meeting-committeecontainer/committee-1'},
+            browser.json['represents'])
+
+    @browsing
     def test_actors_response_for_ogds_user(self, browser):
         self.login(self.regular_user, browser=browser)
 
@@ -194,6 +243,20 @@ class TestActorsGet(IntegrationTestCase):
                 },
             },
             browser.json)
+
+    @browsing
+    def test_full_representation_for_ogds_user(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        actor_id = 'jurgen.konig'
+        url = "{}/{}?full_representation=true".format(self.actors_url, actor_id)
+        browser.open(url, headers=self.api_headers)
+        self.assertEqual(200, browser.status_code)
+
+        self.assertDictContainsSubset({
+            u'@id': u'http://nohost/plone/@ogds-users/jurgen.konig',
+            u'@type': u'virtual.ogds.user',
+            u'email': u'jurgen.konig@gever.local'}, browser.json['represents'])
 
     @browsing
     def test_actors_response_for_ogds_user_with_orgunit(self, browser):
@@ -262,6 +325,20 @@ class TestActorsGet(IntegrationTestCase):
             browser.json)
 
     @browsing
+    def test_full_representation_for_group(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        actor_id = 'projekt_a'
+        url = "{}/{}?full_representation=true".format(self.actors_url, actor_id)
+        browser.open(url, headers=self.api_headers)
+        self.assertEqual(200, browser.status_code)
+
+        self.assertDictContainsSubset({
+            u'@id': u'http://nohost/plone/@ogds-groups/projekt_a',
+            u'@type':  u'virtual.ogds.group',
+            u'title': u'Projekt A'}, browser.json['represents'])
+
+    @browsing
     def test_actors_response_for_plone_user(self, browser):
         self.login(self.regular_user, browser=browser)
 
@@ -289,6 +366,20 @@ class TestActorsGet(IntegrationTestCase):
         )
 
     @browsing
+    def test_full_representation_for_plone_user(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        actor_id = 'admin'
+        url = "{}/{}?full_representation=true".format(self.actors_url, actor_id)
+        browser.open(url, headers=self.api_headers)
+        self.assertEqual(200, browser.status_code)
+
+        self.assertDictContainsSubset({
+            u'@id': u'http://nohost/plone/@users/admin',
+            u'email': None,
+            u'roles': [u'Manager']}, browser.json['represents'])
+
+    @browsing
     def test_actors_response_for_system_actor(self, browser):
         self.login(self.regular_user, browser=browser)
 
@@ -312,6 +403,16 @@ class TestActorsGet(IntegrationTestCase):
             },
             browser.json
         )
+
+    @browsing
+    def test_full_representation_for_system_actor(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        actor_id = '__system__'
+        url = "{}/{}?full_representation=true".format(self.actors_url, actor_id)
+        browser.open(url, headers=self.api_headers)
+        self.assertEqual(200, browser.status_code)
+        self.assertEqual(None, browser.json['represents'])
 
     @browsing
     def test_raises_bad_request_when_actor_is_missing(self, browser):
@@ -357,6 +458,13 @@ class TestActorsGet(IntegrationTestCase):
             },
             browser.json,
         )
+
+    @browsing
+    def test_full_representation_for_invalid_actor_id(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.actors_url + "/foo?full_representation=true", headers=self.api_headers)
+
+        self.assertEqual(None, browser.json['represents'])
 
     @browsing
     def test_is_absent_if_today_is_between_absent_dates(self, browser):

--- a/opengever/ogds/base/actor.py
+++ b/opengever/ogds/base/actor.py
@@ -298,7 +298,7 @@ class InboxActor(Actor):
         return self.org_unit.inbox().assigned_users()
 
     def represents(self):
-        return self.org_unit
+        return get_inbox_for_org_unit(self.org_unit.id())
 
     def represents_url(self):
         inbox = get_inbox_for_org_unit(self.org_unit.id())

--- a/opengever/ogds/base/tests/test_actor.py
+++ b/opengever/ogds/base/tests/test_actor.py
@@ -1,5 +1,6 @@
 from ftw.builder import Builder
 from ftw.builder import create
+from ftw.testbrowser import browsing
 from opengever.kub.testing import KUB_RESPONSES
 from opengever.kub.testing import KuBIntegrationTestCase
 from opengever.ogds.base.actor import Actor
@@ -236,6 +237,31 @@ class TestKuBContactActor(KuBIntegrationTestCase):
         actor = Actor.lookup(contact_id)
 
         self.assertIsInstance(actor, NullActor)
+
+    @browsing
+    def test_actors_response_for_kubcontact(self, mocker, browser):
+        self.mock_get_by_id(mocker, self.person_jean)
+        self.login(self.regular_user, browser=browser)
+        url = "{}/@actors/{}".format(self.portal.absolute_url(), self.person_jean)
+        browser.open(url, headers=self.api_headers)
+        self.assertEqual(200, browser.status_code)
+
+        self.assertDictEqual(
+            {
+                u'@id': url,
+                u'@type': u'virtual.ogds.actor',
+                u'active': True,
+                u'actor_type': u'kubcontact',
+                u'identifier': self.person_jean,
+                u'is_absent': False,
+                u'label': u'Dupont Jean',
+                u'portrait_url': None,
+                u'representatives': [],
+                u'represents': {
+                    u'@id': u'http://nohost/plone/@kub/person:9af7d7cc-b948-423f-979f-587158c6bc65'
+                }
+            },
+            browser.json)
 
 
 class TestSQLContactActor(IntegrationTestCase):

--- a/opengever/ogds/base/tests/test_actor.py
+++ b/opengever/ogds/base/tests/test_actor.py
@@ -263,6 +263,19 @@ class TestKuBContactActor(KuBIntegrationTestCase):
             },
             browser.json)
 
+    @browsing
+    def test_full_representation_for_kubcontact(self, mocker, browser):
+        self.mock_get_by_id(mocker, self.person_jean)
+        self.login(self.regular_user, browser=browser)
+        url = "{}/@actors/{}?full_representation=true".format(
+            self.portal.absolute_url(), self.person_jean)
+        browser.open(url, headers=self.api_headers)
+        self.assertEqual(200, browser.status_code)
+        self.assertDictContainsSubset({
+            u'@id': u'http://nohost/plone/@kub/person:9af7d7cc-b948-423f-979f-587158c6bc65',
+            u'dateOfBirth': u'1992-05-15',
+            u'fullName': u'Dupont Jean'}, browser.json['represents'])
+
 
 class TestSQLContactActor(IntegrationTestCase):
 


### PR DESCRIPTION
This saves some requests in the frontend, because the @actors endpoint can now alse be used to fetch the user/group/... info if needed.

For [CA-2616]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide]
