### PR TITLE
Register description for the new closed-in-progress transition.

### DIFF
--- a/opengever/task/response_description.py
+++ b/opengever/task/response_description.py
@@ -276,7 +276,8 @@ ResponseDescription.add_description(Reopen)
 
 class Revise(ResponseDescription):
 
-    transition = 'task-transition-resolved-in-progress'
+    transitions = ['task-transition-resolved-in-progress',
+                   'task-transition-tested-and-closed-in-progress']
     css_class = 'revise'
 
     def msg(self):


### PR DESCRIPTION
By reusing the revise response description, the state icon is displayed correctly in the classic UI.

Small fix for the new transition introduced in #7400 for the classic ui.

For [CA-3579]


[CA-3579]: https://4teamwork.atlassian.net/browse/CA-3579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ