### PR TITLE
Add new @linked-workspace-participations endpoint.

### DIFF
--- a/changes/CA-3587.feature
+++ b/changes/CA-3587.feature
@@ -1,0 +1,1 @@
+Add new @linked-workspace-participations endpoint. [njohner]

--- a/changes/CA-3587.other
+++ b/changes/CA-3587.other
@@ -1,0 +1,1 @@
+Support adding a list of participants in @participations endpoint. [njohner]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -14,6 +14,7 @@ Other Changes
 - ``@role-assignment-reports``: Handle group prefix in principalid.
 - ``@config``: Add ``dossier_checklist`` feature flag.
 - ``@participations`` endpoint now also support adding a list of participants. (see :ref:`participation`)
+- Add new endpoint ``@linked-workspace-participations``. (see :ref:`linked-workspaces`)
 
 2022.5.0 (2022-03-01)
 ---------------------

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -13,6 +13,7 @@ Other Changes
 ^^^^^^^^^^^^^
 - ``@role-assignment-reports``: Handle group prefix in principalid.
 - ``@config``: Add ``dossier_checklist`` feature flag.
+- ``@participations`` endpoint now also support adding a list of participants. (see :ref:`participation`)
 
 2022.5.0 (2022-03-01)
 ---------------------

--- a/docs/public/dev-manual/api/linked_workspaces.rst
+++ b/docs/public/dev-manual/api/linked_workspaces.rst
@@ -126,6 +126,67 @@ Eine bestehende Verknüpfung eines Teamraums kann mit dem ``@unlink-workspace`` 
       HTTP/1.1 204 No Content
 
 
+Teilnehmer in einem verknüpften Teamraum setzen
+-----------------------------------------------
+
+Mit dem ``@linked-workspace-participations`` Endpoint können Teilnehmer auf einem verknüpften Teamraum hinzugefügt werden.
+
+**Beispiel-Request**:
+
+  .. sourcecode:: http
+
+    POST /ordnungssystem/dossier-23/@linked-workspace-participations HTTP/1.1
+    Accept: application/json
+    Content-Type: application/json
+
+    {
+      "workspace_uid": "c11627f492b6447fb61617bb06b9a21a"
+      "participants": [
+        {"participant": "max.muster", "role": "WorkspaceAdmin"},
+        {"participant": "maria.meier", "role": "WorkspaceGuest"}
+      ]
+    }
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    {
+      "@id": "/ordnungssystem/dossier-23/@linked-workspace-participations",
+      "items": [
+          {
+            "@id": "http://localhost:8080/fd/workspaces/workspace-1/@participations/max.muster",
+            "@type": "virtual.participations.user",
+            "is_editable": true,
+            "role": {
+              "title": "Admin",
+              "token": "WorkspaceAdmin"
+            },
+            "participant_actor": {
+              "@id": "http://localhost:8081/fd/@actors/max.muster",
+              "identifier": "max.muster",
+            },
+            "participant": {
+              "@id": "http://localhost:8081/fd/@ogds-users/max.muster",
+              "@type": "virtual.ogds.user",
+              "active": true,
+              "email": "max.muster@example.com",
+              "title": "Max Muster (max.muster)",
+              "id": "max.muster",
+              "is_local": null
+            },
+          },
+          {
+            "@id": "http://localhost:8080/fd/workspaces/workspace-1/@participations/maria.meier",
+            "...": "..."
+          },
+      ]
+    }
+
+
 Ein GEVER-Dokument in einen verknüpften Teamraum kopieren
 ---------------------------------------------------------
 

--- a/docs/public/dev-manual/api/workspace/participation.rst
+++ b/docs/public/dev-manual/api/workspace/participation.rst
@@ -153,7 +153,7 @@ Ein DELETE Request auf die `@id` einer Beteiligung löscht die entsprechnede Bet
 
 Beteiligungen hinzufügen:
 -------------------------
-In einem selbst verwalteten Teamraum-Ordner (Vererbung wurde unterbrochen) können beteiligungen über einen POST request auf den @participations Endpoint hinzugefügt werden.
+In einem selbst verwalteten Teamraum-Ordner (Vererbung wurde unterbrochen) können Beteiligungen über einen POST Request auf den @participations Endpoint hinzugefügt werden. Im Body werden entweder die Attribute ``participant`` und ``role`` erwartet oder ein Liste von Beteiligungen im Attribut ``participants``.
 
 **Beispiel-Request**:
 
@@ -194,8 +194,68 @@ In einem selbst verwalteten Teamraum-Ordner (Vererbung wurde unterbrochen) könn
         "title": "Maria Meier (maria.meier)",
         "id": "maria.meier",
         "is_local": null
+      }
     }
 
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       POST /workspaces/workspace-1/@participations HTTP/1.1
+       Accept: application/json
+
+       {
+         "participants": [
+            {
+              "participant": "maria.meier",
+              "role": "WorkspaceAdmin"
+            },
+            {
+              "participant": "markus.muller",
+              "role": "WorkspaceGuest"
+            },
+          ]
+        }
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    {
+      "@id": "/workspaces/workspace-1/@participations",
+      "items": [
+          {
+            "@id": "http://localhost:8080/fd/workspaces/workspace-1/@participations/max.muster",
+            "@type": "virtual.participations.user",
+            "is_editable": true,
+            "role": {
+              "title": "Admin",
+              "token": "WorkspaceAdmin"
+            },
+            "participant_actor": {
+              "@id": "http://localhost:8081/fd/@actors/maria.meier",
+              "identifier": "maria.meier",
+            },
+            "participant": {
+              "@id": "http://localhost:8081/fd/@ogds-users/maria.meier",
+              "@type": "virtual.ogds.user",
+              "active": true,
+              "email": "maria.meier@example.com",
+              "title": "Maria Meier (maria.meier)",
+              "id": "maria.meier",
+              "is_local": null
+            },
+          },
+          {
+            "@id": "http://localhost:8080/fd/workspaces/workspace-1/@participations/markus.muller",
+            "...": "..."
+          },
+      ]
+    }
 
 Beteiligungen bearbeiten:
 -------------------------

--- a/docs/public/dev-manual/api/workspace/participation.rst
+++ b/docs/public/dev-manual/api/workspace/participation.rst
@@ -155,8 +155,6 @@ Beteiligungen hinzufügen:
 -------------------------
 In einem selbst verwalteten Teamraum-Ordner (Vererbung wurde unterbrochen) können beteiligungen über einen POST request auf den @participations Endpoint hinzugefügt werden.
 
-**Achtung**: Eine Beteiligung in einem Arbeitsraum kann nur über eine Einladung hinzugefügt werden. Der eingeladene Benutzer muss seine Beteiligung erste bestätigen, bevor der Benutzer effektiv berechtigt wird.
-
 **Beispiel-Request**:
 
    .. sourcecode:: http

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -1138,6 +1138,14 @@
       />
 
   <plone:service
+      method="POST"
+      name="@linked-workspace-participations"
+      for="opengever.dossier.behaviors.dossier.IDossierMarker"
+      factory=".linked_workspaces.AddParticipationsOnWorkspacePost"
+      permission="opengever.workspaceclient.UseWorkspaceClient"
+      />
+
+  <plone:service
       method="GET"
       name="@allowed-roles-and-principals"
       for="Products.CMFCore.interfaces.IContentish"

--- a/opengever/api/linked_workspaces.py
+++ b/opengever/api/linked_workspaces.py
@@ -271,3 +271,28 @@ class ListLinkedDocumentUIDsFromWorkspace(Service):
                 if brain.gever_doc_uid]
 
         return {'gever_doc_uids': uids}
+
+
+class AddParticipationsOnWorkspacePost(LinkedWorkspacesService):
+    """API Endpoint to add participations on a linked workspace.
+    """
+
+    @teamraum_request_error_handler
+    def reply(self):
+        alsoProvides(self.request, IDisableCSRFProtection)
+        data = json_body(self.request)
+        workspace_uid = data.get('workspace_uid')
+        if not workspace_uid:
+            raise BadRequest("Property 'workspace_uid' is required")
+
+        participants = data.get('participants')
+        if not participants:
+            raise BadRequest("Property 'participants' is required")
+
+        items = ILinkedWorkspaces(self.context).add_participations(
+                workspace_uid, participants).get("items", [])
+
+        return {
+            "@id": "{}/@linked-workspace-participations".format(self.context.absolute_url()),
+            "items": items
+        }

--- a/opengever/api/linked_workspaces.py
+++ b/opengever/api/linked_workspaces.py
@@ -1,3 +1,4 @@
+from opengever.api import _
 from opengever.api.utils import create_proxy_request_error_handler
 from opengever.document.behaviors import IBaseDocument
 from opengever.workspaceclient import is_workspace_client_feature_available
@@ -101,7 +102,8 @@ class LinkToWorkspacePost(LinkedWorkspacesService):
         data = json_body(self.request)
         workspace_uid = data.get('workspace_uid')
         if not workspace_uid:
-            raise BadRequest("Property 'workspace_uid' is required")
+            raise BadRequest(_(u"workspace_uid_required",
+                               default=u"Property 'workspace_uid' is required"))
 
         ILinkedWorkspaces(self.context).link_to_workspace(workspace_uid)
         return self.reply_no_content()
@@ -123,7 +125,8 @@ class UnlinkWorkspacePost(LinkedWorkspacesService):
         data = json_body(self.request)
         workspace_uid = data.get('workspace_uid')
         if not workspace_uid:
-            raise BadRequest("Property 'workspace_uid' is required")
+            raise BadRequest(_(u"workspace_uid_required",
+                               default=u"Property 'workspace_uid' is required"))
 
         ILinkedWorkspaces(self.context).unlink_workspace(workspace_uid)
         return self.reply_no_content()
@@ -158,7 +161,8 @@ class CopyDocumentToWorkspacePost(LinkedWorkspacesService):
     def validate_data(self, data):
         workspace_uid = data.get('workspace_uid')
         if not workspace_uid:
-            raise BadRequest("Property 'workspace_uid' is required")
+            raise BadRequest(_(u"workspace_uid_required",
+                               default=u"Property 'workspace_uid' is required"))
 
         document_uid = data.get('document_uid')
         if not document_uid:
@@ -251,7 +255,8 @@ class CopyDocumentFromWorkspacePost(LinkedWorkspacesService):
     def validate_data(self, data):
         workspace_uid = data.get('workspace_uid')
         if not workspace_uid:
-            raise BadRequest("Property 'workspace_uid' is required")
+            raise BadRequest(_(u"workspace_uid_required",
+                               default=u"Property 'workspace_uid' is required"))
         document_uid = data.get('document_uid')
         if not document_uid:
             raise BadRequest("Property 'document_uid' is required")
@@ -283,11 +288,13 @@ class AddParticipationsOnWorkspacePost(LinkedWorkspacesService):
         data = json_body(self.request)
         workspace_uid = data.get('workspace_uid')
         if not workspace_uid:
-            raise BadRequest("Property 'workspace_uid' is required")
+            raise BadRequest(_(u"workspace_uid_required",
+                               default=u"Property 'workspace_uid' is required"))
 
         participants = data.get('participants')
         if not participants:
-            raise BadRequest("Property 'participants' is required")
+            raise BadRequest(_(u"participant_required",
+                               default=u"Property 'participants' is required"))
 
         items = ILinkedWorkspaces(self.context).add_participations(
                 workspace_uid, participants).get("items", [])

--- a/opengever/api/locales/de/LC_MESSAGES/opengever.api.po
+++ b/opengever/api/locales/de/LC_MESSAGES/opengever.api.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-11-24 14:12+0000\n"
+"POT-Creation-Date: 2022-03-07 10:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,10 +19,35 @@ msgstr ""
 msgid "copy_of"
 msgstr "Kopie von ${title}"
 
+#. Default: "The actor ${actorid} is not allowed"
+#: ./opengever/api/participations.py
+msgid "disallowed_participant"
+msgstr "Der Teilnehmer ${actorid} ist nicht erlaubt"
+
+#. Default: "The participant ${actorid} already exists"
+#: ./opengever/api/participations.py
+msgid "duplicate_participant"
+msgstr "${actorid} ist schon Teilnehmer"
+
 #. Default: "It's not possible to have non-.docx documents as proposal documents."
 #: ./opengever/api/tus.py
 msgid "error_proposal_document_type"
 msgstr "Es ist nicht möglich, Dokumente, die nicht im Format docx vorliegen, als Antragsdokumente zu verwenden."
+
+#. Default: "Role ${role} is not available. Available roles are: ${allowed_roles}"
+#: ./opengever/api/participations.py
+msgid "invalid_role"
+msgstr "Die Rolle ${role} ist ungültig. Gültige Rollen sind: ${allowed_roles}"
+
+#. Default: "Missing parameter 'participant'"
+#: ./opengever/api/participations.py
+msgid "missing_participant"
+msgstr "Fehlender Parameter 'participant'"
+
+#. Default: "Missing parameter 'role'"
+#: ./opengever/api/participations.py
+msgid "missing_role"
+msgstr "Fehlender Parameter 'role'"
 
 #. Default: "Already trashed"
 #: ./opengever/api/trash.py
@@ -123,3 +148,18 @@ msgstr "Protokollauszüge können nicht in den Papierkorb verschoben werden"
 #: ./opengever/api/trash.py
 msgid "msg_trash_locked_doc"
 msgstr "Ein gesperrtes Dokument kann nicht in den Papierkorb verschoben werden"
+
+#. Default: "Cannot specify both 'participants' and 'participant' or 'role'"
+#: ./opengever/api/participations.py
+msgid "one_of_participants_and_participant"
+msgstr "Nur einen von 'participants' und 'participant' oder 'role' ist erlaubt"
+
+#. Default: "Property 'participants' is required"
+#: ./opengever/api/linked_workspaces.py
+msgid "participant_required"
+msgstr "Parameter 'participants' ist erforderlich"
+
+#. Default: "Property 'workspace_uid' is required"
+#: ./opengever/api/linked_workspaces.py
+msgid "workspace_uid_required"
+msgstr "Parameter 'workspace_uid' ist erforderlich"

--- a/opengever/api/locales/en/LC_MESSAGES/opengever.api.po
+++ b/opengever/api/locales/en/LC_MESSAGES/opengever.api.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-11-24 14:12+0000\n"
+"POT-Creation-Date: 2022-03-07 10:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,10 +19,35 @@ msgstr ""
 msgid "copy_of"
 msgstr "Copy of ${title}"
 
+#. Default: "The actor ${actorid} is not allowed"
+#: ./opengever/api/participations.py
+msgid "disallowed_participant"
+msgstr "The participant ${actorid} is not allowed"
+
+#. Default: "The participant ${actorid} already exists"
+#: ./opengever/api/participations.py
+msgid "duplicate_participant"
+msgstr "The participant ${actorid} already exists"
+
 #. Default: "It's not possible to have non-.docx documents as proposal documents."
 #: ./opengever/api/tus.py
 msgid "error_proposal_document_type"
 msgstr "Only docx documents are allowed as proposal documents."
+
+#. Default: "Role ${role} is not available. Available roles are: ${allowed_roles}"
+#: ./opengever/api/participations.py
+msgid "invalid_role"
+msgstr "Role ${role} is not available. Available roles are: ${allowed_roles}"
+
+#. Default: "Missing parameter 'participant'"
+#: ./opengever/api/participations.py
+msgid "missing_participant"
+msgstr "Missing parameter 'participant'"
+
+#. Default: "Missing parameter 'role'"
+#: ./opengever/api/participations.py
+msgid "missing_role"
+msgstr "Missing parameter 'role'"
 
 #. Default: "Already trashed"
 #: ./opengever/api/trash.py
@@ -123,3 +148,18 @@ msgstr "Cannot trash a document that has been returned as excerpt"
 #: ./opengever/api/trash.py
 msgid "msg_trash_locked_doc"
 msgstr "Cannot trash a locked document"
+
+#. Default: "Cannot specify both 'participants' and 'participant' or 'role'"
+#: ./opengever/api/participations.py
+msgid "one_of_participants_and_participant"
+msgstr "Cannot specify both 'participants' and 'participant' or 'role'"
+
+#. Default: "Property 'participants' is required"
+#: ./opengever/api/linked_workspaces.py
+msgid "participant_required"
+msgstr "Property 'participants' is required"
+
+#. Default: "Property 'workspace_uid' is required"
+#: ./opengever/api/linked_workspaces.py
+msgid "workspace_uid_required"
+msgstr "Property 'workspace_uid' is required"

--- a/opengever/api/locales/fr/LC_MESSAGES/opengever.api.po
+++ b/opengever/api/locales/fr/LC_MESSAGES/opengever.api.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-11-24 14:12+0000\n"
+"POT-Creation-Date: 2022-03-07 10:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,10 +19,35 @@ msgstr ""
 msgid "copy_of"
 msgstr "Copie de ${title}"
 
+#. Default: "The actor ${actorid} is not allowed"
+#: ./opengever/api/participations.py
+msgid "disallowed_participant"
+msgstr "Le participant ${actorid} n'est pas autorisé"
+
+#. Default: "The participant ${actorid} already exists"
+#: ./opengever/api/participations.py
+msgid "duplicate_participant"
+msgstr "${actorid} est déjà participant"
+
 #. Default: "It's not possible to have non-.docx documents as proposal documents."
 #: ./opengever/api/tus.py
 msgid "error_proposal_document_type"
 msgstr "Seuls les fichiers docx sont autorisés comme documents de requête."
+
+#. Default: "Role ${role} is not available. Available roles are: ${allowed_roles}"
+#: ./opengever/api/participations.py
+msgid "invalid_role"
+msgstr "Le rôle ${role} n'est pas valable. Les rôles valides sont: ${allowed_roles}"
+
+#. Default: "Missing parameter 'participant'"
+#: ./opengever/api/participations.py
+msgid "missing_participant"
+msgstr "Le paramètre 'participant' est requis"
+
+#. Default: "Missing parameter 'role'"
+#: ./opengever/api/participations.py
+msgid "missing_role"
+msgstr "Le paramètre 'role' est requis"
 
 #. Default: "Already trashed"
 #: ./opengever/api/trash.py
@@ -123,3 +148,18 @@ msgstr "Un extrait de protocol ne peut pas être mis à la corbeille."
 #: ./opengever/api/trash.py
 msgid "msg_trash_locked_doc"
 msgstr "Un document verrouillé ne peut pas être mis à la corbeille."
+
+#. Default: "Cannot specify both 'participants' and 'participant' or 'role'"
+#: ./opengever/api/participations.py
+msgid "one_of_participants_and_participant"
+msgstr "Il n'est permis de spécifier que soit 'participants', soit 'participant' ou 'role'"
+
+#. Default: "Property 'participants' is required"
+#: ./opengever/api/linked_workspaces.py
+msgid "participant_required"
+msgstr "Le paramètre 'participants' est requis"
+
+#. Default: "Property 'workspace_uid' is required"
+#: ./opengever/api/linked_workspaces.py
+msgid "workspace_uid_required"
+msgstr "Le paramètre 'workspace_uid' est requis"

--- a/opengever/api/locales/opengever.api.pot
+++ b/opengever/api/locales/opengever.api.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-11-24 14:12+0000\n"
+"POT-Creation-Date: 2022-03-07 10:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,9 +22,34 @@ msgstr ""
 msgid "copy_of"
 msgstr ""
 
+#. Default: "The actor ${actorid} is not allowed"
+#: ./opengever/api/participations.py
+msgid "disallowed_participant"
+msgstr ""
+
+#. Default: "The participant ${actorid} already exists"
+#: ./opengever/api/participations.py
+msgid "duplicate_participant"
+msgstr ""
+
 #. Default: "It's not possible to have non-.docx documents as proposal documents."
 #: ./opengever/api/tus.py
 msgid "error_proposal_document_type"
+msgstr ""
+
+#. Default: "Role ${role} is not available. Available roles are: ${allowed_roles}"
+#: ./opengever/api/participations.py
+msgid "invalid_role"
+msgstr ""
+
+#. Default: "Missing parameter 'participant'"
+#: ./opengever/api/participations.py
+msgid "missing_participant"
+msgstr ""
+
+#. Default: "Missing parameter 'role'"
+#: ./opengever/api/participations.py
+msgid "missing_role"
 msgstr ""
 
 #. Default: "Already trashed"
@@ -125,4 +150,19 @@ msgstr ""
 #. Default: "Cannot trash a locked document"
 #: ./opengever/api/trash.py
 msgid "msg_trash_locked_doc"
+msgstr ""
+
+#. Default: "Cannot specify both 'participants' and 'participant' or 'role'"
+#: ./opengever/api/participations.py
+msgid "one_of_participants_and_participant"
+msgstr ""
+
+#. Default: "Property 'participants' is required"
+#: ./opengever/api/linked_workspaces.py
+msgid "participant_required"
+msgstr ""
+
+#. Default: "Property 'workspace_uid' is required"
+#: ./opengever/api/linked_workspaces.py
+msgid "workspace_uid_required"
 msgstr ""

--- a/opengever/api/participations.py
+++ b/opengever/api/participations.py
@@ -148,8 +148,8 @@ class ParticipationsDelete(ParticipationTraverseService):
         current context.
         """
         if obj.get_context_with_local_roles() == obj and self.find_participant(token, obj):
-                manager = ManageParticipants(obj, self.request)
-                manager._delete(Actor.lookup(token).actor_type, token)
+            manager = ManageParticipants(obj, self.request)
+            manager._delete(Actor.lookup(token).actor_type, token)
 
         for folder in obj.listFolderContents(
                 contentFilter={'portal_type': 'opengever.workspace.folder'}):

--- a/opengever/api/tests/test_linked_workspaces.py
+++ b/opengever/api/tests/test_linked_workspaces.py
@@ -2,7 +2,6 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.exceptions import HTTPServerError
-from opengever.base.behaviors.classification import IClassification
 from opengever.base.command import CreateEmailCommand
 from opengever.base.oguid import Oguid
 from opengever.document.interfaces import ICheckinCheckoutManager
@@ -1313,3 +1312,216 @@ class TestCopyDocumentFromWorkspacePost(FunctionalWorkspaceClientTestCase):
                  u'message': u"Document can't be copied from workspace "
                              u"because it's currently checked out"},
                 browser.json)
+
+
+class TestAddParticipationsOnWorkspacePost(FunctionalWorkspaceClientTestCase):
+
+    def setUp(self):
+        super(TestAddParticipationsOnWorkspacePost, self).setUp()
+
+        # Create a workspaces users
+        self.workspaces_user = api.user.create(email="foo@example.com",
+                                               username='workspaces.user')
+
+        self.grant('WorkspacesUser', 'WorkspacesCreator',
+                   on=self.workspace_root,
+                   user_id=self.workspaces_user.getId())
+
+        # Grant WorkspaceAdmin to TEST_USER
+        self.grant('WorkspaceAdmin', on=self.workspace)
+
+        # Link the workspace to the dossier
+        with self.workspace_client_env():
+            manager = ILinkedWorkspaces(self.dossier)
+            manager.storage.add(self.workspace.UID())
+            transaction.commit()
+
+    @browsing
+    def test_add_participations_raises_for_missing_workspace_uid(self, browser):
+
+        payload = {
+            'participants': [{"participant": self.workspaces_user.getId(),
+                              "role": "WorkspaceGuest"}],
+            }
+
+        with self.workspace_client_env(), browser.expect_http_error(code=400):
+            browser.login()
+            browser.open(
+                self.dossier.absolute_url() + '/@linked-workspace-participations',
+                data=json.dumps(payload),
+                method='POST',
+                headers={'Accept': 'application/json',
+                         'Content-Type': 'application/json'},
+            )
+
+        self.assertNotIn(u'workspaces.user',
+                         self.workspace.__ac_local_roles__)
+
+        self.assertEqual(
+            {u'type': u'BadRequest',
+             u'message': u"Property 'workspace_uid' is required"},
+            browser.json)
+
+    @browsing
+    def test_add_participations_raises_for_missing_participants(self, browser):
+
+        payload = {
+            'workspace_uid': self.workspace.UID(),
+            }
+
+        with self.workspace_client_env(), browser.expect_http_error(code=400):
+            browser.login()
+            browser.open(
+                self.dossier.absolute_url() + '/@linked-workspace-participations',
+                data=json.dumps(payload),
+                method='POST',
+                headers={'Accept': 'application/json',
+                         'Content-Type': 'application/json'},
+            )
+
+        self.assertEqual(
+            {u'type': u'BadRequest',
+             u'message': u"Property 'participants' is required"},
+            browser.json)
+
+    @browsing
+    def test_add_participations_raises_if_user_is_not_workspace_admin(self, browser):
+        self.grant('WorkspaceMember', on=self.workspace)
+
+        payload = {
+            'workspace_uid': self.workspace.UID(),
+            'participants': [{"participant": self.workspaces_user.getId(),
+                              "role": "WorkspaceGuest"}]
+            }
+
+        with self.workspace_client_env():
+            browser.login()
+            browser.exception_bubbling = True
+            with self.assertRaises(HTTPServerError):
+                browser.open(
+                    self.dossier.absolute_url() + '/@linked-workspace-participations',
+                    data=json.dumps(payload),
+                    method='POST',
+                    headers={'Accept': 'application/json',
+                             'Content-Type': 'application/json'},
+                    )
+
+        self.assertEqual(
+            {u'message': u'Error while communicating with the teamraum deployment',
+             u'service_error': {
+                u'message': u'You are not authorized to access this resource.',
+                u'status_code': 401,
+                u'type': u'Unauthorized'},
+             u'type': u'Bad Gateway'},
+            browser.json)
+
+    @browsing
+    def test_add_participations_raises_for_invalid_participant(self, browser):
+
+        payload = {
+            'workspace_uid': self.workspace.UID(),
+            'participants': [{"participant": "invalid",
+                              "role": "WorkspaceGuest"}]
+            }
+
+        with self.workspace_client_env():
+            browser.login()
+            browser.exception_bubbling = True
+            with self.assertRaises(HTTPServerError):
+                browser.open(
+                    self.dossier.absolute_url() + '/@linked-workspace-participations',
+                    data=json.dumps(payload),
+                    method='POST',
+                    headers={'Accept': 'application/json',
+                             'Content-Type': 'application/json'},
+                )
+
+        self.assertEqual(502, browser.status_code)
+        self.assertEqual(
+            {u'message': u'Error while communicating with the teamraum deployment',
+             u'service_error': {u'message': u'The actor is not allowed',
+                                u'status_code': 400,
+                                u'type': u'BadRequest'},
+             u'type': u'Bad Gateway'},
+            browser.json)
+
+    @browsing
+    def test_add_participations_raises_for_invalid_role(self, browser):
+
+        payload = {
+            'workspace_uid': self.workspace.UID(),
+            'participants': [{"participant": self.workspaces_user.getId(),
+                              "role": "invalid"}]
+            }
+
+        with self.workspace_client_env():
+            browser.login()
+            browser.exception_bubbling = True
+            with self.assertRaises(HTTPServerError):
+                browser.open(
+                    self.dossier.absolute_url() + '/@linked-workspace-participations',
+                    data=json.dumps(payload),
+                    method='POST',
+                    headers={'Accept': 'application/json',
+                             'Content-Type': 'application/json'},
+                )
+
+        self.assertEqual(502, browser.status_code)
+        self.assertEqual(
+            {u'message': u'Error while communicating with the teamraum deployment',
+             u'service_error': {
+                u'message': u"Role is not availalbe. Available roles are: "
+                            u"['WorkspaceAdmin', 'WorkspaceMember', 'WorkspaceGuest']",
+                u'status_code': 400,
+                u'type': u'BadRequest'},
+             u'type': u'Bad Gateway'},
+            browser.json)
+
+    @browsing
+    def test_add_participations_handles_multiple_participants(self, browser):
+        # Create second workspaces user
+        workspaces_user2 = api.user.create(email="bar@example.com",
+                                           username='workspaces.user2')
+
+        self.grant('WorkspacesUser',
+                   on=self.workspace_root,
+                   user_id=workspaces_user2.getId())
+
+        payload = {
+            'workspace_uid': self.workspace.UID(),
+            'participants': [{"participant": self.workspaces_user.getId(),
+                              "role": "WorkspaceGuest"},
+                             {"participant": workspaces_user2.getId(),
+                              "role": "WorkspaceMember"}],
+            }
+
+        self.assertEqual(
+            {'test_user_1_': ['WorkspaceAdmin']},
+            self.workspace.__ac_local_roles__)
+
+        with self.workspace_client_env():
+            browser.login()
+            browser.open(
+                self.dossier.absolute_url() + '/@linked-workspace-participations',
+                data=json.dumps(payload),
+                method='POST',
+                headers={'Accept': 'application/json',
+                         'Content-Type': 'application/json'},
+            )
+
+        items = browser.json.get("items")
+        self.assertEqual(2, len(items))
+        self.assertEqual("workspaces.user",
+                         items[0]["participant"]["id"])
+        self.assertEqual({u'token': u'WorkspaceGuest', u'title': u'Guest'},
+                         items[0]["role"])
+        self.assertEqual("workspaces.user2",
+                         items[1]["participant"]["id"])
+        self.assertEqual({u'token': u'WorkspaceMember', u'title': u'Member'},
+                         items[1]["role"])
+
+        self.assertEqual(
+            {u'workspaces.user': [u'WorkspaceGuest'],
+             u'workspaces.user2': [u'WorkspaceMember'],
+             'test_user_1_': ['WorkspaceAdmin']},
+            self.workspace.__ac_local_roles__)

--- a/opengever/api/tests/test_linked_workspaces.py
+++ b/opengever/api/tests/test_linked_workspaces.py
@@ -206,7 +206,7 @@ class TestLinkToWorkspacesPost(FunctionalWorkspaceClientTestCase):
                     method='POST',
                     headers={'Accept': 'application/json',
                              'Content-Type': 'application/json'})
-        self.assertEqual("Property 'workspace_uid' is required", str(cm.exception))
+        self.assertEqual('workspace_uid_required', str(cm.exception))
 
     @browsing
     def test_only_workspace_client_users_can_use_the_api(self, browser):
@@ -390,8 +390,7 @@ class TestCopyDocumentToWorkspacePost(FunctionalWorkspaceClientTestCase):
                     headers={'Accept': 'application/json',
                              'Content-Type': 'application/json'},
                 )
-
-        self.assertEqual("Property 'workspace_uid' is required", str(cm.exception))
+        self.assertEqual('workspace_uid_required', str(cm.exception))
 
     @browsing
     def test_raises_when_document_uid_missing(self, browser):
@@ -943,8 +942,7 @@ class TestCopyDocumentFromWorkspacePost(FunctionalWorkspaceClientTestCase):
                     headers={'Accept': 'application/json',
                              'Content-Type': 'application/json'},
                 )
-
-        self.assertEqual("Property 'workspace_uid' is required", str(cm.exception))
+        self.assertEqual('workspace_uid_required', str(cm.exception))
 
     @browsing
     def test_raises_when_document_cant_be_looked_up_by_uid(self, browser):
@@ -1358,8 +1356,10 @@ class TestAddParticipationsOnWorkspacePost(FunctionalWorkspaceClientTestCase):
                          self.workspace.__ac_local_roles__)
 
         self.assertEqual(
-            {u'type': u'BadRequest',
-             u'message': u"Property 'workspace_uid' is required"},
+            {u'additional_metadata': {},
+             u'message': u'workspace_uid_required',
+             u'translated_message': u"Property 'workspace_uid' is required",
+             u'type': u'BadRequest'},
             browser.json)
 
     @browsing
@@ -1380,8 +1380,10 @@ class TestAddParticipationsOnWorkspacePost(FunctionalWorkspaceClientTestCase):
             )
 
         self.assertEqual(
-            {u'type': u'BadRequest',
-             u'message': u"Property 'participants' is required"},
+            {u'additional_metadata': {},
+             u'message': u'participant_required',
+             u'translated_message': u"Property 'participants' is required",
+             u'type': u'BadRequest'},
             browser.json)
 
     @browsing
@@ -1439,9 +1441,12 @@ class TestAddParticipationsOnWorkspacePost(FunctionalWorkspaceClientTestCase):
         self.assertEqual(502, browser.status_code)
         self.assertEqual(
             {u'message': u'Error while communicating with the teamraum deployment',
-             u'service_error': {u'message': u'The actor is not allowed',
-                                u'status_code': 400,
-                                u'type': u'BadRequest'},
+             u'service_error': {
+                u'additional_metadata': {},
+                u'message': u'disallowed_participant',
+                u'status_code': 400,
+                u'translated_message': u'The participant invalid is not allowed',
+                u'type': u'BadRequest'},
              u'type': u'Bad Gateway'},
             browser.json)
 
@@ -1470,9 +1475,12 @@ class TestAddParticipationsOnWorkspacePost(FunctionalWorkspaceClientTestCase):
         self.assertEqual(
             {u'message': u'Error while communicating with the teamraum deployment',
              u'service_error': {
-                u'message': u"Role is not availalbe. Available roles are: "
-                            u"['WorkspaceAdmin', 'WorkspaceMember', 'WorkspaceGuest']",
+                u'additional_metadata': {},
+                u'message': u'invalid_role',
                 u'status_code': 400,
+                u'translated_message': u"Role invalid is not available. "
+                                       u"Available roles are: ['WorkspaceAdmin', "
+                                       u"'WorkspaceMember', 'WorkspaceGuest']",
                 u'type': u'BadRequest'},
              u'type': u'Bad Gateway'},
             browser.json)

--- a/opengever/api/tests/test_participation.py
+++ b/opengever/api/tests/test_participation.py
@@ -872,6 +872,14 @@ class TestParticipationPostWorkspace(IntegrationTestCase):
             headers=http_headers(),
             )
 
+        # Posting with participant and role returns the serialized participant
+        self.assertEquals(
+            self.workspace_member.id,
+            browser.json.get('participant').get('id'))
+        self.assertEquals(
+            {u'token': u'WorkspaceGuest', u'title': u'Guest'},
+            browser.json.get('role'))
+
         browser.open(
             self.workspace,
             view='@participations',
@@ -883,6 +891,56 @@ class TestParticipationPostWorkspace(IntegrationTestCase):
         self.assertEquals(
             {u'token': u'WorkspaceGuest', u'title': u'Guest'},
             entry.get('role'))
+
+    @browsing
+    def test_add_a_list_of_participants(self, browser):
+        self.login(self.workspace_admin, browser=browser)
+
+        remove_participation(self.workspace, browser, self.workspace_member.id)
+        remove_participation(self.workspace, browser, self.workspace_guest.id)
+
+        self.assertDictEqual(
+            {'fridolin.hugentobler': ['WorkspaceAdmin'],
+             'gunther.frohlich': ['WorkspaceAdmin']},
+            self.workspace.__ac_local_roles__)
+
+        data = {
+            "participants": [
+                {"participant": {"token": self.workspace_member.id},
+                 "role": {"token": 'WorkspaceGuest'}},
+                {"participant": self.workspace_guest.id,
+                 "role": 'WorkspaceMember'}
+            ]
+        }
+
+        browser.open(
+            self.workspace,
+            view='@participations',
+            method='POST',
+            data=json.dumps(data),
+            headers=http_headers(),
+            )
+
+        # Posting with a list of participants returns the list of participants
+        items = browser.json.get('items')
+        self.assertEqual(2, len(items))
+
+        entry = get_entry_by_id(items, self.workspace_member.id)
+        self.assertEquals(
+            {u'token': u'WorkspaceGuest', u'title': u'Guest'},
+            entry.get('role'))
+
+        entry = get_entry_by_id(items, self.workspace_guest.id)
+        self.assertEquals(
+            {u'token': u'WorkspaceMember', u'title': u'Member'},
+            entry.get('role'))
+
+        self.assertDictEqual(
+            {u'beatrice.schrodinger': [u'WorkspaceGuest'],
+             u'fridolin.hugentobler': [u'WorkspaceAdmin'],
+             u'gunther.frohlich': [u'WorkspaceAdmin'],
+             u'hans.peter': [u'WorkspaceMember']},
+            self.workspace.__ac_local_roles__)
 
     @browsing
     def test_let_a_group_participate(self, browser):
@@ -988,6 +1046,33 @@ class TestParticipationPostWorkspace(IntegrationTestCase):
                 data=json.dumps(data),
                 headers=http_headers(),
                 )
+
+    @browsing
+    def test_can_only_pass_one_of_participant_and_participants(self, browser):
+        self.login(self.workspace_admin, browser=browser)
+
+        data = {
+            "participants": [
+                {"participant": {"token": self.workspace_guest.id},
+                 "role": {"token": 'Manager'}}
+                ],
+            "participant": {"token": self.workspace_member.id},
+            "role": {"token": 'Manager'},
+        }
+
+        with browser.expect_http_error(400):
+            browser.open(
+                self.workspace,
+                view='@participations',
+                method='POST',
+                data=json.dumps(data),
+                headers=http_headers(),
+                )
+
+        self.assertEqual(
+            {u'message': u'Cannot specify both participants and participant or role',
+             u'type': u'BadRequest'},
+            browser.json)
 
 
 class TestParticipationPostWorkspaceFolder(IntegrationTestCase):

--- a/opengever/api/tests/test_participation.py
+++ b/opengever/api/tests/test_participation.py
@@ -603,7 +603,7 @@ class TestParticipationPatch(IntegrationTestCase):
         )
 
         entry = get_entry_by_id(browser.json.get('items'), self.workspace_guest.id)
-        self.assertEquals(
+        self.assertEqual(
             {u'token': u'WorkspaceGuest', u'title': u'Guest'},
             entry.get('role'))
 
@@ -625,7 +625,7 @@ class TestParticipationPatch(IntegrationTestCase):
         )
 
         entry = get_entry_by_id(browser.json.get('items'), self.workspace_guest.id)
-        self.assertEquals(
+        self.assertEqual(
             {u'token': u'WorkspaceMember', u'title': u'Member'},
             entry.get('role'))
 
@@ -643,7 +643,7 @@ class TestParticipationPatch(IntegrationTestCase):
         )
 
         entry = get_entry_by_id(browser.json.get('items'), 'projekt_a')
-        self.assertEquals(
+        self.assertEqual(
             {u'token': u'WorkspaceGuest', u'title': u'Guest'},
             entry.get('role'))
 
@@ -665,7 +665,7 @@ class TestParticipationPatch(IntegrationTestCase):
         )
 
         entry = get_entry_by_id(browser.json.get('items'), 'projekt_a')
-        self.assertEquals(
+        self.assertEqual(
             {u'token': u'WorkspaceMember', u'title': u'Member'},
             entry.get('role'))
 
@@ -734,7 +734,7 @@ class TestParticipationPatch(IntegrationTestCase):
         )
 
         entry = get_entry_by_id(browser.json.get('items'), self.workspace_guest.id)
-        self.assertEquals(
+        self.assertEqual(
             {u'token': u'WorkspaceGuest', u'title': u'Guest'},
             entry.get('role'))
 
@@ -756,7 +756,7 @@ class TestParticipationPatch(IntegrationTestCase):
         )
 
         entry = get_entry_by_id(browser.json.get('items'), self.workspace_guest.id)
-        self.assertEquals(
+        self.assertEqual(
             {u'token': u'WorkspaceMember', u'title': u'Member'},
             entry.get('role'),
             'Expect to have the WorkspaceMember role')
@@ -769,7 +769,7 @@ class TestParticipationPatch(IntegrationTestCase):
         )
 
         entry = get_entry_by_id(browser.json.get('items'), self.workspace_guest.id)
-        self.assertEquals(
+        self.assertEqual(
             {u'token': u'WorkspaceGuest', u'title': u'Guest'},
             entry.get('role'),
             'Expect to still have the WorkspaceGuest role on the workspace')
@@ -873,10 +873,10 @@ class TestParticipationPostWorkspace(IntegrationTestCase):
             )
 
         # Posting with participant and role returns the serialized participant
-        self.assertEquals(
+        self.assertEqual(
             self.workspace_member.id,
             browser.json.get('participant').get('id'))
-        self.assertEquals(
+        self.assertEqual(
             {u'token': u'WorkspaceGuest', u'title': u'Guest'},
             browser.json.get('role'))
 
@@ -888,7 +888,7 @@ class TestParticipationPostWorkspace(IntegrationTestCase):
         )
 
         entry = get_entry_by_id(browser.json.get('items'), self.workspace_member.id)
-        self.assertEquals(
+        self.assertEqual(
             {u'token': u'WorkspaceGuest', u'title': u'Guest'},
             entry.get('role'))
 
@@ -926,12 +926,12 @@ class TestParticipationPostWorkspace(IntegrationTestCase):
         self.assertEqual(2, len(items))
 
         entry = get_entry_by_id(items, self.workspace_member.id)
-        self.assertEquals(
+        self.assertEqual(
             {u'token': u'WorkspaceGuest', u'title': u'Guest'},
             entry.get('role'))
 
         entry = get_entry_by_id(items, self.workspace_guest.id)
-        self.assertEquals(
+        self.assertEqual(
             {u'token': u'WorkspaceMember', u'title': u'Member'},
             entry.get('role'))
 
@@ -977,7 +977,7 @@ class TestParticipationPostWorkspace(IntegrationTestCase):
         )
 
         entry = get_entry_by_id(browser.json.get('items'), 'projekt_a')
-        self.assertEquals(
+        self.assertEqual(
             {u'token': u'WorkspaceGuest', u'title': u'Guest'},
             entry.get('role'))
 
@@ -1117,7 +1117,7 @@ class TestParticipationPostWorkspaceFolder(IntegrationTestCase):
         )
 
         entry = get_entry_by_id(browser.json.get('items'), self.workspace_member.id)
-        self.assertEquals(
+        self.assertEqual(
             {u'token': u'WorkspaceGuest', u'title': u'Guest'},
             entry.get('role'))
 

--- a/opengever/api/tests/test_participation.py
+++ b/opengever/api/tests/test_participation.py
@@ -1068,9 +1068,11 @@ class TestParticipationPostWorkspace(IntegrationTestCase):
                 data=json.dumps(data),
                 headers=http_headers(),
                 )
-
         self.assertEqual(
-            {u'message': u'Cannot specify both participants and participant or role',
+            {u'additional_metadata': {},
+             u'message': u'one_of_participants_and_participant',
+             u'translated_message': u"Cannot specify both 'participants' and "
+                                    u"'participant' or 'role'",
              u'type': u'BadRequest'},
             browser.json)
 
@@ -1179,8 +1181,9 @@ class TestParticipationPostWorkspaceFolder(IntegrationTestCase):
                 )
 
         self.assertEqual('BadRequest', browser.json.get('type'))
-        self.assertIn('Role is not availalbe. Available roles are:',
-                      browser.json.get('message'))
+        self.assertEqual(u'invalid_role', browser.json.get('message'))
+        self.assertIn('Role Manager is not available. Available roles are:',
+                      browser.json.get('translated_message'))
 
     @browsing
     def test_do_not_allow_readding_an_already_existing_user(self, browser):
@@ -1212,8 +1215,12 @@ class TestParticipationPostWorkspaceFolder(IntegrationTestCase):
                 headers=http_headers(),
                 )
 
-        self.assertEqual({"message": "The participant already exists",
-                          "type": "BadRequest"}, browser.json)
+        self.assertEqual(
+            {u'additional_metadata': {},
+             u'message': u'duplicate_participant',
+             u'translated_message': u'The participant beatrice.schrodinger already exists',
+             u'type': u'BadRequest'},
+            browser.json)
 
     @browsing
     def test_only_users_from_the_upper_context_are_allowed_to_participate_to_a_folder(self, browser):

--- a/opengever/workspaceclient/linked_workspaces.py
+++ b/opengever/workspaceclient/linked_workspaces.py
@@ -499,3 +499,11 @@ class LinkedWorkspaces(object):
             blacklisted_dict[key] = dict_obj[key]
 
         return blacklisted_dict
+
+    def add_participations(self, workspace_uid, participations):
+        """ Adds participations on the workspace
+        """
+        workspace_url = self._get_linked_workspace_url(workspace_uid)
+        return self.client.post(
+            '{}/@participations'.format(workspace_url),
+            json={'participants': participations})


### PR DESCRIPTION
With this PR we add a new endpoint `@add-participations-on-workspace` allowing to set participations on a linked workspace from the Gever dossier.
To avoid having to do multiple requests to the teamraum deployment and to simplify error handling we enable setting a list of participants in the `@participations` endpoint, so that we have a single request from Gever to Teamraum and setting the participations either works for all participants or None.

I'm not sure whether I should add translations of the error messages. These errors should actually not happen in the new UI.

For [CA-3587]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New translations
  - [ ] All msg-strings are unicode

[CA-3587]: https://4teamwork.atlassian.net/browse/CA-3587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ