### PR TITLE
Switch `@navigation` endpoint to Solr queries.

### DIFF
--- a/changes/CA-3324.other
+++ b/changes/CA-3324.other
@@ -1,0 +1,1 @@
+Switch `@navigation` endpoint to Solr queries. [lgraf]

--- a/opengever/api/navigation.py
+++ b/opengever/api/navigation.py
@@ -41,15 +41,7 @@ class Navigation(object):
             return result
 
         root = self.find_root(root_interface, content_interfaces)
-
-        query = {'object_provides': content_interfaces,
-                 'path': '/'.join(root.getPhysicalPath()),
-                 'sort_on': 'sortable_title'}
-
-        if self.request.form.get('review_state'):
-            query['review_state'] = self.request.form.get('review_state')
-
-        items = api.content.find(**query)
+        items = self.query_catalog(root, content_interfaces)
 
         if self.request.form.get('include_context'):
             items = self.include_context_branch(items, root.UID(), content_interfaces)
@@ -90,6 +82,16 @@ class Navigation(object):
                 raise BadRequest("No root found for interface: {}".format(
                     root_interface.__identifier__))
         return root
+
+    def query_catalog(self, root, content_interfaces):
+        query = {'object_provides': content_interfaces,
+                 'path': '/'.join(root.getPhysicalPath()),
+                 'sort_on': 'sortable_title'}
+
+        if self.request.form.get('review_state'):
+            query['review_state'] = self.request.form.get('review_state')
+
+        return api.content.find(**query)
 
     def include_context_branch(self, items, root_uid, content_interfaces):
         all_uids = {brain.UID for brain in items}

--- a/opengever/api/navigation.py
+++ b/opengever/api/navigation.py
@@ -7,7 +7,6 @@ from opengever.base.solr import OGSolrDocument
 from opengever.repository.interfaces import IRepositoryFolder
 from opengever.repository.repositoryfolder import REPOSITORY_FOLDER_STATE_INACTIVE
 from opengever.repository.repositoryroot import IRepositoryRoot
-from plone import api
 from plone.app.contentlisting.interfaces import IContentListingObject
 from plone.restapi.interfaces import IExpandableElement
 from plone.restapi.serializer.converters import json_compatible
@@ -89,8 +88,13 @@ class Navigation(object):
         if root_interface.providedBy(context):
             root = context
         else:
-            roots = api.content.find(
-                object_provides=root_interface.__identifier__)
+            response = self.solr.search(
+                filters=make_filters(
+                    object_provides=root_interface.__identifier__),
+                sort='path asc',
+            )
+            roots = [OGSolrDocument(d) for d in response.docs]
+
             if roots:
                 root = roots[0].getObject()
             else:

--- a/opengever/api/navigation.py
+++ b/opengever/api/navigation.py
@@ -5,6 +5,7 @@ from opengever.repository.interfaces import IRepositoryFolder
 from opengever.repository.repositoryfolder import REPOSITORY_FOLDER_STATE_INACTIVE
 from opengever.repository.repositoryroot import IRepositoryRoot
 from plone import api
+from plone.app.contentlisting.interfaces import IContentListingObject
 from plone.restapi.interfaces import IExpandableElement
 from plone.restapi.serializer.converters import json_compatible
 from plone.restapi.services import Service
@@ -146,21 +147,24 @@ class Navigation(object):
         return content_interfaces
 
     def brain_to_node(self, brain):
+        wrapper = IContentListingObject(brain)
+        context_url = self.context.absolute_url()
+
         node = {
-            '@type': brain.portal_type,
-            'text': brain.Title,
-            'description': brain.Description,
-            'url': brain.getURL(),
-            'uid': brain.UID,
-            'active': brain.review_state != REPOSITORY_FOLDER_STATE_INACTIVE,
-            'current': self.context.absolute_url() == brain.getURL(),
-            'current_tree': self.context.absolute_url().startswith(brain.getURL()),
+            '@type': wrapper.portal_type,
+            'text': wrapper.Title(),
+            'description': wrapper.Description(),
+            'url': wrapper.getURL(),
+            'uid': wrapper.UID,
+            'active': wrapper.review_state() != REPOSITORY_FOLDER_STATE_INACTIVE,
+            'current': context_url == wrapper.getURL(),
+            'current_tree': context_url.startswith(wrapper.getURL()),
             'is_leafnode': None,
-            'is_subdossier': brain.is_subdossier,
-            'review_state': brain.review_state,
+            'is_subdossier': wrapper.is_subdossier,
+            'review_state': wrapper.review_state(),
         }
-        if brain.portal_type == 'opengever.repository.repositoryfolder':
-            node['is_leafnode'] = not brain.has_sametype_children
+        if wrapper.portal_type == 'opengever.repository.repositoryfolder':
+            node['is_leafnode'] = not wrapper.has_sametype_children
         return json_compatible(node)
 
 

--- a/opengever/api/navigation.py
+++ b/opengever/api/navigation.py
@@ -128,6 +128,7 @@ class Navigation(object):
         resp = self.solr.search(
             filters=filters,
             sort='sortable_title asc',
+            rows=10000,
             fl=self.FIELDS)
 
         return [OGSolrDocument(doc) for doc in resp.docs]

--- a/opengever/api/tests/test_navigation.py
+++ b/opengever/api/tests/test_navigation.py
@@ -1,6 +1,6 @@
 from ftw.testbrowser import browsing
-from opengever.testing import IntegrationTestCase
 from opengever.testing import obj2brain
+from opengever.testing import SolrIntegrationTestCase
 from plone import api
 from urllib import urlencode
 import Missing
@@ -18,7 +18,7 @@ def flatten_tree(items):
     return flattened_items
 
 
-class TestNavigation(IntegrationTestCase):
+class TestNavigation(SolrIntegrationTestCase):
 
     @browsing
     def test_navigation_contains_respository(self, browser):


### PR DESCRIPTION
Switch `@navigation` endpoint to Solr queries.

This is in preparation for later adding the `dossier_type`, which is only indexed in Solr. Also, building the navigation by querying Solr instead of the ZCatalog should be noticably faster.

For [CA-3324](https://4teamwork.atlassian.net/browse/CA-3324)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
