### PR TITLE
Fix content-sharing for multiple recipients.

### DIFF
--- a/changes/CA-3631.bugfix
+++ b/changes/CA-3631.bugfix
@@ -1,0 +1,1 @@
+Fix content-sharing for multiple recipients. [phgross]

--- a/opengever/activity/mailer.py
+++ b/opengever/activity/mailer.py
@@ -86,7 +86,7 @@ class Mailer(object):
         We therefore defer the dispatching of notification mails until the
         very end of the transaction to work around this issue.
         """
-        mail_queue.put(msg, mail_to, mail_from)
+        mail_queue.put(msg, [each.strip() for each in mail_to.split(',')], mail_from)
 
     def prepare_mail(self, subject=u'', to_userid=None, to_email=None,
                      cc_email=None, from_userid=None, data=None):

--- a/opengever/activity/tests/test_mail.py
+++ b/opengever/activity/tests/test_mail.py
@@ -159,7 +159,7 @@ class TestEmailNotification(IntegrationTestCase):
         process_mail_queue()
 
         message, = Mailing(self.portal).get_mailhost().messages
-        self.assertEqual('foo@example.com', message.mto)
+        self.assertEqual(['foo@example.com'], message.mto)
         self.assertEqual('test@localhost', message.mfrom)
 
         mail = email.message_from_string(message.messageText)

--- a/opengever/api/tests/test_share_content.py
+++ b/opengever/api/tests/test_share_content.py
@@ -55,15 +55,21 @@ class TestShareContentPost(IntegrationTestCase):
 
         browser.open(url, method='POST', headers=self.api_headers,
                      data=data)
-        expected_to = ', '.join((self.archivist.getProperty('email'),
-                                 self.workspace_guest.getProperty('email')))
+        expected_to = [self.archivist.getProperty('email'),
+                       self.workspace_guest.getProperty('email')]
         expected_cc = ', '.join((self.workspace_owner.getProperty('email'),
                                  self.workspace_admin.getProperty('email')))
 
         process_mail_queue()
+
+        self.assertEqual(
+            expected_to,
+            mailing.get_mailhost().messages[0].mto)
+
         self.assertEqual(1, len(mailing.get_messages()))
         mail = email.message_from_string(Mailing(self.portal).pop())
-        self.assertEqual(expected_to, mail['To'])
+        self.assertEqual(', '.join(expected_to), mail['To'])
+
         self.assertEqual(expected_cc, mail['Cc'])
         self.assertEqual('=?utf-8?q?Schr=C3=B6dinger_B=C3=A9atrice?= <test@localhost>',
                          mail['From'])


### PR DESCRIPTION
With https://github.com/4teamwork/opengever.core/pull/7270 I broke the content-sharing for multiple recipients. Because we pass in now the `mail_to` manually we need to make sure its a list and not a comma separated string.
 
For [CA-3631]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)



[CA-3631]: https://4teamwork.atlassian.net/browse/CA-3631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ