### PR TITLE
Add comments and custom fields to dossier details pdf

### DIFF
--- a/changes/CA-3336.feature
+++ b/changes/CA-3336.feature
@@ -1,0 +1,1 @@
+Add custom fields to dossier details pdf. [tinagerber]

--- a/changes/CA-3491.feature
+++ b/changes/CA-3491.feature
@@ -1,0 +1,1 @@
+Add comments to dossier details pdf. [tinagerber]

--- a/opengever/latex/configure.zcml
+++ b/opengever/latex/configure.zcml
@@ -51,6 +51,11 @@
       />
 
   <adapter
+      factory=".listing.CommentsLaTeXListing"
+      name="comments"
+      />
+
+  <adapter
       factory=".dossiercover.DossierCoverLaTeXView"
       provides="ftw.pdfgenerator.interfaces.ILaTeXView"
       />

--- a/opengever/latex/dossierdetails.py
+++ b/opengever/latex/dossierdetails.py
@@ -1,5 +1,6 @@
 from Acquisition import aq_inner
 from Acquisition import aq_parent
+from datetime import date
 from ftw.mail.mail import IMail
 from ftw.pdfgenerator.browser.views import ExportPDFView
 from ftw.pdfgenerator.interfaces import ILaTeXLayout
@@ -11,6 +12,7 @@ from opengever.base.interfaces import ISequenceNumber
 from opengever.base.response import IResponseContainer
 from opengever.document.document import IDocumentSchema
 from opengever.dossier import _ as _dossier
+from opengever.dossier.behaviors.customproperties import IDossierCustomProperties
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.behaviors.participation import IParticipationAware
@@ -19,6 +21,7 @@ from opengever.globalindex.model.task import Task
 from opengever.latex import _
 from opengever.latex.listing import ILaTexListing
 from opengever.ogds.base.utils import get_current_admin_unit
+from opengever.propertysheets.storage import PropertySheetSchemaStorage
 from opengever.repository.interfaces import IRepositoryFolder
 from opengever.tabbedview.helper import readable_ogds_author
 from Products.CMFCore.utils import getToolByName
@@ -28,6 +31,7 @@ from zope.component import getMultiAdapter
 from zope.component import getUtility
 from zope.i18n import translate
 from zope.interface import Interface
+from zope.schema import getFields
 
 
 class IDossierDetailsLayer(Interface):
@@ -56,6 +60,7 @@ class DossierDetailsLaTeXView(MakoLaTeXView):
         self.layout.show_contact = False
 
         args = {'dossier_metadata': self.get_dossier_metadata()}
+        args['customfields'] = self.get_custom_fields_data()
 
         parent = aq_parent(aq_inner(self.context))
         args['is_subdossier'] = IDossierMarker.providedBy(parent)
@@ -164,6 +169,44 @@ class DossierDetailsLaTeXView(MakoLaTeXView):
             rows.append('\\bf {} & {} \\\\%%'.format(
                 self.convert_plain(label), value))
 
+        return '\n'.join(rows)
+
+    def get_custom_fields_data(self):
+        rows = []
+        adapted = IDossierCustomProperties(self.context, None)
+        if not adapted:
+            return ''
+        custom_properties = adapted.custom_properties
+        if not custom_properties:
+            return ''
+
+        field = getFields(IDossierCustomProperties).get('custom_properties')
+        active_slot = field.get_active_assignment_slot(self.context)
+        for slot in [active_slot, field.default_slot]:
+            if slot not in custom_properties:
+                continue
+            definition = PropertySheetSchemaStorage().query(slot)
+            if not definition:
+                continue
+            for name, field in definition.get_fields():
+                custom_field_value = custom_properties[slot].get(name)
+                if custom_field_value is None:
+                    continue
+                if isinstance(custom_field_value, bool):
+                    custom_field_value = (
+                        translate(_('label_yes', default=u"Yes"), context=self.request)
+                        if custom_field_value
+                        else translate(_('label_no', default=u"No"), context=self.request))
+                elif isinstance(custom_field_value, date):
+                    custom_field_value = helper.readable_date(self.context, custom_field_value)
+                elif isinstance(custom_field_value, set):
+                    if not custom_field_value:
+                        continue
+                    custom_field_value = u', '.join(custom_field_value)
+                elif isinstance(custom_field_value, int):
+                    custom_field_value = str(custom_field_value)
+                rows.append('\\bf {} & {} \\\\%%'.format(self.convert_plain(field.title),
+                                                         self.convert_plain(custom_field_value)))
         return '\n'.join(rows)
 
     def get_reference_number(self):

--- a/opengever/latex/dossierdetails.py
+++ b/opengever/latex/dossierdetails.py
@@ -8,6 +8,7 @@ from ftw.pdfgenerator.view import MakoLaTeXView
 from ftw.table import helper
 from opengever.base.interfaces import IReferenceNumber
 from opengever.base.interfaces import ISequenceNumber
+from opengever.base.response import IResponseContainer
 from opengever.document.document import IDocumentSchema
 from opengever.dossier import _ as _dossier
 from opengever.dossier.behaviors.dossier import IDossier
@@ -60,6 +61,15 @@ class DossierDetailsLaTeXView(MakoLaTeXView):
         args['is_subdossier'] = IDossierMarker.providedBy(parent)
 
         args['participants'] = self.get_participants()
+
+        # comments
+        args['commentstitle'] = translate(
+            _('label_comments', default="Comments"), context=self.request)
+
+        listing = getMultiAdapter((self.context, self.request, self),
+                                  ILaTexListing, name='comments')
+
+        args['comments'] = listing.get_listing(self.get_comments())
 
         # subdossiers
         args['subdossierstitle'] = translate(
@@ -254,6 +264,9 @@ class DossierDetailsLaTeXView(MakoLaTeXView):
                                 IMail.__identifier__]}
 
         return catalog(query)
+
+    def get_comments(self):
+        return IResponseContainer(self.context).list()
 
     def get_sorting(self, tab_name):
         """Read the sort_on and sort_order attributes from the gridstate,

--- a/opengever/latex/listing.py
+++ b/opengever/latex/listing.py
@@ -326,6 +326,33 @@ class TaskHistoryLaTeXListing(LaTexListing):
 
 @implementer(ILaTexListing)
 @adapter(Interface, Interface, Interface)
+class CommentsLaTeXListing(LaTexListing):
+
+    def get_actor_label(self, item):
+        return Actor.lookup(item.creator).get_label()
+
+    def get_columns(self):
+        return [
+            Column('created',
+                   _('label_time', default=u'Time'),
+                   '10%',
+                   lambda item: helper.readable_date_time(item, item.created),
+                   "left"),
+
+            Column('creator',
+                   _('label_created_by', default=u'Created by'),
+                   '20%',
+                   self.get_actor_label,
+                   "left"),
+
+            Column('text',
+                   _('label_comment', default=u'Comment'),
+                   '70%'),
+        ]
+
+
+@implementer(ILaTexListing)
+@adapter(Interface, Interface, Interface)
 class JournalLaTeXListing(LaTexListing):
 
     template = ViewPageTemplateFile('templates/listing.pt')

--- a/opengever/latex/locales/de/LC_MESSAGES/opengever.latex.po
+++ b/opengever/latex/locales/de/LC_MESSAGES/opengever.latex.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-08 11:40+0000\n"
+"POT-Creation-Date: 2022-02-08 14:09+0000\n"
 "PO-Revision-Date: 2013-11-19 16:25+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,21 @@ msgstr ""
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+
+#. Default: "Comment"
+#: ./opengever/latex/listing.py
+msgid "label_comment"
+msgstr "Kommentar"
+
+#. Default: "Comments"
+#: ./opengever/latex/dossierdetails.py
+msgid "label_comments"
+msgstr "Kommentare"
+
+#. Default: "Created by"
+#: ./opengever/latex/listing.py
+msgid "label_created_by"
+msgstr "Erstellt von"
 
 #. Default: "Changed by"
 #: ./opengever/latex/listing.py
@@ -81,6 +96,11 @@ msgstr "Ende"
 #: ./opengever/latex/listing.py
 msgid "label_issuer"
 msgstr "Auftraggeber"
+
+#. Default: "No"
+#: ./opengever/latex/dossierdetails.py
+msgid "label_no"
+msgstr "Nein"
 
 #. Default: "Page"
 #: ./opengever/latex/layouts/default.py
@@ -179,6 +199,11 @@ msgstr "Titel"
 #: ./opengever/latex/listing.py
 msgid "label_transition"
 msgstr "Aktion"
+
+#. Default: "Yes"
+#: ./opengever/latex/dossierdetails.py
+msgid "label_yes"
+msgstr "Ja"
 
 #. Default: "Repository version"
 #: ./opengever/latex/dossiercover.py

--- a/opengever/latex/locales/en/LC_MESSAGES/opengever.latex.po
+++ b/opengever/latex/locales/en/LC_MESSAGES/opengever.latex.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-18 13:15+0000\n"
+"POT-Creation-Date: 2022-02-08 14:09+0000\n"
 "PO-Revision-Date: 2013-11-19 16:25+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,21 @@ msgstr ""
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+
+#. Default: "Comment"
+#: ./opengever/latex/listing.py
+msgid "label_comment"
+msgstr "Comment"
+
+#. Default: "Comments"
+#: ./opengever/latex/dossierdetails.py
+msgid "label_comments"
+msgstr "Comments"
+
+#. Default: "Created by"
+#: ./opengever/latex/listing.py
+msgid "label_created_by"
+msgstr "Created by"
 
 #. German translation: Geändert von
 #. Default: "Changed by"
@@ -94,6 +109,11 @@ msgstr "End"
 #: ./opengever/latex/listing.py
 msgid "label_issuer"
 msgstr "Issuer"
+
+#. Default: "No"
+#: ./opengever/latex/dossierdetails.py
+msgid "label_no"
+msgstr "No"
 
 #. German translation: Seite
 #. Default: "Page"
@@ -210,6 +230,11 @@ msgstr "Title"
 #: ./opengever/latex/listing.py
 msgid "label_transition"
 msgstr "Action"
+
+#. Default: "Yes"
+#: ./opengever/latex/dossierdetails.py
+msgid "label_yes"
+msgstr "Yes"
 
 #. German translation: Version Ordnungssystem
 #. Default: "Repository version"

--- a/opengever/latex/locales/fr/LC_MESSAGES/opengever.latex.po
+++ b/opengever/latex/locales/fr/LC_MESSAGES/opengever.latex.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-08 11:40+0000\n"
+"POT-Creation-Date: 2022-02-08 14:09+0000\n"
 "PO-Revision-Date: 2017-12-03 09:48+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-latex/fr/>\n"
@@ -15,6 +15,21 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: fr\n"
 "X-Generator: Weblate 2.13.1\n"
+
+#. Default: "Comment"
+#: ./opengever/latex/listing.py
+msgid "label_comment"
+msgstr "Commentaire"
+
+#. Default: "Comments"
+#: ./opengever/latex/dossierdetails.py
+msgid "label_comments"
+msgstr "Commentaires"
+
+#. Default: "Created by"
+#: ./opengever/latex/listing.py
+msgid "label_created_by"
+msgstr "Créé par"
 
 #. Default: "Changed by"
 #: ./opengever/latex/listing.py
@@ -83,6 +98,11 @@ msgstr "Fin"
 #: ./opengever/latex/listing.py
 msgid "label_issuer"
 msgstr "Mandant"
+
+#. Default: "No"
+#: ./opengever/latex/dossierdetails.py
+msgid "label_no"
+msgstr "Non"
 
 #. Default: "Page"
 #: ./opengever/latex/layouts/default.py
@@ -181,6 +201,11 @@ msgstr "Titre"
 #: ./opengever/latex/listing.py
 msgid "label_transition"
 msgstr "Action"
+
+#. Default: "Yes"
+#: ./opengever/latex/dossierdetails.py
+msgid "label_yes"
+msgstr "Oui"
 
 #. Default: "Repository version"
 #: ./opengever/latex/dossiercover.py

--- a/opengever/latex/locales/opengever.latex.pot
+++ b/opengever/latex/locales/opengever.latex.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-08 11:40+0000\n"
+"POT-Creation-Date: 2022-02-08 14:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,21 @@ msgstr ""
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.latex\n"
+
+#. Default: "Comment"
+#: ./opengever/latex/listing.py
+msgid "label_comment"
+msgstr ""
+
+#. Default: "Comments"
+#: ./opengever/latex/dossierdetails.py
+msgid "label_comments"
+msgstr ""
+
+#. Default: "Created by"
+#: ./opengever/latex/listing.py
+msgid "label_created_by"
+msgstr ""
 
 #. Default: "Changed by"
 #: ./opengever/latex/listing.py
@@ -83,6 +98,11 @@ msgstr ""
 #. Default: "Issuer"
 #: ./opengever/latex/listing.py
 msgid "label_issuer"
+msgstr ""
+
+#. Default: "No"
+#: ./opengever/latex/dossierdetails.py
+msgid "label_no"
 msgstr ""
 
 #. Default: "Page"
@@ -181,6 +201,11 @@ msgstr ""
 #. Default: "Transition"
 #: ./opengever/latex/listing.py
 msgid "label_transition"
+msgstr ""
+
+#. Default: "Yes"
+#: ./opengever/latex/dossierdetails.py
+msgid "label_yes"
 msgstr ""
 
 #. Default: "Repository version"

--- a/opengever/latex/templates/dossierdetails.tex
+++ b/opengever/latex/templates/dossierdetails.tex
@@ -12,9 +12,10 @@
 
 \setlength\tabcolsep{0pt}
 
-\begin{tabular}{p{40mm}p{\linewidth-40mm}}
+\begin{tabular}{p{39mm}@{\hskip 1mm}p{\linewidth-40mm}}
 \shrinkheight{60mm}
-${dossier_metadata} \\ \hline
+${dossier_metadata}
+${customfields}
 \end{tabular}
 
 \begin{landscape}

--- a/opengever/latex/templates/dossierdetails.tex
+++ b/opengever/latex/templates/dossierdetails.tex
@@ -25,6 +25,16 @@ ${dossier_metadata} \\ \hline
   \setlength{\tablewidth}{\linewidth}
 
 \scriptsize
+% if comments:
+\vspace{5mm}
+{\bf ${commentstitle}}\\%%
+\vspace{1mm}
+
+${comments}
+
+% endif
+
+
 % if subdossiers:
 \vspace{5mm}
 {\bf ${subdossierstitle}}\\%%


### PR DESCRIPTION
The custom fields are only displayed if a value is set.
<img width="1204" alt="Bildschirmfoto 2022-02-08 um 15 54 18" src="https://user-images.githubusercontent.com/50165195/153012427-b7e954b7-dbb5-466c-9e12-dfa47401e4d1.png">
<img width="1015" alt="Bildschirmfoto 2022-02-08 um 15 53 58" src="https://user-images.githubusercontent.com/50165195/153012430-97b9ba9a-3237-410f-9679-5b8fbe776ad9.png">


For [CA-3491] and [CA-3336] 

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._
- New translations
  - [x] All msg-strings are unicode

[CA-3491]: https://4teamwork.atlassian.net/browse/CA-3491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CA-3336]: https://4teamwork.atlassian.net/browse/CA-3336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ