### PR TITLE
Fix propertysheets `date` field serialization and default

### DIFF
--- a/changes/CA-3506-1.bugfix
+++ b/changes/CA-3506-1.bugfix
@@ -1,0 +1,1 @@
+Custom properties: Don't prematurely make returned values json_compatible(). [lgraf]

--- a/changes/CA-3506-2.bugfix
+++ b/changes/CA-3506-2.bugfix
@@ -1,0 +1,1 @@
+Custom properties: Fix rendering z3c.form widgets in display mode for date fields. [lgraf]

--- a/changes/CA-3506-3.bugfix
+++ b/changes/CA-3506-3.bugfix
@@ -1,0 +1,1 @@
+Fix setting static defaults for propertysheet date fields. [lgraf]

--- a/changes/CA-3506.bugfix
+++ b/changes/CA-3506.bugfix
@@ -1,0 +1,1 @@
+Don't attempt to transport custom properties across admin units. [lgraf]

--- a/opengever/api/tests/test_tus.py
+++ b/opengever/api/tests/test_tus.py
@@ -231,7 +231,7 @@ class TestTUSUpload(IntegrationTestCase):
         doc = self.assert_tus_upload_succeeds(self.dossier, browser)
         expected_defaults = {
             u'IDocument.default': {
-                u'languages': [u'de', u'en'],
+                u'languages': set([u'de', u'en']),
                 u'notrequired': u'Not required, still has default',
             },
         }

--- a/opengever/base/tests/test_quickupload.py
+++ b/opengever/base/tests/test_quickupload.py
@@ -65,7 +65,7 @@ class TestOGQuickupload(IntegrationTestCase):
 
         expected_defaults = {
             u'IDocument.default': {
-                u'languages': [u'de', u'en'],
+                u'languages': set([u'de', u'en']),
                 u'notrequired': u'Not required, still has default',
             },
         }

--- a/opengever/base/transport.py
+++ b/opengever/base/transport.py
@@ -5,6 +5,7 @@ from opengever.base.security import elevated_privileges
 from opengever.ogds.base.utils import decode_for_json
 from opengever.ogds.base.utils import encode_after_json
 from opengever.propertysheets.creation_defaults import initialize_customproperties_defaults
+from opengever.propertysheets.field import IPropertySheetField
 from opengever.task.reminder import Reminder
 from opengever.task.task import ITask
 from plone.dexterity.interfaces import IDexterityContent
@@ -218,6 +219,10 @@ class DexterityFieldDataCollector(object):
             subdata = {}
             repr = schemata(self.context)
             for name, field in schema.getFieldsInOrder(schemata):
+                if IPropertySheetField.providedBy(field):
+                    # Custom properties don't get transported
+                    continue
+
                 value = getattr(repr, name, _marker)
                 if value == _marker:
                     value = getattr(self.context, name, None)
@@ -237,6 +242,10 @@ class DexterityFieldDataCollector(object):
             repr = schemata(self.context)
             subdata = data[schemata.getName()]
             for name, field in schema.getFieldsInOrder(schemata):
+                if IPropertySheetField.providedBy(field):
+                    # Custom properties don't get transported
+                    continue
+
                 value = subdata.get(name, _marker)
                 value = self.unpack(name, field, value)
                 if value != _marker:

--- a/opengever/base/utils.py
+++ b/opengever/base/utils.py
@@ -179,6 +179,26 @@ def make_persistent(data):
         return data
 
 
+def make_nonpersistent(data):
+    """Recursively turn a nested data structure of persistent lists and dicts
+    into one using plain Python lists and dicts.
+    """
+    if isinstance(data, PersistentDict):
+        new = dict()
+        for key, value in data.items():
+            new[make_nonpersistent(key)] = make_nonpersistent(value)
+        return new
+
+    elif isinstance(data, PersistentList):
+        new = list()
+        for value in data:
+            new.append(make_nonpersistent(value))
+        return new
+
+    else:
+        return data
+
+
 def rewrite_path_list_to_absolute_paths(request):
     """If request contains a paths:list param, rewrite these paths so
     they're always absolute (start with the Plone site).

--- a/opengever/mail/tests/test_extract_attachments.py
+++ b/opengever/mail/tests/test_extract_attachments.py
@@ -145,7 +145,7 @@ class TestExtractAttachmentView(FunctionalTestCase):
 
         expected_defaults = {
             u'IDocument.default': {
-                u'languages': [u'de', u'en'],
+                u'languages': set([u'de', u'en']),
                 u'notrequired': u'Not required, still has default',
             },
         }

--- a/opengever/mail/tests/test_inbound.py
+++ b/opengever/mail/tests/test_inbound.py
@@ -214,7 +214,7 @@ class TestMailInbound(FunctionalTestCase):
         obj = inbound.createMailInContainer(dossier, message)
         expected_defaults = {
             u'IDocument.default': {
-                u'languages': [u'de', u'en'],
+                u'languages': set([u'de', u'en']),
                 u'notrequired': u'Not required, still has default',
             },
         }

--- a/opengever/propertysheets/annotation.py
+++ b/opengever/propertysheets/annotation.py
@@ -1,3 +1,4 @@
+from opengever.base.utils import make_nonpersistent
 from opengever.base.utils import make_persistent
 from opengever.propertysheets.exceptions import BadCustomPropertiesFactoryConfiguration
 from opengever.propertysheets.field import IPropertySheetField
@@ -5,7 +6,6 @@ from persistent.dict import PersistentDict
 from plone.behavior.annotation import AnnotationsFactoryImpl
 from plone.behavior.annotation import AnnotationStorage
 from plone.behavior.interfaces import ISchemaAwareFactory
-from plone.restapi.serializer.converters import json_compatible
 from zope.interface import alsoProvides
 
 
@@ -41,8 +41,9 @@ class CustomPropertiesStorageImpl(AnnotationsFactoryImpl):
         super(CustomPropertiesStorageImpl, self).__init__(context, schema)
 
     def __getattr__(self, name):
-        """Make sure to convert Persistent to json compatible data."""
-        return json_compatible(
+        """Convert persistent data structures to non-persistent ones.
+        """
+        return make_nonpersistent(
             super(CustomPropertiesStorageImpl, self).__getattr__(name)
         )
 

--- a/opengever/propertysheets/testing.py
+++ b/opengever/propertysheets/testing.py
@@ -1,3 +1,4 @@
+from datetime import date
 from zope.interface import provider
 from zope.schema.interfaces import IContextAwareDefaultFactory
 
@@ -30,3 +31,8 @@ def dummy_default_factory_some_text_line(context):
 @provider(IContextAwareDefaultFactory)
 def dummy_default_factory_gruen(context):
     return set([u'gr\xfcn'])
+
+
+@provider(IContextAwareDefaultFactory)
+def dummy_default_factory_today(context):
+    return date.today()

--- a/opengever/propertysheets/tests/test_creation_defaults.py
+++ b/opengever/propertysheets/tests/test_creation_defaults.py
@@ -1,3 +1,4 @@
+from datetime import date
 from ftw.builder import Builder
 from ftw.builder import create
 from opengever.document.behaviors.customproperties import IDocumentCustomProperties
@@ -27,7 +28,7 @@ class TestPropertySheetsCreationDefaults(IntegrationTestCase):
 
     def test_dereferences_defaults_declared_as_mutable_kwargs(self):
         self.login(self.regular_user)
-        PropertySheetSchemaStorage().clear()       
+        PropertySheetSchemaStorage().clear()
 
         create(
             Builder('property_sheet_schema')
@@ -110,6 +111,11 @@ class TestPropertySheetsCreationDefaultsForDocument(IntegrationTestCase):
                 required=True,
                 default_from_member={'property': 'email'},
             )
+            .with_field(
+                'date', u'datefield', u'Date with default', u'',
+                required=False,
+                default=date(2022, 1, 31),
+            )
         )
 
         field = IDocumentCustomProperties['custom_properties']
@@ -121,6 +127,7 @@ class TestPropertySheetsCreationDefaultsForDocument(IntegrationTestCase):
                 'location': u'CH',
                 'userid': u'kathi.barfuss',
                 'email': u'foo@example.com',
+                'datefield': date(2022, 1, 31),
             }
         }
         self.assertEqual(expected_defaults, defaults)
@@ -146,7 +153,7 @@ class TestPropertySheetsCreationDefaultsForDossier(IntegrationTestCase):
         defaults = get_customproperties_defaults(field)
         self.assertEqual({}, defaults)
 
-    def test_determine_dossier_defaults(self):       
+    def test_determine_dossier_defaults(self):
         self.login(self.regular_user)
         PropertySheetSchemaStorage().clear()
 
@@ -184,6 +191,11 @@ class TestPropertySheetsCreationDefaultsForDossier(IntegrationTestCase):
                 required=True,
                 default_from_member={'property': 'email'},
             )
+            .with_field(
+                'date', u'datefield', u'Date with default', u'',
+                required=False,
+                default=date(2022, 1, 31),
+            )
         )
 
         field = IDossierCustomProperties['custom_properties']
@@ -195,6 +207,7 @@ class TestPropertySheetsCreationDefaultsForDossier(IntegrationTestCase):
                 'location': u'CH',
                 'userid': u'kathi.barfuss',
                 'email': u'foo@example.com',
+                'datefield': date(2022, 1, 31),
             }
         }
         self.assertEqual(expected_defaults, defaults)

--- a/opengever/propertysheets/tests/test_document_custom_properties.py
+++ b/opengever/propertysheets/tests/test_document_custom_properties.py
@@ -1,3 +1,4 @@
+from datetime import date
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
@@ -52,11 +53,11 @@ class TestDocumentCustomPropertiesPatch(IntegrationTestCase):
             "IDocumentMetadata.document_type.question": {
                 "yesorno": False,
                 "choose": u"zw\xf6i",
-                "choosemulti": ["three", "one"],
+                "choosemulti": set(["one", "three"]),
                 "num": 123,
                 "text": u"bl\xe4\nblub",
                 "textline": u"bl\xe4",
-                "birthday": "2022-01-30",
+                "birthday": date(2022, 1, 30),
             },
         }
         self.assertEqual(

--- a/opengever/propertysheets/tests/test_document_custom_properties.py
+++ b/opengever/propertysheets/tests/test_document_custom_properties.py
@@ -24,6 +24,7 @@ class TestDocumentCustomPropertiesPatch(IntegrationTestCase):
             .with_field("int", u"num", u"Number", u"", True)
             .with_field("text", u"text", u"Some lines of text", u"", True)
             .with_field("textline", u"textline", u"A line of text", u"", True)
+            .with_field("date", u"birthday", u"Birthday", u"", True)
         )
         self.document.document_type = u"question"
 
@@ -37,6 +38,7 @@ class TestDocumentCustomPropertiesPatch(IntegrationTestCase):
                     "num": 123,
                     "text": u"bl\xe4\nblub",
                     "textline": u"bl\xe4",
+                    "birthday": "2022-01-30",
                 },
             }
         }
@@ -54,6 +56,7 @@ class TestDocumentCustomPropertiesPatch(IntegrationTestCase):
                 "num": 123,
                 "text": u"bl\xe4\nblub",
                 "textline": u"bl\xe4",
+                "birthday": "2022-01-30",
             },
         }
         self.assertEqual(

--- a/opengever/propertysheets/tests/test_dossier_custom_properties.py
+++ b/opengever/propertysheets/tests/test_dossier_custom_properties.py
@@ -1,3 +1,4 @@
+from datetime import date
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
@@ -42,9 +43,9 @@ class TestDossierCustomPropertiesPatch(IntegrationTestCase):
         expected_properties = {
             "IDossier.dossier_type.businesscase": {
                 "choose": u"zw\xf6i",
-                "choosemulti": ["three", "one"],
+                "choosemulti": set(["one", "three"]),
                 "textline": u"bl\xe4",
-                "birthday": "2022-01-30",
+                "birthday": date(2022, 1, 30),
             },
         }
         self.assertEqual(

--- a/opengever/propertysheets/tests/test_dossier_custom_properties.py
+++ b/opengever/propertysheets/tests/test_dossier_custom_properties.py
@@ -21,6 +21,7 @@ class TestDossierCustomPropertiesPatch(IntegrationTestCase):
             .with_field("multiple_choice", u"choosemulti",
                         u"Choose Multi", u"", True, values=choices)
             .with_field("textline", u"textline", u"A line of text", u"", True)
+            .with_field("date", u"birthday", u"Birthday", u"", True)
         )
         self.dossier.dossier_type = u"businesscase"
 
@@ -31,6 +32,7 @@ class TestDossierCustomPropertiesPatch(IntegrationTestCase):
                     "choose": u"zw\xf6i".encode("unicode_escape"),
                     "choosemulti": ["one", "three"],
                     "textline": u"bl\xe4",
+                    "birthday": "2022-01-30",
                 },
             }
         }
@@ -42,6 +44,7 @@ class TestDossierCustomPropertiesPatch(IntegrationTestCase):
                 "choose": u"zw\xf6i",
                 "choosemulti": ["three", "one"],
                 "textline": u"bl\xe4",
+                "birthday": "2022-01-30",
             },
         }
         self.assertEqual(
@@ -107,7 +110,6 @@ class TestDossierCustomPropertiesPatch(IntegrationTestCase):
             )
 
         self.assertDictContainsSubset({"type": "BadRequest"}, browser.json)
-
 
     @browsing
     def test_allows_empty_data_if_only_non_required_fields_in_selected_assignment(self, browser):

--- a/opengever/propertysheets/tests/test_mail_custom_properties.py
+++ b/opengever/propertysheets/tests/test_mail_custom_properties.py
@@ -1,3 +1,4 @@
+from datetime import date
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
@@ -48,8 +49,19 @@ class TestMailCustomPropertiesPatch(IntegrationTestCase):
             data=json.dumps(good_data),
             headers=self.api_headers,
         )
+        expected_properties = {
+            "IDocumentMetadata.document_type.question": {
+                "yesorno": False,
+                "choose": "two",
+                "choosemulti": set(["one", "three"]),
+                "num": 123,
+                "text": u"bl\xe4\nblub",
+                "textline": u"bl\xe4",
+                "birthday": date(2022, 1, 30),
+            },
+        }
         self.assertEqual(
-            good_data["custom_properties"],
+            expected_properties,
             IDocumentCustomProperties(self.mail_eml).custom_properties,
         )
 

--- a/opengever/propertysheets/tests/test_mail_custom_properties.py
+++ b/opengever/propertysheets/tests/test_mail_custom_properties.py
@@ -24,6 +24,7 @@ class TestMailCustomPropertiesPatch(IntegrationTestCase):
             .with_field("int", u"num", u"Number", u"", True)
             .with_field("text", u"text", u"Some lines of text", u"", True)
             .with_field("textline", u"textline", u"A line of text", u"", True)
+            .with_field("date", u"birthday", u"Birthday", u"", True)
         )
         self.mail_eml.document_type = u"question"
 
@@ -37,6 +38,7 @@ class TestMailCustomPropertiesPatch(IntegrationTestCase):
                     "num": 123,
                     "text": u"bl\xe4\nblub",
                     "textline": u"bl\xe4",
+                    "birthday": "2022-01-30",
                 },
             }
         }

--- a/opengever/propertysheets/tests/test_schema.py
+++ b/opengever/propertysheets/tests/test_schema.py
@@ -122,6 +122,9 @@ class TestPropertySheetJSONSchema(FunctionalTestCase):
         definition.add_field(
             "textline", u"bla", u"Textline", u"Say something short.", True
         )
+        definition.add_field(
+            "date", u"birthday", u"Birthday", u"", True
+        )
 
         json_schema = definition.get_json_schema()
         Draft4Validator.check_schema(json_schema)
@@ -144,12 +147,20 @@ class TestPropertySheetJSONSchema(FunctionalTestCase):
                        u'num',
                        u'blabla',
                        u'bla',
+                       u'birthday',
                     ],
                     'id': 'default',
                     'title': 'Default',
                 }
             ],
             'properties': {
+                u'birthday': {
+                    u'description': u'',
+                    u'factory': u'Date',
+                    u'title': u'Birthday',
+                    u'type': u'string',
+                    u'widget': u'date',
+                },
                 u'bla': {
                     u'description': u'Say something short.',
                     u'factory': u'Text line (String)',
@@ -322,9 +333,10 @@ class TestPropertySheetJSONSchema(FunctionalTestCase):
                 u'num',
                 u'blabla',
                 u'bla',
+                u'birthday',
             ],
             'title': 'schema',
             'type': 'object',
-        }     
+        }
 
         self.assertEqual(expected, json_schema)

--- a/opengever/propertysheets/tests/test_schema_definition_post.py
+++ b/opengever/propertysheets/tests/test_schema_definition_post.py
@@ -1,3 +1,4 @@
+from datetime import date
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
@@ -8,6 +9,7 @@ from opengever.propertysheets.testing import dummy_default_factory_fr
 from opengever.propertysheets.testing import dummy_default_factory_gruen
 from opengever.propertysheets.testing import dummy_default_factory_some_text
 from opengever.propertysheets.testing import dummy_default_factory_some_text_line
+from opengever.propertysheets.testing import dummy_default_factory_today
 from opengever.propertysheets.testing import dummy_default_factory_true
 from opengever.testing import IntegrationTestCase
 from plone import api
@@ -145,6 +147,11 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
                     "field_type": u"textline",
                     "title": u"zeile"
                 },
+                {
+                    "name": "birthday",
+                    "field_type": u"date",
+                    "title": u"Birthday",
+                },
             ],
             "assignments": ["IDocumentMetadata.document_type.question"],
         }
@@ -160,7 +167,7 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
         definition = storage.get("meinschema")
 
         self.assertEqual(
-            ["yn", "wahl", "colors", "nummer", "text", "zeiletext"],
+            ["yn", "wahl", "colors", "nummer", "text", "zeiletext", "birthday"],
             definition.get_fieldnames()
         )
 
@@ -276,6 +283,12 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
                     "title": u"zeile",
                     "default_factory": dottedname(dummy_default_factory_some_text_line),
                 },
+                {
+                    "name": "birthday",
+                    "field_type": u"date",
+                    "title": u"Birthday",
+                    "default_factory": dottedname(dummy_default_factory_today),
+                },
             ],
             "assignments": ["IDocumentMetadata.document_type.question"],
         }
@@ -313,6 +326,10 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
         self.assertEqual(u'Some text line', fields['zeiletext'].default)
         self.assertEqual(dummy_default_factory_some_text_line,
                          fields['zeiletext'].defaultFactory)
+
+        self.assertEqual(date.today(), fields['birthday'].default)
+        self.assertEqual(dummy_default_factory_today,
+                         fields['birthday'].defaultFactory)
 
     @browsing
     def test_property_sheet_schema_definition_post_supports_setting_default_expressions(self, browser):
@@ -360,6 +377,12 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
                     "title": u"zeile",
                     "default_expression": "python: 'Some text line'",
                 },
+                {
+                    "name": "birthday",
+                    "field_type": u"date",
+                    "title": u"Birthday",
+                    "default_expression": "python: portal.some_date_attribute",
+                },
             ],
             "assignments": ["IDocumentMetadata.document_type.question"],
         }
@@ -403,6 +426,12 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
         self.assertEqual(u'Some text line', fields['zeiletext'].defaultFactory())
         self.assertEqual("python: 'Some text line'",
                          fields['zeiletext'].default_expression)
+
+        self.portal.some_date_attribute = date(2022, 1, 30)
+        self.assertEqual(date(2022, 1, 30), fields['birthday'].default)
+        self.assertEqual(date(2022, 1, 30), fields['birthday'].defaultFactory())
+        self.assertEqual("python: portal.some_date_attribute",
+                         fields['birthday'].default_expression)
 
     @browsing
     def test_property_sheet_schema_definition_post_supports_setting_default_from_member(self, browser):

--- a/opengever/propertysheets/tests/test_schema_definition_post.py
+++ b/opengever/propertysheets/tests/test_schema_definition_post.py
@@ -216,6 +216,13 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
                     "title": u"zeile",
                     "default": u"some text line",
                 },
+                {
+                    "name": "birthday",
+                    "field_type": u"date",
+                    "title": u"Birthday",
+                    "default": u"2022-01-30",
+                },
+
             ],
             "assignments": ["IDocumentMetadata.document_type.question"],
         }
@@ -236,6 +243,7 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
         self.assertEqual(42, fields['nummer'].default)
         self.assertEqual(u'some text', fields['text'].default)
         self.assertEqual(u'some text line', fields['zeiletext'].default)
+        self.assertEqual(date(2022, 1, 30), fields['birthday'].default)
 
     @browsing
     def test_property_sheet_schema_definition_post_supports_setting_default_factories(self, browser):

--- a/opengever/propertysheets/tests/test_transporter.py
+++ b/opengever/propertysheets/tests/test_transporter.py
@@ -1,13 +1,23 @@
+from datetime import date
 from opengever.base.transport import Transporter
 from opengever.document.behaviors.customproperties import IDocumentCustomProperties
 from opengever.testing import IntegrationTestCase
 
 
 class TestTransporterWithCustomProperties(IntegrationTestCase):
-    """Test transporter works with custom properties. This guarantees that
-    documents with custom properties can be used in tasks and in meeting.
+    """Test that custom properties don't break transporter.
+
+    This guarantees that documents with custom properties can be used in
+    tasks and in meeting without causing issues for the transporter.
+
+    They will NOT be transported however, because we can't know what custom
+    propertysheets exist on the other side. Fields might be missing, or even
+    exist with a different type.
+
+    Also, since document_types and dossier_types are customizable, the other
+    side might not even have the same assignment slots available.
     """
-    def test_custom_properties_are_transported(self):
+    def test_custom_properties_dont_break_transporter(self):
         self.login(self.regular_user)
 
         properties = {
@@ -15,6 +25,7 @@ class TestTransporterWithCustomProperties(IntegrationTestCase):
                 "textline": u"b\xe4\xe4",
                 "iwasremoved": 123,
                 "choose": "inolongerexist",
+                "birthday": date(2022, 1, 30),
             }
         }
 
@@ -23,7 +34,6 @@ class TestTransporterWithCustomProperties(IntegrationTestCase):
         transported_doc = Transporter().transport_from(
             self.empty_dossier, 'plone', '/'.join(self.document.getPhysicalPath()))
 
-        self.assertEqual(
-            properties,
+        self.assertIsNone(
             IDocumentCustomProperties(transported_doc).custom_properties,
         )

--- a/opengever/propertysheets/tests/test_widget.py
+++ b/opengever/propertysheets/tests/test_widget.py
@@ -1,3 +1,4 @@
+from datetime import date
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
@@ -18,7 +19,7 @@ class TestPropertySheetWidget(IntegrationTestCase):
         self, browser
     ):
         self.login(self.manager, browser)
-        
+
         choices = ["one", u"zw\xf6i", "three"]
         create(
             Builder("property_sheet_schema")
@@ -56,6 +57,7 @@ class TestPropertySheetWidget(IntegrationTestCase):
             .with_field("int", u"num", u"Number", u"", True)
             .with_field("text", u"text", u"Some lines of text", u"", True)
             .with_field("textline", u"textline", u"A line of text", u"", True)
+            .with_field("date", u"birthday", u"Birthday", u"", True)
         )
         self.document.document_type = u"question"
 
@@ -85,6 +87,7 @@ class TestPropertySheetWidget(IntegrationTestCase):
                 u"Number",
                 u"Some lines of text",
                 u"A line of text",
+                u"Birthday",
             ],
             input_labels,
         )
@@ -97,6 +100,7 @@ class TestPropertySheetWidget(IntegrationTestCase):
                 "Number": "3",
                 "Some lines of text": "Foo\nbar",
                 "A line of text": u"b\xe4\xe4",
+                "Birthday": date(2022, 1, 30),
             }
         )
         browser.click_on("Save")
@@ -108,12 +112,13 @@ class TestPropertySheetWidget(IntegrationTestCase):
                     "num": 3,
                     "yesorno": True,
                     "choose": u"zw\xf6i",
-                    "choosemulti": ["three", "one"],
+                    "choosemulti": set(["one", "three"]),
                     "choose_default": u"fr",
                     "choose_default_factory": u"fr",
                     "choose_default_expression": u"en",
                     "choose_default_from_member": u"CH",
                     "textline": u"b\xe4\xe4",
+                    "birthday": date(2022, 1, 30),
                 }
             },
             IDocumentCustomProperties(self.document).custom_properties,
@@ -152,6 +157,7 @@ class TestPropertySheetWidget(IntegrationTestCase):
             .with_field("int", u"num", u"Number", u"", True)
             .with_field("text", u"text", u"Some lines of text", u"", True)
             .with_field("textline", u"textline", u"A line of text", u"", True)
+            .with_field("date", u"birthday", u"Birthday", u"", True)
         )
 
         self.login(self.regular_user, browser)
@@ -187,6 +193,7 @@ class TestPropertySheetWidget(IntegrationTestCase):
                     "Number": "3",
                     "Some lines of text": "Foo\nbar",
                     "A line of text": u"b\xe4\xe4",
+                    "Birthday": date(2022, 1, 30),
                 }
             ).save()
 
@@ -205,6 +212,7 @@ class TestPropertySheetWidget(IntegrationTestCase):
                     "choose_default_factory": u"fr",
                     "choose_default_expression": u"en",
                     "textline": u"b\xe4\xe4",
+                    "birthday": date(2022, 1, 30),
                 }
             },
             IDocumentCustomProperties(document).custom_properties,

--- a/opengever/propertysheets/widgets.py
+++ b/opengever/propertysheets/widgets.py
@@ -1,7 +1,6 @@
 from opengever.propertysheets import _
 from opengever.propertysheets.field import IPropertySheetField
 from opengever.propertysheets.storage import PropertySheetSchemaStorage
-from plone.restapi.serializer.converters import json_compatible
 from z3c.form import interfaces
 from z3c.form.error import MultipleErrors
 from z3c.form.interfaces import IContextAware
@@ -229,8 +228,7 @@ class PropertySheetFieldDataConverter(object):
         self.widget = widget
 
     def toWidgetValue(self, value):
-        """Make sure to convert Persistent to json compatible data."""
-        return json_compatible(value)
+        return value
 
     def toFieldValue(self, value):
         self.field.validate(value)


### PR DESCRIPTION
This fixes several issues found when adding more tests for the propertysheets `date` field type:

#### `CustomPropertiesStorageImpl`: Don't convert to json_compatible in `__getattr__`:

No longer pass returned properties through `json_compatible()` when reading them from annotations storage, e.g. with a read access to `IDocumentCustomProperties(doc).custom_properties`.

This was originally done to make the task transporter happy, but that doesn't really work, and caused issues with date fields:

- It didn't _really_ work for the transporter, because `json_compatible()` may be a no-op for Python fields that have a direct equivalent in JSON, but actually performs a serialization for types like dates that don't. Those would then need to be deserialized on the other side. But since `json_compatible()` is a one way "serialization" only, a proper serialization/deserialization would have to be done in the transporter (but won't, see below).

 - It caused issues, because for one, setting data again that has been read from `__getattr__` would wreck any non-JSON native types like dates.

It also broke the assumption that on this abstraction layer we're deadling with the Python types implied by the respective `zope.schema` fields.


#### Propertysheets widget: Don't pass widget value through `json_compatible()`:

This may have seemed to work for field types that have a direct JSON equivalent, but in the case of a date field, this will turn a Python native `date` into a string, and lead to the widget failing in display mode when it tries to parse that "date". It's also not necessary, and most likely a relict from the time where the implementation was based on a JSONField.

#### Don't attempt to transport custom properties across admin units:

Instead, skip custom properties and just make sure they don't break the transporter.

But they will not be transported, because we can't know what custom propertysheets exist on the other side. Fields might be missing, or even exist with a different type.

Also, since `document_types` and `dossier_types` are customizable, the other side might not even have the same assignment slots available.

I discussed this with @phgross, and we both came to the same conclusion - it just doesn't make sense to transport custom properties accross admin units. They are very domain-specific and local _by definition_, and any workaround to transport them would likely to be wrong. If we were to do this, we would need a very clearly defined use case first.

For [CA-3506](https://4teamwork.atlassian.net/browse/CA-3506)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
