### PR TITLE
Handle group prefix in principalid in @role-assignment-reports endpoint

### DIFF
--- a/changes/CA-3822.bugfix
+++ b/changes/CA-3822.bugfix
@@ -1,0 +1,1 @@
+Handle group prefix in principalid in @role-assignment-reports endpoint. [tinagerber]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,7 +11,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
-
+- ``@role-assignment-reports``: Handle group prefix in principalid.
 
 2022.5.0 (2022-03-01)
 ---------------------

--- a/opengever/api/role_assignment_reports.py
+++ b/opengever/api/role_assignment_reports.py
@@ -110,6 +110,7 @@ class RoleAssignmentReportsPost(RoleAssignmentReportsBase):
 
         if not self.principal_id:
             raise BadRequest("Property 'principal_id' is required")
+        self.principal_id = self.principal_id.split('group:', 1)[-1]
 
 
 class RoleAssignmentReportsDelete(Service):

--- a/opengever/api/tests/test_role_assignment_reports.py
+++ b/opengever/api/tests/test_role_assignment_reports.py
@@ -138,6 +138,27 @@ class TestRoleAssignmentReportsPost(IntegrationTestCase):
                           u'state': u'in progress'}, browser.json)
 
     @browsing
+    def test_post_role_assignment_reports_can_handle_group_prefix(self, browser):
+        self.login(self.administrator, browser=browser)
+        with freeze(datetime(2020, 4, 18)):
+            browser.open(self.portal.absolute_url() + '/@role-assignment-reports',
+                         method='POST',
+                         headers=self.api_headers,
+                         data=json.dumps({"principal_id": {'token': 'group:projekt_a'}}))
+
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual({u'@id': u'http://nohost/plone/@role-assignment-reports/report_2',
+                          u'@type': u'virtual.report.roleassignmentreport',
+                          u'items': [],
+                          u'items_total': 0,
+                          u'modified': u'2020-04-18T00:00:00+00:00',
+                          u'principal_type': u'group',
+                          u'principal_label': u'Projekt A',
+                          u'principal_id': u'projekt_a',
+                          u'report_id': u'report_2',
+                          u'state': u'in progress'}, browser.json)
+
+    @browsing
     def test_post_role_assignment_reports_with_invalid_principal_id(self, browser):
         self.login(self.administrator, browser=browser)
         with freeze(datetime(2020, 4, 18)):


### PR DESCRIPTION
In the frontend, a source is used to select the `principalid`, which prefixes the group ID with `group:`  Therefore, such group ID were classified as "unknown principal".

For [CA-3822]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))

[CA-3822]: https://4teamwork.atlassian.net/browse/CA-3822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ