### PR TITLE
Add feature flags to disable link actions and restrict workspace creation

### DIFF
--- a/changes/CA-3597-1.feature
+++ b/changes/CA-3597-1.feature
@@ -1,0 +1,1 @@
+Add feature flag for link_to workspace action. [tinagerber]

--- a/changes/CA-3597-2.feature
+++ b/changes/CA-3597-2.feature
@@ -1,0 +1,1 @@
+Add feature flag to restrict workspace creation in UI. [tinagerber]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -14,6 +14,7 @@ Other Changes
 ^^^^^^^^^^^^^
 - ``@external-activities``: ``notification_recipients`` now also accepts group IDs.
 - ``@external-activities``: Privileged users may now create notifications for other users (see :ref:`external-activities`)
+- ``@config``: Add ``workspace_creation_restricted`` feature flag.
 
 
 2022.6.0 (2022-03-15)

--- a/docs/public/dev-manual/api/config.rst
+++ b/docs/public/dev-manual/api/config.rst
@@ -93,6 +93,7 @@ GEVER-Mandanten abgefragt werden.
               "tasks_pdf": false,
               "workspace": false,
               "workspace_client": false,
+              "workspace_creation_restricted": false,
               "workspace_meetings": false,
               "workspace_todo": false,
           },
@@ -258,6 +259,9 @@ features
 
     workspace_client
         Integration von GEVER mit einem Teamraum
+
+    workspace_creation_restricted
+        Direkete Teamraum-Erstellung deaktivieren
 
     workspace_meetings
         Meetings in einem Teamraum

--- a/opengever/api/tests/test_actions.py
+++ b/opengever/api/tests/test_actions.py
@@ -1361,6 +1361,20 @@ class TestWorkspaceClientFolderActions(FunctionalWorkspaceClientTestCase):
             self.assert_workspace_actions_not_available(browser, self.dossier)
 
     @browsing
+    def test_link_to_workspace_action_only_available_if_linking_activated(self, browser):
+        browser.login()
+        with self.workspace_client_env():
+            self.link_workspace(self.dossier)
+            actions = self.get_actions(browser, self.dossier)
+            self.assertIn(self.link_to_workspace_action, actions)
+
+            self.enable_linking(False)
+            transaction.commit()
+
+            actions = self.get_actions(browser, self.dossier)
+            self.assertNotIn(self.link_to_workspace_action, actions)
+
+    @browsing
     def test_workspaces_actions_only_available_if_user_has_permission_to_use_workspace_client(self, browser):
         browser.login()
         with self.workspace_client_env():

--- a/opengever/api/tests/test_actions.py
+++ b/opengever/api/tests/test_actions.py
@@ -1264,6 +1264,11 @@ class TestWorkspaceClientFolderActions(FunctionalWorkspaceClientTestCase):
         u'title': u'Copy back documents from workspace',
         u'icon': u''}
 
+    create_linked_workspace_action = {
+        u'id': u'create_linked_workspace',
+        u'title': u'Create workspace',
+        u'icon': u''}
+
     unlink_workspace_action = {
         u'id': u'unlink_workspace',
         u'title': u'Unlink workspace',
@@ -1273,6 +1278,7 @@ class TestWorkspaceClientFolderActions(FunctionalWorkspaceClientTestCase):
                          link_to_workspace_action,
                          copy_documents_to_workspace_action,
                          copy_documents_from_workspace_action,
+                         create_linked_workspace_action,
                          unlink_workspace_action]
 
     def get_actions(self, browser, context):

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -96,6 +96,7 @@ class TestConfig(IntegrationTestCase):
                 u'tasks_pdf': False,
                 u'workspace': False,
                 u'workspace_client': False,
+                u'workspace_creation_restricted': False,
                 u'workspace_meetings': True,
                 u'workspace_todo': True,
             })

--- a/opengever/base/browser/folder_buttons_availability.py
+++ b/opengever/base/browser/folder_buttons_availability.py
@@ -112,6 +112,12 @@ class FolderButtonsAvailabilityView(BrowserView):
             and self._can_add_content_to_dossier()
         )
 
+    def is_create_linked_workspace_available(self):
+        return (self._is_main_dossier()
+                and self._is_open_dossier()
+                and self._can_use_workspace_client()
+                and self._can_modify_dossier())
+
     def is_link_to_workspace_available(self):
         return (self._is_main_dossier()
                 and self._is_open_dossier()

--- a/opengever/base/browser/folder_buttons_availability.py
+++ b/opengever/base/browser/folder_buttons_availability.py
@@ -7,6 +7,7 @@ from opengever.repository.interfaces import IRepositoryFolder
 from opengever.repository.repositoryroot import IRepositoryRoot
 from opengever.task.task import ITask
 from opengever.trash.trash import ITrasher
+from opengever.workspaceclient import is_linking_enabled
 from opengever.workspaceclient import is_workspace_client_feature_available
 from opengever.workspaceclient.interfaces import ILinkedWorkspaces
 from plone import api
@@ -83,6 +84,9 @@ class FolderButtonsAvailabilityView(BrowserView):
                 and api.user.has_permission('opengever.workspaceclient: '
                                             'Use Workspace Client'))
 
+    def _is_linking_enabled(self):
+        return is_linking_enabled()
+
     def _can_copy_between_workspace_and_dossier(self):
         """Only if the workspace_client_feature is enabled and
         the main dossier is open with linked workspaces.
@@ -122,6 +126,7 @@ class FolderButtonsAvailabilityView(BrowserView):
         return (self._is_main_dossier()
                 and self._is_open_dossier()
                 and self._can_use_workspace_client()
+                and self._is_linking_enabled()
                 and self._can_modify_dossier())
 
     def is_unlink_workspace_available(self):

--- a/opengever/base/configuration.py
+++ b/opengever/base/configuration.py
@@ -174,6 +174,8 @@ class GeverSettingsAdpaterV1(object):
         features['solr'] = api.portal.get_registry_record('use_solr', interface=ISearchSettings)
         features['workspace'] = api.portal.get_registry_record('is_feature_enabled', interface=IWorkspaceSettings)
         features['workspace_client'] = api.portal.get_registry_record('is_feature_enabled', interface=IWorkspaceClientSettings)  # noqa
+        features['workspace_creation_restricted'] = api.portal.get_registry_record(
+            'is_creation_restricted', interface=IWorkspaceSettings)
         features['workspace_meetings'] = api.portal.get_registry_record('is_feature_enabled', interface=IWorkspaceMeetingSettings)  # noqa
         features['workspace_todo'] = api.portal.get_registry_record('is_feature_enabled', interface=IToDoSettings)
         features['private_tasks'] = api.portal.get_registry_record('private_task_feature_enabled', interface=ITaskSettings)

--- a/opengever/base/tests/test_configuration_adapter.py
+++ b/opengever/base/tests/test_configuration_adapter.py
@@ -99,6 +99,7 @@ class TestConfigurationAdapter(IntegrationTestCase):
                 ('solr', True),
                 ('workspace', False),
                 ('workspace_client', False),
+                ('workspace_creation_restricted', False),
                 ('workspace_meetings', True),
                 ('workspace_todo', True),
                 ('private_tasks', True),

--- a/opengever/core/locales/de/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/de/LC_MESSAGES/opengever.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-12-07 12:24+0000\n"
+"POT-Creation-Date: 2022-03-24 14:27+0000\n"
 "PO-Revision-Date: 2017-09-18 15:21+0200\n"
 "Last-Translator: Philippe Gross <p.gross@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -104,10 +104,16 @@ msgid "Create Task"
 msgstr "Aufgabe erstellen"
 
 #: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20220324143655_add_workspace_creation_and_linking_flags/actions.xml
+msgid "Create workspace"
+msgstr "Teamraum erstellen"
+
+#: ./opengever/core/profiles/default/actions.xml
 msgid "Debug docxcompose"
 msgstr "Dateien für docxcompose herunterladen"
 
 #: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20220222082438_allow_to_delete_workspaces/actions.xml
 msgid "Delete"
 msgstr "Löschen"
 

--- a/opengever/core/locales/en/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/en/LC_MESSAGES/opengever.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-12-07 12:24+0000\n"
+"POT-Creation-Date: 2022-03-24 14:27+0000\n"
 "PO-Revision-Date: 2017-09-18 15:21+0200\n"
 "Last-Translator: Philippe Gross <p.gross@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -124,6 +124,11 @@ msgstr "Create proposal"
 msgid "Create Task"
 msgstr "Create task"
 
+#: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20220324143655_add_workspace_creation_and_linking_flags/actions.xml
+msgid "Create workspace"
+msgstr "Create workspace"
+
 #. German translation: Dateien für docxcompose herunterladen
 #: ./opengever/core/profiles/default/actions.xml
 msgid "Debug docxcompose"
@@ -131,6 +136,7 @@ msgstr "Download docxcompose debug files"
 
 #. German translation: Löschen
 #: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20220222082438_allow_to_delete_workspaces/actions.xml
 msgid "Delete"
 msgstr "Delete"
 

--- a/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-12-07 12:24+0000\n"
+"POT-Creation-Date: 2022-03-24 14:27+0000\n"
 "PO-Revision-Date: 2013-03-27 10:44+0100\n"
 "Last-Translator: Philippe Gross <p.gross@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -101,10 +101,16 @@ msgid "Create Task"
 msgstr "Créer une tâche"
 
 #: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20220324143655_add_workspace_creation_and_linking_flags/actions.xml
+msgid "Create workspace"
+msgstr "Créer un espace de travail partagé"
+
+#: ./opengever/core/profiles/default/actions.xml
 msgid "Debug docxcompose"
 msgstr "Télécharger les fichiers docxcompose"
 
 #: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20220222082438_allow_to_delete_workspaces/actions.xml
 msgid "Delete"
 msgstr "Supprimer"
 

--- a/opengever/core/locales/opengever.core.pot
+++ b/opengever/core/locales/opengever.core.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-12-07 12:24+0000\n"
+"POT-Creation-Date: 2022-03-24 14:27+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -104,10 +104,16 @@ msgid "Create Task"
 msgstr ""
 
 #: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20220324143655_add_workspace_creation_and_linking_flags/actions.xml
+msgid "Create workspace"
+msgstr ""
+
+#: ./opengever/core/profiles/default/actions.xml
 msgid "Debug docxcompose"
 msgstr ""
 
 #: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20220222082438_allow_to_delete_workspaces/actions.xml
 msgid "Delete"
 msgstr ""
 

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -596,6 +596,15 @@
       <property name="visible">True</property>
     </object>
 
+    <object name="create_linked_workspace" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Create workspace</property>
+      <property name="description">Gever-UI action</property>
+      <property name="url_expr" />
+      <property name="icon_expr" />
+      <property name="available_expr">object/@@folder_buttons_availability/is_create_linked_workspace_available</property>
+      <property name="visible">True</property>
+    </object>
+
     <object name="link_to_workspace" meta_type="CMF Action" i18n:domain="opengever.core">
       <property name="title" i18n:translate="">Link to workspace</property>
       <property name="description">Gever-UI action</property>

--- a/opengever/core/upgrades/20220324143655_add_workspace_creation_and_linking_flags/actions.xml
+++ b/opengever/core/upgrades/20220324143655_add_workspace_creation_and_linking_flags/actions.xml
@@ -1,0 +1,16 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="portal_actions" meta_type="Plone Actions Tool">
+
+  <object name="folder_actions" meta_type="CMF Action Category">
+
+    <object name="create_linked_workspace" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Create workspace</property>
+      <property name="description">Gever-UI action</property>
+      <property name="url_expr" />
+      <property name="icon_expr" />
+      <property name="available_expr">object/@@folder_buttons_availability/is_create_linked_workspace_available</property>
+      <property name="visible">True</property>
+    </object>
+
+  </object>
+
+</object>

--- a/opengever/core/upgrades/20220324143655_add_workspace_creation_and_linking_flags/registry.xml
+++ b/opengever/core/upgrades/20220324143655_add_workspace_creation_and_linking_flags/registry.xml
@@ -1,0 +1,12 @@
+<registry>
+
+  <records interface="opengever.workspace.interfaces.IWorkspaceSettings">
+    <value key="is_creation_restricted">False</value>
+  </records>
+
+  <records interface="opengever.workspaceclient.interfaces.IWorkspaceClientSettings">
+    <value key="is_linking_enabled">True</value>
+  </records>
+
+</registry>
+

--- a/opengever/core/upgrades/20220324143655_add_workspace_creation_and_linking_flags/upgrade.py
+++ b/opengever/core/upgrades/20220324143655_add_workspace_creation_and_linking_flags/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddWorkspaceCreationAndLinkingFlags(UpgradeStep):
+    """Add workspace creation and linking flags.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/workspace/interfaces.py
+++ b/opengever/workspace/interfaces.py
@@ -22,6 +22,11 @@ class IWorkspaceSettings(Interface):
         description=u'Whether workspace integration is enabled',
         default=False)
 
+    is_creation_restricted = schema.Bool(
+        title=u'Restrict creation',
+        description=u'Whether workspace creation is restricted, i.e. only allowed from Gever',
+        default=False)
+
     invitation_group_dn = schema.TextLine(
         title=u'Invitation Group DN',
         description=u'DN of a group where invited users are added on registration',

--- a/opengever/workspaceclient/__init__.py
+++ b/opengever/workspaceclient/__init__.py
@@ -12,6 +12,10 @@ def is_workspace_client_feature_enabled():
         'is_feature_enabled', IWorkspaceClientSettings, False)
 
 
+def is_linking_enabled():
+    return api.portal.get_registry_record('is_linking_enabled', IWorkspaceClientSettings)
+
+
 def is_workspace_client_feature_available():
     """The feature is available if:
 

--- a/opengever/workspaceclient/interfaces.py
+++ b/opengever/workspaceclient/interfaces.py
@@ -10,6 +10,11 @@ class IWorkspaceClientSettings(Interface):
         description=u'Whether a remote workspace integration is enabled',
         default=False)
 
+    is_linking_enabled = schema.Bool(
+        title=u'Enable linking',
+        description=u'Whether existing workspaces can be linked to a dossier.',
+        default=True)
+
 
 class ILinkedWorkspaces(Interface):
     """Behavior interface to manage remote workspaces

--- a/opengever/workspaceclient/tests/__init__.py
+++ b/opengever/workspaceclient/tests/__init__.py
@@ -74,6 +74,11 @@ class FunctionalWorkspaceClientTestCase(FunctionalTestCase):
             'is_feature_enabled', enabled, IWorkspaceClientSettings)
         transaction.commit()
 
+    def enable_linking(self, enabled=True):
+        api.portal.set_registry_record(
+            'is_linking_enabled', enabled, IWorkspaceClientSettings)
+        transaction.commit()
+
     @contextmanager
     def workspace_client_env(self, url=DEFAULT_MARKER):
         url = self.portal.absolute_url() if url is DEFAULT_MARKER else url


### PR DESCRIPTION
These are configuration options requested by a customer to allow workspace to be created by GEVER only.
The feature flag to restrict workspace creation is only used in the new frontend, we do not restrict anything in the backend.

For [CA-3597]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))

[CA-3597]: https://4teamwork.atlassian.net/browse/CA-3597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ