### PR TITLE
Add a new global permission "opengever.workspace: Access all users and groups"

### DIFF
--- a/changes/CA-3592.other
+++ b/changes/CA-3592.other
@@ -1,0 +1,1 @@
+Add a new global permission "opengever.workspace: Access all users and groups". [elioschmutz]

--- a/opengever/core/lawgiver.zcml
+++ b/opengever/core/lawgiver.zcml
@@ -242,6 +242,7 @@
                    opengever.workspace: Modify Workspace,
                    opengever.workspace: Update Content Order,
                    opengever.workspaceclient: Unlink Workspace,
+                   opengever.workspace: Access all users and groups,
                    opengever.workspaceclient: Use Workspace Client,
                    plone.app.collection: Add Collection,
                    plone.restapi: Access Plone user information,

--- a/opengever/core/profiles/default/rolemap.xml
+++ b/opengever/core/profiles/default/rolemap.xml
@@ -404,6 +404,12 @@
       <role name="Administrator" />
     </permission>
 
+    <permission name="opengever.workspace: Access all users and groups" acquire="True">
+      <role name="Manager" />
+      <role name="Administrator" />
+      <role name="WorkspacesCreator" />
+    </permission>
+
   </permissions>
 
 </rolemap>

--- a/opengever/core/upgrades/20220315151115_add_access_all_users_and_groups_permission/rolemap.xml
+++ b/opengever/core/upgrades/20220315151115_add_access_all_users_and_groups_permission/rolemap.xml
@@ -1,0 +1,11 @@
+<rolemap>
+  <permissions>
+
+    <permission name="opengever.workspace: Access all users and groups" acquire="True">
+      <role name="Manager" />
+      <role name="Administrator" />
+      <role name="WorkspacesCreator" />
+    </permission>
+
+  </permissions>
+</rolemap>

--- a/opengever/core/upgrades/20220315151115_add_access_all_users_and_groups_permission/upgrade.py
+++ b/opengever/core/upgrades/20220315151115_add_access_all_users_and_groups_permission/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddAccessAllUsersAndGroupsPermission(UpgradeStep):
+    """Add access all users and groups permission.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/readonly/tests/test_all_roles_and_permissions_mapped.py
+++ b/opengever/readonly/tests/test_all_roles_and_permissions_mapped.py
@@ -181,6 +181,7 @@ NON_WRITE_PERMISSIONS = [
     'opengever.meeting: Add Member',
     'opengever.repository: Export repository',
     'opengever.sharing: List Protected Objects',
+    'opengever.workspace: Access all users and groups',
     'opengever.workspace: Manage Workspaces',
     'opengever.workspaceclient: Use Workspace Client',
     'Plone Site Setup: Calendar',

--- a/opengever/workspace/permissions.zcml
+++ b/opengever/workspace/permissions.zcml
@@ -26,4 +26,6 @@
 
   <permission id="opengever.workspace.ManageWorkspaces" title="opengever.workspace: Manage Workspaces" />
 
+  <permission id="opengever.workspace.AccessAllUsersAndGroups" title="opengever.workspace: Access all users and groups" />
+
 </configure>


### PR DESCRIPTION
This PR adds a new permission `opengever.workspace: Access all users and groups`.

This permission is used to protect internal users and groups from external users.

For [CA-3592]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-3592]: https://4teamwork.atlassian.net/browse/CA-3592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ