### PR TITLE
Add new @config property: has_dossier_propertysheet_registered

### DIFF
--- a/changes/CA-3325.feature
+++ b/changes/CA-3325.feature
@@ -1,0 +1,1 @@
+Add new @config property: has_dossier_propertysheet_registered [elioschmutz]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,6 +11,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- ``@config``: Add ``has_dossier_propertysheet_registered`` attribute.
 - ``@globalsources``: The ``all_users_and_groups`` source returns now also inactive users.
 
 

--- a/docs/public/dev-manual/api/config.rst
+++ b/docs/public/dev-manual/api/config.rst
@@ -312,4 +312,5 @@ usersnap_api_key
 
     API Schlüssel für Usersnap Integration im neuen Frontend
 
-
+has_dossier_propertysheet_registered
+    Gibt an, ob dieses Deployment eigene Propertysheets für Dossiers definiert oder nicht.

--- a/opengever/api/config.py
+++ b/opengever/api/config.py
@@ -8,6 +8,8 @@ from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.ogds.base.utils import get_current_org_unit
 from opengever.ogds.models.service import ogds_service
 from opengever.private import get_private_folder_url
+from opengever.propertysheets.assignment import get_dossier_assignment_slots
+from opengever.propertysheets.storage import PropertySheetSchemaStorage
 from opengever.repository.browser.primary_repository_root import PrimaryRepositoryRoot
 from plone import api
 from plone.restapi.interfaces import ISerializeToJsonSummary
@@ -23,6 +25,7 @@ class ConfigGet(Service):
         config = IGeverSettings(self.context).get_config()
         self.add_additional_infos(config)
         self.add_current_unit_infos(config)
+        self.add_propertysheet_infos(config)
         return config
 
     def check_permission(self):
@@ -66,3 +69,9 @@ class ConfigGet(Service):
         admin_unit = get_current_admin_unit()
         config['current_admin_unit'] = queryMultiAdapter(
             (admin_unit, self.request), ISerializeToJsonSummary)()
+
+    def add_propertysheet_infos(self, config):
+        storage = PropertySheetSchemaStorage()
+        dossier_slots = get_dossier_assignment_slots()
+
+        config['has_dossier_propertysheet_registered'] = any([storage.query(slot) for slot in dossier_slots])


### PR DESCRIPTION
This PR adds a new `@config` property: `has_dossier_propertysheet_registered`.

This is true if the deployment has one or more propertysheet definitions for dossiers

We use this in the frontend to show a card for custom properties for dossiers.

For [CA-3325]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-3325]: https://4teamwork.atlassian.net/browse/CA-3325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ