### PR TITLE
Add dossier_type_colors whitelabeling setting.

### DIFF
--- a/changes/CA-3324-1.feature
+++ b/changes/CA-3324-1.feature
@@ -1,0 +1,1 @@
+Add dossier_type_colors whitelabeling setting. [tinagebrer]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -12,6 +12,7 @@ Breaking Changes
 Other Changes
 ^^^^^^^^^^^^^
 
+- ``@white-labeling-settings``: Add field ``dossier_type_colors``. (see :ref:`white-labeling-settings`)
 - ``@navigation``: Include dossier_type in response.
 - ``@breadcrumbs`` GET: Include dossier_type in response.
 - Serialization: Include dossier_type in JSON summary for dossiers.

--- a/docs/public/dev-manual/api/schemas/opengever.dossier.businesscasedossier.inc
+++ b/docs/public/dev-manual/api/schemas/opengever.dossier.businesscasedossier.inc
@@ -74,16 +74,6 @@
        
 
 
-   .. py:attribute:: comments
-
-       :Feldname: :field-title:`Kommentar`
-       :Datentyp: ``Text``
-       
-       
-       
-       
-
-
    .. py:attribute:: responsible
 
        :Feldname: :field-title:`Federführend`
@@ -182,6 +172,16 @@
        
        
        :Wertebereich: ["businesscase"]
+
+
+   .. py:attribute:: checklist
+
+       :Feldname: :field-title:`Checkliste`
+       :Datentyp: ``JSONField``
+       
+       
+       
+       
 
 
    .. py:attribute:: classification

--- a/docs/public/dev-manual/api/white_labeling_settings.rst
+++ b/docs/public/dev-manual/api/white_labeling_settings.rst
@@ -26,6 +26,9 @@ Der ``@white-labeling-settings`` Endpoint liefert eine Übersicht über die Whit
             "en": "<div>Soutien en France</div>",
             "fr": "<div>Support in the United Kingdom</div>",
           },
+          "dossier_type_colors": {
+            "project": "#ac00fb"
+          },
           "logo": {
             "src": "data:image/png;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
           },

--- a/opengever/api/tests/test_white_labeling_settings.py
+++ b/opengever/api/tests/test_white_labeling_settings.py
@@ -24,6 +24,7 @@ class TestWhiteLabelingSettingsGet(IntegrationTestCase):
             {u'@id': u'http://nohost/plone/@white-labeling-settings',
              u'custom_support_markup':
              {u'de': u'<div>Kundensupport</div>', u'en': None, u'fr': None},
+             u'dossier_type_colors': {u'project': u'#fb8c00'},
              u'logo': {u'src': u'data:image/png;base64,R2V2ZXIgaXN0IGNvb2w='},
                 u'show_created_by': True,
                 u'themes': {u'light': {u'primary': u'#d000ff'}}},

--- a/opengever/api/white_labeling_settings.py
+++ b/opengever/api/white_labeling_settings.py
@@ -14,6 +14,8 @@ class WhiteLabelingSettingsGet(Service):
         logo_src = api.portal.get_registry_record('logo_src', interface=IWhiteLabelingSettings)
         color_scheme_light = api.portal.get_registry_record(
             'color_scheme_light', interface=IWhiteLabelingSettings)
+        dossier_type_colors = api.portal.get_registry_record(
+            'dossier_type_colors', interface=IWhiteLabelingSettings)
 
         result = {
             '@id': '{}/@white-labeling-settings'.format(self.context.absolute_url()),
@@ -25,6 +27,7 @@ class WhiteLabelingSettingsGet(Service):
                 'fr': api.portal.get_registry_record('custom_support_markup_fr',
                                                      interface=IWhiteLabelingSettings),
             },
+            'dossier_type_colors': json.loads(dossier_type_colors) if dossier_type_colors else {},
             'logo': {
                 'src': 'data:image/png;base64,' + base64.b64encode(logo_src) if logo_src else None
             },

--- a/opengever/base/interfaces.py
+++ b/opengever/base/interfaces.py
@@ -471,6 +471,10 @@ class IWhiteLabelingSettings(Interface):
         title=u'Color scheme light',
         description=u'In json format, eg. {"primary":"#55ff00"}', default=u'{}')
 
+    dossier_type_colors = schema.TextLine(
+        title=u'Dossier type color',
+        description=u'In json format, eg. {"businesscase":"#55ff00"}', default=u'{}')
+
     show_created_by = schema.Bool(
         title=u'Show created by section',
         description=u'Whether created by section should be shown',

--- a/opengever/core/upgrades/20220228151905_add_dossier_type_colors_whitelabeling_setting/registry.xml
+++ b/opengever/core/upgrades/20220228151905_add_dossier_type_colors_whitelabeling_setting/registry.xml
@@ -1,0 +1,10 @@
+<registry>
+
+  <!-- White Labeling -->
+  <records interface="opengever.base.interfaces.IWhiteLabelingSettings">
+    <value key="dossier_type_colors">{}</value>
+  </records>
+
+</registry>
+
+

--- a/opengever/core/upgrades/20220228151905_add_dossier_type_colors_whitelabeling_setting/upgrade.py
+++ b/opengever/core/upgrades/20220228151905_add_dossier_type_colors_whitelabeling_setting/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddDossierTypeColorsWhitelabelingSetting(UpgradeStep):
+    """Add dossier_type_colors whitelabeling setting.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/setup/creation/setuphandler.py
+++ b/opengever/setup/creation/setuphandler.py
@@ -141,7 +141,7 @@ def set_geverui_white_labeling_settings(context):
     settings_file = context.readDataFile('white_labeling/settings.json')
     if settings_file:
         settings = json.loads(settings_file)
-        seperately_treated_fields = ['color_scheme_light', 'logo_src']
+        seperately_treated_fields = ['color_scheme_light', 'dossier_type_colors', 'logo_src']
         white_labeling_fields = [field for field in IWhiteLabelingSettings.names()
                                  if field not in seperately_treated_fields]
         for field in white_labeling_fields:
@@ -152,4 +152,10 @@ def set_geverui_white_labeling_settings(context):
             api.portal.set_registry_record(
                 'color_scheme_light',
                 json.dumps(settings['color_scheme_light'], ensure_ascii=False),
+                interface=IWhiteLabelingSettings)
+
+        if 'dossier_type_colors' in settings:
+            api.portal.set_registry_record(
+                'dossier_type_colors',
+                json.dumps(settings['dossier_type_colors'], ensure_ascii=False),
                 interface=IWhiteLabelingSettings)

--- a/opengever/testing/profiles/testing/white_labeling/settings.json
+++ b/opengever/testing/profiles/testing/white_labeling/settings.json
@@ -2,5 +2,8 @@
     "color_scheme_light": {
         "primary": "#d000ff"
     },
+    "dossier_type_colors": {
+        "project": "#fb8c00"
+    },
     "custom_support_markup_de": "<div>Kundensupport</div>"
 }


### PR DESCRIPTION
The setting is needed to display dosing types with different colors in the new frontend

For [CA-3324]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))

[CA-3324]: https://4teamwork.atlassian.net/browse/CA-3324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ