### PR TITLE
Allow moving TR documents to trash after copying them back to GEVER

### DIFF
--- a/changes/CA-3594.feature
+++ b/changes/CA-3594.feature
@@ -1,0 +1,1 @@
+Add support for trashing TR documents after retrieving them back to GEVER. [lgraf]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -12,6 +12,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- ``@copy-document-from-workspace``: Error responses now include ``translated_message``.
 - ``@external-activities``: ``notification_recipients`` now also accepts group IDs.
 - ``@external-activities``: Privileged users may now create notifications for other users (see :ref:`external-activities`)
 - ``@config``: Add ``workspace_creation_restricted`` feature flag.

--- a/opengever/api/linked_workspaces.py
+++ b/opengever/api/linked_workspaces.py
@@ -241,8 +241,11 @@ class CopyDocumentFromWorkspacePost(LinkedWorkspacesService):
                     workspace_uid, document_uid, as_new_version, trash_tr_document)
         except CopyFromWorkspaceForbidden:
             raise BadRequest(
-                "Document can't be copied from workspace because it's "
-                "currently checked out")
+                _("Document can't be copied from workspace because it's "
+                  "currently checked out"))
+        except LookupError:
+            raise BadRequest(
+                _("Document not in linked workspace"))
 
         serialized = self.serialize_object(destination_document)
         serialized['teamraum_connect_retrieval_mode'] = retrieval_mode

--- a/opengever/api/linked_workspaces.py
+++ b/opengever/api/linked_workspaces.py
@@ -233,12 +233,12 @@ class CopyDocumentFromWorkspacePost(LinkedWorkspacesService):
         # Disable CSRF protection
         alsoProvides(self.request, IDisableCSRFProtection)
 
-        workspace_uid, document_uid, as_new_version = self.validate_data(
+        workspace_uid, document_uid, as_new_version, trash_tr_document = self.validate_data(
             json_body(self.request))
         try:
             destination_document, retrieval_mode = ILinkedWorkspaces(
                 self.context).copy_document_from_workspace(
-                    workspace_uid, document_uid, as_new_version)
+                    workspace_uid, document_uid, as_new_version, trash_tr_document)
         except CopyFromWorkspaceForbidden:
             raise BadRequest(
                 "Document can't be copied from workspace because it's "
@@ -262,7 +262,8 @@ class CopyDocumentFromWorkspacePost(LinkedWorkspacesService):
         if not document_uid:
             raise BadRequest("Property 'document_uid' is required")
         as_new_version = bool(data.get('as_new_version', False))
-        return workspace_uid, document_uid, as_new_version
+        trash_tr_document = bool(data.get("trash_tr_document", False))
+        return workspace_uid, document_uid, as_new_version, trash_tr_document
 
 
 class ListLinkedDocumentUIDsFromWorkspace(Service):

--- a/opengever/api/locales/de/LC_MESSAGES/opengever.api.po
+++ b/opengever/api/locales/de/LC_MESSAGES/opengever.api.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-03-07 10:25+0000\n"
+"POT-Creation-Date: 2022-04-06 19:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,14 @@ msgstr ""
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+
+#: ./opengever/api/linked_workspaces.py
+msgid "Document can't be copied from workspace because it's currently checked out"
+msgstr "Dokument kann nicht zurückgeführt werden, weil das Dokument im Teamraum ausgecheckt ist."
+
+#: ./opengever/api/linked_workspaces.py
+msgid "Document not in linked workspace"
+msgstr "Dokument befindet sich nicht in einem verknüpften Teamraum."
 
 #. Default: "Copy of ${title}"
 #: ./opengever/api/copy_.py

--- a/opengever/api/locales/en/LC_MESSAGES/opengever.api.po
+++ b/opengever/api/locales/en/LC_MESSAGES/opengever.api.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-03-07 10:25+0000\n"
+"POT-Creation-Date: 2022-04-06 19:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,14 @@ msgstr ""
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+
+#: ./opengever/api/linked_workspaces.py
+msgid "Document can't be copied from workspace because it's currently checked out"
+msgstr ""
+
+#: ./opengever/api/linked_workspaces.py
+msgid "Document not in linked workspace"
+msgstr ""
 
 #. Default: "Copy of ${title}"
 #: ./opengever/api/copy_.py

--- a/opengever/api/locales/fr/LC_MESSAGES/opengever.api.po
+++ b/opengever/api/locales/fr/LC_MESSAGES/opengever.api.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-03-07 10:25+0000\n"
+"POT-Creation-Date: 2022-04-06 19:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,14 @@ msgstr ""
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+
+#: ./opengever/api/linked_workspaces.py
+msgid "Document can't be copied from workspace because it's currently checked out"
+msgstr ""
+
+#: ./opengever/api/linked_workspaces.py
+msgid "Document not in linked workspace"
+msgstr ""
 
 #. Default: "Copy of ${title}"
 #: ./opengever/api/copy_.py

--- a/opengever/api/locales/opengever.api.pot
+++ b/opengever/api/locales/opengever.api.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-03-07 10:25+0000\n"
+"POT-Creation-Date: 2022-04-06 19:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,14 @@ msgstr ""
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.api\n"
+
+#: ./opengever/api/linked_workspaces.py
+msgid "Document can't be copied from workspace because it's currently checked out"
+msgstr ""
+
+#: ./opengever/api/linked_workspaces.py
+msgid "Document not in linked workspace"
+msgstr ""
 
 #. Default: "Copy of ${title}"
 #: ./opengever/api/copy_.py

--- a/opengever/api/tests/test_linked_workspaces.py
+++ b/opengever/api/tests/test_linked_workspaces.py
@@ -976,8 +976,8 @@ class TestCopyDocumentFromWorkspacePost(FunctionalWorkspaceClientTestCase):
             transaction.commit()
 
             browser.login()
-            browser.exception_bubbling = True
-            with self.assertRaises(LookupError) as cm:
+
+            with browser.expect_http_error(400):
                 browser.open(
                     self.dossier.absolute_url() + '/@copy-document-from-workspace',
                     data=json.dumps(payload),
@@ -986,9 +986,12 @@ class TestCopyDocumentFromWorkspacePost(FunctionalWorkspaceClientTestCase):
                              'Content-Type': 'application/json'},
                 )
 
-        self.assertEqual(
-            "Document not in linked workspace",
-            str(cm.exception))
+            self.assertEqual(
+                {u'additional_metadata': {},
+                 u'message': u'Document not in linked workspace',
+                 u'translated_message': u'Document not in linked workspace',
+                 u'type': u'BadRequest'},
+                browser.json)
 
     @browsing
     def test_raises_when_document_is_not_within_linked_workspace(self, browser):
@@ -1005,8 +1008,8 @@ class TestCopyDocumentFromWorkspacePost(FunctionalWorkspaceClientTestCase):
             transaction.commit()
 
             browser.login()
-            browser.exception_bubbling = True
-            with self.assertRaises(LookupError) as cm:
+
+            with browser.expect_http_error(400):
                 browser.open(
                     self.dossier.absolute_url() + '/@copy-document-from-workspace',
                     data=json.dumps(payload),
@@ -1015,7 +1018,12 @@ class TestCopyDocumentFromWorkspacePost(FunctionalWorkspaceClientTestCase):
                              'Content-Type': 'application/json'},
                 )
 
-        self.assertEqual("Document not in linked workspace", str(cm.exception))
+            self.assertEqual(
+                {u'additional_metadata': {},
+                 u'message': u'Document not in linked workspace',
+                 u'translated_message': u'Document not in linked workspace',
+                 u'type': u'BadRequest'},
+                browser.json)
 
     @browsing
     def test_copy_document_without_file_from_workspace(self, browser):
@@ -1330,8 +1338,11 @@ class TestCopyDocumentFromWorkspacePost(FunctionalWorkspaceClientTestCase):
             self.assertEqual(len(children['added']), 0)
             self.assertEqual(
                 {u'type': u'BadRequest',
+                 u'additional_metadata': {},
                  u'message': u"Document can't be copied from workspace "
-                             u"because it's currently checked out"},
+                             u"because it's currently checked out",
+                 u'translated_message': u"Document can't be copied from workspace "
+                                        u"because it's currently checked out"},
                 browser.json)
 
 

--- a/opengever/workspaceclient/client.py
+++ b/opengever/workspaceclient/client.py
@@ -153,3 +153,9 @@ class WorkspaceClient(object):
             }
         )
         return response
+
+    def trash_document(self, document_url):
+        """Trashes the specified teamraum document.
+        """
+        response = self.request.post(document_url + '/@trash')
+        return response

--- a/opengever/workspaceclient/client.py
+++ b/opengever/workspaceclient/client.py
@@ -158,4 +158,5 @@ class WorkspaceClient(object):
         """Trashes the specified teamraum document.
         """
         response = self.request.post(document_url + '/@trash')
+        response.raise_for_status()
         return response

--- a/opengever/workspaceclient/linked_workspaces.py
+++ b/opengever/workspaceclient/linked_workspaces.py
@@ -307,9 +307,9 @@ class LinkedWorkspaces(object):
         workspace_title = self.client.get_by_uid(workspace_uid).get('title')
 
         # If the workspace document doesn't have a link to a GEVER document,
-        # or is not a regular document with a file,
-        # or cannot be retrieved, for example because it was trashed,
-        # always create a copy instead of attempting to create a version.
+        # or is not a regular document with a file, or cannot be retrieved,
+        # for example because the GEVER document was trashed, always create
+        # a copy instead of attempting to create a version.
         gever_doc = self._get_corresponding_gever_doc(document_repr)
         is_document_with_file = all((
             document_repr['@type'] == u'opengever.document.document',

--- a/opengever/workspaceclient/linked_workspaces.py
+++ b/opengever/workspaceclient/linked_workspaces.py
@@ -197,7 +197,7 @@ class LinkedWorkspaces(object):
         # Add journal entry to dossier
         title = _(
             u'label_workspace_unlinked',
-            default=u'Unlink workspace ${workspace_title}.',
+            default=u'Unlinked workspace ${workspace_title}.',
             mapping={'workspace_title': workspace.get('title')})
 
         journal_entry_factory(

--- a/opengever/workspaceclient/linked_workspaces.py
+++ b/opengever/workspaceclient/linked_workspaces.py
@@ -334,8 +334,8 @@ class LinkedWorkspaces(object):
                 # the already successully transferred document
                 transaction.commit()
                 raise BadRequest(
-                    _("Document was retrieved, but workspace document could "
-                      "not be moved to trash."))
+                    _("Not moved to trash: Document was retrieved, but "
+                      "workspace document could not be moved to trash."))
 
         return gever_doc, retrieval_mode
 

--- a/opengever/workspaceclient/linked_workspaces.py
+++ b/opengever/workspaceclient/linked_workspaces.py
@@ -268,7 +268,9 @@ class LinkedWorkspaces(object):
         if linked_documents.get('items_total') == 1:
             return linked_documents['items'][0]
 
-    def copy_document_from_workspace(self, workspace_uid, document_uid, as_new_version=False):
+    def copy_document_from_workspace(
+            self, workspace_uid, document_uid,
+            as_new_version=False, trash_tr_document=False):
         """Will copy a document from a linked workspace.
         """
         document = self._get_document_by_uid(workspace_uid, document_uid)
@@ -321,6 +323,9 @@ class LinkedWorkspaces(object):
         else:
             retrieval_mode = RETRIEVAL_MODE_COPY
             gever_doc = self._retrieve_as_copy(document_repr, workspace_title)
+
+        if trash_tr_document:
+            self.client.trash_document(document_url)
 
         return gever_doc, retrieval_mode
 

--- a/opengever/workspaceclient/locales/de/LC_MESSAGES/opengever.workspaceclient.po
+++ b/opengever/workspaceclient/locales/de/LC_MESSAGES/opengever.workspaceclient.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-04-06 19:33+0000\n"
+"POT-Creation-Date: 2022-04-06 19:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,10 @@ msgstr ""
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+
+#: ./opengever/workspaceclient/linked_workspaces.py
+msgid "Document was retrieved, but workspace document could not be moved to trash."
+msgstr "Dokument wurde erfolgreich zurückgeführt, aber das Teamraum-Dokument konnte nicht in den Papierkorb verschoben werden."
 
 #. Default: "Document retrieved from teamraum"
 #: ./opengever/workspaceclient/linked_workspaces.py

--- a/opengever/workspaceclient/locales/de/LC_MESSAGES/opengever.workspaceclient.po
+++ b/opengever/workspaceclient/locales/de/LC_MESSAGES/opengever.workspaceclient.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-04-06 19:47+0000\n"
+"POT-Creation-Date: 2022-04-07 13:05+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,8 +15,8 @@ msgstr ""
 "Domain: DOMAIN\n"
 
 #: ./opengever/workspaceclient/linked_workspaces.py
-msgid "Document was retrieved, but workspace document could not be moved to trash."
-msgstr "Dokument wurde erfolgreich zurückgeführt, aber das Teamraum-Dokument konnte nicht in den Papierkorb verschoben werden."
+msgid "Not moved to trash: Document was retrieved, but workspace document could not be moved to trash."
+msgstr "Nicht in Papierkorb verschoben: Dokument wurde erfolgreich zurückgeführt, aber das Teamraum-Dokument konnte nicht in den Papierkorb verschoben werden."
 
 #. Default: "Document retrieved from teamraum"
 #: ./opengever/workspaceclient/linked_workspaces.py

--- a/opengever/workspaceclient/locales/de/LC_MESSAGES/opengever.workspaceclient.po
+++ b/opengever/workspaceclient/locales/de/LC_MESSAGES/opengever.workspaceclient.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-08 11:40+0000\n"
+"POT-Creation-Date: 2022-04-06 19:33+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -53,3 +53,8 @@ msgstr "Teamraum ${workspace_title} zu diesem Dossier eröffnet."
 #: ./opengever/workspaceclient/linked_workspaces.py
 msgid "label_workspace_linked"
 msgstr "Mit Teamraum ${workspace_title} verknüpft."
+
+#. Default: "Unlinked workspace ${workspace_title}."
+#: ./opengever/workspaceclient/linked_workspaces.py
+msgid "label_workspace_unlinked"
+msgstr "Verknüpfung zu Teamraum ${workspace_title} entfernt."

--- a/opengever/workspaceclient/locales/en/LC_MESSAGES/opengever.workspaceclient.po
+++ b/opengever/workspaceclient/locales/en/LC_MESSAGES/opengever.workspaceclient.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-04-06 19:35+0000\n"
+"POT-Creation-Date: 2022-04-06 19:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,10 @@ msgstr ""
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+
+#: ./opengever/workspaceclient/linked_workspaces.py
+msgid "Document was retrieved, but workspace document could not be moved to trash."
+msgstr ""
 
 #. German translation: Dokument aus Teamraum zurückgeführt.
 #. Default: "Document retrieved from teamraum"

--- a/opengever/workspaceclient/locales/en/LC_MESSAGES/opengever.workspaceclient.po
+++ b/opengever/workspaceclient/locales/en/LC_MESSAGES/opengever.workspaceclient.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-04-06 19:47+0000\n"
+"POT-Creation-Date: 2022-04-07 13:05+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,7 +15,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 
 #: ./opengever/workspaceclient/linked_workspaces.py
-msgid "Document was retrieved, but workspace document could not be moved to trash."
+msgid "Not moved to trash: Document was retrieved, but workspace document could not be moved to trash."
 msgstr ""
 
 #. German translation: Dokument aus Teamraum zurückgeführt.

--- a/opengever/workspaceclient/locales/en/LC_MESSAGES/opengever.workspaceclient.po
+++ b/opengever/workspaceclient/locales/en/LC_MESSAGES/opengever.workspaceclient.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-18 11:06+0000\n"
+"POT-Creation-Date: 2022-04-06 19:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -61,3 +61,8 @@ msgstr "Linked workspace ${workspace_title} created."
 #: ./opengever/workspaceclient/linked_workspaces.py
 msgid "label_workspace_linked"
 msgstr "Linked to workspace ${workspace_title}."
+
+#. Default: "Unlinked workspace ${workspace_title}."
+#: ./opengever/workspaceclient/linked_workspaces.py
+msgid "label_workspace_unlinked"
+msgstr ""

--- a/opengever/workspaceclient/locales/fr/LC_MESSAGES/opengever.workspaceclient.po
+++ b/opengever/workspaceclient/locales/fr/LC_MESSAGES/opengever.workspaceclient.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-04-06 19:47+0000\n"
+"POT-Creation-Date: 2022-04-07 13:05+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,7 +15,7 @@ msgstr ""
 "Domain: DOMAIN\n"
 
 #: ./opengever/workspaceclient/linked_workspaces.py
-msgid "Document was retrieved, but workspace document could not be moved to trash."
+msgid "Not moved to trash: Document was retrieved, but workspace document could not be moved to trash."
 msgstr ""
 
 #. Default: "Document retrieved from teamraum"

--- a/opengever/workspaceclient/locales/fr/LC_MESSAGES/opengever.workspaceclient.po
+++ b/opengever/workspaceclient/locales/fr/LC_MESSAGES/opengever.workspaceclient.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-04-06 19:33+0000\n"
+"POT-Creation-Date: 2022-04-06 19:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,10 @@ msgstr ""
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+
+#: ./opengever/workspaceclient/linked_workspaces.py
+msgid "Document was retrieved, but workspace document could not be moved to trash."
+msgstr ""
 
 #. Default: "Document retrieved from teamraum"
 #: ./opengever/workspaceclient/linked_workspaces.py

--- a/opengever/workspaceclient/locales/fr/LC_MESSAGES/opengever.workspaceclient.po
+++ b/opengever/workspaceclient/locales/fr/LC_MESSAGES/opengever.workspaceclient.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-08 11:40+0000\n"
+"POT-Creation-Date: 2022-04-06 19:33+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -53,3 +53,8 @@ msgstr "Espace de travail ${workspace_title} créé pour ce dossier."
 #: ./opengever/workspaceclient/linked_workspaces.py
 msgid "label_workspace_linked"
 msgstr "Lié à l'espace de travail ${workspace_title}."
+
+#. Default: "Unlinked workspace ${workspace_title}."
+#: ./opengever/workspaceclient/linked_workspaces.py
+msgid "label_workspace_unlinked"
+msgstr ""

--- a/opengever/workspaceclient/locales/opengever.workspaceclient.pot
+++ b/opengever/workspaceclient/locales/opengever.workspaceclient.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-04-06 19:47+0000\n"
+"POT-Creation-Date: 2022-04-07 13:05+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Domain: opengever.workspaceclient\n"
 
 #: ./opengever/workspaceclient/linked_workspaces.py
-msgid "Document was retrieved, but workspace document could not be moved to trash."
+msgid "Not moved to trash: Document was retrieved, but workspace document could not be moved to trash."
 msgstr ""
 
 #. Default: "Document retrieved from teamraum"

--- a/opengever/workspaceclient/locales/opengever.workspaceclient.pot
+++ b/opengever/workspaceclient/locales/opengever.workspaceclient.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-08 11:40+0000\n"
+"POT-Creation-Date: 2022-04-06 19:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -55,4 +55,9 @@ msgstr ""
 #. Default: "Linked to workspace ${workspace_title}."
 #: ./opengever/workspaceclient/linked_workspaces.py
 msgid "label_workspace_linked"
+msgstr ""
+
+#. Default: "Unlinked workspace ${workspace_title}."
+#: ./opengever/workspaceclient/linked_workspaces.py
+msgid "label_workspace_unlinked"
 msgstr ""

--- a/opengever/workspaceclient/locales/opengever.workspaceclient.pot
+++ b/opengever/workspaceclient/locales/opengever.workspaceclient.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-04-06 19:35+0000\n"
+"POT-Creation-Date: 2022-04-06 19:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,10 @@ msgstr ""
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.workspaceclient\n"
+
+#: ./opengever/workspaceclient/linked_workspaces.py
+msgid "Document was retrieved, but workspace document could not be moved to trash."
+msgstr ""
 
 #. Default: "Document retrieved from teamraum"
 #: ./opengever/workspaceclient/linked_workspaces.py

--- a/opengever/workspaceclient/tests/test_linked_workspaces.py
+++ b/opengever/workspaceclient/tests/test_linked_workspaces.py
@@ -1088,7 +1088,7 @@ class TestUnlinkWorkspace(FunctionalWorkspaceClientTestCase):
                 manager.unlink_workspace(self.workspace.UID())
 
             self.assert_journal_entry(self.dossier, 'Unlinked workspace',
-                                      u'Unlink workspace Ein Teamraum.')
+                                      u'Unlinked workspace Ein Teamraum.')
 
     def test_unlink_workspace_unlocks_linked_documents(self):
         with self.workspace_client_env():


### PR DESCRIPTION
Corresponding Frontend PR: 4teamwork/gever-ui#2219

---

This adds support for allowing Teamraum documents to be **moved to the trash** after copying them back to GEVER via the `@copy-document-from-workspace` endpoint.

I changed the endpoint's error responses so that they include a `translated_message`. These will be displayed by the frontend when moving the document to the trash fails for some reason (and in some other cases as well):

![Screenshot 2022-04-07 at 15 13 01](https://user-images.githubusercontent.com/405124/162207392-e35f2122-f9b6-4a7e-8202-e1a9c68ddd8c.png)

In order to cover the case where only moving the teamraum document to trash failed, but everything else was successful, the transaction is explicitly committed in that case, to avoid rolling back the already successful transfer of the document to GEVER.

Note: This feature currently does not work when developing locally. See follow up issue [CA-3986](https://4teamwork.atlassian.net/browse/CA-3986)

For [CA-3594](https://4teamwork.atlassian.net/browse/CA-3594)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- API change:
  - [x] API Changelog entry (see [guide]

- New functionality:
  - [x] for `document` also works for `mail`

- Further improvements needed:
  - [x] Create follow-up stories and link them in the PR and Jira issue

