### PR TITLE
Allow normal users to revive bumblebee previews in Teamraum.

### DIFF
--- a/changes/CA-3890.other
+++ b/changes/CA-3890.other
@@ -1,0 +1,1 @@
+Allow normal users to revive bumblebee previews in Teamraum. [njohner]

--- a/opengever/bumblebee/tests/test_revive_bumblebee_preview.py
+++ b/opengever/bumblebee/tests/test_revive_bumblebee_preview.py
@@ -58,6 +58,16 @@ class TestReviveBumblebeePreview(IntegrationTestCase):
             browser.css('.actionMenuContent li').text)
 
     @browsing
+    def test_action_is_enabled_for_workspace_member_on_bumblebee_document(self, browser):
+        self.login(self.workspace_member, browser)
+        browser.visit(self.workspace_document)
+
+        self.assertTrue(IBumblebeeable.providedBy(self.workspace_document))
+        self.assertIn(
+            'Regenerate PDF preview',
+            browser.css('.actionMenuContent li').text)
+
+    @browsing
     def test_show_status_message_after_reviving(self, browser):
         self.login(self.administrator, browser)
 

--- a/opengever/core/profiles/default/rolemap.xml
+++ b/opengever/core/profiles/default/rolemap.xml
@@ -73,6 +73,9 @@
       <role name="LimitedAdmin" />
       <role name="Manager" />
       <role name="Reader" />
+      <role name="WorkspaceAdmin" />
+      <role name="WorkspaceMember" />
+      <role name="WorkspaceGuest" />
     </permission>
 
     <permission name="opengever.api: View AllowedRolesAndPrincipals" acquire="False">

--- a/opengever/core/upgrades/20220323170920_allow_to_revive_bumblebee_previews_in_teamraum/rolemap.xml
+++ b/opengever/core/upgrades/20220323170920_allow_to_revive_bumblebee_previews_in_teamraum/rolemap.xml
@@ -1,0 +1,15 @@
+<rolemap>
+  <permissions>
+
+    <permission name="opengever.bumblebee: Revive Preview" acquire="True">
+      <role name="Administrator" />
+      <role name="LimitedAdmin" />
+      <role name="Manager" />
+      <role name="Reader" />
+      <role name="WorkspaceAdmin" />
+      <role name="WorkspaceMember" />
+      <role name="WorkspaceGuest" />
+    </permission>
+
+  </permissions>
+</rolemap>

--- a/opengever/core/upgrades/20220323170920_allow_to_revive_bumblebee_previews_in_teamraum/upgrade.py
+++ b/opengever/core/upgrades/20220323170920_allow_to_revive_bumblebee_previews_in_teamraum/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AllowToReviveBumblebeePreviewsInTeamraum(UpgradeStep):
+    """Allow to revive bumblebee previews in teamraum.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
In https://github.com/4teamwork/opengever.core/pull/7127 we allowed normal users to revive bumblebee previews in Gever, but forgot that in teamraum deployments nobody is `Reader`... This is confusing as the action appears for broken previews in the new frontend but basically does nothing.

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-3890]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)

[CA-3890]: https://4teamwork.atlassian.net/browse/CA-3890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ