### PR TITLE
Add inactive user to fixture.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -623,6 +623,7 @@ Users
 - ``self.dossier_manager``: ``faivel.fruhling``
 - ``self.dossier_responsible``: ``robert.ziegler``
 - ``self.foreign_contributor``: ``james.bond``
+- ``self.inactive_user``: ``inactive.user``
 - ``self.limited_admin``: ``maja.harzig``
 - ``self.manager``: ``admin``
 - ``self.meeting_user``: ``herbert.jager``

--- a/changes/CA-3883.other
+++ b/changes/CA-3883.other
@@ -1,0 +1,1 @@
+Add inactive user to testing fixture. [njohner]

--- a/opengever/api/tests/test_dossier_participations.py
+++ b/opengever/api/tests/test_dossier_participations.py
@@ -783,7 +783,7 @@ class TestPossibleParticipantsGetWithContactFeatureEnabled(SolrIntegrationTestCa
 
         browser.open(url, method='GET', headers=self.api_headers)
         self.assertEqual(5, len(browser.json.get('items')))
-        self.assertEqual(23, browser.json.get('items_total'))
+        self.assertEqual(24, browser.json.get('items_total'))
         self.assertIn('batching', browser.json)
 
 

--- a/opengever/api/tests/test_globalsources.py
+++ b/opengever/api/tests/test_globalsources.py
@@ -75,8 +75,10 @@ class TestGlobalSourcesGet(IntegrationTestCase):
         self.assertEqual(
             {u'@id': u'http://nohost/plone/@globalsources/all_users_and_groups?query=inacti',
              u'items': [{u'title': u'Inactive Peter (peter.inactive)',
-                         u'token': u'peter.inactive'}],
-             u'items_total': 1},
+                         u'token': u'peter.inactive'},
+                        {u'title': u'User Inactive (inactive.user)',
+                         u'token': u'inactive.user'}],
+             u'items_total': 2},
             browser.json)
 
 

--- a/opengever/api/tests/test_local_roles.py
+++ b/opengever/api/tests/test_local_roles.py
@@ -18,7 +18,7 @@ class TestLocalRolesSerializer(IntegrationTestCase):
 
         with disabled_permission_check():
             result = serializer(search="A")
-        self.assertEqual(23, result['items_total'])
+        self.assertEqual(24, result['items_total'])
         self.assertEqual(3, len(result['items']))
         self.assertIn('batching', result)
 

--- a/opengever/api/tests/test_ogdsuserlisting.py
+++ b/opengever/api/tests/test_ogdsuserlisting.py
@@ -46,7 +46,7 @@ class TestOGDSUserListingGet(IntegrationTestCase):
              u'title': u'B\xf6nd James',
              u'userid': u'james.bond'}],
             browser.json.get('items')[:2])
-        self.assertEqual(21, browser.json['items_total'])
+        self.assertEqual(22, browser.json['items_total'])
 
     @browsing
     def test_last_login_is_visible_in_ogds_user_listing(self, browser):
@@ -73,7 +73,7 @@ class TestOGDSUserListingGet(IntegrationTestCase):
              u'nicole.kohler',
              u'jurgen.konig'],
             [each['userid'] for each in browser.json['items']])
-        self.assertEqual(21, browser.json['items_total'])
+        self.assertEqual(22, browser.json['items_total'])
 
     @browsing
     def test_batch_large_offset_returns_empty_items(self, browser):
@@ -85,7 +85,7 @@ class TestOGDSUserListingGet(IntegrationTestCase):
         self.assertEqual(200, browser.status_code)
 
         self.assertEqual(0, len(browser.json['items']))
-        self.assertEqual(21, browser.json['items_total'])
+        self.assertEqual(22, browser.json['items_total'])
 
     @browsing
     def test_batch_disallows_negative_size(self, browser):
@@ -108,8 +108,6 @@ class TestOGDSUserListingGet(IntegrationTestCase):
     @browsing
     def test_state_filter_inactive_only(self, browser):
         self.login(self.regular_user, browser=browser)
-        ogds_user = self.get_ogds_user(self.reader_user)
-        ogds_user.active = False
 
         browser.open(self.portal,
                      view='@ogds-user-listing?filters.state:record:list=inactive',
@@ -139,12 +137,12 @@ class TestOGDSUserListingGet(IntegrationTestCase):
 
         browser.open(self.portal,
                      view='@ogds-user-listing'
-                           '?filters.state:record:list=inactive'
+                          '?filters.state:record:list=inactive'
                           '&filters.state:record:list=active',
                      headers=self.api_headers)
 
-        self.assertEqual(21, len(browser.json['items']))
-        self.assertEqual(21, browser.json['items_total'])
+        self.assertEqual(22, len(browser.json['items']))
+        self.assertEqual(22, browser.json['items_total'])
 
     @browsing
     def test_last_login_filter(self, browser):
@@ -238,11 +236,11 @@ class TestOGDSUserListingGet(IntegrationTestCase):
                      view=u'@ogds-user-listing?sort_on=firstname',
                      headers=self.api_headers)
 
-        self.assertEqual(21, len(browser.json['items']))
+        self.assertEqual(22, len(browser.json['items']))
         self.assertEqual(
             [u'B\xe9atrice', u'C\xf6mmittee', u'David', u'Fridolin'],
             [each['firstname'] for each in browser.json['items'][:4]])
-        self.assertEqual(21, browser.json['items_total'])
+        self.assertEqual(22, browser.json['items_total'])
 
     @browsing
     def test_listing_always_has_a_secondary_sort_by_userid(self, browser):
@@ -253,8 +251,8 @@ class TestOGDSUserListingGet(IntegrationTestCase):
 
         subset = [item['userid'] for item in browser.json['items']
                   if item['department'] is None]
-        self.assertEqual(20, len(subset))
-        self.assertEqual(21, browser.json['items_total'])
+        self.assertEqual(21, len(subset))
+        self.assertEqual(22, browser.json['items_total'])
 
         expected = sorted([item.userid for item in User.query.all()
                            if item.department is None])
@@ -270,8 +268,8 @@ class TestOGDSUserListingGet(IntegrationTestCase):
 
         subset = [item['userid'] for item in browser.json['items']
                   if item['department'] is None]
-        self.assertEqual(20, len(subset))
-        self.assertEqual(21, browser.json['items_total'])
+        self.assertEqual(21, len(subset))
+        self.assertEqual(22, browser.json['items_total'])
 
         expected = sorted(
             [item.userid for item in User.query.all() if item.department is None],
@@ -285,11 +283,11 @@ class TestOGDSUserListingGet(IntegrationTestCase):
                      view=u'@ogds-user-listing?sort_order=descending',
                      headers=self.api_headers)
 
-        self.assertEqual(21, len(browser.json['items']))
+        self.assertEqual(22, len(browser.json['items']))
         self.assertEqual(
-            [u'Ziegler', u'User', u'Secretary', u'Schr\xf6dinger'],
-            [each['lastname'] for each in browser.json['items'][:4]])
-        self.assertEqual(21, browser.json['items_total'])
+            [u'Ziegler', u'User', 'User', u'Secretary', u'Schr\xf6dinger'],
+            [each['lastname'] for each in browser.json['items'][:5]])
+        self.assertEqual(22, browser.json['items_total'])
 
     @browsing
     def test_handles_non_ascii_userids(self, browser):

--- a/opengever/api/tests/test_serializer.py
+++ b/opengever/api/tests/test_serializer.py
@@ -334,7 +334,7 @@ class TestGroupSerializer(IntegrationTestCase):
                                     u'@type': u'virtual.plone.user',
                                     u'title': u'User Service (service.user)',
                                     u'token': u'service.user'}],
-                        u'items_total': 19}},
+                        u'items_total': 20}},
             response)
 
 

--- a/opengever/api/tests/test_users.py
+++ b/opengever/api/tests/test_users.py
@@ -14,7 +14,7 @@ class TestUsersGet(IntegrationTestCase):
         browser.open('{}/@users'.format(self.portal.absolute_url()),
                      headers=self.api_headers)
 
-        self.assertEqual(21, len(browser.json))
+        self.assertEqual(22, len(browser.json))
 
     @browsing
     def test_enumarating_users_unauthorized_raises(self, browser):

--- a/opengever/sharing/tests/test_sharing.py
+++ b/opengever/sharing/tests/test_sharing.py
@@ -391,7 +391,7 @@ class TestOpengeverSharing(IntegrationTestCase):
                      method='Get', headers={'Accept': 'application/json'})
 
         result = browser.json
-        self.assertEqual(21, result['items_total'])
+        self.assertEqual(22, result['items_total'])
         self.assertEqual(3, len(result['items']))
         self.assertIn('batching', result)
 
@@ -432,7 +432,8 @@ class TestOpengeverSharing(IntegrationTestCase):
              u'rk Inbox Users Group',
              u'Fr\xfchling F\xe4ivel',
              u'Hugentobler Fridolin',
-             u'Schr\xf6dinger B\xe9atrice'],
+             u'Schr\xf6dinger B\xe9atrice',
+             u'User Inactive'],
             [each["title"] for each in browser.json["items"]])
 
 

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -399,6 +399,13 @@ class OpengeverContentFixture(object):
             ['PropertySheetsManager'],
         )
 
+        self.inactive_user = self.create_user(
+            'inactive_user',
+            u'Inactive',
+            u'User',
+            active=False,
+        )
+
         # This user is intended to be used in situations where you need a user
         # which has only the 'Reader' role on some context and one has to build
         # the granting of that themselves


### PR DESCRIPTION
This is to allow testing vocabularies in the Gever-UI (see https://github.com/4teamwork/gever-ui/pull/2199).

For [CA-3883]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-3883]: https://4teamwork.atlassian.net/browse/CA-3883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ