### PR TITLE
Rename badly named class for the @task-template-structure endpoint

### DIFF
--- a/docs/public/dev-manual/api/trigger_task_template.rst
+++ b/docs/public/dev-manual/api/trigger_task_template.rst
@@ -135,7 +135,7 @@ Struktur der Standardabläufe anzeigen
       Content-Type: application/json
 
       {
-        "@id": "/vorlagen/tasktemplate-1/@trigger-task-template-structure",
+        "@id": "/vorlagen/tasktemplate-1/@task-template-structure",
         "@type": "opengever.tasktemplates.tasktemplatefolder",
         "UID": "fc1a5fd76afa41f4962f2660887c601c",
         "items": [
@@ -152,7 +152,7 @@ Struktur der Standardabläufe anzeigen
                 "...": "..."
             },
             {
-                "@id": "/vorlagen/tasktemplate-1/@trigger-task-template-structure",
+                "@id": "/vorlagen/tasktemplate-1/@task-template-structure",
                 "@type": "opengever.tasktemplates.tasktemplatefolder",
                 "UID": "4a8ea261042949efb3abc3e706abf62c",
                 "items": [

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -1102,7 +1102,7 @@
       method="GET"
       name="@task-template-structure"
       for="opengever.tasktemplates.content.templatefoldersschema.ITaskTemplateFolderSchema"
-      factory=".templatefolder.TriggerTaskTemplateStructureGet"
+      factory=".templatefolder.TaskTemplateStructureGet"
       permission="zope2.View"
       />
 

--- a/opengever/api/templatefolder.py
+++ b/opengever/api/templatefolder.py
@@ -403,7 +403,7 @@ class TriggerTaskTemplatePost(Service):
         return documents, invalid_urls
 
 
-class TriggerTaskTemplateStructureGet(Service):
+class TaskTemplateStructureGet(Service):
     """
     """
     def reply(self):


### PR DESCRIPTION
This is a follow-up PR for https://github.com/4teamwork/opengever.core/pull/7413

- This PR fixes a copy&paste failure in the dev-manual which ended in a wrong `@id`.
- Renames a  badly named class for the @task-template-structure endpoint 

For [CA-3725]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] Changelog entry ℹ️ follow-up pr in same release
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-3725]: https://4teamwork.atlassian.net/browse/CA-3725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ