### PR TITLE
 Add response to parent task when subtask is closed or cancelled

### DIFF
--- a/changes/CA-3573.feature
+++ b/changes/CA-3573.feature
@@ -1,0 +1,1 @@
+Add response to parent task when subtask is closed. [tinagerber]

--- a/changes/CA-3573.feature
+++ b/changes/CA-3573.feature
@@ -1,1 +1,1 @@
-Add response to parent task when subtask is closed. [tinagerber]
+Add response to parent task when subtask is closed or cancelled. [tinagerber]

--- a/opengever/api/tests/test_forwarding.py
+++ b/opengever/api/tests/test_forwarding.py
@@ -36,6 +36,7 @@ class TestForwardingSerialization(SolrIntegrationTestCase):
               u'related_items': [],
               u'text': u'',
               u'mimetype': u'',
+              u'subtask': None,
               u'successor_oguid': u'',
               u'rendered_text': u'',
               u'transition': u'transition-add-document'}],

--- a/opengever/api/tests/test_task.py
+++ b/opengever/api/tests/test_task.py
@@ -53,6 +53,7 @@ class TestTaskSerialization(SolrIntegrationTestCase):
              u'rendered_text': u'',
              u'response_id': 1472652213000000,
              u'response_type': u'default',
+             u'subtask': None,
              u'successor_oguid': u'',
              u'text': u'',
              u'transition': u'transition-add-subtask'},
@@ -80,6 +81,20 @@ class TestTaskSerialization(SolrIntegrationTestCase):
             [{u'field_id': u'deadline', u'field_title': u'Deadline',
               u'after': u'2023-01-01', u'before': u'2016-11-01'}],
             response['changes'])
+
+    @browsing
+    def test_task_response_contains_subtask(self, browser):
+        self.login(self.dossier_responsible, browser=browser)
+        api.content.transition(obj=self.subtask,
+                               transition='task-transition-resolved-tested-and-closed')
+
+        browser.open(self.task, method="GET", headers=self.api_headers)
+
+        response = browser.json['responses'][-1]
+        self.assertDictContainsSubset(
+            {u'@id': self.subtask.absolute_url(),
+             u'title': self.subtask.title},
+            response['subtask'])
 
     @browsing
     def test_response_key_contains_empty_list_for_task_without_responses(self, browser):
@@ -116,6 +131,7 @@ class TestTaskSerialization(SolrIntegrationTestCase):
                  u'title': u'B\xe4rfuss K\xe4thi'},
              u'text': u'Angebot \xfcberpr\xfcft',
              u'transition': u'task-commented',
+             u'subtask': None,
              u'successor_oguid': u'',
              u'rendered_text': u'',
              u'related_items': [],

--- a/opengever/task/activities.py
+++ b/opengever/task/activities.py
@@ -216,6 +216,7 @@ class TaskTransitionActivity(BaseTaskResponseActivity):
 
     IGNORED_TRANSITIONS = [
         'transition-add-subtask',
+        'transition-cancel-subtask',
         'transition-close-subtask',
         'task-transition-reassign',
         'task-transition-change-issuer',

--- a/opengever/task/activities.py
+++ b/opengever/task/activities.py
@@ -216,6 +216,7 @@ class TaskTransitionActivity(BaseTaskResponseActivity):
 
     IGNORED_TRANSITIONS = [
         'transition-add-subtask',
+        'transition-close-subtask',
         'task-transition-reassign',
         'task-transition-change-issuer',
         'forwarding-transition-reassign',

--- a/opengever/task/configure.zcml
+++ b/opengever/task/configure.zcml
@@ -270,7 +270,7 @@
       />
 
   <adapter
-      factory=".transition.DefaultTransitionExtender"
+      factory=".transition.CancelTransitionExtender"
       name="task-transition-open-cancelled"
       />
 

--- a/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2022-03-31 15:12+0000\n"
+"POT-Creation-Date: 2022-03-31 17:41+0000\n"
 "PO-Revision-Date: 2015-02-17 18:41+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -938,6 +938,11 @@ msgstr "Dokument ${doc} hinzugefügt durch ${user}"
 msgid "transition_add_subtask"
 msgstr "Unteraufgabe ${task} hinzugefügt durch ${user}"
 
+#. Default: "Subtask ${task} cancelled by ${user}"
+#: ./opengever/task/response_description.py
+msgid "transition_cancel_subtask"
+msgstr "Unteraufgabe ${task} abgebrochen durch ${user}"
+
 #. Default: "Subtask ${task} closed by ${user}"
 #: ./opengever/task/response_description.py
 msgid "transition_close_subtask"
@@ -962,6 +967,11 @@ msgstr "Unteraufgabe zur Aufgabe hinzugefügt"
 #: ./opengever/task/response_description.py
 msgid "transition_label_assign_to_dossier"
 msgstr "Weiterleitung zu einem Dossier hinzugefügt"
+
+#. Default: "Subtask cancelled"
+#: ./opengever/task/response_description.py
+msgid "transition_label_cancel_subtask"
+msgstr "Unteraufgabe abgebrochen"
 
 #. Default: "Task cancelled"
 #: ./opengever/task/response_description.py

--- a/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-08-18 08:25+0000\n"
+"POT-Creation-Date: 2022-03-31 15:12+0000\n"
 "PO-Revision-Date: 2015-02-17 18:41+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -938,6 +938,11 @@ msgstr "Dokument ${doc} hinzugefügt durch ${user}"
 msgid "transition_add_subtask"
 msgstr "Unteraufgabe ${task} hinzugefügt durch ${user}"
 
+#. Default: "Subtask ${task} closed by ${user}"
+#: ./opengever/task/response_description.py
+msgid "transition_close_subtask"
+msgstr "Unteraufgabe ${task} abgeschlossen durch ${user}"
+
 #. Default: "Task accepted"
 #: ./opengever/task/response_description.py
 msgid "transition_label_accept"
@@ -972,6 +977,11 @@ msgstr "Auftraggeber der Aufgabe gewechselt"
 #: ./opengever/task/response_description.py
 msgid "transition_label_close"
 msgstr "Aufgabe abgeschlossen"
+
+#. Default: "Subtask closed"
+#: ./opengever/task/response_description.py
+msgid "transition_label_close_subtask"
+msgstr "Unteraufgabe abgeschlossen"
 
 #. Default: "Created by ${user}."
 #: ./opengever/task/viewlets/response.py

--- a/opengever/task/locales/en/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/en/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-08-18 08:25+0000\n"
+"POT-Creation-Date: 2022-03-31 15:12+0000\n"
 "PO-Revision-Date: 2015-02-17 18:41+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -1121,6 +1121,11 @@ msgstr "Document ${doc} added by ${user}"
 msgid "transition_add_subtask"
 msgstr "Subtask ${task} added by ${user}"
 
+#. Default: "Subtask ${task} closed by ${user}"
+#: ./opengever/task/response_description.py
+msgid "transition_close_subtask"
+msgstr "Subtask ${task} closed by ${user}"
+
 #. German translation: Aufgabe akzeptiert
 #. Default: "Task accepted"
 #: ./opengever/task/response_description.py
@@ -1162,6 +1167,11 @@ msgstr "Issuer of task changed"
 #: ./opengever/task/response_description.py
 msgid "transition_label_close"
 msgstr "Task closed"
+
+#. Default: "Subtask closed"
+#: ./opengever/task/response_description.py
+msgid "transition_label_close_subtask"
+msgstr "Subtask closed"
 
 #. German translation: Erstellt durch ${user}.
 #. Default: "Created by ${user}."

--- a/opengever/task/locales/en/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/en/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2022-03-31 15:12+0000\n"
+"POT-Creation-Date: 2022-03-31 17:41+0000\n"
 "PO-Revision-Date: 2015-02-17 18:41+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -1121,6 +1121,11 @@ msgstr "Document ${doc} added by ${user}"
 msgid "transition_add_subtask"
 msgstr "Subtask ${task} added by ${user}"
 
+#. Default: "Subtask ${task} cancelled by ${user}"
+#: ./opengever/task/response_description.py
+msgid "transition_cancel_subtask"
+msgstr "Subtask ${task} cancelled by ${user}"
+
 #. Default: "Subtask ${task} closed by ${user}"
 #: ./opengever/task/response_description.py
 msgid "transition_close_subtask"
@@ -1149,6 +1154,11 @@ msgstr "Subtask added to task"
 #: ./opengever/task/response_description.py
 msgid "transition_label_assign_to_dossier"
 msgstr "Forwarding assigned to Dossier"
+
+#. Default: "Subtask cancelled"
+#: ./opengever/task/response_description.py
+msgid "transition_label_cancel_subtask"
+msgstr "Subtask cancelled"
 
 #. German translation: Aufgabe abgebrochen
 #. Default: "Task cancelled"

--- a/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-08-18 08:25+0000\n"
+"POT-Creation-Date: 2022-03-31 15:12+0000\n"
 "PO-Revision-Date: 2017-12-03 11:47+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-task/fr/>\n"
@@ -940,6 +940,11 @@ msgstr "Document ${doc} ajouté par ${user}"
 msgid "transition_add_subtask"
 msgstr "Sous-tâche ${task} ajoutée par ${user}"
 
+#. Default: "Subtask ${task} closed by ${user}"
+#: ./opengever/task/response_description.py
+msgid "transition_close_subtask"
+msgstr "Sous-tâche ${task} clôturée par ${user}"
+
 #. Default: "Task accepted"
 #: ./opengever/task/response_description.py
 msgid "transition_label_accept"
@@ -974,6 +979,11 @@ msgstr "Mandant de la tâche modifié"
 #: ./opengever/task/response_description.py
 msgid "transition_label_close"
 msgstr "Tâche clôturée"
+
+#. Default: "Subtask closed"
+#: ./opengever/task/response_description.py
+msgid "transition_label_close_subtask"
+msgstr "Sous-tâche clôturée"
 
 #. Default: "Created by ${user}."
 #: ./opengever/task/viewlets/response.py

--- a/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-03-31 15:12+0000\n"
+"POT-Creation-Date: 2022-03-31 17:41+0000\n"
 "PO-Revision-Date: 2017-12-03 11:47+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-task/fr/>\n"
@@ -940,6 +940,11 @@ msgstr "Document ${doc} ajouté par ${user}"
 msgid "transition_add_subtask"
 msgstr "Sous-tâche ${task} ajoutée par ${user}"
 
+#. Default: "Subtask ${task} cancelled by ${user}"
+#: ./opengever/task/response_description.py
+msgid "transition_cancel_subtask"
+msgstr "Sous-tâche ${task} annulée par ${user}"
+
 #. Default: "Subtask ${task} closed by ${user}"
 #: ./opengever/task/response_description.py
 msgid "transition_close_subtask"
@@ -965,10 +970,15 @@ msgstr "Sous-tâche ajoutée à la tâche"
 msgid "transition_label_assign_to_dossier"
 msgstr "Transmission assignée au dossier"
 
+#. Default: "Subtask cancelled"
+#: ./opengever/task/response_description.py
+msgid "transition_label_cancel_subtask"
+msgstr "Tâche annulée"
+
 #. Default: "Task cancelled"
 #: ./opengever/task/response_description.py
 msgid "transition_label_cancelled"
-msgstr "Tâche annulée"
+msgstr "Sous-tâche annulée"
 
 #. Default: "Issuer of task changed"
 #: ./opengever/task/response_description.py

--- a/opengever/task/locales/opengever.task.pot
+++ b/opengever/task/locales/opengever.task.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2022-03-31 15:12+0000\n"
+"POT-Creation-Date: 2022-03-31 17:41+0000\n"
 "PO-Revision-Date: 2009-02-25 14:39+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -936,6 +936,11 @@ msgstr ""
 msgid "transition_add_subtask"
 msgstr ""
 
+#. Default: "Subtask ${task} cancelled by ${user}"
+#: ./opengever/task/response_description.py
+msgid "transition_cancel_subtask"
+msgstr ""
+
 #. Default: "Subtask ${task} closed by ${user}"
 #: ./opengever/task/response_description.py
 msgid "transition_close_subtask"
@@ -959,6 +964,11 @@ msgstr ""
 #. Default: "Forwarding assigned to Dossier"
 #: ./opengever/task/response_description.py
 msgid "transition_label_assign_to_dossier"
+msgstr ""
+
+#. Default: "Subtask cancelled"
+#: ./opengever/task/response_description.py
+msgid "transition_label_cancel_subtask"
 msgstr ""
 
 #. Default: "Task cancelled"

--- a/opengever/task/locales/opengever.task.pot
+++ b/opengever/task/locales/opengever.task.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-08-18 08:25+0000\n"
+"POT-Creation-Date: 2022-03-31 15:12+0000\n"
 "PO-Revision-Date: 2009-02-25 14:39+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -936,6 +936,11 @@ msgstr ""
 msgid "transition_add_subtask"
 msgstr ""
 
+#. Default: "Subtask ${task} closed by ${user}"
+#: ./opengever/task/response_description.py
+msgid "transition_close_subtask"
+msgstr ""
+
 #. Default: "Task accepted"
 #: ./opengever/task/response_description.py
 msgid "transition_label_accept"
@@ -969,6 +974,11 @@ msgstr ""
 #. Default: "Task closed"
 #: ./opengever/task/response_description.py
 msgid "transition_label_close"
+msgstr ""
+
+#. Default: "Subtask closed"
+#: ./opengever/task/response_description.py
+msgid "transition_label_close_subtask"
 msgstr ""
 
 #. Default: "Created by ${user}."

--- a/opengever/task/response_description.py
+++ b/opengever/task/response_description.py
@@ -493,6 +493,27 @@ class SubTaskClosed(ResponseDescription):
 ResponseDescription.add_description(SubTaskClosed)
 
 
+class SubTaskCancelled(ResponseDescription):
+
+    transition = 'transition-cancel-subtask'
+    css_class = 'cancelled'
+
+    def msg(self):
+        subtask = self.response.subtask.to_object
+        label = subtask.get_sql_object().get_link()
+
+        return _('transition_cancel_subtask',
+                 u'Subtask ${task} cancelled by ${user}',
+                 mapping={'user': self.creator_link(),
+                          'task': label})
+
+    def label(self):
+        return _('transition_label_cancel_subtask', u'Subtask cancelled')
+
+
+ResponseDescription.add_description(SubTaskCancelled)
+
+
 class DocumentAdded(ResponseDescription):
 
     transition = 'transition-add-document'

--- a/opengever/task/response_description.py
+++ b/opengever/task/response_description.py
@@ -472,6 +472,27 @@ class SubTaskAdded(ResponseDescription):
 ResponseDescription.add_description(SubTaskAdded)
 
 
+class SubTaskClosed(ResponseDescription):
+
+    transition = 'transition-close-subtask'
+    css_class = 'close'
+
+    def msg(self):
+        subtask = self.response.subtask.to_object
+        label = subtask.get_sql_object().get_link()
+
+        return _('transition_close_subtask',
+                 u'Subtask ${task} closed by ${user}',
+                 mapping={'user': self.creator_link(),
+                          'task': label})
+
+    def label(self):
+        return _('transition_label_close_subtask', u'Subtask closed')
+
+
+ResponseDescription.add_description(SubTaskClosed)
+
+
 class DocumentAdded(ResponseDescription):
 
     transition = 'transition-add-document'

--- a/opengever/task/task_response.py
+++ b/opengever/task/task_response.py
@@ -2,6 +2,7 @@ from opengever.base.response import IResponse
 from opengever.base.response import Response
 from persistent.list import PersistentList
 from z3c.relationfield.schema import RelationList
+from z3c.relationfield.schema import Relation
 from zope import schema
 from zope.interface import implements
 from zope.schema import List
@@ -28,6 +29,8 @@ class ITaskResponse(IResponse):
 
     # Documents approved during task resolution
     approved_documents = RelationList(required=False)
+
+    subtask = Relation(required=False)
 
 
 class TaskResponse(Response):

--- a/opengever/task/tests/test_task.py
+++ b/opengever/task/tests/test_task.py
@@ -337,6 +337,27 @@ class TestTaskIntegration(SolrIntegrationTestCase):
         self.assertEqual('transition-close-subtask', response.transition)
         self.assertEqual(response.subtask.to_object, self.subtask)
 
+    def test_cancelling_an_open_subtask_adds_response_on_parent_task(self):
+        self.login(self.dossier_responsible)
+        subtask = create(
+            Builder("task")
+            .within(self.task)
+            .titled("Subtask")
+            .having(
+                issuer=self.dossier_responsible.getId(),
+                responsible=self.regular_user.getId(),
+                responsible_client=u'fa',
+                task_type=u'information',
+            )
+        )
+
+        api.content.transition(obj=subtask,
+                               transition='task-transition-open-cancelled')
+
+        response = IResponseContainer(self.task).list()[-1]
+        self.assertEqual('transition-cancel-subtask', response.transition)
+        self.assertEqual(response.subtask.to_object, subtask)
+
     @browsing
     def test_responsible_client_for_multiple_orgunits(self, browser):
         self.login(self.dossier_responsible, browser=browser)

--- a/opengever/task/transition.py
+++ b/opengever/task/transition.py
@@ -1,3 +1,4 @@
+from Acquisition import aq_inner, aq_parent
 from opengever.activity import notification_center
 from opengever.activity.roles import TASK_RESPONSIBLE_ROLE
 from opengever.base.source import DossierPathSourceBinder
@@ -336,6 +337,10 @@ class CloseTransitionExtender(DefaultTransitionExtender):
 
         self.save_related_items(response, transition_params.get('relatedItems'))
         pass_documents = self.pass_documents_to_next_task(transition, transition_params)
+        parent = aq_parent(aq_inner(self.context))
+        if ITask.providedBy(parent):
+            add_simple_response(parent, transition='transition-close-subtask',
+                                subtask=self.context)
         self.sync_change(transition,
                          transition_params.get('text'),
                          disable_sync,

--- a/opengever/task/transition.py
+++ b/opengever/task/transition.py
@@ -349,6 +349,19 @@ class CloseTransitionExtender(DefaultTransitionExtender):
 
 @implementer(ITransitionExtender)
 @adapter(ITask, IBrowserRequest)
+class CancelTransitionExtender(DefaultTransitionExtender):
+
+    def after_transition_hook(self, transition, disable_sync, transition_params):
+        super(CancelTransitionExtender, self).after_transition_hook(
+            transition, disable_sync, transition_params)
+        parent = aq_parent(aq_inner(self.context))
+        if ITask.providedBy(parent):
+            add_simple_response(parent, transition='transition-cancel-subtask',
+                                subtask=self.context)
+
+
+@implementer(ITransitionExtender)
+@adapter(ITask, IBrowserRequest)
 class ReassignTransitionExtender(DefaultTransitionExtender):
 
     schemas = [IResponse, INewResponsibleSchema]

--- a/opengever/task/util.py
+++ b/opengever/task/util.py
@@ -93,8 +93,8 @@ def get_task_type_title(task_type, language):
 
 
 def add_simple_response(task, text='', field_changes=None, added_objects=None,
-                        successor_oguid=None, supress_events=False,
-                        supress_activity=False, approved_documents=(), **kwargs):
+                        successor_oguid=None, supress_events=False, supress_activity=False,
+                        approved_documents=(), subtask=None, **kwargs):
     """Add a simple response which does (not change the task itself).
     `task`: task context
     `text`: fulltext
@@ -129,6 +129,10 @@ def add_simple_response(task, text='', field_changes=None, added_objects=None,
         for obj in approved_documents:
             iid = intids.getId(obj)
             response.approved_documents.append(RelationValue(iid))
+
+    if subtask:
+        iid = getUtility(IIntIds).getId(subtask)
+        response.subtask = RelationValue(iid)
 
     if successor_oguid:
         response.successor_oguid = successor_oguid


### PR DESCRIPTION
Journal entries are created only for newly closed or canceled tasks.

<img width="607" alt="Bildschirmfoto 2022-04-01 um 17 15 46" src="https://user-images.githubusercontent.com/50165195/161292387-c95f2e2d-6e94-420e-bfe6-7e2c21cc70aa.png">


For [CA-3573]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-3573]: https://4teamwork.atlassian.net/browse/CA-3573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ