### PR TITLE
Fix OneOffixx favorites

### DIFF
--- a/changes/CA-3820.bugfix
+++ b/changes/CA-3820.bugfix
@@ -1,0 +1,1 @@
+Fix getting OneOffixx favorites for templates that are not whitelisted. [buchi]

--- a/changes/CA-3820a.bugfix
+++ b/changes/CA-3820a.bugfix
@@ -1,0 +1,1 @@
+Add labels to OneOffixx templates whitelist. [buchi]

--- a/opengever/oneoffixx/templates.py
+++ b/opengever/oneoffixx/templates.py
@@ -15,7 +15,9 @@ def get_whitelisted_oneoffixx_templates(api_client):
 def get_oneoffixx_favorites(api_client):
     return [
         OneOffixxTemplate(template) for template in
-        api_client.get_oneoffixx_favorites()]
+        api_client.get_oneoffixx_favorites()
+        if template.get(u'metaTemplateId') in whitelisted_template_types
+    ]
 
 
 def get_oneoffixx_template_groups(api_client):

--- a/opengever/oneoffixx/utils.py
+++ b/opengever/oneoffixx/utils.py
@@ -1,18 +1,27 @@
 whitelisted_template_types = {
+    # Content
     '275af32e-bc40-45c2-85b7-afb1c0382653': {
         'content-type': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
         'extension': 'docx',
     },
+    # Excel template
     'e31ca353-2ab1-4408-921b-a70ae2f57ad1': {
         'content-type': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
         'extension': 'xlsx',
     },
+    # PowerPoint template
     'a2c9b700-86cd-4481-a17f-533fe9c504a2': {
         'content-type': 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
         'extension': 'pptx',
     },
+    # Function
     '0a3ac64d-ec36-4bcd-b057-41379a502fed': {
         'content-type': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
         'extension': 'docx',
-    }
+    },
+    # Label
+    '90b5aa90-dadd-47c1-8d1a-a49016c2bcb3': {
+        'content-type': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'extension': 'docx',
+    },
 }


### PR DESCRIPTION
Filter OneOffixx favorites to only include white listed templates. This fixes a KeyError if the user has favorites of not white listed templates.

```
2022-01-26T10:11:19 ERROR Zope.SiteErrorLog 1643188279.660.546125934712 https://gever.sg.ch/kapo/ordnungssystem/fuehrung-und-koordination/operative-fuehrung/aufbauorganisation/fuehrung-hauptabteilungen-leitungsstellen-abteilungen-gruppen/kriminalpolizei-kripo/administration-fuehrung-kripo/dossier-55851/@oneoffixx-templates
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module plone.rest.service, line 23, in __call__
  Module plone.restapi.services, line 21, in render
  Module opengever.oneoffixx.service, line 86, in reply
  Module opengever.oneoffixx.templates, line 18, in get_oneoffixx_favorites
  Module opengever.oneoffixx.templates, line 36, in __init__
KeyError: u'90b5aa90-dadd-47c1-8d1a-a49016c2bcb3'
```

Add Label (Adressetiketten) to template white list.

For [CA-3820](https://4teamwork.atlassian.net/browse/CA-3820)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
