### PR TITLE
Allow Administrator and LimitedAdmin to export repository as excel.

### DIFF
--- a/changes/CA-3917.bugfix
+++ b/changes/CA-3917.bugfix
@@ -1,0 +1,1 @@
+Allow Administrator and LimitedAdmin to export repository as excel. [njohner]

--- a/opengever/repository/browser/configure.zcml
+++ b/opengever/repository/browser/configure.zcml
@@ -111,7 +111,7 @@
       for="opengever.repository.repositoryroot.IRepositoryRoot"
       name="download_excel"
       class=".excel_export.RepositoryRootExcelExport"
-      permission="opengever.repository.AddRepositoryFolder"
+      permission="opengever.repository.ExportRepository"
       />
 
 </configure>

--- a/opengever/repository/tests/test_repository_workflow.py
+++ b/opengever/repository/tests/test_repository_workflow.py
@@ -32,14 +32,26 @@ class TestRepositoryWorkflow(IntegrationTestCase):
         self.login(self.regular_user, browser)
         browser.open(self.repository_root)
         self.assertNotIn('Export as Excel file', editbar.menu_options("Actions"))
+        with browser.expect_unauthorized():
+            browser.open(self.repository_root, view="download_excel")
 
         self.login(self.limited_admin, browser)
         browser.open(self.repository_root)
         self.assertIn('Export as Excel file', editbar.menu_options("Actions"))
+        browser.open(self.repository_root, view="download_excel")
+        self.assertEqual(200, browser.status_code)
+        self.assertEqual(
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            browser.mimetype)
 
         self.login(self.administrator, browser)
         browser.open(self.repository_root)
         self.assertIn('Export as Excel file', editbar.menu_options("Actions"))
+        browser.open(self.repository_root, view="download_excel")
+        self.assertEqual(200, browser.status_code)
+        self.assertEqual(
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            browser.mimetype)
 
     @browsing
     def test_repository_excel_export_is_available_for_managers(self, browser):
@@ -50,3 +62,8 @@ class TestRepositoryWorkflow(IntegrationTestCase):
         self.login(self.manager, browser)
         browser.open(self.repository_root)
         self.assertIn('Export as Excel file', editbar.menu_options("Actions"))
+        browser.open(self.repository_root, view="download_excel")
+        self.assertEqual(200, browser.status_code)
+        self.assertEqual(
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            browser.mimetype)


### PR DESCRIPTION
I don't want to point fingers at anyone, but it seems [someone introduced a new permission to allow Administrators to export the repository as Excel, but used it only for the action and not for the corresponding view.](https://github.com/4teamwork/opengever.core/pull/4659) It still worked for Administrators because they did also have the `AddRepositoryFolder` permission, but now it did not work anymore for `LimitedAdmin`

For [CA-3917]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-3917]: https://4teamwork.atlassian.net/browse/CA-3917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ