### PR TITLE
Add @process endpoint supporting nested task sequences.

### DIFF
--- a/changes/CA-3725.feature
+++ b/changes/CA-3725.feature
@@ -1,0 +1,1 @@
+Added new `@process` endpoint. [njohner]

--- a/opengever/api/add.py
+++ b/opengever/api/add.py
@@ -237,17 +237,17 @@ class SchemaValidationData(object):
     z3c.form.validator.Data class used during form invariants validation.
     """
     def __init__(self, schema, data, context):
-        self.context = context
-        self.data = data
-        self.schema = schema
+        self._Data_data___ = data
+        self._Data_schema___ = schema
+        self.__context__ = context
 
     def __getattr__(self, name):
-        if name in self.data:
-            return self.data.get(name)
-        if hasattr(self.context, name):
-            return getattr(self.context, name)
-        if name in self.schema:
-            return self.schema.get(name).default
+        if name in self._Data_data___:
+            return self._Data_data___.get(name)
+        if hasattr(self.__context__, name):
+            return getattr(self.__context__, name)
+        if name in self._Data_schema___:
+            return self._Data_schema___.get(name).default
         return None
 
 

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -1099,6 +1099,14 @@
       />
 
   <plone:service
+      method="POST"
+      name="@process"
+      for="opengever.dossier.behaviors.dossier.IDossierMarker"
+      factory=".process.ProcessPost"
+      permission="cmf.AddPortalContent"
+      />
+
+  <plone:service
       method="GET"
       name="@task-template-structure"
       for="opengever.tasktemplates.content.templatefoldersschema.ITaskTemplateFolderSchema"

--- a/opengever/api/process.py
+++ b/opengever/api/process.py
@@ -1,0 +1,205 @@
+from opengever.api.add import get_validation_errors
+from opengever.api.task import deserialize_responsible
+from opengever.base.source import DossierPathSourceBinder
+from opengever.ogds.base.utils import get_current_org_unit
+from opengever.task.task import ITask
+from opengever.tasktemplates.content.templatefoldersschema import sequence_type_vocabulary
+from opengever.tasktemplates.tasktemplatefolder import ProcessCreator
+from opengever.tasktemplates.tasktemplatefolder import ProcessDataPreprocessor
+from plone import api
+from plone.protect.interfaces import IDisableCSRFProtection
+from plone.restapi.deserializer import json_body
+from plone.restapi.interfaces import IFieldDeserializer
+from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.services import Service
+from plone.supermodel import model
+from z3c.relationfield.schema import RelationChoice
+from z3c.relationfield.schema import RelationList
+from zExceptions import BadRequest
+from zope import schema
+from zope.component import queryMultiAdapter
+from zope.interface import alsoProvides
+from opengever.task import _ as task_mf
+from opengever.tasktemplates import _ as tasktemplate_mf
+
+
+class IProcessSchema(model.Schema):
+
+    start_immediately = schema.Bool(
+        required=True,
+        default=True
+    )
+
+    process = schema.Dict(
+        title=u'process',
+        key_type=schema.TextLine(),
+        required=True)
+
+    related_documents = RelationList(
+        required=False,
+        default=[],
+        missing_value=[],
+        value_type=RelationChoice(
+            source=DossierPathSourceBinder(
+                portal_type=("opengever.document.document", "ftw.mail.mail"),
+                navigation_tree_query={
+                    'review_state': {'not': 'document-state-shadow'},
+                    'object_provides':
+                    ['opengever.dossier.behaviors.dossier.IDossierMarker',
+                     'opengever.document.document.IDocumentSchema',
+                     'opengever.task.task.ITask',
+                     'ftw.mail.mail.IMail', ],
+                }),
+        )
+    )
+
+
+class ITaskContainer(model.Schema):
+
+    items = schema.List(
+        title=u'items',
+        required=True)
+
+    sequence_type = schema.Choice(
+        title=tasktemplate_mf(u'label_sequence_type', default='Type'),
+        vocabulary=sequence_type_vocabulary,
+        required=True,
+    )
+
+    title = schema.TextLine(
+        title=task_mf(u"label_title", default=u"Title"),
+        description=task_mf('help_title', default=u""),
+        required=True,
+        max_length=256,
+        )
+
+    text = schema.Text(
+        title=task_mf(u"label_text", default=u"Text"),
+        description=task_mf(u"help_text", default=u""),
+        required=False,
+        )
+
+    relatedItems = RelationList(
+        title=task_mf(u'label_related_items', default=u'Related Items'),
+        default=[],
+        missing_value=[],
+        value_type=RelationChoice(
+            title=u"Related",
+            source=DossierPathSourceBinder(
+                portal_type=("opengever.document.document", "ftw.mail.mail"),
+                navigation_tree_query={
+                    'review_state': {'not': 'document-state-shadow'},
+                    'object_provides': [
+                        'opengever.dossier.behaviors.dossier.IDossierMarker',
+                        'opengever.document.document.IDocumentSchema',
+                        'opengever.task.task.ITask',
+                        'ftw.mail.mail.IMail',
+                        'opengever.meeting.proposal.IProposal',
+                        ],
+                    },
+                ),
+            ),
+        required=False,
+        )
+
+
+class ProcessPost(Service):
+    """API Endpoint to create a process.
+    """
+
+    def reply(self):
+        # Disable CSRF protection
+        alsoProvides(self.request, IDisableCSRFProtection)
+
+        data = json_body(self.request)
+
+        # use schema validation for basic fields
+        errors = get_validation_errors(self.context, data, IProcessSchema)
+        if errors:
+            self.raise_bad_request(errors)
+
+        data = ProcessDataPreprocessor(self.context, data)()
+        self.validate_tasks(data["process"], errors)
+
+        if errors:
+            self.raise_bad_request(errors)
+
+        self.fill_task_container_data(data["process"])
+
+        process_creator = ProcessCreator(self.context, data)
+        task = process_creator()
+
+        serializer = queryMultiAdapter((task, self.request), ISerializeToJson)
+        result = serializer()
+        # the folder serializer uses the current url to display the @id. this
+        # wont work as we are using the serializer outside a request to the
+        # actual item, we are in the @trigger-task-template service. thus we
+        # have to make sure to return the correct id.
+        result['@id'] = task.absolute_url()
+        return result
+
+    def fill_task_container_data(self, data):
+        """The task containers have some automatic values for certain fields,
+        as they are simply used to contain a set of parallel or sequential
+        subtasks.
+        """
+        default_data = {
+            "issuer": api.user.get_current().getId(),
+            "responsible": api.user.get_current().getId(),
+            "responsible_client": get_current_org_unit().id(),
+            "task_type": "direct-execution"
+        }
+        self.recursive_fill_task_container_data(data, default_data)
+
+    def recursive_fill_task_container_data(self, data, default_data):
+        if self.is_task_container(data):
+            data.update(default_data)
+            for subtask_data in data.get("items", []):
+                self.recursive_fill_task_container_data(subtask_data, default_data)
+
+    @staticmethod
+    def is_task_container(data):
+        if "items" in data or "sequence_type" in data:
+            return True
+        return False
+
+    @staticmethod
+    def raise_bad_request(errors):
+        errors = [{"field": each[0], "error": each[1]} for each in errors]
+        raise BadRequest(errors)
+
+    def get_schema(self, data):
+        if self.is_task_container(data):
+            return ITaskContainer
+        return ITask
+
+    def deserialize_data_with_schema(self, data, schema):
+        # responsible needs to be treated before any further deserialization as
+        # it might need to get split up into responsible_client and responsible.
+        responsible = deserialize_responsible(data.get('responsible'))
+        if responsible:
+            data.update(responsible)
+
+        for name, value in data.items():
+            field = schema.get(name)
+            if field is None:
+                continue
+            deserializer = queryMultiAdapter(
+                (field, self.context, self.request), IFieldDeserializer)
+            data[name] = deserializer(value)
+
+    def deserialize_data(self, data):
+        self.deserialize_data_with_schema(data, IProcessSchema)
+        self._recursive_deserialization(data.get("process", {}))
+
+    def _recursive_deserialization(self, data):
+        self.deserialize_data_with_schema(data, self.get_schema(data))
+        for subtask_data in data.get("items", []):
+            self._recursive_deserialization(subtask_data)
+
+    def validate_tasks(self, data, errors):
+        errors.extend(get_validation_errors(
+            self.context, data, self.get_schema(data)))
+
+        for subtask_data in data.get("items", []):
+            self.validate_tasks(subtask_data, errors)

--- a/opengever/api/tests/test_process.py
+++ b/opengever/api/tests/test_process.py
@@ -1,0 +1,551 @@
+from datetime import date
+from datetime import datetime
+from ftw.testbrowser import browsing
+from ftw.testing import freeze
+from opengever.ogds.base.actor import INTERACTIVE_ACTOR_CURRENT_USER_ID
+from opengever.ogds.base.actor import INTERACTIVE_ACTOR_RESPONSIBLE_ID
+from opengever.ogds.models.team import Team
+from opengever.tasktemplates.interfaces import IFromParallelTasktemplate
+from opengever.tasktemplates.interfaces import IFromSequentialTasktemplate
+from opengever.tasktemplates.tasktemplatefolder import ProcessDataPreprocessor
+from opengever.testing import IntegrationTestCase
+from plone import api
+import json
+
+
+class TestProcessDataPreprocessor(IntegrationTestCase):
+
+    def test_deadline_is_the_longest_deadline_of_children_plus_five(self):
+        self.login(self.regular_user)
+        data = {
+            "process": {
+                "items": [
+                    {"deadline": date(2022, 03, 01)},
+                    {"deadline": date(2022, 03, 05)},
+                    {"deadline": date(2022, 03, 02)},
+                ]
+            }
+        }
+        processor = ProcessDataPreprocessor(self.dossier, data)
+        with freeze(datetime(2022, 02, 01)):
+            processor.recursive_set_deadlines()
+
+        self.assertEqual(date(2022, 03, 10), data["process"]["deadline"])
+
+    def test_deadline_at_least_today_plus_five(self):
+        self.login(self.regular_user)
+        data = {
+            "process": {
+                "items": [
+                    {"deadline": date(2022, 03, 05)},
+                    {"deadline": date(2022, 03, 01)},
+                    {"deadline": date(2022, 03, 02)},
+                ]
+            }
+        }
+        processor = ProcessDataPreprocessor(self.dossier, data)
+        with freeze(datetime(2022, 04, 01)):
+            processor.recursive_set_deadlines()
+
+        self.assertEqual(date(2022, 04, 06), data["process"]["deadline"])
+
+    def test_recursive_deadline_propagation(self):
+        self.login(self.regular_user)
+        data = {
+            "process": {
+                "items": [
+                    {"deadline": date(2022, 03, 01)},
+                    {"items": [
+                        {"deadline": date(2022, 03, 10)},
+                        {"items": [
+                            {"deadline": date(2022, 04, 2)},
+                        ]},
+                    ]},
+                    {"items": [
+                        {"deadline": date(2022, 03, 10)},
+                        {"deadline": date(2022, 03, 05)},
+                    ]},
+                ]
+            }
+        }
+        processor = ProcessDataPreprocessor(self.dossier, data)
+        with freeze(datetime(2022, 02, 01)):
+            processor.recursive_set_deadlines()
+
+        expected_data = {
+            "process": {
+                "deadline": date(2022, 4, 17),
+                "items": [
+                    {"deadline": date(2022, 03, 01)},
+                    {"deadline": date(2022, 4, 12),
+                     "items": [
+                        {"deadline": date(2022, 03, 10)},
+                        {"deadline": date(2022, 4, 7),
+                         "items": [
+                            {"deadline": date(2022, 04, 2)},
+                        ]},
+                    ]},
+                    {"deadline": date(2022, 03, 15),
+                     "items": [
+                        {"deadline": date(2022, 03, 10)},
+                        {"deadline": date(2022, 03, 05)},
+                    ]},
+                ]
+            }
+        }
+
+        self.assertEqual(expected_data, data)
+
+
+class TestProcessPost(IntegrationTestCase):
+
+    @browsing
+    def test_create_simple_process(self, browser):
+        self.login(self.regular_user, browser)
+        data = {
+            "related_documents": [],
+            "start_immediately": False,
+            "process": {
+                "title": "New employee",
+                "text": "A new employee arrives.",
+                "sequence_type": "sequential",
+                "items": [
+                    {
+                        "title": "Assign userid",
+                        "responsible": "fa:{}".format(self.regular_user.id),
+                        "issuer": self.secretariat_user.id,
+                        "deadline": "2022-03-01",
+                        "task_type": "direct-execution",
+                        "is_private": False,
+                    }
+                ]
+            }
+        }
+
+        with self.observe_children(self.dossier) as children, freeze(datetime(2022, 02, 01)):
+            browser.open('{}/@process'.format(
+                         self.dossier.absolute_url()),
+                         data=json.dumps(data),
+                         headers=self.api_headers)
+
+        self.assertEqual(1, len(children['added']))
+        main_task = children['added'].pop()
+
+        self.assertEqual(browser.json['@id'], main_task.absolute_url())
+        self.assertEqual(u'New employee', main_task.title)
+        self.assertEqual(self.regular_user.getId(), main_task.issuer)
+        self.assertEqual(self.regular_user.getId(), main_task.responsible)
+        self.assertEqual('fa', main_task.responsible_client)
+        self.assertEqual('direct-execution', main_task.task_type)
+        self.assertEqual('task-state-in-progress',
+                         api.content.get_state(main_task))
+        self.assertEqual(date(2022, 3, 6), main_task.deadline)
+
+        subtasks = main_task.listFolderContents()
+        self.assertEqual(1, len(subtasks))
+        subtask = subtasks.pop()
+        self.assertEqual(u'Assign userid', subtask.title)
+        self.assertEqual(self.secretariat_user.id, subtask.issuer)
+        self.assertEqual(self.regular_user.getId(), subtask.responsible)
+        self.assertEqual('fa', subtask.responsible_client)
+        self.assertEqual('task-state-planned',
+                         api.content.get_state(subtask))
+        self.assertEqual(date(2022, 3, 1), subtask.deadline)
+
+    @browsing
+    def test_create_nested_process(self, browser):
+        self.login(self.regular_user, browser)
+        data = {
+            "related_documents": [],
+            "start_immediately": True,
+            "process": {
+                "title": "New employee",
+                "text": "A new employee arrives.",
+                "sequence_type": "sequential",
+                "items": [
+                    {
+                        "title": "Assign userid",
+                        "responsible": "fa:{}".format(self.regular_user.id),
+                        "issuer": self.secretariat_user.id,
+                        "deadline": "2022-03-01",
+                        "task_type": "direct-execution",
+                        "is_private": False,
+                    },
+                    {
+                        "title": "Training",
+                        "sequence_type": "parallel",
+                        "items": [
+                            {
+                                "title": "Present Gever",
+                                "responsible": "fa:{}".format(self.regular_user.id),
+                                "issuer": self.dossier_responsible.id,
+                                "deadline": "2022-03-10",
+                                "task_type": "direct-execution",
+                                "is_private": False,
+                            },
+                            {
+                                "title": "Present Teamraum",
+                                "responsible": "fa:{}".format(self.workspace_admin.id),
+                                "issuer": self.dossier_responsible.id,
+                                "deadline": "2022-03-12",
+                                "task_type": "direct-execution",
+                                "is_private": False,
+                            },
+                        ]
+
+                    }
+                ]
+            }
+        }
+
+        with self.observe_children(self.dossier) as children, freeze(datetime(2022, 02, 01)):
+            browser.open('{}/@process'.format(
+                         self.dossier.absolute_url()),
+                         data=json.dumps(data),
+                         headers=self.api_headers)
+
+        self.assertEqual(1, len(children['added']))
+        main_task = children['added'].pop()
+
+        subtasks = main_task.listFolderContents()
+        self.assertEqual(2, len(subtasks))
+        subtask = subtasks[0]
+        subtask_container = subtasks[1]
+
+        self.assertEqual(0, len(subtask.listFolderContents()))
+        subsubtasks = subtask_container.listFolderContents()
+        self.assertEqual(2, len(subsubtasks))
+        subsubtask1, subsubtask2 = subsubtasks
+
+        # Check data that is automatically set for the subtask container
+        self.assertEqual(u'Training', subtask_container.title)
+        self.assertEqual(self.regular_user.getId(), subtask_container.issuer)
+        self.assertEqual(self.regular_user.getId(), subtask_container.responsible)
+        self.assertEqual('fa', subtask_container.responsible_client)
+        self.assertEqual('direct-execution', subtask_container.task_type)
+        # Only state of main task is set to in progress
+        self.assertEqual('task-state-in-progress',
+                         api.content.get_state(main_task))
+        self.assertEqual('task-state-open',
+                         api.content.get_state(subtask_container))
+
+        # Check deadline propagation
+        self.assertEqual(date(2022, 3, 10), subsubtask1.deadline)
+        self.assertEqual(date(2022, 3, 12), subsubtask2.deadline)
+        self.assertEqual(date(2022, 3, 17), subtask_container.deadline)
+        self.assertEqual(date(2022, 3, 1), subtask.deadline)
+        self.assertEqual(date(2022, 3, 22), main_task.deadline)
+
+        # check parallel and sequential interfaces
+        self.assertTrue(IFromSequentialTasktemplate.providedBy(main_task))
+        self.assertTrue(IFromSequentialTasktemplate.providedBy(subtask))
+        self.assertTrue(IFromParallelTasktemplate.providedBy(subtask_container))
+        self.assertTrue(IFromParallelTasktemplate.providedBy(subsubtask1))
+        self.assertTrue(IFromParallelTasktemplate.providedBy(subsubtask2))
+
+        # Check tasktemplatefolder predecessor
+        # Not set for parallel process
+        self.assertIsNone(subsubtask2.get_sql_object().get_previous_task())
+        # Should be set for sequential but broken for now because the
+        # subtask_container did not inherit the IFromSequentialTasktemplate
+        # from the parent and is therefore not identified as sequential
+        self.assertNotEqual(subtask.get_sql_object(),
+                            subtask_container.get_sql_object().get_previous_task())
+
+    @browsing
+    def test_sets_related_documents_on_all_subtasks(self, browser):
+        self.login(self.regular_user, browser)
+        data = {
+            'related_documents': [
+                {
+                    '@id': self.document.absolute_url()
+                }
+            ],
+            "start_immediately": True,
+            "process": {
+                "title": "New employee",
+                "text": "A new employee arrives.",
+                "sequence_type": "sequential",
+                "items": [
+                    {
+                        "title": "Assign userid",
+                        "responsible": "fa:{}".format(self.regular_user.id),
+                        "issuer": self.secretariat_user.id,
+                        "deadline": "2022-03-01",
+                        "task_type": "direct-execution",
+                        "is_private": False,
+                    },
+                    {
+                        "title": "Training",
+                        "sequence_type": "parallel",
+                        "items": [
+                            {
+                                "title": "Present Gever",
+                                "responsible": "fa:{}".format(self.regular_user.id),
+                                "issuer": self.dossier_responsible.id,
+                                "deadline": "2022-03-10",
+                                "task_type": "direct-execution",
+                                "is_private": False,
+                            },
+                            {
+                                "title": "Present Teamraum",
+                                "responsible": "fa:{}".format(self.workspace_admin.id),
+                                "issuer": self.dossier_responsible.id,
+                                "deadline": "2022-03-12",
+                                "task_type": "direct-execution",
+                                "is_private": False,
+                            },
+                        ]
+
+                    }
+                ]
+            }
+        }
+        with self.observe_children(self.dossier) as children, freeze(datetime(2022, 02, 01)):
+            browser.open('{}/@process'.format(
+                         self.dossier.absolute_url()),
+                         data=json.dumps(data),
+                         headers=self.api_headers)
+
+        self.assertEqual(1, len(children['added']))
+        main_task = children['added'].pop()
+        subtasks = main_task.listFolderContents()
+        self.assertEqual(2, len(subtasks))
+        subtask, subtask_container = subtasks
+
+        self.assertEqual(
+            [self.document],
+            [rel.to_object for rel in subtask.relatedItems])
+
+        self.assertEqual(
+            [self.document],
+            [rel.to_object for rel in subtask_container.relatedItems])
+
+        subsubtasks = subtask_container.listFolderContents()
+        self.assertEqual(2, len(subtasks))
+        for subsubtask in subsubtasks:
+            self.assertEqual(
+                [self.document],
+                [rel.to_object for rel in subsubtask.relatedItems])
+
+    @browsing
+    def test_raises_bad_request_for_missing_main_fields(self, browser):
+        self.login(self.regular_user, browser)
+        data = {
+            "start_immediately": True,
+        }
+
+        with browser.expect_http_error(400):
+            browser.open('{}/@process'.format(
+                         self.dossier.absolute_url()),
+                         data=json.dumps(data),
+                         headers=self.api_headers)
+        self.assertEqual(u'Inputs not valid',
+                         browser.json[u'translated_message'])
+
+        self.assertItemsEqual(
+            [{u'field': u'process',
+              u'translated_message': u'None',
+              u'type': u'process'}],
+            browser.json[u'additional_metadata']['fields'])
+
+    @browsing
+    def test_raises_bad_request_for_missing_field_in_subtask(self, browser):
+        self.login(self.regular_user, browser)
+        data = {
+            "related_documents": [],
+            "start_immediately": True,
+            "process": {
+                "title": "New employee",
+                "text": "A new employee arrives.",
+                "sequence_type": "sequential",
+                "items": [
+                    {
+                        "title": "Assign userid",
+                        "issuer": self.secretariat_user.id,
+                        "deadline": "2022-03-01",
+                        "task_type": "direct-execution",
+                        "is_private": False,
+                    }
+                ]
+            }
+        }
+
+        with browser.expect_http_error(400):
+            browser.open('{}/@process'.format(
+                         self.dossier.absolute_url()),
+                         data=json.dumps(data),
+                         headers=self.api_headers)
+
+        self.assertEqual(u'Inputs not valid',
+                         browser.json[u'translated_message'])
+
+        self.assertItemsEqual(
+            [{u'field': u'responsible_client',
+              u'translated_message': u'None',
+              u'type': u'responsible_client'},
+             {u'field': u'responsible',
+              u'translated_message': u'None',
+              u'type': u'responsible'}],
+            browser.json[u'additional_metadata']['fields'])
+
+    @browsing
+    def test_respects_start_immediately_flag(self, browser):
+        self.login(self.regular_user, browser)
+        data = {
+            "related_documents": [],
+            "start_immediately": True,
+            "process": {
+                "title": "New employee",
+                "text": "A new employee arrives.",
+                "sequence_type": "sequential",
+                "items": [
+                    {
+                        "title": "Assign userid",
+                        "responsible": "fa:{}".format(self.regular_user.id),
+                        "issuer": self.secretariat_user.id,
+                        "deadline": "2022-03-01",
+                        "task_type": "direct-execution",
+                        "is_private": False,
+                    },
+                    {
+                        "title": "Assign desk",
+                        "responsible": "fa:{}".format(self.regular_user.id),
+                        "issuer": self.secretariat_user.id,
+                        "deadline": "2022-03-01",
+                        "task_type": "direct-execution",
+                        "is_private": False,
+                    },
+                ]
+            }
+        }
+
+        with self.observe_children(self.dossier) as children, freeze(datetime(2022, 02, 01)):
+            browser.open('{}/@process'.format(
+                         self.dossier.absolute_url()),
+                         data=json.dumps(data),
+                         headers=self.api_headers)
+
+        main_task = children['added'].pop()
+        self.assertEquals('task-state-in-progress',
+                          api.content.get_state(main_task))
+        subtask_1, subtask_2 = main_task.listFolderContents()
+        self.assertEquals('task-state-open',
+                          api.content.get_state(subtask_1))
+        self.assertEquals('task-state-planned',
+                          api.content.get_state(subtask_2))
+
+        data["start_immediately"] = False
+        with self.observe_children(self.dossier) as children, freeze(datetime(2022, 02, 01)):
+            browser.open('{}/@process'.format(
+                         self.dossier.absolute_url()),
+                         data=json.dumps(data),
+                         headers=self.api_headers)
+
+        main_task = children['added'].pop()
+        self.assertEquals('task-state-in-progress',
+                          api.content.get_state(main_task))
+        subtask_1, subtask_2 = main_task.listFolderContents()
+        self.assertEquals('task-state-planned',
+                          api.content.get_state(subtask_1))
+        self.assertEquals('task-state-planned',
+                          api.content.get_state(subtask_2))
+
+    @browsing
+    def test_handles_interactive_actors(self, browser):
+        self.login(self.regular_user, browser)
+        data = {
+            "related_documents": [],
+            "start_immediately": True,
+            "process": {
+                "title": "New employee",
+                "text": "A new employee arrives.",
+                "sequence_type": "sequential",
+                "items": [
+                    {
+                        "title": "Assign userid",
+                        "responsible": INTERACTIVE_ACTOR_RESPONSIBLE_ID,
+                        "issuer": INTERACTIVE_ACTOR_CURRENT_USER_ID,
+                        "deadline": "2022-03-01",
+                        "task_type": "direct-execution",
+                        "is_private": False,
+                    },
+                    {
+                        "title": "Assign desk",
+                        "responsible": INTERACTIVE_ACTOR_CURRENT_USER_ID,
+                        "issuer": INTERACTIVE_ACTOR_RESPONSIBLE_ID,
+                        "deadline": "2022-03-01",
+                        "task_type": "direct-execution",
+                        "is_private": False,
+                    }
+                ]
+            }
+        }
+
+        with self.observe_children(self.dossier) as children, freeze(datetime(2022, 02, 01)):
+            browser.open('{}/@process'.format(
+                         self.dossier.absolute_url()),
+                         data=json.dumps(data),
+                         headers=self.api_headers)
+
+        self.assertEqual(1, len(children['added']))
+        main_task = children['added'].pop()
+        subtasks = main_task.listFolderContents()
+        self.assertEqual(2, len(subtasks))
+        subtask1, subtask2 = subtasks
+        self.assertEqual(subtask1.responsible, self.dossier_responsible.id)
+        self.assertEqual(subtask1.responsible_client, 'fa')
+        self.assertEqual(subtask1.issuer, self.regular_user.id)
+        self.assertEqual(subtask2.responsible, self.regular_user.id)
+        self.assertEqual(subtask2.responsible_client, 'fa')
+        self.assertEqual(subtask2.issuer, self.dossier_responsible.id)
+
+    @browsing
+    def test_handles_teams_and_inbox_as_task_responsible(self, browser):
+        self.login(self.regular_user, browser)
+        team = Team.get_by(groupid='projekt_a')
+        team_id = 'team:{}'.format(team.team_id)
+        inbox_id = 'inbox:fa'
+        data = {
+            "related_documents": [],
+            "start_immediately": True,
+            "process": {
+                "title": "New employee",
+                "text": "A new employee arrives.",
+                "sequence_type": "sequential",
+                "items": [
+                    {
+                        "title": "Assign userid",
+                        "responsible": team_id,
+                        "issuer": self.regular_user.id,
+                        "deadline": "2022-03-01",
+                        "task_type": "direct-execution",
+                        "is_private": False,
+                    },
+                    {
+                        "title": "Assign desk",
+                        "responsible": inbox_id,
+                        "issuer": self.regular_user.id,
+                        "deadline": "2022-03-01",
+                        "task_type": "direct-execution",
+                        "is_private": False,
+                    }
+                ]
+            }
+        }
+
+        with self.observe_children(self.dossier) as children, freeze(datetime(2022, 02, 01)):
+            browser.open('{}/@process'.format(
+                         self.dossier.absolute_url()),
+                         data=json.dumps(data),
+                         headers=self.api_headers)
+
+        self.assertEqual(1, len(children['added']))
+        main_task = children['added'].pop()
+        subtasks = main_task.listFolderContents()
+        self.assertEqual(2, len(subtasks))
+        subtask1, subtask2 = subtasks
+        self.assertEqual(subtask1.responsible, team_id)
+        self.assertEqual(subtask1.responsible_client, 'fa')
+        self.assertEqual(subtask2.responsible, inbox_id)
+        self.assertEqual(subtask2.responsible_client, 'fa')

--- a/opengever/meeting/vocabulary.py
+++ b/opengever/meeting/vocabulary.py
@@ -216,7 +216,7 @@ class ProposalTemplatesForCommitteeVocabulary(object):
         """Return a list of documents from the predecessor proposal.
         The returned documents can additionally be selected as proposal template.
         """
-        if isinstance(context, SchemaValidationData) and "predecessor_proposal" in context.data:
+        if isinstance(context, SchemaValidationData) and "predecessor_proposal" in context._Data_data___:
             # Proposal is being added through the REST-API.
             predecessor = api.content.get(UID=context.predecessor_proposal)
             return [predecessor.get_proposal_document()]

--- a/opengever/tasktemplates/tasktemplatefolder.py
+++ b/opengever/tasktemplates/tasktemplatefolder.py
@@ -131,8 +131,6 @@ class TaskTemplateFolderTrigger(object):
         return main_task
 
     def create_subtasks(self, main_task):
-        predecessor = None
-
         subtasks = []
         for template in self.selected_templates:
             subtask = self.create_subtask(

--- a/opengever/tasktemplates/tasktemplatefolder.py
+++ b/opengever/tasktemplates/tasktemplatefolder.py
@@ -212,10 +212,10 @@ class ProcessCreator(object):
     def __init__(self, dossier, process_data):
         self.dossier = dossier
         self.process_data = process_data
-        self.start_immediately = self.process_data.pop("start_immediately")
+        self.start_immediately = self.process_data.get("start_immediately")
         self.request = getRequest()
         self.first_subtask_created = False
-        self.related_documents = self.process_data.pop("related_documents")
+        self.related_documents = self.process_data.get("related_documents", [])
 
     def __call__(self):
         main_task_data = self.process_data["process"]

--- a/opengever/tasktemplates/tasktemplatefolder.py
+++ b/opengever/tasktemplates/tasktemplatefolder.py
@@ -147,7 +147,7 @@ class TaskTemplateFolderTrigger(object):
         tasktemplatefolder except for the first if start_immediately is True.
         Tasks of a parallel tasktemplatefolder are skipped.
         """
-        if not self.context.is_sequential:
+        if not IFromSequentialTasktemplate.providedBy(task):
             return
 
         if not self.start_immediately \

--- a/opengever/tasktemplates/tasktemplatefolder.py
+++ b/opengever/tasktemplates/tasktemplatefolder.py
@@ -96,9 +96,9 @@ class TaskTemplateFolderTrigger(object):
         self.request = getRequest()
 
     def generate(self):
-        self.process_creator = ProcessCreator()
+        self.process_creator = ProcessCreator(self.dossier)
         main_task_data = self.get_main_task_data()
-        main_task = self.create_main_task(main_task_data)
+        main_task = self.process_creator.create_main_task(main_task_data)
         alsoProvides(self.request, IDuringTaskTemplateFolderTriggering)
         subtasks_data = self.get_subtasks_data()
         self.create_subtasks(main_task, subtasks_data)
@@ -118,16 +118,6 @@ class TaskTemplateFolderTrigger(object):
             task_type='direct-execution',
             deadline=deadline,
             sequence_type=self.context.sequence_type)
-
-    def create_main_task(self, data):
-        main_task = self.process_creator.add_task(
-            self.dossier, data)
-
-        # set the main_task in to the in progress state
-        api.content.transition(obj=main_task,
-                               transition='task-transition-open-in-progress')
-
-        return main_task
 
     def get_subtasks_data(self):
         subtasks_data = []
@@ -226,6 +216,18 @@ class TaskTemplateFolderTrigger(object):
 
 
 class ProcessCreator(object):
+
+    def __init__(self, dossier):
+        self.dossier = dossier
+
+    def create_main_task(self, data):
+        main_task = self.add_task(self.dossier, data)
+
+        # set the main_task in to the in progress state
+        api.content.transition(obj=main_task,
+                               transition='task-transition-open-in-progress')
+
+        return main_task
 
     @staticmethod
     def is_sequential(sequence_type):

--- a/opengever/tasktemplates/tasktemplatefolder.py
+++ b/opengever/tasktemplates/tasktemplatefolder.py
@@ -316,7 +316,6 @@ class ProcessCreator(object):
         task = createContent('opengever.task.task',
                              relatedItems=related_documents,
                              **data)
-        notify(ObjectCreatedEvent(task))
         task = addContentToContainer(container, task, checkConstraints=True)
         self.mark_as_generated_from_tasktemplate(task, sequential)
         return task

--- a/opengever/tasktemplates/tasktemplatefolder.py
+++ b/opengever/tasktemplates/tasktemplatefolder.py
@@ -97,6 +97,7 @@ class TaskTemplateFolderTrigger(object):
 
     def generate(self):
         process_data = {
+            "start_immediately": self.start_immediately,
             "process": self.get_main_task_data(),
         }
         process_data["process"]["items"] = self.get_subtasks_data()
@@ -162,6 +163,7 @@ class ProcessCreator(object):
     def __init__(self, dossier, process_data):
         self.dossier = dossier
         self.process_data = process_data
+        self.start_immediately = self.process_data.pop("start_immediately")
         self.request = getRequest()
 
     def __call__(self):

--- a/opengever/tasktemplates/tasktemplatefolder.py
+++ b/opengever/tasktemplates/tasktemplatefolder.py
@@ -97,17 +97,18 @@ class TaskTemplateFolderTrigger(object):
 
     def generate(self):
         self.process_creator = ProcessCreator()
-        main_task = self.create_main_task()
+        main_task_data = self.get_main_task_data()
+        main_task = self.create_main_task(main_task_data)
         alsoProvides(self.request, IDuringTaskTemplateFolderTriggering)
         self.create_subtasks(main_task)
         noLongerProvides(self.request, IDuringTaskTemplateFolderTriggering)
         return main_task
 
-    def create_main_task(self):
+    def get_main_task_data(self):
         title = self.main_task_overrides.get("title", self.context.title)
         text = self.main_task_overrides.get("text", self.context.text)
         deadline = self.main_task_overrides.get("deadline", self.get_main_task_deadline())
-        data = dict(
+        return dict(
             title=title,
             text=text,
             issuer=api.user.get_current().getId(),
@@ -116,6 +117,7 @@ class TaskTemplateFolderTrigger(object):
             task_type='direct-execution',
             deadline=deadline)
 
+    def create_main_task(self, data):
         main_task = self.process_creator.add_task(
             self.dossier, data, sequential=self.context.is_sequential)
 

--- a/opengever/tasktemplates/tasktemplatefolder.py
+++ b/opengever/tasktemplates/tasktemplatefolder.py
@@ -144,13 +144,6 @@ class TaskTemplateFolderTrigger(object):
         data.update(values)
         return data
 
-    def set_tasktemplate_predecessor(self, task, predecessor):
-        if not self.context.is_sequential:
-            return
-
-        if predecessor:
-            task.set_tasktemplate_predecessor(predecessor)
-
 
 class ProcessDataPreprocessor(object):
 


### PR DESCRIPTION
In this PR we implement a new endpoint `@process` which allows to create task sequences. This endpoint is a substitute for the `@trigger-task-template`, but allowing more flexibility. It notably supports nested task sequences and the created process does not need to come from a `TaskTemplateFolder`. The old functionality and endpoint is kept for now, so that we do not have an API change. A few notable points:
- The `@process` can now validate the data of subtasks directly using the `ITask` schema, as we do not have half the data coming from the corresponding `TaskTemplate` which forced us to validate everything by hand before.
- All fields from `ITask` are now supported for the subtasks
- Validation, deadline calculation, data preprocessing and process creation are now all recursive and support any nesting depth

A few things that still need to be addressed:
- The interfaces used for marking Sequential and Parallel processes (`IFromSequentialTasktemplate`, `IFromParallelTasktemplate`) are not sufficient anymore as is, because we were relying on the main task and the subtasks to provide the same interface. With nesting this is not possible anymore, because a sequential `TasktemplateFolder` can be nested into a parallel one, so that the created task should have both interfaces, `IFromParallelTasktemplate` because it is part of a parallel process because of its parent, and `IFromSequentialTasktemplate` because it is the parent of a sequential set of tasks. This leads to various issues and needs to be looked at, notably:
  - Initial states of the created Tasks are not yet as expected (This is at least partially linked to the next point)
  - tasktemplate predecessor is not set correctly
- Check start next
- Check event handlers
- Documentation

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-3725]

## Checklist
- [ ] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue

[CA-3725]: https://4teamwork.atlassian.net/browse/CA-3725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ