### PR TITLE
Fix dossier_types vocabulary for testserver

### DIFF
--- a/opengever/core/testserver.py
+++ b/opengever/core/testserver.py
@@ -14,6 +14,7 @@ from opengever.core.testing import OpengeverFixture
 from opengever.core.testserver_zope2server import ISOLATION_READINESS
 from opengever.dossier.interfaces import IDossierType
 from opengever.testing.helpers import incrementing_intids
+from opengever.testing.helpers import MockDossierTypes
 from plone import api
 from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
@@ -150,7 +151,7 @@ class TestserverLayer(OpengeverFixture):
         api.portal.set_registry_record('use_solr', True, interface=ISearchSettings)
         activate_bumblebee_feature()
 
-        self.replaceDossierTypesVocabulary()
+        MockDossierTypes.install(getGlobalSiteManager())
 
         setRequest(portal.REQUEST)
         print 'Installing fixture. Have patience.'
@@ -181,25 +182,6 @@ class TestserverLayer(OpengeverFixture):
         lang_tool = api.portal.get_tool('portal_languages')
         lang_tool.setDefaultLanguage('de')
         lang_tool.supported_langs = ['de-ch', 'fr-ch']
-
-    def replaceDossierTypesVocabulary(self):
-        """Register testserver-specific dossier-types.
-        It does not work with overrides.zcml for testserver only. So we have to do it manually
-        """
-        def dossier_types_vocabulary_factory(context):
-            return SimpleVocabulary([
-                SimpleTerm('businesscase', title=u'Gesch\xe4ftsfall'),
-                SimpleTerm('project', title='Projektdossier')
-                ])
-
-        utility_name = 'opengever.dossier.dossier_types'
-        gsm = getGlobalSiteManager()
-        gsm.unregisterUtility(provided=IVocabularyFactory, name=utility_name)
-        gsm.registerUtility(dossier_types_vocabulary_factory, provided=IVocabularyFactory, name=utility_name)
-
-        # Do not hide the initial dossier_type.
-        api.portal.set_registry_record(
-            name='hidden_dossier_types', interface=IDossierType, value=[])
 
     def get_fixture_class(self):
         """The fixture of the testserver should be replaceable from the outside.

--- a/opengever/testing/helpers.py
+++ b/opengever/testing/helpers.py
@@ -255,6 +255,6 @@ class MockDossierTypes(VdexVocabulary):
         super(MockDossierTypes, self).__init__(vdex_filename, **kwargs)
 
     @classmethod
-    def install(cls):
-        sm = getSiteManager()
+    def install(cls, sm=None):
+        sm = sm or getSiteManager()
         sm.registerUtility(cls(), name='opengever.dossier.dossier_types')


### PR DESCRIPTION
We already mocked the `dossier_types` vdex in the `testserver` to get more than one dossier type.

We mocked it by just registering a function as a vocabulary factory. The PR: https://github.com/4teamwork/opengever.core/pull/7368/ introduced a new endpoint called `@raw-dossier-types` which uses the `getTerms` function from the VDEX-Object instance. So the endpoint was broken in e2e tests because our factory function has not provided such a function:

<img width="457" alt="Bildschirmfoto 2022-02-25 um 15 19 02" src="https://user-images.githubusercontent.com/557005/155730622-9860e41e-87d9-4567-b887-2af6014e82c8.png">

We now use the `MockDossierTypes` object which was also introduced in the PR #7368 . This object properly registers the vocabulary as a vdex vocabulary.

In addition, we have to use the global site manager to register the vocabulary, otherwise the testserver will raise a `TypeError: can't pickle _Element objects` on startup after committing the transaction.

<img width="964" alt="Bildschirmfoto 2022-02-25 um 15 22 01" src="https://user-images.githubusercontent.com/557005/155731076-aedc33f6-d3b7-4597-b58b-a14c35d7c311.png">

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-3324]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] Changelog entry (⚠️ no changelog because it's a fix in this release and for testing only)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-3324]: https://4teamwork.atlassian.net/browse/CA-3324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ