### PR TITLE
Add documentation for @process endpoint

### DIFF
--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -16,6 +16,7 @@ Other Changes
 - ``@external-activities``: Privileged users may now create notifications for other users (see :ref:`external-activities`)
 - ``@config``: Add ``workspace_creation_restricted`` feature flag.
 - Add new endpoint ``@task-template-structure``.
+- Add new endpoint ``@process`` (see :ref:`process`).
 
 2022.6.0 (2022-03-15)
 ---------------------

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -63,6 +63,7 @@ Inhalt:
    templatefolder.rst
    dossier_from_template.rst
    trigger_task_template.rst
+   process.rst
    remote_workflow.rst
    accept_remote_task.rst
    accept_remote_forwarding.rst

--- a/docs/public/dev-manual/api/process.rst
+++ b/docs/public/dev-manual/api/process.rst
@@ -1,0 +1,82 @@
+.. _process:
+
+Prozess erstellen
+=================
+
+In einem Dossier kann mit dem Endpoint ``@process`` ein Prozess erstellt werden. Die Daten um ein Prozess zu erstellen können zum Beispiel von einem Standardablauf kommen.
+
+Der Endpoint erwartet folgende Parameter:
+
+- ``related_documents``: Optionale Verweise auf Dokumente/Mails
+- ``start_immediately``: Erste Aufgabe nach Erstellung sofort starten
+- ``process``: Daten des zu erstellenden Prozesses. Dies ist ein verschateltes Objekt, welches die Struktur des Prozesses abbildet. Es beinhaltet zwei Typen von Objekten:
+  - Aufgaben Behälter. Benötigt ein ``title``, ``sequence_type`` (entweder ``parallel`` oder ``sequential``) und ``items`` (eine Liste von Aufgaben oder Aufgaben Behälter).
+  - Aufgaben (Schema analog Aufgaben-Schema.)
+
+Beim Erstellen werden aus Aufgaben Behälter neue Aufgaben mit Typ "zur direkten Erledigung" erstellt und der aktuelle Benutzer als Auftraggeber und Auftragnehmer hinzugefügt. Diese Aufgaben werden dann automatisch abgeschlossen wenn alle Unteraufgaben abgeschlossen sind.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+        POST /ordnungssystem/fuehrung/dossier-23/@trigger-task-template HTTP/1.1
+        Accept: application/json
+
+
+        {
+            "related_documents": [
+                {
+                    "@id": "http://localhost:8080/fd/ordnungssystem/fuehrung/dossier-23/document-23515"
+                }
+            ],
+            "start_immediately": true,
+            "process": {
+                "title": "New employee",
+                "text": "A new employee arrives.",
+                "sequence_type": "sequential",
+                "items": [
+                    {
+                        "title": "Assign userid",
+                        "responsible": "fa:hugo.noss",
+                        "issuer": "john.doe",
+                        "deadline": "2022-03-01",
+                        "task_type": "direct-execution",
+                        "is_private": false,
+                    },
+                    {
+                        "title": "Training",
+                        "sequence_type": "parallel",
+                        "items": [
+                            {
+                                "title": "Present Gever",
+                                "responsible": "fa:john.doe",
+                                "issuer": "hans.mueller",
+                                "deadline": "2022-03-10",
+                                "task_type": "direct-execution",
+                                "is_private": false,
+                            },
+                            {
+                                "title": "Present Teamraum",
+                                "responsible": "fa:hugo.boss",
+                                "issuer": "hans.mueller",
+                                "deadline": "2022-03-12",
+                                "task_type": "direct-execution",
+                                "is_private": false,
+                            },
+                        ]
+                    }
+                ]
+            }
+        }
+
+Als Response wird die JSON-Repräsentation der neu erstellten Aufgabe geliefert,
+siehe :ref:`Inhaltstypen <content-types>`.
+
+
+Interaktive Auftragnehmer
+-------------------------
+
+Interaktiven Benutzer sind als Auftragnehmer und Auftraggeber unterstützt. Es gibt dabei folgende Möglichkeiten:
+
+- ``interactive_actor:current_user``: Der aktuelle Benutzer
+- ``interactive_actor:responsible``:  Die Federführende Person des Dossiers, in dem die Aufgabe erstellt wird

--- a/docs/public/dev-manual/api/schemas/ftw.mail.mail.inc
+++ b/docs/public/dev-manual/api/schemas/ftw.mail.mail.inc
@@ -174,6 +174,16 @@
        
 
 
+   .. py:attribute:: gever_url
+
+       :Feldname: :field-title:`GEVER URL`
+       :Datentyp: ``TextLine``
+       
+       
+       
+       
+
+
    .. py:attribute:: title
 
        :Feldname: :field-title:`Titel`

--- a/docs/public/dev-manual/api/schemas/opengever.document.document.inc
+++ b/docs/public/dev-manual/api/schemas/opengever.document.document.inc
@@ -194,6 +194,16 @@
        
 
 
+   .. py:attribute:: gever_url
+
+       :Feldname: :field-title:`GEVER URL`
+       :Datentyp: ``TextLine``
+       
+       
+       
+       
+
+
    .. py:attribute:: custom_properties
 
        :Feldname: :field-title:`Benutzerdefinierte Felder`

--- a/docs/public/dev-manual/api/schemas/opengever.workspace.workspace.inc
+++ b/docs/public/dev-manual/api/schemas/opengever.workspace.workspace.inc
@@ -34,6 +34,16 @@
        
 
 
+   .. py:attribute:: gever_url
+
+       :Feldname: :field-title:`GEVER URL`
+       :Datentyp: ``TextLine``
+       
+       
+       
+       
+
+
    .. py:attribute:: changed
 
        :Feldname: :field-title:`Zuletzt verändert`

--- a/docs/public/dev-manual/api/trigger_task_template.rst
+++ b/docs/public/dev-manual/api/trigger_task_template.rst
@@ -1,7 +1,7 @@
 .. _trigger_task_template:
 
-Standardabläufe auslösen
-========================
+Standardabläufe auslösen (deprecated, wurde mit :ref:`@process <process>`. ersetzt)
+===================================================================================
 
 In einem Dossier kann mit dem Endpoint ``@trigger-task-template`` ein
 bestehender Standardablauf ausgelöst werden.


### PR DESCRIPTION
Add missing documentation for the `@process` endpoint. This is a follow-up for https://github.com/4teamwork/opengever.core/pull/7416

For [CA-3725]

## Checklist
- [ ] Changelog entry -> changelog was in https://github.com/4teamwork/opengever.core/pull/7416
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed

[CA-3725]: https://4teamwork.atlassian.net/browse/CA-3725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ