### PR TITLE
Fix reference_prefixes update mechanism for removed documents.

### DIFF
--- a/changes/CA-3880.bugfix
+++ b/changes/CA-3880.bugfix
@@ -1,0 +1,1 @@
+Fix reference_prefixes update mechanism for removed documents. [phgross]

--- a/opengever/repository/subscribers.py
+++ b/opengever/repository/subscribers.py
@@ -1,3 +1,4 @@
+from opengever.base.security import elevated_privileges
 from opengever.document.behaviors import IBaseDocument
 from opengever.repository.interfaces import IDuringRepositoryDeletion
 from plone import api
@@ -32,15 +33,16 @@ def update_reference_prefixes(obj, event):
         catalog = api.portal.get_tool('portal_catalog')
         children = catalog.unrestrictedSearchResults(
             path='/'.join(obj.getPhysicalPath()))
-        for child in children:
-            obj = child.getObject()
-            idxs = ['reference', 'sortable_reference']
-            if IBaseDocument.providedBy(obj):
-                idxs.append('metadata')
-            else:
-                idxs.append('SearchableText')
+        with elevated_privileges():
+            for child in children:
+                obj = child.getObject()
+                idxs = ['reference', 'sortable_reference']
+                if IBaseDocument.providedBy(obj):
+                    idxs.append('metadata')
+                else:
+                    idxs.append('SearchableText')
 
-            obj.reindexObject(idxs=idxs)
+                obj.reindexObject(idxs=idxs)
 
 
 def check_delete_preconditions(repository, event):


### PR DESCRIPTION
It's not guaranteed that the user which changes the reference_prefix on a repositoryfolder, are allowed to access all content inside this folder, even if its a Administrator, for example if a document is in the removed-state. Therefore we need to reindex the objects with elevated_privileges.

For [CA-3880]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)



[CA-3880]: https://4teamwork.atlassian.net/browse/CA-3880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ