### PR TITLE
Avoid unnecessary security updates

### DIFF
--- a/changes/CA-3625.other
+++ b/changes/CA-3625.other
@@ -1,0 +1,1 @@
+Avoid unnecessary security updates when adding new content or renaming existing content. [buchi]


### PR DESCRIPTION
If a new object is added or an existing one is renamed, there's no need to update the security or perform any of the other index updates in this event handler. Further if an object is copied, the security is now updated only once. It was updated twice before, because the object is renamed after beeing added to the container.

This speeds up object creation and copying of objects significantly. E.g. bundle import time is reduced by approximately 30%.

For [CA-3625](https://4teamwork.atlassian.net/browse/CA-3625)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
