### PR TITLE
Suppress creation of todo completion activities during upgrades:

### DIFF
--- a/changes/CA-3574.bugfix
+++ b/changes/CA-3574.bugfix
@@ -1,0 +1,1 @@
+Suppress creation of todo completion activities during upgrades to avoid failing upgrades. [lgraf]


### PR DESCRIPTION
We suppress creation of activities in the `todo_review_state_changed()` handler if it gets called during an upgrade to avoid failing upgrade steps.

This is because the creation of activities will emit SQL statements (queries, as well as inserts) which are likely to fail:

They will use the current models SQL (for Activities, Notifications, Users, ...) as present in the already updated code, but may run against an SQL database that hasn't had its schema fully upgraded yet.

(There may be later upgrade steps pending that would upgrade it and bring it in line with the schema on the Python models).

This has specifically been a problem with the upgrade [`20211105114219_add_completed_state_for_todos`](https://github.com/4teamwork/opengever.core/blob/master/opengever/core/upgrades/20211105114219_add_completed_state_for_todos/upgrade.py), which triggers state transitions for todos, and then fails e.g. because the `absent` field on the `User` model, or `external_resource_url` field on the `Activitiy` model isn't there yet.

Additionally, it's probably undesirable anyway to dispatch notifications to users during our upgrades.

With this change, I was able to sucessfully run through upgrades from `2021.12.1` to current master (2021.12.1 is the oldest real OnPremise deployment around).


For [CA-3574](https://4teamwork.atlassian.net/browse/CA-3574)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

