### PR TITLE
Prevent triggering nested TaskTemplateFolders in the classic UI

### DIFF
--- a/opengever/tasktemplates/browser/trigger.py
+++ b/opengever/tasktemplates/browser/trigger.py
@@ -121,6 +121,15 @@ class SelectTaskTemplateFolderWizardStep(BaseWizardStepForm, Form):
         if errors:
             return
 
+        uid = data.get('tasktemplatefolder')
+        tasktemplatefolder = api.content.get(UID=uid)
+        if tasktemplatefolder.contains_subtasktemplatefolders():
+            msg = _(u'error_nested_tasktemplatefolder',
+                    default=u'Nested TaskTemplateFolders are only supported '
+                            u'in the new UI.')
+            api.portal.show_message(msg, self.request, type='error')
+            return
+
         dm = getUtility(IWizardDataStorage)
         dm.update(get_datamanger_key(self.context), data)
 

--- a/opengever/tasktemplates/locales/de/LC_MESSAGES/opengever.tasktemplates.po
+++ b/opengever/tasktemplates/locales/de/LC_MESSAGES/opengever.tasktemplates.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-10-28 09:03+0000\n"
+"POT-Creation-Date: 2022-04-01 15:20+0000\n"
 "PO-Revision-Date: 2012-02-23 14:39+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -47,6 +47,11 @@ msgstr "Auslösen"
 #: ./opengever/tasktemplates/browser/trigger.py
 msgid "description_start_immediately"
 msgstr "Erste Aufgabe nach Erstellung sofort starten."
+
+#. Default: "Nested TaskTemplateFolders are only supported in the new UI."
+#: ./opengever/tasktemplates/browser/trigger.py
+msgid "error_nested_tasktemplatefolder"
+msgstr "Verschachtelte Standardabläufe sind nur in der neuen Ansicht unterstützt."
 
 #. Default: "Common"
 #: ./opengever/tasktemplates/content/tasktemplate.py
@@ -227,3 +232,8 @@ msgstr "Zurzeit sind keine aktiven Standardabläufe hinterlegt."
 #: ./opengever/tasktemplates/browser/tasktemplates.py
 msgid "preselected_yes"
 msgstr "Ja"
+
+#. Default: "Nested TaskTemplateFolders can only be viewed and edited correctly in the new UI."
+#: ./opengever/tasktemplates/browser/tabbed.py
+msgid "warning_nested_tasktemplatefolder"
+msgstr "Verschachtelte Standardabläufe können nur in der neuen Ansicht korrekt dargestellt und bearbeitet werden."

--- a/opengever/tasktemplates/locales/en/LC_MESSAGES/opengever.tasktemplates.po
+++ b/opengever/tasktemplates/locales/en/LC_MESSAGES/opengever.tasktemplates.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-10-28 09:03+0000\n"
+"POT-Creation-Date: 2022-04-01 15:20+0000\n"
 "PO-Revision-Date: 2012-02-23 14:39+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -55,6 +55,11 @@ msgstr "Trigger"
 #: ./opengever/tasktemplates/browser/trigger.py
 msgid "description_start_immediately"
 msgstr "Immediately open the first task after creation."
+
+#. Default: "Nested TaskTemplateFolders are only supported in the new UI."
+#: ./opengever/tasktemplates/browser/trigger.py
+msgid "error_nested_tasktemplatefolder"
+msgstr "Nested TaskTemplateFolders are only supported in the new UI."
 
 #. German translation: Allgemein
 #. Default: "Common"
@@ -275,3 +280,8 @@ msgstr "Currently there are no active task template folders."
 #: ./opengever/tasktemplates/browser/tasktemplates.py
 msgid "preselected_yes"
 msgstr "Yes"
+
+#. Default: "Nested TaskTemplateFolders can only be viewed and edited correctly in the new UI."
+#: ./opengever/tasktemplates/browser/tabbed.py
+msgid "warning_nested_tasktemplatefolder"
+msgstr "Nested TaskTemplateFolders can only be viewed and edited correctly in the new UI."

--- a/opengever/tasktemplates/locales/fr/LC_MESSAGES/opengever.tasktemplates.po
+++ b/opengever/tasktemplates/locales/fr/LC_MESSAGES/opengever.tasktemplates.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-10-28 09:03+0000\n"
+"POT-Creation-Date: 2022-04-01 15:20+0000\n"
 "PO-Revision-Date: 2017-12-03 11:48+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-tasktemplates/fr/>\n"
@@ -49,6 +49,11 @@ msgstr "Enclencher"
 #: ./opengever/tasktemplates/browser/trigger.py
 msgid "description_start_immediately"
 msgstr "Commencer la première tâche immédiatement après la création"
+
+#. Default: "Nested TaskTemplateFolders are only supported in the new UI."
+#: ./opengever/tasktemplates/browser/trigger.py
+msgid "error_nested_tasktemplatefolder"
+msgstr "Les déroulements standard imbriqués ne sont supportés que dans la nouvelle interface."
 
 #. Default: "Common"
 #: ./opengever/tasktemplates/content/tasktemplate.py
@@ -229,3 +234,8 @@ msgstr "Aucun déroulement standard actif n'est enregistré pour le moment."
 #: ./opengever/tasktemplates/browser/tasktemplates.py
 msgid "preselected_yes"
 msgstr "Oui"
+
+#. Default: "Nested TaskTemplateFolders can only be viewed and edited correctly in the new UI."
+#: ./opengever/tasktemplates/browser/tabbed.py
+msgid "warning_nested_tasktemplatefolder"
+msgstr "Les déroulements standard imbriqués ne peuvent être affichés et édités correctement que dans la nouvelle interface."

--- a/opengever/tasktemplates/locales/opengever.tasktemplates.pot
+++ b/opengever/tasktemplates/locales/opengever.tasktemplates.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-10-28 09:03+0000\n"
+"POT-Creation-Date: 2022-04-01 15:20+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -49,6 +49,11 @@ msgstr ""
 #. Default: "Immediately open the first task after creation."
 #: ./opengever/tasktemplates/browser/trigger.py
 msgid "description_start_immediately"
+msgstr ""
+
+#. Default: "Nested TaskTemplateFolders are only supported in the new UI."
+#: ./opengever/tasktemplates/browser/trigger.py
+msgid "error_nested_tasktemplatefolder"
 msgstr ""
 
 #. Default: "Common"
@@ -229,4 +234,9 @@ msgstr ""
 #. Default: "Yes"
 #: ./opengever/tasktemplates/browser/tasktemplates.py
 msgid "preselected_yes"
+msgstr ""
+
+#. Default: "Nested TaskTemplateFolders can only be viewed and edited correctly in the new UI."
+#: ./opengever/tasktemplates/browser/tabbed.py
+msgid "warning_nested_tasktemplatefolder"
 msgstr ""

--- a/opengever/tasktemplates/tests/test_trigger.py
+++ b/opengever/tasktemplates/tests/test_trigger.py
@@ -68,6 +68,28 @@ class TestTriggeringTaskTemplate(IntegrationTestCase):
             browser.css('#formfield-form-widgets-tasktemplatefolder').first.options)
 
     @browsing
+    def test_selecting_nested_tasktemplatefolder_returns_and_shows_error_message(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        create(Builder('tasktemplatefolder')
+               .having(title=u'Sub tasktemplatefolder',
+                       type='parallel')
+               .within(self.tasktemplatefolder))
+
+        browser.open(self.dossier, view='add-tasktemplate')
+        self.assertEqual(['Select task template folder'],
+                         browser.css('h1').text)
+
+        browser.fill({'Task template folder': 'Verfahren Neuanstellung'})
+        browser.click_on('Continue')
+
+        self.assertEqual(['Select task template folder'],
+                         browser.css('h1').text)
+        self.assertEqual(
+            ['Nested TaskTemplateFolders are only supported in the new UI.'],
+            error_messages())
+
+    @browsing
     def test_step2_list_all_tasktemplates_of_the_selected_folder_and_preselects_them_correctly(self, browser):
         self.login(self.regular_user, browser=browser)
 

--- a/opengever/tasktemplates/tests/test_vocabularies.py
+++ b/opengever/tasktemplates/tests/test_vocabularies.py
@@ -1,0 +1,33 @@
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import factoriesmenu
+from opengever.tasktemplates.vocabularies import ActiveTasktemplatefoldersVocabulary
+from opengever.testing import IntegrationTestCase
+
+
+class TestActiveTasktemplatefoldersVocabulary(IntegrationTestCase):
+
+    @browsing
+    def test_contains_only_active_tasktemplatefolders(self, browser):
+        self.login(self.administrator, browser=browser)
+        vocabulary = ActiveTasktemplatefoldersVocabulary()(None)
+        self.assertIn(self.tasktemplatefolder.UID(), vocabulary)
+
+        url = '{}/@workflow/tasktemplatefolder-transition-activ-inactiv'.format(
+            self.tasktemplatefolder.absolute_url())
+        browser.open(url, method='POST', headers=self.api_headers)
+        vocabulary = ActiveTasktemplatefoldersVocabulary()(None)
+        self.assertNotIn(self.tasktemplatefolder.UID(), vocabulary)
+
+    @browsing
+    def test_does_not_contain_subtasktemplatefolders(self, browser):
+        self.activate_feature('tasktemplatefolder_nesting')
+        self.login(self.administrator, browser=browser)
+
+        browser.open(self.tasktemplatefolder)
+        factoriesmenu.add(u'Task Template Folder')
+        browser.fill({'Title': 'Baugesuch', 'Type': 'parallel'}).submit()
+        subtasktemplatefolder = browser.context
+
+        vocabulary = ActiveTasktemplatefoldersVocabulary()(None)
+        self.assertIn(self.tasktemplatefolder.UID(), vocabulary)
+        self.assertNotIn(subtasktemplatefolder.UID(), vocabulary)

--- a/opengever/tasktemplates/vocabularies.py
+++ b/opengever/tasktemplates/vocabularies.py
@@ -14,6 +14,8 @@ class ActiveTasktemplatefoldersVocabulary(object):
     def __call__(self, context):
         terms = []
         for templatefolder in self.get_tasktemplatefolder():
+            if templatefolder.getObject().is_subtasktemplatefolder():
+                continue
             terms.append(SimpleTerm(value=templatefolder.UID,
                                     token=templatefolder.UID,
                                     title=templatefolder.Title))


### PR DESCRIPTION
In this PR we:
- Prevent selection of sub-TaskTemplateFolders for triggering in the classic UI. Note that the vocabulary now needs to get the objects, making it inefficient. We could base it on solr instead, but I don't really expect this to be an issue...
- Prevent triggering nested TaskTemplateFolders in the classic UI. When a TaskTemplateFolder containing sub-TaskTemplateFolders is selected for triggering, an error message is shown and the user has to select again.

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-3725]

## Checklist
- [ ] Changelog entry -> no changelog entry for now, we will make one in a future PR
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- New translations
  - [x] All msg-strings are unicode

[CA-3725]: https://4teamwork.atlassian.net/browse/CA-3725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ