### PR TITLE
Avoid ending up with ou=ou=... in the ldap plugin.

### DIFF
--- a/changes/CA-3716.other
+++ b/changes/CA-3716.other
@@ -1,0 +1,1 @@
+Improve policy templates LDAP base OU. [njohner]

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/profiles/ldap/ldap_plugin.xml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/profiles/ldap/ldap_plugin.xml.bob
@@ -23,7 +23,7 @@
                 <item value="cn"/>
             </property>
             <property id="users_base" type="str">
-                <item value="ou=Users,ou={{{deployment.ldap_ou}}}"/>
+                <item value="ou=Users,{{{deployment.ldap_ou}}}"/>
             </property>
             <property id="users_scope" type="int">
                 <item value="2"/>
@@ -35,7 +35,7 @@
                 <item value="0"/>
             </property>
             <property id="groups_base" type="str">
-                <item value="ou=Groups,ou={{{deployment.ldap_ou}}}"/>
+                <item value="ou=Groups,{{{deployment.ldap_ou}}}"/>
             </property>
             <property id="groups_scope" type="int">
                 <item value="2"/>


### PR DESCRIPTION
Am I the only one who always ends up with two `ou=` in a row after creating a policy? IMO the response to the question "LDAP ou name" will be something starting with `ou=`, e.g. `ou=MyClientID,ou=OneGovGEVER,dc=4teamwork,dc=ch`, so we do not need the `ou=` in the ldap plugin template.

For [CA-3716]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-3716]: https://4teamwork.atlassian.net/browse/CA-3716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ