### PR TITLE
Use relative paths for the @solrsearch path_parent filter query.

### DIFF
--- a/changes/CA-2174.other
+++ b/changes/CA-2174.other
@@ -1,0 +1,1 @@
+Use relative paths for the @solrsearch path_parent filter query. [elioschmutz]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -8,7 +8,7 @@ API Changelog
 
 Breaking Changes
 ^^^^^^^^^^^^^^^^
-
+- ``@solrsearch:``: Change ``path_parent`` filter query to no longer expect physical paths but relative paths instead.
 
 Other Changes
 ^^^^^^^^^^^^^

--- a/docs/public/dev-manual/api/searching.rst
+++ b/docs/public/dev-manual/api/searching.rst
@@ -305,7 +305,7 @@ Beispiel für eine Suche mit diversen Kriterien als Übersicht für die Verwendu
     "fl": "UID,Title",
     "fq": [
       "portal_type:opengever.document.document",
-      "path_parent:/fd/os/dossier-1"
+      "path_parent:/os/dossier-1"
     ],
     "facet": true,
     "facet.field": "responsible"

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -183,6 +183,7 @@ def relative_to_physical_path(relative_path):
     path of an object.
     """
     physical_path = api.portal.get().getPhysicalPath()
+    relative_path = relative_path.strip('/')
     if relative_path:
         physical_path += (relative_path, )
 
@@ -191,7 +192,7 @@ def relative_to_physical_path(relative_path):
 
 def url_to_physical_path(value):
     portal_url = api.portal.get().absolute_url()
-    return relative_to_physical_path(value.replace(portal_url, '').strip('/'))
+    return relative_to_physical_path(value.replace(portal_url, ''))
 
 
 class SimpleListingField(object):

--- a/opengever/api/tests/test_solrsearch.py
+++ b/opengever/api/tests/test_solrsearch.py
@@ -227,7 +227,9 @@ class TestSolrSearchGet(SolrIntegrationTestCase):
         url = (u'{}/@solrsearch?q=wichtig&fq=portal_type:opengever.document.document&'
                u'fq=path_parent:{}'.format(
                    self.portal.absolute_url(),
-                   self.subdossier.absolute_url_path().replace("/", "\\/")))
+                   self.subdossier.absolute_url()
+                       .replace(self.portal.absolute_url(), '')
+                       .replace("/", "\\/")))
         browser.open(url, method='GET', headers=self.api_headers)
         filtered_items = browser.json["items"]
         self.assertEqual(1, len(filtered_items))
@@ -839,7 +841,7 @@ class TestSolrSearchGet(SolrIntegrationTestCase):
     def test_filter_by_path_parent(self, browser):
         self.login(self.regular_user, browser=browser)
 
-        url = u'{}/@solrsearch?fq=path_parent:/plone/private/kathi-barfuss'.format(
+        url = u'{}/@solrsearch?fq=path_parent:/private/kathi-barfuss'.format(
             self.portal.absolute_url())
 
         browser.open(url, method='GET', headers=self.api_headers)
@@ -861,8 +863,8 @@ class TestSolrSearchGet(SolrIntegrationTestCase):
         url = u'{}/@solrsearch?{}'.format(
             self.portal.absolute_url(),
             '&'.join([
-                'fq:list=path_parent:/plone/private/kathi-barfuss',
-                'fq:list=path_parent:/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/dossier-2'
+                'fq:list=path_parent:/private/kathi-barfuss',
+                'fq:list=path_parent:/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/dossier-2'
             ]))
 
         browser.open(url, method='GET', headers=self.api_headers)
@@ -891,7 +893,7 @@ class TestSolrSearchGet(SolrIntegrationTestCase):
 
     def test_add_path_parent_filters_replaces_an_existing_path_parent_filter_with_the_internal_phyisical_path(self):
         solrsearch = getMultiAdapter((self.portal, self.request), name='GET_application_json_@solrsearch')
-        filters = ['path_parent:/plone/ordnungssystem/dossier\\-1']
+        filters = ['path_parent:/ordnungssystem/dossier\\-1']
         solrsearch.add_path_parent_filters(filters)
 
         self.assertEqual([u'path_parent:(\\/plone\\/ordnungssystem\\/dossier\\-1)'], filters)
@@ -899,24 +901,17 @@ class TestSolrSearchGet(SolrIntegrationTestCase):
     def test_add_path_parent_filters_connects_multiple_path_parent_filters_with_an_or_operator(self):
         solrsearch = getMultiAdapter((self.portal, self.request), name='GET_application_json_@solrsearch')
         filters = [
-            'path_parent:/plone/inbox',
-            'path_parent:/plone/private',
+            'path_parent:/inbox',
+            'path_parent:/private',
             ]
         solrsearch.add_path_parent_filters(filters)
 
         self.assertEqual(
             [u'path_parent:(\\/plone\\/inbox OR \\/plone\\/private)'], filters)
 
-    def test_add_path_parent_filters_does_nothing_if_the_path_parent_is_not_prefixed_with_the_portal_absolute_path(self):
-        solrsearch = getMultiAdapter((self.portal, self.request), name='GET_application_json_@solrsearch')
-        filters = ['path_parent:\\/inbox']
-        solrsearch.add_path_parent_filters(filters)
-
-        self.assertEqual(['path_parent:\\/inbox'], filters)
-
     def test_add_path_parent_filters_respects_escaped_filter_values(self):
         solrsearch = getMultiAdapter((self.portal, self.request), name='GET_application_json_@solrsearch')
-        filters = ['path_parent:\\/plone\\/inbox']
+        filters = ['path_parent:\\/inbox']
         solrsearch.add_path_parent_filters(filters)
 
         self.assertEqual([u'path_parent:(\\/plone\\/inbox)'], filters)
@@ -1076,7 +1071,10 @@ class TestSolrSearchPost(SolrIntegrationTestCase):
             'q': 'wichtig',
             'fq': [
                 'portal_type:opengever.document.document OR ftw.mail.mail',
-                'path_parent:{}'.format(self.subdossier.absolute_url_path().replace("/", "\\/"))
+                'path_parent:{}'.format(
+                    self.subdossier.absolute_url()
+                        .replace(self.portal.absolute_url(), '')
+                        .replace("/", "\\/"))
             ]
         }
 

--- a/opengever/core/testserver_selftest.py
+++ b/opengever/core/testserver_selftest.py
@@ -65,7 +65,7 @@ class TestserverSelftest(object):
             browser.replace_request_header('Accept', 'application/json')
             browser.replace_request_header('Content-Type', 'application/json')
 
-            search_url = self.plone_url + '@solrsearch?fq=path_parent:\\/plone\\/ordnungssystem\\/rechnungspruefungskommission&fl=path,UID'
+            search_url = self.plone_url + '@solrsearch?fq=path_parent:\\/ordnungssystem\\/rechnungspruefungskommission&fl=path,UID'
             browser.open(search_url)
             self.assertEqual(
                 {u'/plone/ordnungssystem/rechnungspruefungskommission': u'createrepositorytree000000000004'},


### PR DESCRIPTION
This PR changes the `path_parent` filter query.

Since the physical path of an object is only for internal use, we have to change the `path_parent` filter query to accept relativ paths.

For [CA-2174]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [x] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-2174]: https://4teamwork.atlassian.net/browse/CA-2174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ