### PR TITLE
Add `@raw-dossier-types` endpoint:

### DIFF
--- a/changes/CA-3324-1.feature
+++ b/changes/CA-3324-1.feature
@@ -1,0 +1,1 @@
+Add `@raw-dossier-types` endpoint. [lgraf]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -12,6 +12,8 @@ Breaking Changes
 Other Changes
 ^^^^^^^^^^^^^
 
+- ``@raw-dossier-types``: New endpoint that returns dossier types in unaltered order.
+
 
 2022.4.0 (2022-02-16)
 ---------------------

--- a/docs/public/dev-manual/api/vocabularies.rst
+++ b/docs/public/dev-manual/api/vocabularies.rst
@@ -74,3 +74,10 @@ beides zugleich.
      ],
      "items_total": 1
    }
+
+Dossier-Typen
+-------------
+
+Für die gängigen Anwendungsfälle können die Dossier-Typen über die oben beschriebenen Vokabular-Endpoints bezogen werden. Für gewisse Zwecke ist es aber nötig, die Dossier-Typen in einer "rohen" Form zu beziehen - dafür kann der ``@raw-dossier-types`` Endpoint verwendet werden.
+
+Dieser Endpoint gibt die Dossier-Typen ungefiltert zurück (auch versteckte / deaktivierte Typen werden aufgeführt), und die Typen werden in der Reihenfolge zurückgegeben, in der sie erfasst wurden (statt alphabetisch sortiert wie bei normalen Vocabularies).

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -1624,4 +1624,12 @@
       permission="cmf.SetOwnProperties"
       />
 
+  <plone:service
+      method="GET"
+      name="@raw-dossier-types"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      factory=".raw_dossier_types.RawDossierTypesGet"
+      permission="zope2.View"
+      />
+
 </configure>

--- a/opengever/api/raw_dossier_types.py
+++ b/opengever/api/raw_dossier_types.py
@@ -1,0 +1,63 @@
+from collective.vdexvocabulary.term import VdexTerm
+from plone import api
+from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.services import Service
+from zope.component import getMultiAdapter
+from zope.component import getUtility
+from zope.schema.interfaces import IVocabularyFactory
+from zope.schema.vocabulary import SimpleVocabulary
+
+
+class RawDossierTypesGet(Service):
+    """API Endpoint that returns the raw contents of the dossier_types VDEX
+    vocabulary. They are returned
+
+    - in unaltered order (even though orderSignificant may be False)
+    - unfiltered (hidden terms are included)
+
+    This is needed in order for the frontend to be able to map dossier types
+    to colors in a deterministic way that is stable over time.
+
+    Because dossier types are mapped to a fixed-length color palette, and
+    types that have already been mapped to a color once MUST keep that color,
+    we need to provide the frontend with a list of dossier types where
+    historical terms keep their position, and new terms only ever are appended
+    at the end.
+
+    This endpoint facilitates this, together with the following rules for
+    editing the dossier_types.vdex file:
+
+    - New terms must only be appended at the end
+    - Terms are never removed, but set to hidden instead (registry).
+      They will then be omitted from the regular vocabularies / sources,
+      which are elephant vocabs, but not this endpoint.
+    - Renames are ok (if the type is supposed to keep its color)
+
+    GET /@raw-dossier-types HTTP/1.1
+    """
+
+    def reply(self):
+        vf = getUtility(IVocabularyFactory, name='opengever.dossier.dossier_types')
+        lang_tool = api.portal.get_tool('portal_languages')
+        lang = lang_tool.getPreferredLanguage()
+
+        items = vf.getTerms(lang)
+        terms = []
+
+        for item in items:
+            terms.append(
+                VdexTerm(
+                    item["key"],
+                    item["key"],
+                    item["value"],
+                    item["description"],
+                )
+            )
+
+        serializer = getMultiAdapter(
+            (SimpleVocabulary(terms), self.request),
+            interface=ISerializeToJson,
+        )
+
+        vocab_id = '/'.join([self.context.absolute_url(), '@raw-dossier-types'])
+        return serializer(vocab_id)

--- a/opengever/dossier/vdexvocabs/dossier_types.vdex
+++ b/opengever/dossier/vdexvocabs/dossier_types.vdex
@@ -1,6 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <vdex xmlns="http://www.imsglobal.org/xsd/imsvdex_v1p0"
       orderSignificant="false" language="en">
+
+    <!-- ###################################################################
+    Do not change the order of terms in this file!
+    ########################################################################
+
+    Even though it says 'orderSignificant="false"' at the top, the order of
+    terms in this file matters for the `@raw-dossier-types` endpoint
+    (in order to allow the frontend to assign stable dossier colors).
+
+    When making changes to these dossier types, the following rules apply:
+
+    - New terms must only be appended at the end
+    - Existing terms must not be removed, but should instead be hidden via
+      the IDossier.hidden_dossier_types registry entry
+    - Renames are ok. That type will then keep its existing color.
+
+    ##################################################################### -->
+
     <vocabIdentifier>opengever.dossier.dossier_types</vocabIdentifier>
     <term>
         <termIdentifier>businesscase</termIdentifier>

--- a/opengever/testing/assets/dossier_types.vdex
+++ b/opengever/testing/assets/dossier_types.vdex
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vdex xmlns="http://www.imsglobal.org/xsd/imsvdex_v1p0"
+      orderSignificant="false" language="en">
+    <vocabIdentifier>opengever.dossier.dossier_types</vocabIdentifier>
+    <term>
+        <termIdentifier>businesscase</termIdentifier>
+        <caption>
+            <langstring language="en">Business case</langstring>
+            <langstring language="en-us">Business case</langstring>
+            <langstring language="de-ch">Geschäftsfall</langstring>
+            <langstring language="de">Geschäftsfall</langstring>
+            <langstring language="fr">Commercial</langstring>
+            <langstring language="fr-ch">Commercial</langstring>
+        </caption>
+    </term>
+    <term>
+        <termIdentifier>zzz</termIdentifier>
+        <caption>
+            <langstring language="en">ZZZZZZ</langstring>
+            <langstring language="en-us">ZZZZZZ</langstring>
+            <langstring language="de-ch">ZZZZZZ</langstring>
+            <langstring language="de">ZZZZZZ</langstring>
+            <langstring language="fr">ZZZZZZ</langstring>
+            <langstring language="fr-ch">ZZZZZZ</langstring>
+        </caption>
+    </term>
+    <term>
+        <termIdentifier>aaa</termIdentifier>
+        <caption>
+            <langstring language="en">AAAAAA</langstring>
+            <langstring language="en-us">AAAAAA</langstring>
+            <langstring language="de-ch">AAAAAA</langstring>
+            <langstring language="de">AAAAAA</langstring>
+            <langstring language="fr">AAAAAA</langstring>
+            <langstring language="fr-ch">AAAAAA</langstring>
+        </caption>
+    </term>
+
+</vdex>


### PR DESCRIPTION
This endpoint returns the raw contents of the `dossier_types` VDEX vocabulary.

They are returned

- in **inherent order** (even though orderSignificant may be False)
- **unfiltered** (hidden terms are included)

This is needed in order for the frontend to be able to map dossier types to colors in a deterministic way that is stable over time.

Because dossier types are mapped to a fixed-length color palette, and types that have already been mapped to a color once MUST keep that color, we need to provide the frontend with a list of dossier types where historical terms keep their position, and new terms only ever are appended at the end.

This endpoint facilitates this, together with the following rules for editing the `dossier_types.vdex` file:

- New terms must only be **appended at the end**
- Terms are **never removed**, but set to hidden instead (registry).
  They will then be omitted from the regular vocabularies / sources, which are elephant vocabs, but not this endpoint.
- Renames are ok (if the type is supposed to keep its color)

---

**Note**: _This is implemented as a separate endpoint, because if we were to just change `orderSignificant=True` in the VDEX file, the actual vocabularies (as returned by `@sources` for example) would then return terms in their inherent order, instead of sorting them alphabetically (which is not what we want for widgets etc..)._ 

For [CA-3324](https://4teamwork.atlassian.net/browse/CA-3324)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry
