### PR TITLE
Fix BCC address if sending documents over email in teamraum

### DIFF
--- a/changes/CA-3732.bugfix
+++ b/changes/CA-3732.bugfix
@@ -1,0 +1,1 @@
+Properly handle the BCC address in teamraum if sending documents by email. [elioschmutz]


### PR DESCRIPTION
This PR fixes an issue where the `BCC` address was not set in the mail-client if sending a document within a teamraum over email.

## Before
https://user-images.githubusercontent.com/557005/155532647-43b05b35-b5e7-40ac-b6cf-7cf5fb345ba8.mov


## After
https://user-images.githubusercontent.com/557005/155532338-514ff255-00ca-4f1f-9293-36598a0c036e.mov


For [CA-3732]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-3732]: https://4teamwork.atlassian.net/browse/CA-3732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ