### PR TITLE
Include inactive users in the all_users_and_groups source.

### DIFF
--- a/changes/CA-3551.bugfix
+++ b/changes/CA-3551.bugfix
@@ -1,0 +1,1 @@
+Include inactive users in the all_users_and_groups source. [phgross]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,6 +11,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- ``@globalsources``: The ``all_users_and_groups`` source returns now also inactive users.
 
 
 2022.3.0 (2022-02-02)

--- a/opengever/api/schema/globalsources.py
+++ b/opengever/api/schema/globalsources.py
@@ -11,7 +11,7 @@ from zope.schema import getFieldsInOrder
 class IGlobalSourceSchema(model.Schema):
 
     all_users_and_groups = schema.Choice(
-        source=AllUsersAndGroupsSourceBinder(),
+        source=AllUsersAndGroupsSourceBinder(only_active_orgunits=False),
     )
 
     filtered_groups = schema.Choice(

--- a/opengever/api/tests/test_globalsources.py
+++ b/opengever/api/tests/test_globalsources.py
@@ -1,5 +1,8 @@
+from ftw.builder import Builder
+from ftw.builder import create
 from ftw.testbrowser import browsing
 from opengever.kub.testing import KuBIntegrationTestCase
+from opengever.ogds.models.user import User
 from opengever.testing import IntegrationTestCase
 import requests_mock
 
@@ -55,6 +58,24 @@ class TestGlobalSourcesGet(IntegrationTestCase):
             {u'@id': u'http://nohost/plone/@globalsources/all_users_and_groups?query=Rober',
              u'items': [{u'title': u'Ziegler Robert (robert.ziegler)',
                          u'token': u'robert.ziegler'}],
+             u'items_total': 1},
+            browser.json)
+
+    @browsing
+    def test_all_users_and_groups_find_also_inactive_users_not_assigned_to_org_units(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        create(Builder('ogds_user').id('peter.inactive')
+               .having(firstname='Peter', lastname='Inactive', active=False))
+
+        url = '{}/@globalsources/all_users_and_groups?query=inacti'.format(
+            self.portal.absolute_url())
+        browser.open(url, headers=self.api_headers)
+
+        self.assertEqual(
+            {u'@id': u'http://nohost/plone/@globalsources/all_users_and_groups?query=inacti',
+             u'items': [{u'title': u'Inactive Peter (peter.inactive)',
+                         u'token': u'peter.inactive'}],
              u'items_total': 1},
             browser.json)
 

--- a/opengever/ogds/base/sources.py
+++ b/opengever/ogds/base/sources.py
@@ -954,9 +954,20 @@ class AllUsersAndGroupsSource(BaseMultipleSourcesQuerySource):
 
     source_classes = [AllFilteredGroupsSourcePrefixed, AllUsersSource]
 
+    def __init__(self, context, only_active_orgunits=True):
+        super(AllUsersAndGroupsSource, self).__init__(context)
+
+        self.source_instances = [source_class(
+            context, only_active_orgunits=only_active_orgunits)
+                                 for source_class in self.source_classes]
+
 
 @implementer(IContextSourceBinder)
 class AllUsersAndGroupsSourceBinder(object):
 
+    def __init__(self, only_active_orgunits=True):
+        self.only_active_orgunits = only_active_orgunits
+
     def __call__(self, context):
-        return AllUsersAndGroupsSource(context)
+        return AllUsersAndGroupsSource(
+            context, only_active_orgunits=self.only_active_orgunits)


### PR DESCRIPTION
The name `all_users_and_groups` actually already lets the API user assume that inactive users will also be found.

This allows administrators to create a permission_report also for inactive users which are no longer assigned to a org_unit.
For [CA-3551]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- API change:
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))

[CA-3551]: https://4teamwork.atlassian.net/browse/CA-3551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ