### PR TITLE
Allow uploading a file with @tus-upload endpoint if the document has no file yet

### DIFF
--- a/changes/CA-3831.bugfix
+++ b/changes/CA-3831.bugfix
@@ -1,0 +1,1 @@
+Allow uploading a file with @tus-upload endpoint if the document has no file yet. [tinagerber]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,10 +11,11 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
-
+- ``@tus-upload``: Allow uploading a file if the document has no file yet.
 
 2022.8.0 (2022-04-12)
 ---------------------
+
 Other Changes
 ^^^^^^^^^^^^^
 - ``@copy-document-from-workspace``: Error responses now include ``translated_message``.

--- a/opengever/api/tests/test_tus.py
+++ b/opengever/api/tests/test_tus.py
@@ -152,6 +152,11 @@ class TestTUSUpload(IntegrationTestCase):
         self.assert_tus_replace_fails(self.document, browser)
 
     @browsing
+    def test_can_upload_file_if_document_has_no_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.assert_tus_replace_succeeds(self.empty_document, browser)
+
+    @browsing
     def test_cannot_replace_document_if_checked_out_by_other(self, browser):
         self.login(self.dossier_responsible, browser)
         self.checkout(self.document, browser)

--- a/opengever/api/tus.py
+++ b/opengever/api/tus.py
@@ -73,7 +73,7 @@ class UploadPatch(GeverUploadPatch):
 
         manager = getMultiAdapter((self.context, self.context.REQUEST),
                                   ICheckinCheckoutManager)
-        if not manager.is_checked_out_by_current_user():
+        if self.context.has_file() and not manager.is_checked_out_by_current_user():
             raise Forbidden("Document not checked out.")
 
         # XXX: Currently not supported by the latest Office Connector 1.10.0


### PR DESCRIPTION
At the moment it is not possible to upload a document later via @tus-upload for a document that exists only in paper form.

For [CA-3831]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
 

[CA-3831]: https://4teamwork.atlassian.net/browse/CA-3831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ