### PR TITLE
Handle errors in nightly jobs.

### DIFF
--- a/changes/CA-3786.bugfix
+++ b/changes/CA-3786.bugfix
@@ -1,0 +1,1 @@
+Handle errors in nightly jobs. [tinagerber]


### PR DESCRIPTION
Until now, all nightly jobs were aborted when an unexpected error occurred. Now it continues with the next job.

For [CA-3786]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-3786]: https://4teamwork.atlassian.net/browse/CA-3786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ