### PR TITLE
Actor portrait_url from different sources

### DIFF
--- a/changes/CA-1938.feature
+++ b/changes/CA-1938.feature
@@ -1,0 +1,1 @@
+Actor portrait_url respects the IActorSettings to choose the portrait_url from plone or the portal. [elioschmutz]

--- a/opengever/base/casauth.py
+++ b/opengever/base/casauth.py
@@ -4,6 +4,7 @@ from opengever.ogds.base.utils import get_current_admin_unit
 from plone import api
 from Products.PluggableAuthService.interfaces.plugins import IChallengePlugin
 from urlparse import urljoin
+import hashlib
 import re
 
 
@@ -58,6 +59,13 @@ def get_cas_server_url():
     cas_auth = acl_users.cas_auth
     url = getattr(cas_auth, 'cas_server_url', None)
     return url
+
+
+def get_user_avatar_url(userid):
+    """Get the avatar url for a specific userid
+    """
+    userhash = hashlib.md5(userid).hexdigest()
+    return '{}/media/avatars/{}'.format(get_gever_portal_url(), userhash)
 
 
 def build_cas_server_url(cas_path):

--- a/opengever/base/interfaces.py
+++ b/opengever/base/interfaces.py
@@ -490,3 +490,25 @@ class IWhiteLabelingSettings(Interface):
 
     logo_src = schema.Bytes(title=u'Logo image',
                             description=u'Format must be png, height must be 30px')
+
+
+AVATAR_SOURCE_PLONE_ONLY = 'plone_only'
+AVATAR_SOURCE_PORTAL_ONLY = 'portal_only'
+AVATAR_SOURCE_AUTO = 'auto'
+
+
+def get_user_avatar_image_sources():
+    return SimpleVocabulary.fromValues([
+        AVATAR_SOURCE_PLONE_ONLY,
+        AVATAR_SOURCE_PORTAL_ONLY,
+        AVATAR_SOURCE_AUTO,
+        ])
+
+
+class IActorSettings(Interface):
+
+    user_avatar_image_source = schema.Choice(
+        title=u"User avatar image source",
+        source=get_user_avatar_image_sources(),
+        default=AVATAR_SOURCE_PLONE_ONLY,
+    )

--- a/opengever/base/tests/test_casauth.py
+++ b/opengever/base/tests/test_casauth.py
@@ -3,6 +3,7 @@ from ftw.builder import create
 from opengever.base.casauth import get_cas_server_url
 from opengever.base.casauth import get_cluster_base_url
 from opengever.base.casauth import get_gever_portal_url
+from opengever.base.casauth import get_user_avatar_url
 from opengever.base.interfaces import IPortalSettings
 from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.testing import IntegrationTestCase
@@ -87,3 +88,13 @@ class TestGEVERPortalURL(IntegrationTestCase):
 
         self.assertEquals(
             'http://example.com/my-special-portal', get_gever_portal_url())
+
+
+class TestUserAvatarUrl(IntegrationTestCase):
+
+    def test_user_avatar_url_contains_the_md5_encoded_username(self):
+        get_current_admin_unit().public_url = 'http://example.com'
+        get_current_admin_unit().unit_id = 'foobar'
+        self.assertEquals(
+            'http://example.com/portal/media/avatars/04f98100995b2f5633210e10f21ee022',
+            get_user_avatar_url('foo.bar'))

--- a/opengever/core/profiles/default/registry.xml
+++ b/opengever/core/profiles/default/registry.xml
@@ -12,6 +12,7 @@
   <records interface="opengever.base.interfaces.IRecentlyTouchedSettings" />
   <records interface="opengever.base.interfaces.IOGMailSettings" />
   <records interface="opengever.base.interfaces.IPortalSettings" />
+  <records interface="opengever.base.interfaces.IActorSettings" />
 
   <!-- BUMBLEBEE -->
   <records interface="opengever.bumblebee.interfaces.IGeverBumblebeeSettings" />

--- a/opengever/core/upgrades/20220126084051_add_actor_settings_registry/registry.xml
+++ b/opengever/core/upgrades/20220126084051_add_actor_settings_registry/registry.xml
@@ -1,0 +1,5 @@
+<registry>
+
+  <records interface="opengever.base.interfaces.IActorSettings" />
+
+</registry>

--- a/opengever/core/upgrades/20220126084051_add_actor_settings_registry/upgrade.py
+++ b/opengever/core/upgrades/20220126084051_add_actor_settings_registry/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddActorSettingsRegistry(UpgradeStep):
+    """Add actor settings registry.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
This PR implements an  `IActorSettings` registry interface with a `user_avatar_image_source_type` property.

This allows us to configure the portrait_url lookup between the three modes:

- plone only
- portal only
- plone with fallback to portal

The `@actors` endpoint respects this setting and returns the expected portrait url.

For [CA-1938]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-1938]: https://4teamwork.atlassian.net/browse/CA-1938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ