### PR TITLE
Default value acquisition: Skip intermediate objects missing attribute.

### DIFF
--- a/changes/CA-2878.bugfix
+++ b/changes/CA-2878.bugfix
@@ -1,0 +1,1 @@
+Default value acquisition: Skip intermediate objects missing attribute. [lgraf]

--- a/opengever/base/acquisition.py
+++ b/opengever/base/acquisition.py
@@ -40,7 +40,12 @@ def acquire_field_value(field, container):
                 # could not adapt
                 pass
             else:
-                value = get_persisted_value_for_field(obj, field)
+                try:
+                    value = get_persisted_value_for_field(obj, field)
+                except AttributeError:
+                    # has field, but missing attribute
+                    obj = obj.aq_inner.aq_parent
+                    continue
                 try:
                     field.validate(value)
                     return value

--- a/opengever/base/tests/test_classification.py
+++ b/opengever/base/tests/test_classification.py
@@ -1,3 +1,4 @@
+from Acquisition import aq_parent
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
@@ -79,6 +80,24 @@ class TestClassificationDefault(IntegrationTestCase):
         dossier = browser.context
 
         value = self.get_classification(dossier)
+        self.assertEqual(u'confidential', value)
+
+    @browsing
+    def test_intermediate_obj_with_missing_attr_doesnt_break_default_aq(self, browser):
+        # An intermediate object with the field in its schema, but missing the
+        # actual attribute shouldn't break acquisition of the default
+        self.login(self.regular_user, browser=browser)
+
+        parent_folder = aq_parent(self.leaf_repofolder)
+        self.set_classification(parent_folder, u'confidential')
+
+        del self.leaf_repofolder.classification
+
+        browser.open(self.leaf_repofolder)
+        factoriesmenu.add(u'Business Case Dossier')
+        browser.fill({'Title': 'My Dossier'}).save()
+
+        value = self.get_classification(browser.context)
         self.assertEqual(u'confidential', value)
 
 


### PR DESCRIPTION
When acquiring default values, the [`acquire_field_value()`](https://github.com/4teamwork/opengever.core/blob/cfa50aed2f6acc85fe81bf6c7e1bcd11be0d15b0/opengever/base/acquisition.py#L10-L51) function may encounter objects in the chain that do claim to provide the field, but are missing the actual attribute because it never got persisted properly.

Because we now [use `get_persisted_value_for_field()`](https://github.com/4teamwork/opengever.core/blob/cfa50aed2f6acc85fe81bf6c7e1bcd11be0d15b0/opengever/base/acquisition.py#L43) to fetch the field value, we need to account for the `AttributeError` it [may raise](https://github.com/4teamwork/opengever.core/blob/cfa50aed2f6acc85fe81bf6c7e1bcd11be0d15b0/opengever/base/default_values.py#L112) (unlike the `field.get()` that was used before).

For [CA-2878](https://4teamwork.atlassian.net/browse/CA-2878)

❗ This needs to be backported to `2022.4-stable`.

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

