### PR TITLE
Add @task-template-structure endpoint

### DIFF
--- a/changes/CA-3725.change
+++ b/changes/CA-3725.change
@@ -1,0 +1,1 @@
+Add a new endpoint @task-template-structure [elioschmutz]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -15,7 +15,7 @@ Other Changes
 - ``@external-activities``: ``notification_recipients`` now also accepts group IDs.
 - ``@external-activities``: Privileged users may now create notifications for other users (see :ref:`external-activities`)
 - ``@config``: Add ``workspace_creation_restricted`` feature flag.
-
+- Add new endpoint ``@task-template-structure``.
 
 2022.6.0 (2022-03-15)
 ---------------------

--- a/docs/public/dev-manual/api/trigger_task_template.rst
+++ b/docs/public/dev-manual/api/trigger_task_template.rst
@@ -113,3 +113,66 @@ folgende Felder zur Verfügung:
 
             "start_immediately": true
         }
+
+Struktur der Standardabläufe anzeigen
+=====================================
+Über den Endpint ``@task-template-structure`` kann die Struktur des Templatefolders angezeigt werden.
+
+
+
+   **Beispiel-Request**:
+
+   .. sourcecode:: http
+
+      GET /vorlagen/tasktemplate-1/@task-template-structure HTTP/1.1
+      Accept: application/json
+
+   **Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+        "@id": "/vorlagen/tasktemplate-1/@trigger-task-template-structure",
+        "@type": "opengever.tasktemplates.tasktemplatefolder",
+        "UID": "fc1a5fd76afa41f4962f2660887c601c",
+        "items": [
+            {
+                "@id": "/vorlagen/tasktemplate-1/aufgabe-2",
+                "@type": "opengever.tasktemplates.tasktemplate",
+                "UID": "480d0557a3ac43f0be76aa7f2a597aa6",
+                "...": "..."
+            },
+            {
+                "@id": "/vorlagen/tasktemplate-1/aufgabe-1",
+                "@type": "opengever.tasktemplates.tasktemplate",
+                "UID": "1c1752e49f024e4682cb632e40f6d78c",
+                "...": "..."
+            },
+            {
+                "@id": "/vorlagen/tasktemplate-1/@trigger-task-template-structure",
+                "@type": "opengever.tasktemplates.tasktemplatefolder",
+                "UID": "4a8ea261042949efb3abc3e706abf62c",
+                "items": [
+                    {
+                        "@id": "/vorlagen/tasktemplate-1/aufgabengruppe-1-parallel/aufgabe-in-gruppe-1",
+                        "@type": "opengever.tasktemplates.tasktemplate",
+                        "UID": "54a26da5992148ce90f68a428817b065",
+                        "...": "..."
+                    },
+                    {
+                        "@id": "/vorlagen/tasktemplate-1/aufgabengruppe-1-parallel/aufgabe-in-gruppe-2",
+                        "@type": "opengever.tasktemplates.tasktemplate",
+                        "UID": "9090d410f9114628a2edcadaade2dc08",
+                        "...": "..."
+                    }
+                ],
+                "items_total": 2,
+                "...": "..."
+            }
+        ],
+        "items_total": 3,
+        "...": "..."
+      }

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -1100,6 +1100,14 @@
 
   <plone:service
       method="GET"
+      name="@task-template-structure"
+      for="opengever.tasktemplates.content.templatefoldersschema.ITaskTemplateFolderSchema"
+      factory=".templatefolder.TriggerTaskTemplateStructureGet"
+      permission="cmf.AddPortalContent"
+      />
+
+  <plone:service
+      method="GET"
       name="@list-documents-in-linked-workspace"
       for="opengever.dossier.behaviors.dossier.IDossierMarker"
       factory=".linked_workspaces.ListDocumentsInLinkedWorkspaceGet"


### PR DESCRIPTION
This PR introduces a new endpoint `@task-template-structure` to fetch the full structure of a task-template folder. This allows us to easely render a nested form in the frontend without doing lots of requests or manually building a tree in the frontend.

For [CA-3725]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-3725]: https://4teamwork.atlassian.net/browse/CA-3725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ