### PR TITLE
NightlyWorkflowSecurityUpdater: Gracefully skip objs that can't be resolved

### DIFF
--- a/changes/CA-2878-1.bugfix
+++ b/changes/CA-2878-1.bugfix
@@ -1,0 +1,1 @@
+NightlyWorkflowSecurityUpdater: Gracefully skip objs that can't be resolved. [lgraf]

--- a/opengever/core/upgrade.py
+++ b/opengever/core/upgrade.py
@@ -680,6 +680,13 @@ class NightlyWorkflowSecurityUpdater(IntIdMaintenanceJobContextManagerMixin, Wor
     @classmethod
     def update_security_for(cls, key, reindex_security):
         obj = cls.key_to_obj(key)
+
+        if obj is None:
+            logger.warn(
+                'NightlyWorkflowSecurityUpdater: Failed to resolve key %r to '
+                'object, skipping' % key)
+            return
+
         update_security_for(obj, reindex_security)
 
 


### PR DESCRIPTION
If an object has been deleted for example, it's intid or UID won't resolve any more, resulting in `None`, and we must not attempt to run `update_security_for(None)`, because that will result in an `AttributeError` (via `ftw.upgrade`).

This blocked nightly jobs (only on `02-digs-test`) when updating SG test. I've made these changes in the source checkout of `opengever.core` and ran nightly jobs again, and then they all ran through successfully.

Sentry: https://sentry.4teamwork.ch/organizations/sentry/issues/82311

❗ Needs backport to `2022.4-stable`.

For [CA-2878](https://4teamwork.atlassian.net/browse/CA-2878)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- Bug fixed:
  - [x] Resolved any Sentry issues caused by this bug
