### PR TITLE
Use static fixtures for workspace fixtures

### DIFF
--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -2174,6 +2174,7 @@ class OpengeverContentFixture(object):
 
         return committee
 
+    @staticuid()
     def create_workspace_root(self):
         self.workspace_root = self.register('workspace_root', create(
             Builder('workspace_root')
@@ -2185,6 +2186,7 @@ class OpengeverContentFixture(object):
             )
         ))
 
+    @staticuid()
     def create_workspace(self):
         self.workspace = self.register('workspace', create(
             Builder('workspace')
@@ -2255,6 +2257,7 @@ class OpengeverContentFixture(object):
                     outputMimeType='text/x-html-safe'),
             )))
 
+    @staticuid()
     def create_todos(self):
         self.todolist_general = self.register('todolist_general', create(
             Builder('todolist')


### PR DESCRIPTION
This PR uses static uids for the workspace testing fixtures. It seems that we've forgotten it while adding the fixtures.

We need this change to make frontend testing fixtures static.