### PR TITLE
Accept groups in `notification_recipients` for `@external-activities` endpoint 

### DIFF
--- a/changes/CA-3274-1.feature
+++ b/changes/CA-3274-1.feature
@@ -1,0 +1,1 @@
+Also accept group IDs in ``@external-activities`` notification_recipients. [lgraf]

--- a/changes/CA-3274-2.bugfix
+++ b/changes/CA-3274-2.bugfix
@@ -1,0 +1,1 @@
+NotificationDispatcher: Only return failed notification as not_dispatched. [lgraf]

--- a/changes/CA-3274.feature
+++ b/changes/CA-3274.feature
@@ -1,0 +1,1 @@
+Allow privileged users to notify others via `@external-activities` endpoint. [lgraf]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,6 +11,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- ``@external-activities``: ``notification_recipients`` now also accepts group IDs.
 - ``@external-activities``: Privileged users may now create notifications for other users (see :ref:`external-activities`)
 
 

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,6 +11,8 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- ``@external-activities``: Privileged users may now create notifications for other users (see :ref:`external-activities`)
+
 
 2022.6.0 (2022-03-15)
 ---------------------

--- a/docs/public/dev-manual/api/external_activities.rst
+++ b/docs/public/dev-manual/api/external_activities.rst
@@ -11,15 +11,23 @@ Externe Aktivität erzeugen (POST)
 
 .. http:post:: /@external-activities
 
-   Erzeugt eine externe Aktivität und damit eine Benachrichtigung an den angegebenen Benutzer.
+   Erzeugt eine externe Aktivität und damit eine Benachrichtigung an die angegebenen Benutzer oder Gruppen.
 
-   Die in ``notification_recipients`` angegebene Liste muss genau dem Benutzer entsprechen, mit welchem der Request authentisiert ist. Es ist also nicht erlaubt, Benachrichtigungen an andere Benutzer auszulösen, sondern nur an sich selbst.
+   Beim Aufrufen einer solchen Benachrichtigung wird der Empfänger zu der in ``resource_url`` angegebenen URL weitergeleitet.
 
-   **Ausnahme**: Benutzer mit der Rolle ``PrivilegedNotificationDispatcher`` dürfen auch Benachrichtigungen an andere Benutzer als sich selbst auslösen.
+   Die in ``notification_recipients`` angegebene Liste muss IDs von Benutzern und/oder Gruppen enthalten, an welche eine Benachrichtigung ausgelöst werden soll.
 
-   Dies setzt dementsprechend voraus, dass die externe Applikation als vertrauenswürdig eingestuft wurde, und GEVER so konfiguriert ist, von dieser Applikation Requests im Kontext des Benutzers zu erlauben.
 
-   Beim Aufrufen einer solchen Benachrichtigung wird der Benutzer zu der in ``resource_url`` angegebenen URL weitergeleitet.
+   .. note::
+
+      API-Benutzer mit normalen Berechtigungen dürfen ausschliesslich Benachrichtigungen **an ihren eigenen Benutzer auslösen** (Schutz vor Missbrauch).
+
+      Dieser Anwendungsfall setzt dementsprechend voraus, dass die externe Applikation als vertrauenswürdig eingestuft wurde, und GEVER so konfiguriert ist, von dieser Applikation Requests im *Kontext des Benutzers* zu erlauben (Impersonation).
+
+      API-Benutzer mit der Rolle ``PrivilegedNotificationDispatcher`` dürfen hingegen Benachrichtigungen an **beliebige Benutzer** auslösen, insbesondere indirekt via Angabe von Gruppen.
+
+      Dieser Anwendungsfall bedingt einen Service-Account für die externe Applikation, welchem die ``PrivilegedNotificationDispatcher`` Rolle zugewiesen wird. Die Anmeldung erfolgt in diesem fall nicht im Kontext des Benutzers, sondern regulär mit dem Service-Account.
+
 
    **Request**:
 

--- a/docs/public/dev-manual/api/external_activities.rst
+++ b/docs/public/dev-manual/api/external_activities.rst
@@ -15,6 +15,8 @@ Externe Aktivität erzeugen (POST)
 
    Die in ``notification_recipients`` angegebene Liste muss genau dem Benutzer entsprechen, mit welchem der Request authentisiert ist. Es ist also nicht erlaubt, Benachrichtigungen an andere Benutzer auszulösen, sondern nur an sich selbst.
 
+   **Ausnahme**: Benutzer mit der Rolle ``PrivilegedNotificationDispatcher`` dürfen auch Benachrichtigungen an andere Benutzer als sich selbst auslösen.
+
    Dies setzt dementsprechend voraus, dass die externe Applikation als vertrauenswürdig eingestuft wurde, und GEVER so konfiguriert ist, von dieser Applikation Requests im Kontext des Benutzers zu erlauben.
 
    Beim Aufrufen einer solchen Benachrichtigung wird der Benutzer zu der in ``resource_url`` angegebenen URL weitergeleitet.

--- a/opengever/activity/dispatcher.py
+++ b/opengever/activity/dispatcher.py
@@ -83,7 +83,7 @@ class NotificationDispatcher(object):
             except BaseException:
                 e_type, e_value, tb = sys.exc_info()
                 maybe_report_exception(self.context, self.request, e_type, e_value, tb)
-                not_dispatched.append(notifications)
+                not_dispatched.append(notification)
                 formatted_traceback = ''.join(traceback.format_exception(e_type, e_value, tb))
                 logger.error('Exception while dispatch activity (MailDispatcher):\n%s', formatted_traceback)
 

--- a/opengever/activity/tests/test_plone_center.py
+++ b/opengever/activity/tests/test_plone_center.py
@@ -117,8 +117,8 @@ class TestNotifactionCenterErrorHandling(FunctionalTestCase):
 
         browser.css('#form-buttons-save').first.click()
 
-        self.assertEquals([], warning_messages())
-        self.assertEquals(['Item created'], info_messages())
+        self.assertEqual([], warning_messages())
+        self.assertEqual(['Item created'], info_messages())
 
     @browsing
     def test_missing_email_address_for_notification_recipient_doesnt_produce_warning(self, browser):
@@ -136,5 +136,5 @@ class TestNotifactionCenterErrorHandling(FunctionalTestCase):
 
         browser.css('#form-buttons-save').first.click()
 
-        self.assertEquals([], warning_messages())
-        self.assertEquals(['Item created'], info_messages())
+        self.assertEqual([], warning_messages())
+        self.assertEqual(['Item created'], info_messages())

--- a/opengever/activity/tests/test_plone_center.py
+++ b/opengever/activity/tests/test_plone_center.py
@@ -1,6 +1,5 @@
 from ftw.builder import Builder
 from ftw.builder import create
-from ftw.testbrowser import browser
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages.statusmessages import info_messages
 from ftw.testbrowser.pages.statusmessages import warning_messages
@@ -65,7 +64,7 @@ class TestPloneNotificationCenter(FunctionalTestCase):
         self.dossier = create(Builder('dossier').titled(u'Dossier A'))
 
     @browsing
-    def test_add_watcher_adds_subscription_for_each_actor(self, member):
+    def test_add_watcher_adds_subscription_for_each_actor(self, browser):
         browser.login().open(self.dossier, view='++add++opengever.task.task')
         browser.fill({'Title': 'Test Task',
                       'Task type': 'comment'})
@@ -104,7 +103,7 @@ class TestNotifactionCenterErrorHandling(FunctionalTestCase):
         self.dossier = create(Builder('dossier').titled(u'Dossier A'))
 
     @browsing
-    def test_successfully_add_activity(self, member):
+    def test_successfully_add_activity(self, browser):
         create(Builder('ogds_user')
                .having(userid='hugo.boss'))
 
@@ -122,7 +121,7 @@ class TestNotifactionCenterErrorHandling(FunctionalTestCase):
         self.assertEquals(['Item created'], info_messages())
 
     @browsing
-    def test_missing_email_address_for_notification_recipient_doesnt_produce_warning(self, member):
+    def test_missing_email_address_for_notification_recipient_doesnt_produce_warning(self, browser):
         create(Builder('ogds_user')
                .having(userid='hugo.boss', email=None)
                .in_group(self.org_unit.users_group))

--- a/opengever/api/external_activities.py
+++ b/opengever/api/external_activities.py
@@ -29,10 +29,12 @@ class ExternalActivitiesPost(Service):
 
     def check_authorization(self, data):
         current_userid = api.user.get_current().getId()
-        if data.get('notification_recipients') != [current_userid]:
-            raise Unauthorized(
-                "Insufficient privileges to create external activities with "
-                "notification recipients other than yourself.")
+        recipients = data.get('notification_recipients')
+        if recipients and recipients != [current_userid]:
+            if not api.user.has_permission('opengever.api: Notify Arbitrary Users'):
+                raise Unauthorized(
+                    "Insufficient privileges to create external activities "
+                    "with notification recipients other than yourself.")
 
     def reply(self):
         # Disable CSRF protection

--- a/opengever/api/permissions.zcml
+++ b/opengever/api/permissions.zcml
@@ -6,5 +6,6 @@
   <permission id="opengever.api.TransferAssignment" title="opengever.api: Transfer Assignment" />
   <permission id="opengever.api.ManageRoleAssignmentReports" title="opengever.api: Manage Role Assignment Reports" />
   <permission id="opengever.api.ManageGroups" title="opengever.api: Manage Groups" />
+  <permission id="opengever.api.NotifyArbitraryUsers" title="opengever.api: Notify Arbitrary Users" />
 
 </configure>

--- a/opengever/base/monkey/patches/readonly.py
+++ b/opengever/base/monkey/patches/readonly.py
@@ -124,6 +124,7 @@ class PatchMembershipToolCreateMemberarea(MonkeyPatch):
 WRITER_ROLES = [
     'Contributor',
     'Editor',
+    'PrivilegedNotificationDispatcher',
     'PropertySheetsManager',
     'Publisher',
     'Reviewer',
@@ -227,6 +228,7 @@ WRITE_PERMISSIONS = [
     'ftw.usermigration: Migrate users',
     'opengever.api: Manage Groups',
     'opengever.api: Manage Role Assignment Reports',
+    'opengever.api: Notify Arbitrary Users',
     'opengever.api: Transfer Assignment',
     'opengever.contact: Edit person',
     'opengever.contact: Edit team',

--- a/opengever/core/lawgiver.zcml
+++ b/opengever/core/lawgiver.zcml
@@ -219,6 +219,7 @@
                    ftw.usermigration: Migrate users,
                    opengever.api: Manage Groups,
                    opengever.api: Manage Role Assignment Reports,
+                   opengever.api: Notify Arbitrary Users,
                    opengever.api: Transfer Assignment,
                    opengever.api: View AllowedRolesAndPrincipals,
                    opengever.bumblebee: Revive Preview,

--- a/opengever/core/profiles/default/rolemap.xml
+++ b/opengever/core/profiles/default/rolemap.xml
@@ -10,6 +10,7 @@
     <role name="Impersonator" />
     <role name="LimitedAdmin" />
     <role name="MeetingUser" />
+    <role name="PrivilegedNotificationDispatcher" />
     <role name="PropertySheetsManager" />
     <role name="Publisher" />
     <role name="Records Manager" />
@@ -26,6 +27,11 @@
   </roles>
 
   <permissions>
+
+    <!-- API -->
+    <permission name="opengever.api: Notify Arbitrary Users" acquire="True">
+      <role name="PrivilegedNotificationDispatcher" />
+    </permission>
 
     <!-- BASE -->
     <permission name="Remove GEVER content" acquire="True">

--- a/opengever/core/upgrades/20220316122716_add_global_privileged_notification_dispatcher_role/rolemap.xml
+++ b/opengever/core/upgrades/20220316122716_add_global_privileged_notification_dispatcher_role/rolemap.xml
@@ -1,0 +1,16 @@
+<rolemap>
+
+  <roles>
+    <role name="PrivilegedNotificationDispatcher" />
+  </roles>
+
+  <permissions>
+
+    <!-- API -->
+    <permission name="opengever.api: Notify Arbitrary Users" acquire="True">
+      <role name="PrivilegedNotificationDispatcher" />
+    </permission>
+
+  </permissions>
+
+</rolemap>

--- a/opengever/core/upgrades/20220316122716_add_global_privileged_notification_dispatcher_role/upgrade.py
+++ b/opengever/core/upgrades/20220316122716_add_global_privileged_notification_dispatcher_role/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddGlobalPrivilegedNotificationDispatcherRole(UpgradeStep):
+    """Add global PrivilegedNotificationDispatcher role.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
This adds support for the `notification_recipients` parameter on `@external-activities` to also accept group IDs, resolve them to their members, and dispatch notification to those users.

For this, sending notifications to users _other than yourself_ had to be allowed in that endpoint for users with the necessary privileges. The new permission `opengever.api: Notify Arbitrary Users` allows this (assigned to the new `PrivilegedNotificationDispatcher` role).

In addition, I improved the error handling in that endpoint. Most problems should only cause soft errors, that are reported in an `{'errors': [...]}` list in the response, but still with status `201 Created`.

For [CA-3274](https://4teamwork.atlassian.net/browse/CA-3274)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry
