### PR TITLE
Fix missing msgstr in propertysheet po file.

### DIFF
--- a/opengever/propertysheets/locales/fr/LC_MESSAGES/opengever.propertysheets.po
+++ b/opengever/propertysheets/locales/fr/LC_MESSAGES/opengever.propertysheets.po
@@ -178,5 +178,6 @@ msgstr "Champ ${field_no} ('${field_name}'):"
 #. Default: "The form contains errors:\n${error_string}"
 #: ./opengever/propertysheets/api/error_serialization.py
 msgid "msg_propertysheet_has_errors"
+msgstr ""
 "Le formulaire contient des erreurs:\n"
 "${error_string}"


### PR DESCRIPTION
This fixes an error that prevents us from building the docker images `ogcore` and its dependant `testserver`.

I've run `bin/i18n-build opengever.propertysheets` after changing the file to make sure it remains stable. Apparently it prefers to have the newlines as provided in this PR.

The build error in detail:
```
 => ERROR [build-stage 11/18] RUN find /app/opengever -name "*.po" | xargs -I@ sh -c 'msgfmt @ -o "$(dirname @)/$(basename @ .po)".mo' &&     find /app/plonetheme -name "*.po" | xargs -I@ sh -c 'msgfmt @ -o "$(dirname @)/$(basename @ .po)".mo'                                                                                                                  0.8s
------
 > [build-stage 11/18] RUN find /app/opengever -name "*.po" | xargs -I@ sh -c 'msgfmt @ -o "$(dirname @)/$(basename @ .po)".mo' &&     find /app/plonetheme -name "*.po" | xargs -I@ sh -c 'msgfmt @ -o "$(dirname @)/$(basename @ .po)".mo':
#17 0.721 /app/opengever/propertysheets/locales/fr/LC_MESSAGES/opengever.propertysheets.po:180: missing 'msgstr' section
#17 0.721 msgfmt: found 1 fatal error
------
```

For [HG-2168](https://4teamwork.atlassian.net/browse/HG-2168)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] ~~Changelog entry~~
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

