### PR TITLE
Add configuration option for gever-ui dashboard cards.

### DIFF
--- a/changes/CA-3682.feature
+++ b/changes/CA-3682.feature
@@ -1,0 +1,1 @@
+Add configuration option for dashboard cards. [phgross]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -15,6 +15,7 @@ Other Changes
 - ``@config``: Add ``dossier_checklist`` feature flag.
 - ``@participations`` endpoint now also support adding a list of participants. (see :ref:`participation`)
 - Add new endpoint ``@linked-workspace-participations``. (see :ref:`linked-workspaces`)
+- ``@dashboard-settings``: Add new endpoint to fetch the current dashboard settings.
 
 2022.5.0 (2022-03-01)
 ---------------------

--- a/docs/public/dev-manual/api/dashboard.rst
+++ b/docs/public/dev-manual/api/dashboard.rst
@@ -22,13 +22,16 @@ Dashboard Konfiguration
       {
           "cards": [
               {
+                  "id": "newest_gever_notifications",
                   "componentName": "NewestGeverNotificationsCard"
               },
               {
+                  "id": "recently_touched_items"
                   "componentName": "RecentlyTouchedItemsCard"
               },
               {
-                  "componentName": "MyDossiersCard"
+                  "id": "my_dossiers"
+                  "componentName": "DossiersCard"
               }
           ]
       }

--- a/docs/public/dev-manual/api/dashboard.rst
+++ b/docs/public/dev-manual/api/dashboard.rst
@@ -1,0 +1,34 @@
+.. _dashboard:
+
+Dashboard Konfiguration
+=======================
+
+Über den ``/@dashboard-settings`` Endpoint kann die aktuelle Konfiguration des Dashboards abgefragt werden.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       GET /@dashboard-settings HTTP/1.1
+       Accept: application/json
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+          "cards": [
+              {
+                  "componentName": "NewestGeverNotificationsCard"
+              },
+              {
+                  "componentName": "RecentlyTouchedItemsCard"
+              },
+              {
+                  "componentName": "MyDossiersCard"
+              }
+          ]
+      }

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -35,6 +35,7 @@ Inhalt:
    metadata.rst
    config.rst
    favorite.rst
+   dashboard.rst
    notifications.rst
    external_activities.rst
    recently_touched.rst

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -1673,4 +1673,12 @@
       permission="cmf.SetOwnProperties"
       />
 
+  <plone:service
+      method="GET"
+      name="@dashboard-settings"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      factory=".dashboard.DashboardSettings"
+      permission="zope2.View"
+      />
+
 </configure>

--- a/opengever/api/dashboard.py
+++ b/opengever/api/dashboard.py
@@ -1,0 +1,11 @@
+from opengever.base.interfaces import IGeverUI
+from plone import api
+from plone.restapi.services import Service
+import json
+
+
+class DashboardSettings(Service):
+
+    def reply(self):
+        return {'cards': json.loads(api.portal.get_registry_record(
+            'custom_dashboard_cards', interface=IGeverUI))}

--- a/opengever/api/dashboard.py
+++ b/opengever/api/dashboard.py
@@ -1,5 +1,7 @@
 from opengever.base.interfaces import IGeverUI
+from opengever.base.utils import get_preferred_language_code
 from plone import api
+from plone.dexterity.utils import safe_utf8
 from plone.restapi.services import Service
 import json
 
@@ -7,5 +9,16 @@ import json
 class DashboardSettings(Service):
 
     def reply(self):
-        return {'cards': json.loads(api.portal.get_registry_record(
-            'custom_dashboard_cards', interface=IGeverUI))}
+        language_code = get_preferred_language_code()
+        cards = json.loads(api.portal.get_registry_record(
+            'custom_dashboard_cards', interface=IGeverUI))
+
+        return {'cards': self.localized_dashboard_card(cards, language_code)}
+
+    def localized_dashboard_card(self, cards, language_code):
+        for card in cards:
+            title = card.get('title_{}'.format(language_code)) or card.get('title', '')
+            if title:
+                card['title'] = safe_utf8(title)
+
+        return cards

--- a/opengever/api/tests/test_dashboard.py
+++ b/opengever/api/tests/test_dashboard.py
@@ -1,0 +1,40 @@
+from ftw.testbrowser import browsing
+from opengever.base.interfaces import DEFAULT_DASHBOARD_CARDS
+from opengever.base.interfaces import IGeverUI
+from opengever.testing import IntegrationTestCase
+from plone import api
+import json
+
+
+class TestDashboardSettings(IntegrationTestCase):
+
+    @browsing
+    def test_returns_default_dashboard_cards(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(self.portal.absolute_url() + '/@dashboard-settings',
+                     method='GET', headers=self.api_headers)
+
+        self.assertEquals(DEFAULT_DASHBOARD_CARDS, browser.json['cards'])
+
+    @browsing
+    def test_returns_customized_dashboard_card_list(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        custom_dashboard_list = [
+            {'componentName': 'NewestGeverNotificationsCard'},
+            {'componentName': 'RecentlyTouchedItemsCard'},
+            {'componentName': 'DossiersCard',
+             'title_de': 'Falldossiers',
+             'filters': {
+                 'dossierType': 'Falldossier'}}
+        ]
+
+        api.portal.set_registry_record(
+            interface=IGeverUI, name='custom_dashboard_cards',
+            value=json.dumps(custom_dashboard_list).decode('utf-8'))
+
+        browser.open(self.portal.absolute_url() + '/@dashboard-settings',
+                     method='GET', headers=self.api_headers)
+
+        self.assertEquals(custom_dashboard_list, browser.json['cards'])

--- a/opengever/base/interfaces.py
+++ b/opengever/base/interfaces.py
@@ -6,6 +6,7 @@ from zope.interface import implementer
 from zope.interface import Interface
 from zope.schema.interfaces import IVocabularyFactory
 from zope.schema.vocabulary import SimpleVocabulary, SimpleTerm
+import json
 
 
 class IOpengeverBaseLayer(Interface):
@@ -371,12 +372,38 @@ class IOGMailSettings(Interface):
         default=False)
 
 
+DEFAULT_DASHBOARD_CARDS = [
+    {'componentName': 'NewestGeverNotificationsCard'},
+    {'componentName': 'RecentlyTouchedItemsCard'},
+    {'componentName': 'MyDossiersCard'},
+    {'componentName': 'SubstituteDossiersCard'},
+    {'componentName': 'DashboardPendingTasksCard'},
+    {'componentName': 'SubstituteTasksCard'},
+    {'componentName': 'DashboardAllPendingTasksCard'},
+    {'componentName': 'MyProposalsCard',
+     'listingKey': 'proposals',
+     'pivotKey': 'issuer-current-user'},
+    {'componentName': 'MyWatchedTasksCard',
+     'listingKey': 'tasks',
+     'pivotKey': 'watcher-current-user'},
+    {'componentName': 'MyWatchedDocumentsCard',
+     'listingKey': 'documents',
+     'pivotKey': 'watcher-current-user'}]
+
+
 class IGeverUI(Interface):
 
     is_feature_enabled = schema.Bool(
         title=u'Enable new GEVER UI',
         description=u'Whether new GEVER UI is enabled',
         default=False)
+
+    custom_dashboard_cards = schema.Text(
+        title=u'custom dashboard cards',
+        description=u'In json format, eg. [{"componentName": "DossiersCard", "'
+        'title_de": "Falldossiers", "filters": { "dossierType": "Falldossier"'
+        ' }}]',
+        default=json.dumps(DEFAULT_DASHBOARD_CARDS).decode('utf-8'))
 
 
 class IHubSpotSettings(Interface):

--- a/opengever/base/interfaces.py
+++ b/opengever/base/interfaces.py
@@ -373,22 +373,51 @@ class IOGMailSettings(Interface):
 
 
 DEFAULT_DASHBOARD_CARDS = [
-    {'componentName': 'NewestGeverNotificationsCard'},
-    {'componentName': 'RecentlyTouchedItemsCard'},
-    {'componentName': 'MyDossiersCard'},
-    {'componentName': 'SubstituteDossiersCard'},
-    {'componentName': 'DashboardPendingTasksCard'},
-    {'componentName': 'SubstituteTasksCard'},
-    {'componentName': 'DashboardAllPendingTasksCard'},
-    {'componentName': 'MyProposalsCard',
-     'listingKey': 'proposals',
-     'pivotKey': 'issuer-current-user'},
-    {'componentName': 'MyWatchedTasksCard',
-     'listingKey': 'tasks',
-     'pivotKey': 'watcher-current-user'},
-    {'componentName': 'MyWatchedDocumentsCard',
-     'listingKey': 'documents',
-     'pivotKey': 'watcher-current-user'}]
+    {
+        'id': 'newest_gever_notifications',
+        'componentName': 'NewestGeverNotificationsCard'
+    },
+    {
+        'id': 'recently_touched_items',
+        'componentName': 'RecentlyTouchedItemsCard'
+    },
+    {
+        'id': 'my_dossiers',
+        'componentName': 'MyDossiersCard'
+    },
+    {
+        'id': 'substitute_dossiers',
+        'componentName': 'SubstituteDossiersCard'
+    },
+    {
+        'id': 'dashboard_pending_tasks',
+        'componentName': 'DashboardPendingTasksCard'
+    },
+    {
+        'id': 'substitute_tasks',
+        'componentName': 'SubstituteTasksCard'
+    },
+    {
+        'id': 'dashboard_all_pending_tasks',
+        'componentName': 'DashboardAllPendingTasksCard'
+    },
+    {
+        'id': 'my_proposals',
+        'componentName': 'MyProposalsCard',
+        'listingKey': 'proposals',
+        'pivotKey': 'issuer-current-user'
+    },
+    {
+        'id': 'my_watched_tasks',
+        'componentName': 'MyWatchedTasksCard',
+        'listingKey': 'tasks',
+        'pivotKey': 'watcher-current-user'},
+    {
+        'id': 'my_watched_documents',
+        'componentName': 'MyWatchedDocumentsCard',
+        'listingKey': 'documents',
+        'pivotKey': 'watcher-current-user'
+    }]
 
 
 class IGeverUI(Interface):
@@ -400,7 +429,7 @@ class IGeverUI(Interface):
 
     custom_dashboard_cards = schema.Text(
         title=u'custom dashboard cards',
-        description=u'In json format, eg. [{"componentName": "DossiersCard", "'
+        description=u'In json format, eg. [{"id": "dossiers", "componentName": "DossiersCard", "'
         'title_de": "Falldossiers", "filters": { "dossierType": "Falldossier"'
         ' }}]',
         default=json.dumps(DEFAULT_DASHBOARD_CARDS).decode('utf-8'))

--- a/opengever/base/interfaces.py
+++ b/opengever/base/interfaces.py
@@ -383,7 +383,11 @@ DEFAULT_DASHBOARD_CARDS = [
     },
     {
         'id': 'my_dossiers',
-        'componentName': 'MyDossiersCard'
+        'title_de': 'Meine Dossiers',
+        'title_en': 'My dossiers',
+        'title_fr': 'Mes dossiers',
+        'componentName': 'DossiersCard',
+        'myDossiersOnly': True
     },
     {
         'id': 'substitute_dossiers',

--- a/opengever/core/upgrades/20220224150211_add_dashboard_cards_configuration/registry.xml
+++ b/opengever/core/upgrades/20220224150211_add_dashboard_cards_configuration/registry.xml
@@ -1,0 +1,3 @@
+<registry>
+  <record interface="opengever.base.interfaces.IGeverUI" field="custom_dashboard_cards" />
+</registry>

--- a/opengever/core/upgrades/20220224150211_add_dashboard_cards_configuration/upgrade.py
+++ b/opengever/core/upgrades/20220224150211_add_dashboard_cards_configuration/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddDashboardCardsConfiguration(UpgradeStep):
+    """Add dashboard cards configuration.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
The new configuration options, allows us to add a customer specific dossier Card, which only lists dossiers of a specific type for example. The current dashboard-settings can be fetched by the `@dashboard-settings` endpoint.

For [CA-3682]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- Upgrade-Steps:
  - [ ] Make it deferrable if possible
- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))


[CA-3682]: https://4teamwork.atlassian.net/browse/CA-3682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ