### PR TITLE
Allow all documents of a linked workspace to be copied to a dossier.

### DIFF
--- a/changes/CA-3711.bugfix
+++ b/changes/CA-3711.bugfix
@@ -1,0 +1,1 @@
+Allow all documents of a linked workspace to be copied to a dossier. [tinagerber]

--- a/opengever/api/tests/test_linked_workspaces.py
+++ b/opengever/api/tests/test_linked_workspaces.py
@@ -1076,6 +1076,46 @@ class TestCopyDocumentFromWorkspacePost(FunctionalWorkspaceClientTestCase):
                 browser.json.get('teamraum_connect_retrieval_mode'))
 
     @browsing
+    def test_copy_document_from_second_batch_from_a_workspace(self, browser):
+        for i in range(25):
+            create(Builder('document')
+                   .within(self.workspace)
+                   .with_dummy_content())
+
+        document = create(Builder('document')
+                          .titled('Another document')
+                          .within(self.workspace)
+                          .with_dummy_content())
+
+        payload = {
+            'workspace_uid': self.workspace.UID(),
+            'document_uid': document.UID(),
+        }
+
+        with self.workspace_client_env():
+            manager = ILinkedWorkspaces(self.dossier)
+            manager.storage.add(self.workspace.UID())
+            transaction.commit()
+            documents_first_batch = manager.list_documents_in_linked_workspace(
+                self.workspace.UID())['items']
+            self.assertNotIn(document.UID(), [doc['UID'] for doc in documents_first_batch])
+
+            browser.login()
+            fix_publisher_test_bug(browser, document)
+            with self.observe_children(self.dossier) as children:
+                browser.open(
+                    self.dossier.absolute_url() + '/@copy-document-from-workspace',
+                    data=json.dumps(payload),
+                    method='POST',
+                    headers={'Accept': 'application/json',
+                             'Content-Type': 'application/json'},
+                )
+
+            self.assertEqual(len(children['added']), 1)
+            document_copy = children['added'].pop()
+            self.assertEqual(document_copy.title, document.title)
+
+    @browsing
     def test_copy_document_from_workspace_as_new_version(self, browser):
         gever_doc = create(Builder('document')
                            .within(self.dossier)

--- a/opengever/workspaceclient/linked_workspaces.py
+++ b/opengever/workspaceclient/linked_workspaces.py
@@ -260,10 +260,9 @@ class LinkedWorkspaces(object):
         return response
 
     def _get_document_by_uid(self, workspace_uid, document_uid):
-        linked_documents = self.list_documents_in_linked_workspace(workspace_uid)
-        for document in linked_documents["items"]:
-            if document.get('UID') == document_uid:
-                return document
+        linked_documents = self.list_documents_in_linked_workspace(workspace_uid, UID=document_uid)
+        if linked_documents.get('items_total') == 1:
+            return linked_documents['items'][0]
 
     def copy_document_from_workspace(self, workspace_uid, document_uid, as_new_version=False):
         """Will copy a document from a linked workspace.


### PR DESCRIPTION
This was not possible because the @search endpoint is batched.

For [CA-3711]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-3711]: https://4teamwork.atlassian.net/browse/CA-3711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ