### PR TITLE
Fix content-sharing for cc recipients.

### DIFF
--- a/changes/CA-3631.bugfix
+++ b/changes/CA-3631.bugfix
@@ -1,1 +1,1 @@
-Fix content-sharing for multiple recipients. [phgross]
+Fix content-sharing for multiple recipients and cc recipients. [phgross]

--- a/opengever/activity/mailer.py
+++ b/opengever/activity/mailer.py
@@ -128,8 +128,12 @@ class Mailer(object):
         if to_userid:
             to_email = ogds_service().fetch_user(to_userid).email
         msg['To'] = to_email
+        recipients_email = to_email
+
         if cc_email:
             msg['Cc'] = cc_email
+            recipients_email = ', '.join((recipients_email, cc_email))
+
         msg['Subject'] = Header(subject, 'utf-8')
 
         # Break (potential) description out into a list element per newline
@@ -138,7 +142,7 @@ class Mailer(object):
 
         html = self.prepare_html(data)
         msg.attach(MIMEText(html.encode('utf-8'), 'html', 'utf-8'))
-        return msg, to_email, from_mail
+        return msg, recipients_email, from_mail
 
     def get_users_language(self):
         # XXX TODO Right now there is no support to store users preferred

--- a/opengever/api/tests/test_share_content.py
+++ b/opengever/api/tests/test_share_content.py
@@ -57,20 +57,19 @@ class TestShareContentPost(IntegrationTestCase):
                      data=data)
         expected_to = [self.archivist.getProperty('email'),
                        self.workspace_guest.getProperty('email')]
-        expected_cc = ', '.join((self.workspace_owner.getProperty('email'),
-                                 self.workspace_admin.getProperty('email')))
+        expected_cc = [self.workspace_owner.getProperty('email'),
+                       self.workspace_admin.getProperty('email')]
 
         process_mail_queue()
 
         self.assertEqual(
-            expected_to,
+            expected_to + expected_cc,
             mailing.get_mailhost().messages[0].mto)
 
         self.assertEqual(1, len(mailing.get_messages()))
         mail = email.message_from_string(Mailing(self.portal).pop())
         self.assertEqual(', '.join(expected_to), mail['To'])
-
-        self.assertEqual(expected_cc, mail['Cc'])
+        self.assertEqual(', '.join(expected_cc), mail['Cc'])
         self.assertEqual('=?utf-8?q?Schr=C3=B6dinger_B=C3=A9atrice?= <test@localhost>',
                          mail['From'])
         self.assertIn('Check out this fantastic w=C3=B6rkspace!', mail.as_string())


### PR DESCRIPTION
The previous fix #7356 only worked for To recipients but the cc recipients are still ignored.

For [CA-3631]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-3631]: https://4teamwork.atlassian.net/browse/CA-3631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ