### PR TITLE
Add is_subtasktemplatefolder to breadcrumbs.

### DIFF
--- a/opengever/api/breadcrumbs.py
+++ b/opengever/api/breadcrumbs.py
@@ -2,8 +2,10 @@ from Acquisition import aq_inner
 from Acquisition import aq_parent
 from opengever.api.serializer import extend_with_dossier_type
 from opengever.api.serializer import extend_with_is_subdossier
+from opengever.api.tasktemplatefolder import extend_with_is_subtasktemplatefolder
 from opengever.base.interfaces import IOpengeverBaseLayer
 from opengever.repository.interfaces import IRepositoryFolder
+from opengever.tasktemplates.content.templatefoldersschema import ITaskTemplateFolderSchema
 from plone.restapi.interfaces import IExpandableElement
 from plone.restapi.interfaces import ISerializeToJsonSummary
 from plone.restapi.services import Service
@@ -52,6 +54,9 @@ class Breadcrumbs(object):
                 item['is_leafnode'] = None
                 if IRepositoryFolder.providedBy(obj):
                     item['is_leafnode'] = obj.is_leaf_node()
+
+                if ITaskTemplateFolderSchema.providedBy(obj):
+                    extend_with_is_subtasktemplatefolder(item, obj, self.request)
 
                 extend_with_is_subdossier(item, obj, self.request)
                 extend_with_dossier_type(item, obj, self.request)

--- a/opengever/api/tasktemplatefolder.py
+++ b/opengever/api/tasktemplatefolder.py
@@ -6,11 +6,15 @@ from zope.interface import implementer
 from zope.interface import Interface
 
 
+def extend_with_is_subtasktemplatefolder(result, context, request):
+    result['is_subtasktemplatefolder'] = context.is_subtasktemplatefolder()
+
+
 @implementer(ISerializeToJson)
 @adapter(ITaskTemplateFolderSchema, Interface)
 class SerializeTaskTemplateFolderToJson(GeverSerializeFolderToJson):
 
     def __call__(self, *args, **kwargs):
         result = super(SerializeTaskTemplateFolderToJson, self).__call__(*args, **kwargs)
-        result['is_subtasktemplatefolder'] = self.context.is_subtasktemplatefolder()
+        extend_with_is_subtasktemplatefolder(result, self.context, self.request)
         return result

--- a/opengever/api/tests/test_breadcrumbs.py
+++ b/opengever/api/tests/test_breadcrumbs.py
@@ -169,3 +169,15 @@ class TestBreadcrumbsSerialization(IntegrationTestCase):
             ],
             browser.json['@components']['breadcrumbs']['items']
         )
+
+    @browsing
+    def test_is_subtasktemplatefolder_in_breadcrumbs(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.tasktemplate.absolute_url() + '/@breadcrumbs',
+                     headers=self.api_headers)
+
+        self.assertIsNone(getattr(self.templates, 'is_subtasktemplatefolder', None))
+        self.assertNotIn('is_subtasktemplatefolder', browser.json['items'][0])
+
+        self.assertFalse(self.tasktemplatefolder.is_subtasktemplatefolder())
+        self.assertFalse(browser.json['items'][1]['is_subtasktemplatefolder'])


### PR DESCRIPTION
So that the frontend can avoid showing the review state of sub-TaskTemplateFolders in the breadcrumbs.

For [CA-3586]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] Changelog entry -> no changelog, as this amends https://github.com/4teamwork/opengever.core/pull/7396
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-3586]: https://4teamwork.atlassian.net/browse/CA-3586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ