### PR TITLE
Do not set security header for responses without content type

### DIFF
--- a/opengever/base/subscribers.py
+++ b/opengever/base/subscribers.py
@@ -136,6 +136,13 @@ def set_security_headers(event):
     """Set headers related to security"""
     response = getattr(getattr(event, 'request', None), 'response', None)
     if response is not None:
+        content_type = response.headers.get('content-type', None)
+
+        # Do not set any headers if the response doesn't have a content type
+        # This is e.g. the case for 304 not modified responses.
+        if content_type is None:
+            return
+
         # Only load scripts and stylesheets with the correct content type
         response.setHeader('X-Content-Type-Options', 'nosniff')
 
@@ -144,7 +151,6 @@ def set_security_headers(event):
 
         # Keep existing CSP header to allow browser views to set a custom CSP
         if response.getHeader('Content-Security-Policy') is None:
-            content_type = response.headers.get('content-type', '')
             if content_type.startswith('text/html'):
                 # Allow resources from current origin, eval, inline js and css
                 # Allow images from current origin and data urls

--- a/opengever/base/tests/test_security_headers.py
+++ b/opengever/base/tests/test_security_headers.py
@@ -32,3 +32,14 @@ class TestSecurityHeaders(IntegrationTestCase):
         self.login(self.regular_user, browser=browser)
         browser.open(self.portal, view='csp-test')
         self.assertEqual(browser.headers['Content-Security-Policy'], 'default-src *')
+
+    @browsing
+    def test_304_response_doesnt_contain_security_headers(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.dossier)
+        etag = browser.headers['ETag']
+        browser.open(self.dossier, headers={'If-None-Match': etag})
+        self.assertNotIn('X-Content-Type-Options', browser.headers)
+        self.assertNotIn('X-XSS-Protection', browser.headers)
+        self.assertNotIn('Content-Security-Policy', browser.headers)
+        self.assertNotIn('Referrer-Policy', browser.headers)


### PR DESCRIPTION
For responses without a body it doesn't make sense to set the securtiy headers. Also fixes setting the wrong CSP for 304 responses, which breaks the classic frontend if HTTP caching is enabled.

Fix for: https://github.com/4teamwork/opengever.core/pull/6894

## Checklist

- [ ] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)
