### PR TITLE
Fix deleting workspace participations of inactive users,

### DIFF
--- a/changes/CA-3865.bugfix
+++ b/changes/CA-3865.bugfix
@@ -1,0 +1,1 @@
+Fix deleting workspace participations of inactive users. [phgross]

--- a/opengever/workspace/participation/browser/manage_participants.py
+++ b/opengever/workspace/participation/browser/manage_participants.py
@@ -111,7 +111,10 @@ class ManageParticipants(BrowserView):
             storage.remove_invitation(token)
             return
 
-        elif type_ in ['user', 'group'] and can_manage_member(self.context, Actor.lookup(token)):
+        # A type_ of `null` (NullActor) happens when an inactive user gets
+        # deleted which is no present in the OGDS.
+        # Usually a leftover of a migration
+        elif type_ in ['user', 'group', 'null'] and can_manage_member(self.context, Actor.lookup(token)):
             RoleAssignmentManager(self.context).clear_by_cause_and_principal(
                 ASSIGNMENT_VIA_SHARING, token)
             self._require_admin_assignment()
@@ -120,6 +123,7 @@ class ManageParticipants(BrowserView):
             manager = WorkspaceWatcherManager(self.context)
             manager.participant_removed(token)
             return
+
         else:
             raise BadRequest('Oh my, something went wrong')
 


### PR DESCRIPTION
without a corresponding OGDS user. Usually a leftover of a migration

For [CA-3865] 

Needs backport to LTS release `2022.4.x`

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- Bug fixed:
  - [x] Resolved any Sentry issues caused by this bug ([https://sentry.4teamwork.ch/organizations/sentry/issues/81466](sentry-issue))

[CA-3865]: https://4teamwork.atlassian.net/browse/CA-3865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ