### PR TITLE
Fix IntIdMaintenanceJobContextManagerMixin obj_to_key if there is no registered intid.

### DIFF
--- a/changes/CA-3771.bugfix
+++ b/changes/CA-3771.bugfix
@@ -1,0 +1,1 @@
+Fix IntIdMaintenanceJobContextManagerMixin obj_to_key if there is no registered intid. [elioschmutz]

--- a/opengever/core/tests/test_upgrade.py
+++ b/opengever/core/tests/test_upgrade.py
@@ -126,6 +126,25 @@ class TestIntIdMaintenanceJobContextManagerMixins(IntegrationTestCase):
         self.assertEqual(self.dossier,
                          job_manager.key_to_obj(job.variable_argument))
 
+    def test_obj_to_key_returns_existing_intid(self):
+        self.login(self.manager)
+        job_manager = DummyIntIdMaintenanceJobManager()
+        intid = getUtility(IIntIds).getId(self.dossier)
+        self.assertEqual(intid, job_manager.obj_to_key(self.dossier))
+
+    def test_obj_to_key_registers_intid_if_missing(self):
+        self.login(self.manager)
+        job_manager = DummyIntIdMaintenanceJobManager()
+
+        intids = getUtility(IIntIds)
+        intids.unregister(self.dossier)
+        self.assertIsNone(intids.queryId(self.dossier))
+
+        intid = job_manager.obj_to_key(self.dossier)
+
+        self.assertIsNotNone(intids.queryId(self.dossier))
+        self.assertEqual(intid, intids.queryId(self.dossier))
+
 
 class DummyUIDMaintenanceJobManager(UIDMaintenanceJobContextManagerMixin):
 

--- a/opengever/core/upgrade.py
+++ b/opengever/core/upgrade.py
@@ -558,7 +558,10 @@ class IntIdMaintenanceJobContextManagerMixin(MaintenanceJobContextManagerMixin):
         self.intids = getUtility(IIntIds)
 
     def obj_to_key(self, obj):
-        return self.intids.getId(obj)
+        int_id = self.intids.queryId(obj)
+        if not int_id:
+            int_id = self.intids.register(obj)
+        return int_id
 
     @staticmethod
     def key_to_obj(key):


### PR DESCRIPTION
This PR fixes an issue where upgradesteps are failing when using the `IntIdMaintenanceJobContextManagerMixin` and the queued object has currently no intid.

![Bildschirmfoto 2022-03-02 um 11 42 11](https://user-images.githubusercontent.com/557005/156346464-5f385d4e-dcbf-4e1b-a81e-79120dd47a17.png)

For [CA-3771]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-3771]: https://4teamwork.atlassian.net/browse/CA-3771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ