### PR TITLE
Improve error handling for workflow transitions over the API

### DIFF
--- a/changes/CA-3809.other
+++ b/changes/CA-3809.other
@@ -1,0 +1,1 @@
+Improve error handling for workflow transitions over the API. [njohner]

--- a/opengever/api/errors.py
+++ b/opengever/api/errors.py
@@ -1,4 +1,4 @@
-from opengever.base import _
+from opengever.api import _
 from plone.rest.errors import ErrorHandling
 from plone.rest.interfaces import IAPIRequest
 from zope.component import adapter

--- a/opengever/api/tests/test_language.py
+++ b/opengever/api/tests/test_language.py
@@ -20,7 +20,7 @@ class TestLanguageToolPatch(IntegrationTestCase):
 
         self.assertEqual(u'BadRequest', browser.json[u'type'])
         self.assertEqual(
-            u'Inputs not valid', browser.json[u'translated_message'])
+            u'Eingaben sind ung\xfcltig', browser.json[u'translated_message'])
 
         self.assertEqual(
             {u'fields': [{

--- a/opengever/api/transition.py
+++ b/opengever/api/transition.py
@@ -99,9 +99,6 @@ class GEVERWorkflowTransition(WorkflowTransition):
                     message=translate(str(e), context=self.request),
                 )
             )
-        except BadRequest as e:
-            self.request.response.setStatus(400)
-            return dict(error=dict(type="Bad Request", message=str(e)))
 
         with elevated_privileges():
             history = self.wftool.getInfoFor(self.context, "review_history")

--- a/opengever/task/tests/test_api_support.py
+++ b/opengever/task/tests/test_api_support.py
@@ -181,9 +181,13 @@ class TestAPITransitions(IntegrationTestCase):
             browser.open(url, method='POST', data=json.dumps(data),
                          headers=self.api_headers)
 
+        self.assertEqual(
+            u'The entered deadline is the same as the current one.',
+            browser.json['additional_metadata']["fields"][0]['translated_message'])
+
         self.assertIn(
             'same_deadline_error',
-            browser.json.get('error').get('message'))
+            browser.json.get('message'))
 
     @browsing
     def test_close_successful(self, browser):
@@ -700,8 +704,7 @@ class TestApprovalViaTask(IntegrationTestCase):
                          headers=self.api_headers)
 
         self.assertEqual({
-            u'error': {
-                u'message': u"Param 'approved_documents' is only supported "
-                            u"for tasks of task_type 'approval'.",
-                u'type': u'Bad Request'}},
+            u'message': u"Param 'approved_documents' is only supported "
+                        u"for tasks of task_type 'approval'.",
+            u'type': u'BadRequest'},
             browser.json)


### PR DESCRIPTION
For some reason we were serialising `Bad Requests` into a dictionary when executing transitions over the API. Instead now, we do nothing special so that the `Bad Request` actually gets raised and handled by our `GeverErrorHandling`, which will also take care of translating the error if possible.
This also helps the Gever-UI, so that it's automatic error handling will correctly display the returned error. With this change, an error is at least displayed when reassigning an open Task to a Team, although the error is simply displayed as a message and not in the form under the corresponding field (see screenshot). The frontend currently does not have error handling for field validation errors.

![Screenshot 2022-03-16 at 14 56 30](https://user-images.githubusercontent.com/7374243/159222208-18a6b769-7a58-4067-88df-508f57eec319.png)

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-3809]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- API change: I don't think this needs to be added in the API changelog
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed

[CA-3809]: https://4teamwork.atlassian.net/browse/CA-3809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ