### PR TITLE
Update DEFAULT_DASHBOARD_CARDS with the responsibleToggleFilters

### DIFF
--- a/opengever/base/interfaces.py
+++ b/opengever/base/interfaces.py
@@ -387,7 +387,7 @@ DEFAULT_DASHBOARD_CARDS = [
         'title_en': 'My dossiers',
         'title_fr': 'Mes dossiers',
         'componentName': 'DossiersCard',
-        'myDossiersOnly': True
+        'responsibleToggleFilters': ['myDossiers', 'anyParticipation'],
     },
     {
         'id': 'substitute_dossiers',


### PR DESCRIPTION
This PR updates the DEFAULT_DASHBOARD_CARDS with the responsibleToggleFilters for the `DashboardCard`.

This is required since we no longer provide the `myDossiersOnly` property in the frontend for more flexibility in configuring the cards.

For [CA-3682]

This is a follow-up PR for https://github.com/4teamwork/gever-ui/pull/2189

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] Changelog entry (not required because it's a follow-up pr in the same release)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-3682]: https://4teamwork.atlassian.net/browse/CA-3682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ