### PR TITLE
Propertysheets: Make sure preprocessing of static defaults doesn't choke on non-string types.

### DIFF
--- a/opengever/propertysheets/api/base.py
+++ b/opengever/propertysheets/api/base.py
@@ -128,7 +128,7 @@ class PropertySheetWriter(PropertySheetLocator):
             try:
                 field['default'] = datetime.strptime(
                     field['default'], '%Y-%m-%d').date()
-            except ValueError:
+            except (ValueError, TypeError):
                 # Optimistic parsing - if it's not a valid date, it will
                 # be caught by actual field validation later.
                 pass

--- a/opengever/propertysheets/tests/test_schema_definition_post.py
+++ b/opengever/propertysheets/tests/test_schema_definition_post.py
@@ -885,3 +885,28 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
                 }),
                 headers=self.api_headers,
             )
+
+    @browsing
+    def test_default_preprocessing_doesnt_choke_on_non_string_types(self, browser):
+        self.login(self.propertysheets_manager, browser)
+
+        data = {
+            "fields": [
+                {
+                    "name": "birthday",
+                    "field_type": "date",
+                    "title": "Birthday",
+                    "default": None,
+                }
+            ],
+            "assignments": ["IDocumentMetadata.document_type.question"],
+        }
+
+        browser.open(
+            view="@propertysheets/foo",
+            method="POST",
+            data=json.dumps(data),
+            headers=self.api_headers,
+        )
+        self.assertEqual(201, browser.status_code)
+        self.assertNotIn('default', browser.json['fields'][0])


### PR DESCRIPTION
Because the new frontend apprently omits empty fields on **add**, but sends them with `null` on **edit**, the static `default` for a propertysheet field may receive `None`, instead of a string.

`strptime` then raises a `TypeError` instead of a `ValueError` which also needs to be handled.

For [CA-3506](https://4teamwork.atlassian.net/browse/CA-3506)

## Checklist

- [ ] Changelog entry _(deemed unnecessary, because the bug was introduced and fixed in the same release)_
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

