### PR TITLE
Update changelog after backports to 2022.4.1.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,16 @@ Versions are of the form MAJOR.MINOR.PATCH. Each MINOR release (MAJOR.MINOR.0) i
 
 .. towncrier release notes start
 
+2022.4.1 (2022-02-24)
+---------------------
+
+Bug fixes:
+
+
+- Default value acquisition: Skip intermediate objects missing attribute. [lgraf]
+- NightlyWorkflowSecurityUpdater: Gracefully skip objs that can't be resolved. [lgraf]
+
+
 2022.4.0 (2022-02-16)
 ---------------------
 

--- a/changes/CA-2878-1.bugfix
+++ b/changes/CA-2878-1.bugfix
@@ -1,1 +1,0 @@
-NightlyWorkflowSecurityUpdater: Gracefully skip objs that can't be resolved. [lgraf]

--- a/changes/CA-2878.bugfix
+++ b/changes/CA-2878.bugfix
@@ -1,1 +1,0 @@
-Default value acquisition: Skip intermediate objects missing attribute. [lgraf]


### PR DESCRIPTION
Update changelog after backports to `2022.4.1`.

I _think_ this should be the way to do it. I'm coping over the `2022.4.1` section from the `2022.4-stable` branch here, and deleting the two respective news fragments. But I'm not 100% how towncrier will handle this, might need double checking.

For [CA-2874](https://4teamwork.atlassian.net/browse/CA-2874)
