### PR TITLE
Allow regular users to read task template structures

### DIFF
--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -1103,7 +1103,7 @@
       name="@task-template-structure"
       for="opengever.tasktemplates.content.templatefoldersschema.ITaskTemplateFolderSchema"
       factory=".templatefolder.TriggerTaskTemplateStructureGet"
-      permission="cmf.AddPortalContent"
+      permission="zope2.View"
       />
 
   <plone:service

--- a/opengever/api/tests/test_templatefolder.py
+++ b/opengever/api/tests/test_templatefolder.py
@@ -1401,3 +1401,15 @@ class TestTaskTemplateStructure(IntegrationTestCase):
             ],
             [item.get('title') for item in flatten_tree(browser.json)]
         )
+
+    @browsing
+    def test_regular_users_can_fetch_task_template_structures(self, browser):
+        self.activate_feature('tasktemplatefolder_nesting')
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(
+            '{}/@task-template-structure'.format(
+                self.tasktemplatefolder.absolute_url()),
+            headers=self.api_headers)
+
+        self.assertEqual(200, browser.status_code)


### PR DESCRIPTION
This is a follow-up PR for #7413 

Everyone with view permission should be able to read the task template structure.

This PR fixes an issue For [CA-3725]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] Changelog entry ℹ️  follow-up pr in same release
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-3725]: https://4teamwork.atlassian.net/browse/CA-3725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ