### PR TITLE
Extend @task-template-structure endpoint with useful attributes

### DIFF
--- a/changes/CA-3725-2.feature
+++ b/changes/CA-3725-2.feature
@@ -1,0 +1,1 @@
+@task-template-structure endpoint returns the absolute deadline for tasktemplates. [elioschmutz]

--- a/changes/CA-3725-3.feature
+++ b/changes/CA-3725-3.feature
@@ -1,0 +1,1 @@
+@task-template-structure endpoint returns the `is_private` attribute for tasktemplates with a static value of False. [elioschmutz]

--- a/opengever/api/templatefolder.py
+++ b/opengever/api/templatefolder.py
@@ -17,6 +17,7 @@ from opengever.kub.entity import KuBEntity
 from opengever.ogds.base.actor import ActorLookup
 from opengever.ogds.models.service import ogds_service
 from opengever.task.task import ITask
+from opengever.tasktemplates.content.tasktemplate import ITaskTemplate
 from opengever.tasktemplates.sources import TaskResponsibleSourceBinder
 from plone import api
 from plone.dexterity.interfaces import IDexterityContainer
@@ -24,7 +25,7 @@ from plone.protect.interfaces import IDisableCSRFProtection
 from plone.restapi.deserializer import json_body
 from plone.restapi.interfaces import IFieldDeserializer
 from plone.restapi.interfaces import ISerializeToJson
-from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.serializer.converters import json_compatible
 from plone.restapi.services import Service
 from plone.supermodel import model
 from z3c.form.field import Fields
@@ -411,6 +412,9 @@ class TaskTemplateStructureGet(Service):
 
     def recursive_serialize(self, obj):
         result = queryMultiAdapter((obj, self.request), ISerializeToJson)()
+
+        if ITaskTemplate.providedBy(obj):
+            result['deadline'] = json_compatible(obj.get_absolute_deadline())
 
         if IDexterityContainer.providedBy(obj):
             items = []

--- a/opengever/api/templatefolder.py
+++ b/opengever/api/templatefolder.py
@@ -415,6 +415,7 @@ class TaskTemplateStructureGet(Service):
 
         if ITaskTemplate.providedBy(obj):
             result['deadline'] = json_compatible(obj.get_absolute_deadline())
+            result['is_private'] = False
 
         if IDexterityContainer.providedBy(obj):
             items = []

--- a/opengever/api/tests/test_templatefolder.py
+++ b/opengever/api/tests/test_templatefolder.py
@@ -1427,3 +1427,14 @@ class TestTaskTemplateStructure(IntegrationTestCase):
                 headers=self.api_headers)
 
         self.assertEqual(u'2021-12-15', browser.json.get('items')[0].get('deadline'))
+
+    @browsing
+    def test_include_static_is_private_attribute_for_tasktemplates(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        browser.open(
+            '{}/@task-template-structure'.format(
+                self.tasktemplatefolder.absolute_url()),
+            headers=self.api_headers)
+
+        self.assertEqual(False, browser.json.get('items')[0].get('is_private'))

--- a/opengever/api/tests/test_templatefolder.py
+++ b/opengever/api/tests/test_templatefolder.py
@@ -1413,3 +1413,17 @@ class TestTaskTemplateStructure(IntegrationTestCase):
             headers=self.api_headers)
 
         self.assertEqual(200, browser.status_code)
+
+    @browsing
+    def test_deadline_of_tasktemplate_is_absolute(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        self.tasktemplate.deadline = 5
+
+        with freeze(datetime(2021, 12, 10)):
+            browser.open(
+                '{}/@task-template-structure'.format(
+                    self.tasktemplatefolder.absolute_url()),
+                headers=self.api_headers)
+
+        self.assertEqual(u'2021-12-15', browser.json.get('items')[0].get('deadline'))

--- a/opengever/tasktemplates/content/tasktemplate.py
+++ b/opengever/tasktemplates/content/tasktemplate.py
@@ -1,3 +1,5 @@
+from datetime import date
+from datetime import timedelta
 from ftw.keywordwidget.widget import KeywordFieldWidget
 from opengever.ogds.base.utils import get_current_org_unit
 from opengever.task import util
@@ -100,6 +102,9 @@ class ITaskTemplate(model.Schema):
 
 class TaskTemplate(Item):
     implements(ITaskTemplate)
+
+    def get_absolute_deadline(self):
+        return date.today() + timedelta(days=self.deadline)
 
 
 default_responsible_client = widget.ComputedWidgetAttribute(

--- a/opengever/tasktemplates/tests/test_tasktemplate.py
+++ b/opengever/tasktemplates/tests/test_tasktemplate.py
@@ -1,6 +1,9 @@
+from datetime import date
+from datetime import datetime
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages.statusmessages import info_messages
+from ftw.testing import freeze
 from opengever.ogds.base.actor import INTERACTIVE_ACTOR_RESPONSIBLE_ID
 from opengever.testing import SolrIntegrationTestCase
 from plone import api
@@ -226,3 +229,11 @@ class TestTaskTemplates(SolrIntegrationTestCase):
             ["10"],
             [cell.text for cell in cells]
         )
+
+    def test_get_absolute_deadline_returns_the_resolved_deadline(self):
+        self.login(self.administrator)
+
+        self.tasktemplate.deadline = 5
+
+        with freeze(datetime(2021, 12, 10)):
+            self.assertEqual(date(2021, 12, 15), self.tasktemplate.get_absolute_deadline())

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -796,6 +796,7 @@ class OpengeverContentFixture(object):
                 'issuer': INTERACTIVE_ACTOR_RESPONSIBLE_ID,
                 'responsible_client': 'fa',
                 'responsible': 'robert.ziegler',
+                'task_type': 'correction',
                 'deadline': 10,
             })
             .within(self.tasktemplatefolder)


### PR DESCRIPTION
This PR extends the `@task-template-structure` endpoint with the following:

- serialized tasktemplates includes the `is_private` with a static value of `False`. This attribute is required if creating a task through the `@process` endpoint
- serialized tasktemplates replaces the relative deadline with the absolute deadline. The relative deadline is only relevant if manipulating the template itself, but if we use it to create a `@process`, we need the absolute one

I did not touch the `TaskTemplate` serializer itself because both attributes are only relevant for the `@task-template-structure` endpoint. We do not want to change the template itself since this is used in the add/edit form of the template.

For [CA-3725]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change: ℹ️  there is nothing to update since the docu for the `@task-template-structure` endpoint is not exposing details of the serialized items.
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide] (https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines)) ℹ️  not required because it's the same release as the `@task-template-structure` endpoint was introduced.
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-3725]: https://4teamwork.atlassian.net/browse/CA-3725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ