### PR TITLE
Remove unnecessary field from ITaskContainer.

### DIFF
--- a/opengever/api/process.py
+++ b/opengever/api/process.py
@@ -82,29 +82,6 @@ class ITaskContainer(model.Schema):
         required=False,
         )
 
-    relatedItems = RelationList(
-        title=task_mf(u'label_related_items', default=u'Related Items'),
-        default=[],
-        missing_value=[],
-        value_type=RelationChoice(
-            title=u"Related",
-            source=DossierPathSourceBinder(
-                portal_type=("opengever.document.document", "ftw.mail.mail"),
-                navigation_tree_query={
-                    'review_state': {'not': 'document-state-shadow'},
-                    'object_provides': [
-                        'opengever.dossier.behaviors.dossier.IDossierMarker',
-                        'opengever.document.document.IDocumentSchema',
-                        'opengever.task.task.ITask',
-                        'ftw.mail.mail.IMail',
-                        'opengever.meeting.proposal.IProposal',
-                        ],
-                    },
-                ),
-            ),
-        required=False,
-        )
-
 
 class ProcessPost(Service):
     """API Endpoint to create a process.


### PR DESCRIPTION
`relatedItems` is not necessary in the `ITaskContainer` schema, as the related items are set after validation from the `related_documents` of the process.

For [CA-3725]

## Checklist
- [ ] Changelog entry -> changelog in other PR
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-3725]: https://4teamwork.atlassian.net/browse/CA-3725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ