### PR TITLE
Mention setuptools/buildout to use with bootstrap.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ below are satisfied and run the following steps:
     $ git clone git@github.com:4teamwork/opengever.core.git
     $ cd opengever.core
     $ ln -s development.cfg buildout.cfg
-    $ python bootstrap.py
+    $ python bootstrap.py --setuptools-version 44.1.1 --buildout-version 2.13.3
     $ bin/buildout
 
 Dependencies


### PR DESCRIPTION
Currently we need to use very specific versions to be able to bootstrap a local GEVER. This should be mentioned in the readme
