### PR TITLE
Optimize warmup for large sites

### DIFF
--- a/changes/CA-3625.change
+++ b/changes/CA-3625.change
@@ -1,0 +1,1 @@
+Optimize warmup: reduce warmup time and memory consumption after warmup. [buchi]

--- a/opengever/base/warmup.py
+++ b/opengever/base/warmup.py
@@ -1,15 +1,38 @@
 from ftw.monitor.interfaces import IWarmupPerformer
 from ftw.monitor.warmup import DefaultWarmupPerformer
+from opengever.base.interfaces import IOpengeverBaseLayer
 from Products.CMFPlone.interfaces import IPloneSiteRoot
 from zope.component import adapter
+from zope.component import getMultiAdapter
+from zope.interface import alsoProvides
 from zope.interface import implementer
+from zope.interface import noLongerProvides
 from zope.publisher.interfaces.browser import IBrowserRequest
+from zope.publisher.interfaces.browser import IDefaultBrowserLayer
+import plone.api
 
 
 @implementer(IWarmupPerformer)
 @adapter(IPloneSiteRoot, IBrowserRequest)
 class GEVERWarmupPerformer(DefaultWarmupPerformer):
-    """Extends DefaultWarmupPerformer from ftw.monitor with 'trashed' index.
+    """Call some REST API endpoints to warmup the instance.
     """
 
-    WARMUP_INDEXES = DefaultWarmupPerformer.WARMUP_INDEXES + ['trashed']
+    VIEW_NAMES = [
+        u'GET_application_json_',
+        u'GET_application_json_@config',
+        u'GET_application_json_@navigation',
+    ]
+
+    def perform(self):
+        # Skins and browser layers are not correctly setup during warmup.
+        # Fix 'em before calling our endpoints
+        self.context.setupCurrentSkin()
+        alsoProvides(self.request, IOpengeverBaseLayer)
+        noLongerProvides(self.request, IDefaultBrowserLayer)
+        alsoProvides(self.request, IDefaultBrowserLayer)
+
+        with plone.api.env.adopt_user(username=self.context.getOwner().getId()):
+            for view_name in self.VIEW_NAMES:
+                view = getMultiAdapter((self.context, self.request), name=view_name)
+                view()


### PR DESCRIPTION
Loading the most important catalog indexes into memory doesn't work well for larger sites. It takes several minutes and fills up a lot of memory. We try another approach by calling REST API endpoints that are always called by the frontend on a new page load. At least for read access and when using the new frontend this approach seems to be superior.

Test with ogg1m, new approach:

Warmup duration: `24s`
Memory consumption after warmup: `500 MB`
First Page Load after warmup (Dashboard of new frontend): `7.5s`

Test with ogg1m, old approach:

Warmup duration: `5m 13s`
Memory consumption after warmup: `3.4 GB`
First Page Load after warmup (Dashboard of new frontend): `9.7s`

Test Köniz (very slow disk system), new approach:

Warmup duration: `56s`
Memory consumption after warmup: `400 MB`
First Page Load after warmup (Personal overview of classic frontend): `22.45s`

Test Köniz, old approach:

Warmup duration: `7m 11s`
Memory consumption after warmup: `2.2 GB`
First Page Load after warmup (Personal overview of classic frontend): `30.53s`

There are some views in the classic frontend that are significantly slower on the first call with the new approach. E.g. repository overview (`tabbed_view/listing?view_name=overview`). These views can be improved by using Solr.

For [CA-3625](https://4teamwork.atlassian.net/browse/CA-3625)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

