### PR TITLE
Fix ech0160 export: include documents inside tasks and proposals.

### DIFF
--- a/changes/CA-3543.bugfix
+++ b/changes/CA-3543.bugfix
@@ -1,0 +1,1 @@
+Include documents inside task and proposals in the ech0160 export. [phgross]

--- a/opengever/disposition/ech0160/model/dossier.py
+++ b/opengever/disposition/ech0160/model/dossier.py
@@ -9,7 +9,9 @@ from opengever.disposition.ech0160.utils import set_classification_attributes
 from opengever.document.behaviors import IBaseDocument
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.behaviors.dossier import IDossierMarker
+from opengever.meeting.proposal import IProposal
 from opengever.repository.repositoryroot import IRepositoryRoot
+from opengever.task.task import ITask
 from Products.CMFCore.utils import getToolByName
 
 
@@ -42,6 +44,15 @@ class Dossier(object):
                 self.dossiers[obj.UID()] = Dossier(obj)
             elif IBaseDocument.providedBy(obj):
                 self.documents[obj.UID()] = Document(obj)
+            elif ITask.providedBy(obj) or IProposal.providedBy(obj):
+                self._add_task_and_proposal_documents(obj, self.documents)
+
+    def _add_task_and_proposal_documents(self, obj, documents):
+        for item in obj.objectValues():
+            if IBaseDocument.providedBy(item):
+                documents[item.UID()] = Document(item)
+            else:
+                self._add_task_and_proposal_documents(item, documents)
 
     def binding(self):
         dossier = arelda.dossierGeverSIP(id=u'_{}'.format(self.obj.UID()))

--- a/opengever/disposition/tests/test_model.py
+++ b/opengever/disposition/tests/test_model.py
@@ -273,9 +273,19 @@ class TestDossier(IntegrationTestCase):
         brains = api.content.find(context=self.dossier, depth=1,
                                   portal_type=['opengever.document.document',
                                                'ftw.mail.mail'])
-        expected_documents = set([brain.getObject() for brain in brains])
+        expected_documents = [brain.getObject() for brain in brains]
 
-        self.assertEquals(expected_documents,
+        # proposal and task documents
+        brains = api.content.find(context=self.dossier, depth=1,
+                                  portal_type=['opengever.meeting.proposal',
+                                               'opengever.task.task'])
+        paths = [brain.getPath() for brain in brains]
+        brains = api.content.find(path=paths,
+                                  portal_type=['opengever.document.document',
+                                               'ftw.mail.mail'])
+        expected_documents += [brain.getObject() for brain in brains]
+
+        self.assertEquals(set(expected_documents),
                           set([doc.obj for doc in model.documents.values()]))
 
     @unittest.skip('Currently not implemented')
@@ -392,9 +402,11 @@ class TestFolderAndFileModel(IntegrationTestCase):
         # self.dossier
         # two subdossiers, self.subdossier and self.subdossier2
         self.assertEquals(2, len(dossier_model.folders))
-        # dossier a contains 4 files, for self.document, self.mail_eml,
-        # self.mail_msg and one automatically generated for self.decided_proposal
-        self.assertEquals(4, len(dossier_model.files))
+        # dossier a contains 9 files. 4 files direcly in the dossier (
+        # self.document, self.mail_eml, self.mail_msg and one automatically
+        # generated for self.decided_proposal), 4 documents inside the
+        # proposal and the self.taskdocument.
+        self.assertEquals(9, len(dossier_model.files))
         subdossier_model = dossier_model.folders[0]
         subdossier2_model = dossier_model.folders[1]
 


### PR DESCRIPTION
Currently the documents inside a proposal or a task, are not included in the eCH-0160 SIP export. This PR fixes that.

For [CA-3543]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-3543]: https://4teamwork.atlassian.net/browse/CA-3543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ