### PR TITLE
Fix dossierdetails for dossier with SQL participations.

### DIFF
--- a/changes/CA-3673.bugfix
+++ b/changes/CA-3673.bugfix
@@ -1,0 +1,1 @@
+Fix dossierdetails for dossier with SQL participations. [njohner]

--- a/opengever/dossier/browser/participants.py
+++ b/opengever/dossier/browser/participants.py
@@ -44,12 +44,12 @@ def role_list_helper(item, value):
         # translate the message
         return translate(value, context=getRequest())
 
-    elif sum([int(isinstance(value, t)) for t in (str, unicode)]):
+    elif any([isinstance(value, t) for t in (str, unicode)]):
         # is it a string or unicode or a subtype of them?
         return translate_participation_role(value)
 
-    elif sum([int(isinstance(value, t)) for t in (list, tuple, set,
-                                                  PersistentList)]):
+    elif any([isinstance(value, t) for t in (list, tuple, set,
+                                             PersistentList)]):
         # if it's a list, lets iterate over it
         translated_values = []
         for role in value:

--- a/opengever/latex/dossierdetails.py
+++ b/opengever/latex/dossierdetails.py
@@ -17,6 +17,7 @@ from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.behaviors.participation import IParticipationAware
 from opengever.dossier.browser.participants import role_list_helper
+from opengever.dossier.participations import IParticipationData
 from opengever.globalindex.model.task import Task
 from opengever.latex import _
 from opengever.latex.listing import ILaTexListing
@@ -270,13 +271,13 @@ class DossierDetailsLaTeXView(MakoLaTeXView):
                           context=self.request)))
 
         # add the participants
-        participants = list(IParticipationAware(
-                self.context).get_participations())
+        participants = IParticipationAware(self.context).get_participations()
 
         for participant in participants:
+            participation_data = IParticipationData(participant)
             rows.append('%s, %s' % (
-                    readable_ogds_author(participant, participant.contact),
-                    role_list_helper(participant, participant.roles)))
+                    participation_data.participant_title,
+                    role_list_helper(participant, participation_data.roles)))
 
         values = ['{', '\\vspace{-\\baselineskip}\\begin{itemize}']
         for row in self.convert_list(rows):

--- a/opengever/usermigration/tests/test_creator_migrator.py
+++ b/opengever/usermigration/tests/test_creator_migrator.py
@@ -77,7 +77,7 @@ class TestCreatorMigrator(FunctionalTestCase):
             self.portal, {'old.user': 'new.user'}, 'move')
         results = migrator.migrate()
 
-        self.assertEquals(
+        self.assertItemsEqual(
             [
                 ('/plone/dossier-1', 'old.user', 'new.user'),
                 ('/plone/dossier-1/document-1', 'old.user', 'new.user'),


### PR DESCRIPTION
With this PR we fix the `dossierdetails` view for dossiers containing SQL participations.

For [CA-3673]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-3673]: https://4teamwork.atlassian.net/browse/CA-3673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ