### PR TITLE
Provide `@reference-number` expansion and view

### DIFF
--- a/changes/HG-2215.feature
+++ b/changes/HG-2215.feature
@@ -1,0 +1,1 @@
+Add `@reference-number` API endpoint and expansion for plone site and dexterity content. [deiferni]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -19,6 +19,7 @@ Other Changes
 - ``@favorites`` GET: Include dossier_type in response.
 - Add new endpoint ``@remove-dossier-reference``
 - ``@unlink-workspace``: Allow unlinking workspaces even if the dossier is closed.
+- ``@reference-number``: Add new endpoint and expansion parameter to serialize reference number formatted, sortable and raw.
 
 
 2022.4.0 (2022-02-16)

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -18,6 +18,7 @@ Inhalt:
    listing_stats.rst
    navigation.rst
    breadcrumbs.rst
+   reference_number.rst
    searching.rst
    dossiers.rst
    dossier_participations.rst

--- a/docs/public/dev-manual/api/reference_number.rst
+++ b/docs/public/dev-manual/api/reference_number.rst
@@ -1,0 +1,45 @@
+.. _reference_number:
+
+Aktenzeichen
+============
+
+Über den ``@reference-number`` Endpoint kann Details über das Aktenzeichen und seine Komponenten eines beliebigen Inhalts abgefragt werden.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       GET /ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-14 HTTP/1.1
+       Accept: application/json
+
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+        "@id": "http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-14/@reference-number",
+        "parts": {
+            "document": ["14"],
+            "dossier": ["1"],
+            "repository": ["1", "1"],
+            "repositoryroot": [""],
+            "site": ["Client1"],
+        },
+        "reference_number": "Client1 1.1 / 1 / 14",
+        "sortable_reference_number": "client00000001 00000001.00000001 / 00000001 / 00000014"
+      }
+
+
+Das Aktenzeichen kann beim Abfragen eines Inhaltes über den ``expand``-Parameter eingebettet werden,
+so dass keine zusätzliche Abfrage nötig ist.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       GET /ordnungssystem?expand=reference-number HTTP/1.1
+       Accept: application/json

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -491,6 +491,39 @@
       name="listing-stats"
       />
 
+
+  <plone:service
+      method="GET"
+      for="Products.CMFCore.interfaces.ISiteRoot"
+      factory=".reference_number.ReferenceNumberGet"
+      name="@reference-number"
+      permission="zope2.View"
+      />
+
+  <adapter
+      for="Products.CMFCore.interfaces.ISiteRoot
+           opengever.base.interfaces.IOpengeverBaseLayer"
+      provides="plone.restapi.interfaces.IExpandableElement"
+      factory=".reference_number.ReferenceNumber"
+      name="reference-number"
+      />
+
+  <plone:service
+      method="GET"
+      for="plone.dexterity.interfaces.IDexterityContent"
+      factory=".reference_number.ReferenceNumberGet"
+      name="@reference-number"
+      permission="zope2.View"
+      />
+
+  <adapter
+      for="plone.dexterity.interfaces.IDexterityContent
+           opengever.base.interfaces.IOpengeverBaseLayer"
+      provides="plone.restapi.interfaces.IExpandableElement"
+      factory=".reference_number.ReferenceNumber"
+      name="reference-number"
+      />
+
   <plone:service
       method="GET"
       for="Products.CMFCore.interfaces.IFolderish"

--- a/opengever/api/reference_number.py
+++ b/opengever/api/reference_number.py
@@ -1,0 +1,42 @@
+from opengever.base.interfaces import IReferenceNumber
+from plone.restapi.services import Service
+
+
+class ReferenceNumber(object):
+    """Return reference number information for an object."""
+
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+
+    def __call__(self, expand=False):
+        url = u"{}/@reference-number".format(self.context.absolute_url())
+        result = {
+            "reference-number": {
+                "@id": url,
+            },
+        }
+
+        if not expand:
+            return result
+
+        ref_num = IReferenceNumber(self.context)
+        reference = {
+            "parts": ref_num.get_numbers(),
+            "reference_number": ref_num.get_number(),
+            "sortable_reference_number": ref_num.get_sortable_number(),
+        }
+
+        result["reference-number"].update(reference)
+        return result
+
+
+class ReferenceNumberGet(Service):
+    """API Endpoint to return reference number information.
+
+    GET folder-1/@reference-number HTTP/1.1
+    """
+
+    def reply(self):
+        reference_number = ReferenceNumber(self.context, self.request)
+        return reference_number(expand=True)["reference-number"]

--- a/opengever/api/tests/test_reference_number.py
+++ b/opengever/api/tests/test_reference_number.py
@@ -1,0 +1,227 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+
+
+class TestExpandableReferenceNumberBase(IntegrationTestCase):
+
+    maxDiff = None
+    compact_json = None
+    expanded_json = None
+
+    def assert_compact_components_contain_reference_number(
+        self, context, browser
+    ):
+        browser.open(context, headers=self.api_headers)
+        self.assertIn(u"reference-number", browser.json["@components"])
+        self.assertDictEqual(
+            self.compact_json,
+            browser.json["@components"]["reference-number"],
+        )
+
+    def assert_expanded_components_contain_reference_number(
+        self, context, browser
+    ):
+        browser.open(
+            context,
+            view="?expand=reference-number",
+            headers=self.api_headers,
+        )
+        self.assertIn(u"reference-number", browser.json["@components"])
+        self.assertDictEqual(
+            self.expanded_json,
+            browser.json["@components"]["reference-number"],
+        )
+
+    def assert_reference_number_view_response(self, context, browser):
+        browser.open(
+            context,
+            view="@reference-number",
+            headers=self.api_headers,
+        )
+        self.assertDictEqual(
+            self.expanded_json,
+            browser.json,
+        )
+
+
+class TestPloneSiteExpandableReferenceNumber(
+    TestExpandableReferenceNumberBase
+):
+
+    compact_json = {
+        u"@id": u"http://nohost/plone/@reference-number",
+    }
+    expanded_json = {
+        u"@id": u"http://nohost/plone/@reference-number",
+        u"parts": {u"site": [u"Client1"]},
+        u"reference_number": u"Client1",
+        u"sortable_reference_number": u"client00000001",
+    }
+
+    @browsing
+    def test_plone_site_unexpanded_reference_number(self, browser):
+        self.login(self.regular_user, browser=browser)
+        self.assert_compact_components_contain_reference_number(
+            self.portal, browser
+        )
+
+    @browsing
+    def test_plone_site_expanded_reference_number(self, browser):
+        self.login(self.regular_user, browser=browser)
+        self.assert_expanded_components_contain_reference_number(
+            self.portal, browser
+        )
+
+    @browsing
+    def test_plone_site_reference_number_view(self, browser):
+        self.login(self.regular_user, browser=browser)
+        self.assert_reference_number_view_response(self.portal, browser)
+
+
+class TestRepoRootExpandableReferenceNumber(TestExpandableReferenceNumberBase):
+
+    compact_json = {
+        u"@id": u"http://nohost/plone/ordnungssystem/@reference-number",
+    }
+    expanded_json = {
+        u"@id": u"http://nohost/plone/ordnungssystem/@reference-number",
+        u"parts": {u"repositoryroot": [u""], u"site": [u"Client1"]},
+        u"reference_number": u"Client1",
+        u"sortable_reference_number": u"client00000001",
+    }
+
+    @browsing
+    def test_repo_root_unexpanded_reference_number(self, browser):
+        self.login(self.regular_user, browser=browser)
+        self.assert_compact_components_contain_reference_number(
+            self.repository_root, browser
+        )
+
+    @browsing
+    def test_repo_root_expanded_reference_number(self, browser):
+        self.login(self.regular_user, browser=browser)
+        self.assert_expanded_components_contain_reference_number(
+            self.repository_root, browser
+        )
+
+    @browsing
+    def test_repo_root_reference_number_view(self, browser):
+        self.login(self.regular_user, browser=browser)
+        self.assert_reference_number_view_response(
+            self.repository_root, browser
+        )
+
+
+class TestRepoFolderExpandableReferenceNumber(
+    TestExpandableReferenceNumberBase
+):
+
+    compact_json = {
+        u"@id": u"http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/@reference-number",  # noqa
+    }
+    expanded_json = {
+        u"@id": u"http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/@reference-number",  # noqa
+        u"parts": {
+            u"repository": [u"1", u"1"],
+            u"repositoryroot": [u""],
+            u"site": [u"Client1"],
+        },
+        u"reference_number": u"Client1 1.1",
+        u"sortable_reference_number": u"client00000001 00000001.00000001",
+    }
+
+    @browsing
+    def test_repo_folder_unexpanded_reference_number(self, browser):
+        self.login(self.regular_user, browser=browser)
+        self.assert_compact_components_contain_reference_number(
+            self.leaf_repofolder, browser
+        )
+
+    @browsing
+    def test_repo_folder_expanded_reference_number(self, browser):
+        self.login(self.regular_user, browser=browser)
+        self.assert_expanded_components_contain_reference_number(
+            self.leaf_repofolder, browser
+        )
+
+    @browsing
+    def test_repo_folder_reference_number_view(self, browser):
+        self.login(self.regular_user, browser=browser)
+        self.assert_reference_number_view_response(
+            self.leaf_repofolder, browser
+        )
+
+
+class TestDossierExpandableReferenceNumber(TestExpandableReferenceNumberBase):
+
+    compact_json = {
+        u"@id": u"http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/@reference-number",  # noqa
+    }
+    expanded_json = {
+        u"@id": u"http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/@reference-number",  # noqa
+        u"parts": {
+            u"dossier": [u"1"],
+            u"repository": [u"1", u"1"],
+            u"repositoryroot": [u""],
+            u"site": [u"Client1"],
+        },
+        u"reference_number": u"Client1 1.1 / 1",
+        u"sortable_reference_number": u"client00000001 00000001.00000001 / 00000001",  # noqa
+    }
+
+    @browsing
+    def test_document_unexpanded_reference_number(self, browser):
+        self.login(self.regular_user, browser=browser)
+        self.assert_compact_components_contain_reference_number(
+            self.dossier, browser
+        )
+
+    @browsing
+    def test_document_expanded_reference_number(self, browser):
+        self.login(self.regular_user, browser=browser)
+        self.assert_expanded_components_contain_reference_number(
+            self.dossier, browser
+        )
+
+    @browsing
+    def test_document_reference_number_view(self, browser):
+        self.login(self.regular_user, browser=browser)
+        self.assert_reference_number_view_response(self.dossier, browser)
+
+
+class TestDocumentExpandableReferenceNumber(TestExpandableReferenceNumberBase):
+
+    compact_json = {
+        u"@id": u"http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-14/@reference-number",  # noqa
+    }
+    expanded_json = {
+        u"@id": u"http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-14/@reference-number",  # noqa
+        u"parts": {
+            u"document": [u"14"],
+            u"dossier": [u"1"],
+            u"repository": [u"1", u"1"],
+            u"repositoryroot": [u""],
+            u"site": [u"Client1"],
+        },
+        u"reference_number": u"Client1 1.1 / 1 / 14",
+        u"sortable_reference_number": u"client00000001 00000001.00000001 / 00000001 / 00000014",  # noqa
+    }
+
+    @browsing
+    def test_document_unexpanded_reference_number(self, browser):
+        self.login(self.regular_user, browser=browser)
+        self.assert_compact_components_contain_reference_number(
+            self.document, browser
+        )
+
+    @browsing
+    def test_document_expanded_reference_number(self, browser):
+        self.login(self.regular_user, browser=browser)
+        self.assert_expanded_components_contain_reference_number(
+            self.document, browser
+        )
+
+    @browsing
+    def test_document_reference_number_view(self, browser):
+        self.login(self.regular_user, browser=browser)
+        self.assert_reference_number_view_response(self.document, browser)

--- a/opengever/api/tests/test_repository.py
+++ b/opengever/api/tests/test_repository.py
@@ -24,6 +24,7 @@ class TestRepositoryAPI(IntegrationTestCase):
                 u'breadcrumbs': {u'@id': u'http://nohost/plone/ordnungssystem/@breadcrumbs'},
                 u'listing-stats': {u'@id': u'http://nohost/plone/ordnungssystem/@listing-stats'},
                 u'lock': {u'@id': 'http://nohost/plone/ordnungssystem/@lock'},
+                u"reference-number": {u"@id": u"http://nohost/plone/ordnungssystem/@reference-number"},
                 u'main-dossier': None,
                 u'navigation': {u'@id': u'http://nohost/plone/ordnungssystem/@navigation'},
                 u'types': {u'@id': u'http://nohost/plone/ordnungssystem/@types'},


### PR DESCRIPTION
Provide an expandable view `@reference-number` that returns the formatted reference number, a sortable reference number and the unformatted reference number parts.

This helps client applications that need to use the raw reference number or parts of the raw reference.

I did not find an interface for which to register a single service. Instead i found that the `IReferenceNumber` adapter is registered for `ISiteRoot` and `IDexterityContent`. Thus the new service and adapter
mirror the adapter registrations of `IReferenceNumber`. The same service and adapter are registered twice for different interfaces.

This can be used in a client application when raw reference numbers or sortable reference numbers are needed.

For [HG-2215](https://4teamwork.atlassian.net/browse/HG-2215)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
