### PR TITLE
Reindex 'filename' when creating a new document version:

### DIFF
--- a/changes/CA-3677.bugfix
+++ b/changes/CA-3677.bugfix
@@ -1,0 +1,1 @@
+Reindex 'filename' when creating a new document version. [lgraf]

--- a/opengever/document/tests/test_checkout.py
+++ b/opengever/document/tests/test_checkout.py
@@ -14,6 +14,7 @@ from opengever.journal.handlers import DOCUMENT_CHECKED_IN
 from opengever.officeconnector.helpers import create_oc_url
 from opengever.officeconnector.interfaces import IOfficeConnectorSettings
 from opengever.testing import FunctionalTestCase
+from opengever.testing import index_data_for
 from opengever.testing import IntegrationTestCase
 from opengever.testing import obj2brain
 from opengever.testing.helpers import create_document_version
@@ -339,6 +340,9 @@ class TestReverting(FunctionalTestCase):
         # affected by reverting). The extension on the other hand should
         # get updated.
         self.assertEqual("New title.docx", self.document.get_filename())
+
+        # Indexed file extension should also be updated
+        self.assertEqual(u'.docx', index_data_for(self.document)['file_extension'])
 
     def test_revert_disallowed_for_unprivileded_user(self):
         self.grant('Authenticated')

--- a/opengever/document/versioner.py
+++ b/opengever/document/versioner.py
@@ -35,7 +35,14 @@ class Versioner(object):
         """Creates a new version in CMFEditions.
         """
         self.repository.save(obj=self.document, comment=comment)
-        self.document.reindexObject(idxs=['UID', 'approval_state'])
+        self.document.reindexObject(
+            idxs=[
+                'UID',
+                'approval_state',
+                'filename',
+                'file_extension',
+            ]
+        )
 
     def has_initial_version(self):
         return self.get_history_metadata() != []


### PR DESCRIPTION
When a new version is saved, the file's type may have changed (e.g. from .pdf to .docx), and the filename therefore is updated, and needs to be reindexed.

In particular this was the case in a situation where a PDF was reverted (which creates a new version) to a version that was a Word-Document. In this case the filename in Solr was outdated, because unlike the catalog, metadata in Solr doesn't get updated unless the index is explicitly listed.

❗ FYI: I decided to not add an upgrade step for this issue. I couldn't easily find a way to recognize just the documents that exhibit this specific problem, which would mean reindexing `filename` for all documents. And that is just not justified IMHO for a problem this rare and minor. Also, the situation is self-healing, in the sense that the `filename` in Solr will eventually get updated the next time the document's metadata is updated.

For [CA-3677](https://4teamwork.atlassian.net/browse/CA-3677)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

