### PR TITLE
Add gever_url field to workspaces, documents and mails

### DIFF
--- a/changes/CA-3707.feature
+++ b/changes/CA-3707.feature
@@ -1,0 +1,1 @@
+Add gever_url field to workspaces, documents and mails. [tinagerber]

--- a/docs/schema-dumps/ftw.mail.mail.schema.json
+++ b/docs/schema-dumps/ftw.mail.mail.schema.json
@@ -142,6 +142,12 @@
             "description": "",
             "_zope_schema_type": "Int"
         },
+        "gever_url": {
+            "type": "string",
+            "title": "GEVER URL",
+            "description": "",
+            "_zope_schema_type": "TextLine"
+        },
         "title": {
             "type": "string",
             "title": "Titel",
@@ -189,6 +195,7 @@
         "preserved_as_paper",
         "archival_file",
         "archival_file_state",
+        "gever_url",
         "title",
         "original_message",
         "message_source",

--- a/docs/schema-dumps/opengever.document.document.schema.json
+++ b/docs/schema-dumps/opengever.document.document.schema.json
@@ -155,6 +155,12 @@
             "description": "",
             "_zope_schema_type": "Int"
         },
+        "gever_url": {
+            "type": "string",
+            "title": "GEVER URL",
+            "description": "",
+            "_zope_schema_type": "TextLine"
+        },
         "custom_properties": {
             "type": "object",
             "title": "Benutzerdefinierte Felder",
@@ -182,6 +188,7 @@
         "preserved_as_paper",
         "archival_file",
         "archival_file_state",
+        "gever_url",
         "custom_properties"
     ]
 }

--- a/docs/schema-dumps/opengever.workspace.workspace.schema.json
+++ b/docs/schema-dumps/opengever.workspace.workspace.schema.json
@@ -24,6 +24,12 @@
             "description": "",
             "_zope_schema_type": "TextLine"
         },
+        "gever_url": {
+            "type": "string",
+            "title": "GEVER URL",
+            "description": "",
+            "_zope_schema_type": "TextLine"
+        },
         "changed": {
             "type": "string",
             "title": "Zuletzt ver\u00e4ndert",
@@ -51,6 +57,7 @@
         "responsible",
         "videoconferencing_url",
         "external_reference",
+        "gever_url",
         "changed",
         "title",
         "description"

--- a/opengever/api/linked_workspaces.py
+++ b/opengever/api/linked_workspaces.py
@@ -141,6 +141,7 @@ class RemoveDossierReferencePost(Service):
         if not user_agent.startswith('opengever.core/'):
             raise Unauthorized
         self.context.external_reference = u''
+        self.context.gever_url = u''
         self.context.reindexObject(idxs=["external_reference"])
         return self.reply_no_content()
 

--- a/opengever/api/tests/test_linked_workspaces.py
+++ b/opengever/api/tests/test_linked_workspaces.py
@@ -4,6 +4,7 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser.exceptions import HTTPServerError
 from opengever.base.command import CreateEmailCommand
 from opengever.base.oguid import Oguid
+from opengever.document.behaviors.metadata import IDocumentMetadata
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.document.versioner import Versioner
 from opengever.locking.lock import LOCK_TYPE_COPIED_TO_WORKSPACE_LOCK
@@ -537,6 +538,8 @@ class TestCopyDocumentToWorkspacePost(FunctionalWorkspaceClientTestCase):
                 [],
                 ILinkedDocuments(document).linked_workspace_documents)
 
+            self.assertEqual(u'', IDocumentMetadata(workspace_document).gever_url)
+
     @browsing
     def test_copy_document_with_file_to_a_workspace(self, browser):
         document = create(Builder('document')
@@ -583,6 +586,10 @@ class TestCopyDocumentToWorkspacePost(FunctionalWorkspaceClientTestCase):
             self.assertEqual(
                 {'UID': IUUID(document)},
                 ILinkedDocuments(workspace_document).linked_gever_document)
+
+            expected_gever_url = '{}/@resolve-oguid?oguid={}'.format(
+                api.portal.get().absolute_url(), Oguid.for_object(document).id)
+            self.assertEqual(expected_gever_url, IDocumentMetadata(workspace_document).gever_url)
 
             # XXX: Because of the way these tests works, setting of the link
             # to the workspace documents on this GEVER document happens in
@@ -640,6 +647,10 @@ class TestCopyDocumentToWorkspacePost(FunctionalWorkspaceClientTestCase):
             self.assertEqual(
                 {'UID': IUUID(mail)},
                 ILinkedDocuments(workspace_mail).linked_gever_document)
+
+            expected_gever_url = '{}/@resolve-oguid?oguid={}'.format(
+                api.portal.get().absolute_url(), Oguid.for_object(mail).id)
+            self.assertEqual(expected_gever_url, IDocumentMetadata(workspace_mail).gever_url)
 
             # XXX: Because of the way these tests works, setting of the link
             # to the workspace documents on this GEVER document happens in
@@ -1140,11 +1151,13 @@ class TestCopyDocumentFromWorkspacePost(FunctionalWorkspaceClientTestCase):
 
         workspace_doc = create(Builder('document')
                                .within(self.workspace)
+                               .having(gever_url=u'url')
                                .attach_file_containing(new_content,
                                                        name=new_filename))
 
         ILinkedDocuments(workspace_doc).link_gever_document(IUUID(gever_doc))
         ILinkedDocuments(gever_doc).link_workspace_document(IUUID(workspace_doc))
+        self.assertEqual(u'url', IDocumentMetadata(workspace_doc).gever_url)
 
         payload = {
             'workspace_uid': IUUID(self.workspace),
@@ -1192,6 +1205,8 @@ class TestCopyDocumentFromWorkspacePost(FunctionalWorkspaceClientTestCase):
             self.assertEqual(
                 RETRIEVAL_MODE_VERSION,
                 browser.json.get('teamraum_connect_retrieval_mode'))
+
+            self.assertEqual(u'', IDocumentMetadata(gever_doc).gever_url)
 
     @browsing
     def test_copy_eml_mail_from_a_workspace(self, browser):

--- a/opengever/api/tests/test_linked_workspaces.py
+++ b/opengever/api/tests/test_linked_workspaces.py
@@ -78,10 +78,13 @@ class TestLinkedWorkspacesPost(FunctionalWorkspaceClientTestCase):
                       [aa.absolute_url() for aa in children['added']])
 
         linked_workspace = children['added'].pop()
-        self.assertIn(browser.json.get('title'),
-                      linked_workspace.title)
-        self.assertIn(browser.json.get('external_reference'),
-                      Oguid.for_object(self.dossier).id)
+        self.assertEqual(browser.json.get('title'),
+                         linked_workspace.title)
+        dossier_oguid = Oguid.for_object(self.dossier).id
+        expected_gever_url = '{}/@resolve-oguid?oguid={}'.format(
+            api.portal.get().absolute_url(), dossier_oguid)
+        self.assertEqual(browser.json.get('external_reference'), dossier_oguid)
+        self.assertEqual(expected_gever_url, linked_workspace.gever_url)
 
     @browsing
     def test_raise_not_found_if_feature_is_not_activated(self, browser):
@@ -166,7 +169,12 @@ class TestLinkToWorkspacesPost(FunctionalWorkspaceClientTestCase):
                          'Content-Type': 'application/json'})
 
         self.assertEqual(204, browser.status_code)
-        self.assertEqual(Oguid.for_object(self.dossier).id, self.workspace.external_reference)
+        dossier_oguid = Oguid.for_object(self.dossier).id
+        expected_gever_url = '{}/@resolve-oguid?oguid={}'.format(
+            api.portal.get().absolute_url(), dossier_oguid)
+
+        self.assertEqual(dossier_oguid, self.workspace.external_reference)
+        self.assertEqual(expected_gever_url, self.workspace.gever_url)
 
     @browsing
     def test_raises_not_found_if_workspaceclient_feature_not_enabled(self, browser):

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -149,6 +149,7 @@ DOCUMENT_DEFAULTS = {
     'digitally_available': True,
     'document_date': FROZEN_TODAY,
     'file': None,  # needs to be updated with NamedBlobFile in actual test
+    'gever_url': u'',
     'keywords': (),
     'preserved_as_paper': True,
     'privacy_layer': u'privacy_layer_no',
@@ -180,6 +181,7 @@ MAIL_DEFAULTS = {
     'digitally_available': True,
     'document_author': u'from@example.org',
     'document_date': date(2010, 1, 1),
+    'gever_url': u'',
     'keywords': (),
     'preserved_as_paper': True,
     'privacy_layer': u'privacy_layer_no',

--- a/opengever/bundle/schemas/documents.schema.json
+++ b/opengever/bundle/schemas/documents.schema.json
@@ -192,6 +192,15 @@
                     "_zope_schema_type": "Bool",
                     "default": true
                 },
+                "gever_url": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "title": "GEVER URL",
+                    "description": "",
+                    "_zope_schema_type": "TextLine"
+                },
                 "custom_properties": {
                     "type": [
                         "null",
@@ -295,6 +304,7 @@
                 "preserved_as_paper",
                 "archival_file",
                 "archival_file_state",
+                "gever_url",
                 "custom_properties"
             ]
         }

--- a/opengever/bundle/schemas/workspaces.schema.json
+++ b/opengever/bundle/schemas/workspaces.schema.json
@@ -39,6 +39,15 @@
                     "description": "",
                     "_zope_schema_type": "TextLine"
                 },
+                "gever_url": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "title": "GEVER URL",
+                    "description": "",
+                    "_zope_schema_type": "TextLine"
+                },
                 "changed": {
                     "type": [
                         "null",
@@ -111,6 +120,7 @@
                 "responsible",
                 "videoconferencing_url",
                 "external_reference",
+                "gever_url",
                 "changed",
                 "title",
                 "description"

--- a/opengever/document/behaviors/metadata.py
+++ b/opengever/document/behaviors/metadata.py
@@ -175,6 +175,14 @@ class IDocumentMetadata(model.Schema):
         required=False,
         )
 
+    form.omitted('gever_url')
+    gever_url = schema.TextLine(
+        title=_(u'label_gever_url', default=u'GEVER URL'),
+        required=False,
+        default=u'',
+        missing_value=u''
+    )
+
     @invariant
     def scan_for_virus(data):
         if data.archival_file:
@@ -184,4 +192,3 @@ class IDocumentMetadata(model.Schema):
 
 
 alsoProvides(IDocumentMetadata, IFormFieldProvider)
-

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-11-05 08:34+0000\n"
+"POT-Creation-Date: 2022-03-22 12:50+0000\n"
 "PO-Revision-Date: 2017-10-13 14:27+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -522,6 +522,11 @@ msgstr "Datei"
 #: ./opengever/document/behaviors/metadata.py
 msgid "label_foreign_reference"
 msgstr "Fremdzeichen"
+
+#. Default: "GEVER URL"
+#: ./opengever/document/behaviors/metadata.py
+msgid "label_gever_url"
+msgstr "GEVER URL"
 
 #. Default: "Keywords"
 #: ./opengever/document/behaviors/metadata.py

--- a/opengever/document/locales/en/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/en/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-11-05 08:34+0000\n"
+"POT-Creation-Date: 2022-03-22 12:50+0000\n"
 "PO-Revision-Date: 2017-10-13 14:27+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -631,6 +631,11 @@ msgstr "File"
 #: ./opengever/document/behaviors/metadata.py
 msgid "label_foreign_reference"
 msgstr "Foreign reference"
+
+#. Default: "GEVER URL"
+#: ./opengever/document/behaviors/metadata.py
+msgid "label_gever_url"
+msgstr "GEVER URL"
 
 #. German translation: Schlagwörter
 #. Default: "Keywords"

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-11-05 08:34+0000\n"
+"POT-Creation-Date: 2022-03-22 12:50+0000\n"
 "PO-Revision-Date: 2017-09-03 08:50+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-document/fr/>\n"
@@ -519,6 +519,11 @@ msgstr "Fichier"
 #: ./opengever/document/behaviors/metadata.py
 msgid "label_foreign_reference"
 msgstr "Code externe"
+
+#. Default: "GEVER URL"
+#: ./opengever/document/behaviors/metadata.py
+msgid "label_gever_url"
+msgstr "GEVER URL"
 
 #. Default: "Keywords"
 #: ./opengever/document/behaviors/metadata.py

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-11-05 08:34+0000\n"
+"POT-Creation-Date: 2022-03-22 12:50+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -516,6 +516,11 @@ msgstr ""
 #. Default: "Foreign Reference"
 #: ./opengever/document/behaviors/metadata.py
 msgid "label_foreign_reference"
+msgstr ""
+
+#. Default: "GEVER URL"
+#: ./opengever/document/behaviors/metadata.py
+msgid "label_gever_url"
 msgstr ""
 
 #. Default: "Keywords"

--- a/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-12-17 09:30+0000\n"
+"POT-Creation-Date: 2022-03-22 12:17+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -185,6 +185,11 @@ msgstr "Ende"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_folders"
 msgstr "Ordner"
+
+#. Default: "GEVER URL"
+#: ./opengever/workspace/workspace.py
+msgid "label_gever_url"
+msgstr "GEVER URL"
 
 #. Default: "Journal"
 #: ./opengever/workspace/browser/tabbed.py

--- a/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-12-17 09:30+0000\n"
+"POT-Creation-Date: 2022-03-22 12:17+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -216,6 +216,11 @@ msgstr "End"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_folders"
 msgstr "Folders"
+
+#. Default: "GEVER URL"
+#: ./opengever/workspace/workspace.py
+msgid "label_gever_url"
+msgstr "GEVER URL"
 
 #. German translation: Journal
 #. Default: "Journal"

--- a/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-12-17 09:30+0000\n"
+"POT-Creation-Date: 2022-03-22 12:17+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -185,6 +185,11 @@ msgstr "Fin"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_folders"
 msgstr "Répertoires"
+
+#. Default: "GEVER URL"
+#: ./opengever/workspace/workspace.py
+msgid "label_gever_url"
+msgstr "GEVER URL"
 
 #. Default: "Journal"
 #: ./opengever/workspace/browser/tabbed.py

--- a/opengever/workspace/locales/opengever.workspace.pot
+++ b/opengever/workspace/locales/opengever.workspace.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-12-17 09:30+0000\n"
+"POT-Creation-Date: 2022-03-22 12:17+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -181,6 +181,11 @@ msgstr ""
 #. Default: "Folders"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_folders"
+msgstr ""
+
+#. Default: "GEVER URL"
+#: ./opengever/workspace/workspace.py
+msgid "label_gever_url"
 msgstr ""
 
 #. Default: "Journal"

--- a/opengever/workspace/workspace.py
+++ b/opengever/workspace/workspace.py
@@ -103,7 +103,7 @@ class WorkspaceContentPatch(ContentPatch):
     def reply(self):
         data = json_body(self.request)
         if data.keys() != ['ordering']:
-            if data.keys() == ['external_reference']:
+            if data.keys() == ['gever_url', 'external_reference']:
                 if not api.user.has_permission('Modify portal content', obj=self.context):
                     raise Unauthorized()
             else:

--- a/opengever/workspace/workspace.py
+++ b/opengever/workspace/workspace.py
@@ -59,6 +59,13 @@ class IWorkspaceSchema(model.Schema):
         default=u'',
         missing_value=u''
     )
+    directives.omitted('gever_url')
+    gever_url = schema.TextLine(
+        title=_(u'label_gever_url', default=u'GEVER URL'),
+        required=False,
+        default=u'',
+        missing_value=u''
+    )
 
 
 class Workspace(WorkspaceBase):

--- a/opengever/workspaceclient/client.py
+++ b/opengever/workspaceclient/client.py
@@ -79,6 +79,9 @@ class WorkspaceClient(object):
 
         return self.request.post('/workspaces', json=payload).json()
 
+    def get_gever_url(self, oguid):
+        return '{}/@resolve-oguid?oguid={}'.format(api.portal.get().absolute_url(), oguid)
+
     def link_to_workspace(self, workspace_uid, dossier_oguid):
         """ Sets dossier_oguid as external_reference of the workspace
         and returns the serialization of the workspace
@@ -87,7 +90,8 @@ class WorkspaceClient(object):
         if workspace.get('external_reference'):
             raise LookupError("Workspace is already linked to a dossier")
         return self.request.patch(workspace.get('@id'),
-                                  json={'external_reference': dossier_oguid},
+                                  json={'external_reference': dossier_oguid,
+                                        'gever_url': self.get_gever_url(dossier_oguid)},
                                   headers={'Prefer': 'return=representation'}).json()
 
     def update_dossier_uid(self, workspace_uid, new_dossier_oguid):
@@ -96,7 +100,8 @@ class WorkspaceClient(object):
         workspace = self.get_by_uid(uid=workspace_uid)
         return self.request.patch(
             workspace.get('@id'),
-            json={'external_reference': new_dossier_oguid})
+            json={'external_reference': new_dossier_oguid,
+                  'gever_url': self.get_gever_url(new_dossier_oguid)})
 
     def unlink_workspace(self, workspace_uid):
         """Removes external_reference on the workspace"""

--- a/opengever/workspaceclient/linked_workspaces.py
+++ b/opengever/workspaceclient/linked_workspaces.py
@@ -233,6 +233,8 @@ class LinkedWorkspaces(object):
             # since there's no file that could be transferred back.
             return self.client.post(workspace_url, json=document_repr)
 
+        document_metadata['gever_url'] = self.client.get_gever_url(Oguid.for_object(document).id)
+
         content_type = document.content_type()
         filename = document.get_filename()
         gever_document_uid = document.UID()
@@ -300,7 +302,7 @@ class LinkedWorkspaces(object):
             document_repr['message']['data'] = data.content
 
         # We should avoid setting the id ourselves, can lead to conflicts
-        document_repr = self._blacklisted_dict(document_repr, ['id'])
+        document_repr = self._blacklisted_dict(document_repr, ['id', 'gever_url'])
 
         workspace_title = self.client.get_by_uid(workspace_uid).get('title')
 

--- a/opengever/workspaceclient/linked_workspaces.py
+++ b/opengever/workspaceclient/linked_workspaces.py
@@ -130,7 +130,9 @@ class LinkedWorkspaces(object):
         This function returns the serialized workspace.
         """
         if isinstance(data, dict):
-            data['external_reference'] = Oguid.for_object(self.context).id
+            oguid = Oguid.for_object(self.context).id
+            data['external_reference'] = oguid
+            data['gever_url'] = self.client.get_gever_url(oguid)
         workspace = self.client.create_workspace(**data)
         self.storage.add(workspace.get('UID'))
         if not ILinkedToWorkspace.providedBy(self.context):

--- a/opengever/workspaceclient/tests/test_client.py
+++ b/opengever/workspaceclient/tests/test_client.py
@@ -129,10 +129,14 @@ class TestWorkspaceClient(FunctionalWorkspaceClientTestCase):
             client.link_to_workspace(self.workspace.UID(), dossier_oguid)
             transaction.commit()
             self.assertEqual(dossier_oguid, self.workspace.external_reference)
+            gever_url = '{}/@resolve-oguid?oguid={}'.format(
+                api.portal.get().absolute_url(), dossier_oguid)
+            self.assertEqual(gever_url, self.workspace.gever_url)
 
             client.unlink_workspace(self.workspace.UID())
             transaction.commit()
             self.assertEqual(u'', self.workspace.external_reference)
+            self.assertEqual(u'', self.workspace.gever_url)
 
     def test_unlink_deactivated_workspace(self):
         dossier_oguid = Oguid.for_object(self.dossier).id
@@ -140,6 +144,9 @@ class TestWorkspaceClient(FunctionalWorkspaceClientTestCase):
             client.link_to_workspace(self.workspace.UID(), dossier_oguid)
             transaction.commit()
             self.assertEqual(dossier_oguid, self.workspace.external_reference)
+            gever_url = '{}/@resolve-oguid?oguid={}'.format(
+                api.portal.get().absolute_url(), dossier_oguid)
+            self.assertEqual(gever_url, self.workspace.gever_url)
 
             self.grant('WorkspaceAdmin', *api.user.get_roles(), on=self.workspace)
             api.content.transition(
@@ -150,3 +157,4 @@ class TestWorkspaceClient(FunctionalWorkspaceClientTestCase):
             client.unlink_workspace(self.workspace.UID())
             transaction.commit()
             self.assertEqual(u'', self.workspace.external_reference)
+            self.assertEqual(u'', self.workspace.gever_url)

--- a/opengever/workspaceclient/tests/test_linked_workspaces.py
+++ b/opengever/workspaceclient/tests/test_linked_workspaces.py
@@ -848,11 +848,13 @@ class TestMoveLinkedWorkspacesDossiers(FunctionalWorkspaceClientTestCase):
             manager = ILinkedWorkspaces(self.dossier)
             manager.storage.add(self.workspace.UID())
             alsoProvides(self.dossier, ILinkedToWorkspace)
-            self.workspace.reindexObject(idxs=['object_provides'])
-            self.workspace.external_reference = self.dossier.UID()
+            self.dossier.reindexObject(idxs=['object_provides'])
+            self.workspace.external_reference = 'an oguid'
+            self.workspace.gever_url = u'url'
 
             target_dossier = create(Builder('dossier'))
-            api.content.move(source=self.dossier, target=target_dossier)
+            with auto_commit_after_request(manager.client):
+                api.content.move(source=self.dossier, target=target_dossier)
 
             self.assertTrue(ILinkedToWorkspace.providedBy(target_dossier))
             self.assertFalse(ILinkedToWorkspace.providedBy(self.dossier))
@@ -863,6 +865,10 @@ class TestMoveLinkedWorkspacesDossiers(FunctionalWorkspaceClientTestCase):
             target_dossier_adapter = ILinkedWorkspaces(target_dossier)
             self.assertEqual(1, target_dossier_adapter.list()['items_total'])
             self.assertIn(self.workspace.UID(), target_dossier_adapter.storage)
+            gever_url = '{}/@resolve-oguid?oguid={}'.format(
+                api.portal.get().absolute_url(), Oguid.for_object(target_dossier).id)
+            self.assertEqual(Oguid.for_object(target_dossier).id, self.workspace.external_reference)
+            self.assertEqual(gever_url, self.workspace.gever_url)
 
 
 class TestLinkedWorkspacesJournalization(FunctionalWorkspaceClientTestCase):


### PR DESCRIPTION
We add a field `gever_url` to workspaces and documents. If a workspace is linked to a dossier, `gever_url` refers to the linked dossier. If a workspace document is linked to GEVER document, `gever_url` refers to the linked GEVER document.

For [CA-3707]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- New functionality:
  - [x] for `document` also works for `mail`
- New translations
  - [x] All msg-strings are unicode


[CA-3707]: https://4teamwork.atlassian.net/browse/CA-3707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ