### PR TITLE
Solr with docker

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -217,22 +217,10 @@ with these contents:
 respective user in our development LDAP tree.
 
 
-Installing and activating Solr
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Solr
+~~~~
 
-Solr is installed automatically during Buildout but needs to be activated in GEVER.
-
-Just start Solr:
-
-.. code::
-
-    $ bin/solr start
-
-Then run the `activate_solr` maintenance script:
-
-.. code::
-
-    $ bin/instance run src/opengever.maintenance/opengever/maintenance/scripts/activate_solr.py
+Solr is provided as a Docker image and started with other services using `docker-compose`. 
 
 
 Activating Solr update chain
@@ -241,7 +229,7 @@ Activating Solr update chain
 The custom Solr update chain allows to propagate document updates to another Solr. This can be enabled for specific portal types.
 A StatelessScriptUpdateProcessor with the name ``sync.chain`` provides a script that is using a JavaScript Script to sync the documents.
 
-To activate the ``sync.chain``, provide an overlayconfig using the ``overlayconfig`` option in the ``ftw.recipe.solr``.
+To activate the ``sync.chain``, create a `configoverlay.json` file in the `conf` directory of the Solr core or if you are using Buildout provide an overlayconfig using the ``overlayconfig`` option in the ``ftw.recipe.solr``.
 See https://github.com/4teamwork/ftw.recipe.solr#supported-options for more information.
 
 In order for the StatelessScriptUpdateProcessor to work, add the following overlayconfig under the solr section in the buildout.cfg.
@@ -394,6 +382,7 @@ for local development by default:
 - `msgconvert <https://github.com/4teamwork/msgconvert>`_
 - `pdflatex <https://github.com/4teamwork/pdflatex>`_
 - Sablon_
+- `Solr <https://github.com/4teamwork/opengever.core/blob/master/docker/solr/Dockerfile>`_
 
 To run these services, Docker is required.
 See `Get Docker <https://docs.docker.com/get-docker/>`_ for how to install
@@ -406,7 +395,7 @@ To start the services simply run:
 
 .. code::
 
-  docker-compose up
+  docker-compose up -d
 
 
 ``opengever.core`` will use the services if the service URL is configured
@@ -1166,18 +1155,6 @@ The ports used by the testserver can easily be changed through environment varia
 - ``TESTSERVER_CTL_PORT`` - the port of the XMLRPC control server (default: ``55002``).
 - ``SOLR_PORT`` - the port of the Solr server which is controlled by the testserver (default: ``55003``).
 - ``TESTSERVER_REUSE_RUNNING_SOLR`` -  reuse the solr on the given port (default: ``None``).
-
-Special case for local development:
-
-A running solr is blocking all of its cores. Thus, running two solr servers on different ports with the same configuration is not possible. The first running server is blocking the core of the second one. This happens if you try to run the testserver with an `opengever.core` checkout where you already started a solr server manually. This is normally the case while developing.
-
-You can tell the testserver to reuse the already running solr instead of starting an own server. To do this, set the ``SOLR_PORT`` to the running solr and the ``TESTSERVER_REUSE_RUNNING_SOLR`` to the same port.
-
-This will tell the testserver to run a solr on port ``SOLR_PORT`` but reuse the existing server if there is already a running server.
-
-.. code::
-
-   SOLR_PORT=8983 TESTSERVER_REUSE_RUNNING_SOLR=8983 ./bin/testserver
 
 
 Custom fixtures

--- a/base-plone-4.3.x.cfg
+++ b/base-plone-4.3.x.cfg
@@ -5,22 +5,22 @@ extends =
     sources.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-4.cfg
-    https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/solr.cfg
 
 package-name = opengever.core
 package-namespace = opengever
 test-egg = opengever.core[api, tests]
 
+solr-host = localhost
+solr-port = 8983
 solr-core-name = testing
-solr-port = 8984
+solr-zcml =
+    <configure xmlns:solr="http://namespaces.plone.org/solr">
+        <solr:connection host="${:solr-host}"
+                         port="${:solr-port}"
+                         base="/solr/${:solr-core-name}"/>
+    </configure>
 
-[solr]
-gever-cores =
-    ${buildout:solr-core-name}
-    testing
-    functionaltesting
-    testserver
-cores = ${solr:gever-cores}
+zcml-additional-fragments += ${buildout:solr-zcml}
 
 [test]
 initialization +=

--- a/base-plone-4.3.x.cfg
+++ b/base-plone-4.3.x.cfg
@@ -17,7 +17,8 @@ solr-zcml =
     <configure xmlns:solr="http://namespaces.plone.org/solr">
         <solr:connection host="${:solr-host}"
                          port="${:solr-port}"
-                         base="/solr/${:solr-core-name}"/>
+                         base="/solr/${:solr-core-name}"
+                         upload_blobs="true"/>
     </configure>
 
 zcml-additional-fragments += ${buildout:solr-zcml}

--- a/development.cfg
+++ b/development.cfg
@@ -6,7 +6,6 @@ extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/bumblebee.cfg
     sphinx.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/format-xml.cfg
-    https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/solr.cfg
     start_all.cfg
     base-testserver.cfg
 
@@ -18,7 +17,6 @@ tool-parts +=
     docxcompose
 
 solr-core-name = development
-solr-port = 8983
 
 development-parts +=
     ${buildout:sphinx-parts}
@@ -48,6 +46,8 @@ parts -=
 #ogds-dsn = mysql://${buildout:ogds-db-user}:${buildout:ogds-db-pw}@localhost/${buildout:ogds-db-name}?charset=utf8
 #ogds-db-driver = MySQL-python
 
+zcml-additional-fragments += ${buildout:solr-zcml}
+
 [upgrade]
 eggs += ftw.upgrade[colors]
 
@@ -66,9 +66,6 @@ environment-vars +=
 
 zcml +=
   opengever.core
-
-[solr]
-cores = ${solr:gever-cores}
 
 [test]
 initialization +=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,17 +92,13 @@ services:
     build:
       context: .
       dockerfile: ./docker/solr/Dockerfile
-    command:
-      - solr-precreate
-      - ogsite
-      - /opt/solr/server/solr/configsets/ogsite
+    command: solr-foreground
     volumes:
       - ./var/solr:/var/solr/data
+    environment:
+      - SOLR_CORES=development testing functionaltesting testserver
     ports:
-      - 18983:8983
-    profiles:
-      - all
-      - solr
+      - 8983:8983
   ianus-frontend:
     image: ghcr.io/4teamwork/ianus-frontend:2021.4.4
     ports:
@@ -158,10 +154,9 @@ services:
     build:
       context: .
       dockerfile: ./docker/solr/Dockerfile
-    command:
-      - solr-precreate
-      - testserver
-      - /opt/solr/server/solr/configsets/ogsite
+    command: solr-foreground
+    environment:
+      - SOLR_CORES=testserver
     ports:
       - 18983:8983
     profiles:

--- a/docker/solr/Dockerfile
+++ b/docker/solr/Dockerfile
@@ -1,4 +1,6 @@
 FROM solr:8.4
 
 ENV SOLR_OPTS="-Dlog4j2.formatMsgNoLookups=true"
+ENV SOLR_CORES="ogsite"
 COPY ./solr-conf /opt/solr/server/solr/configsets/ogsite
+COPY ./docker/solr/create_and_update_cores.sh /docker-entrypoint-initdb.d/create_and_update_cores.sh

--- a/docker/solr/create_and_update_cores.sh
+++ b/docker/solr/create_and_update_cores.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+CONFIG_SOURCE=/opt/solr/server/solr/configsets/ogsite
+CORES_DIR=/var/solr/data
+
+for core in ${SOLR_CORES}; do
+	coredir="$CORES_DIR/$core"
+	if [ ! -d "$coredir" ]; then
+		mkdir -p "$coredir/conf"
+		echo "name=$core" >"$coredir/core.properties"
+		cp -r "$CONFIG_SOURCE/"* "$coredir/conf/"
+	else
+		cp -r "$CONFIG_SOURCE/"* "$coredir/conf/"
+	fi
+done

--- a/opengever/core/solr_testing.py
+++ b/opengever/core/solr_testing.py
@@ -30,7 +30,8 @@ class SolrServer(object):
         self.port = int(port)
         self.core = core
         self.container_name = 'opengever_testserver_solr_{}'.format(self.port)
-        SolrReplicationAPIClient.get_instance().configure(port, core, hostname)
+        SolrReplicationAPIClient.get_instance().configure(
+            port, core, hostname, container_name=self.container_name)
         return self
 
     def start(self):
@@ -53,6 +54,7 @@ class SolrServer(object):
             '4teamwork/ogsolr:latest',
             'solr-foreground',
         ]
+
         proc = subprocess.Popen(
             command, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -166,11 +168,12 @@ class SolrReplicationAPIClient(object):
             klass._instance = klass()
         return klass._instance
 
-    def configure(self, port, core, hostname='localhost'):
+    def configure(self, port, core, hostname='localhost', container_name=None):
         self._configured = True
         self.hostname = hostname
         self.port = int(port)
         self.core = core
+        self.container_name = container_name
         self.base_url = 'http://{}:{}/solr/{}'.format(self.hostname, port, core)
         return self
 

--- a/opengever/core/solr_testing.py
+++ b/opengever/core/solr_testing.py
@@ -29,6 +29,7 @@ class SolrServer(object):
         self.hostname = hostname
         self.port = int(port)
         self.core = core
+        self.container_name = 'opengever_testserver_solr_{}'.format(self.port)
         SolrReplicationAPIClient.get_instance().configure(port, core, hostname)
         return self
 
@@ -48,7 +49,7 @@ class SolrServer(object):
             '-e',
             'SOLR_CORES=testing functionaltesting testserver',
             '--name',
-            'opengever_testserver_solr',
+            self.container_name,
             '4teamwork/ogsolr:latest',
             'solr-foreground',
         ]
@@ -91,7 +92,7 @@ class SolrServer(object):
 
         self._require_configured()
 
-        command = ['docker', 'stop', 'opengever_testserver_solr']
+        command = ['docker', 'stop', self.container_name]
         proc = subprocess.Popen(
             command, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,

--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -575,7 +575,8 @@ class SolrTestingBase(object):
             '<configure xmlns:solr="http://namespaces.plone.org/solr">'
             '  <solr:connection host="localhost"'
             '                   port="{SOLR_PORT}"'
-            '                   base="/solr/{SOLR_CORE}" />'
+            '                   base="/solr/{SOLR_CORE}"'
+            '                   upload_blobs="true"/>'
             '</configure>'.format(SOLR_PORT=self.solr_port, SOLR_CORE=self.solr_core),
             context=configurationContext)
 

--- a/test-functional-solr.cfg
+++ b/test-functional-solr.cfg
@@ -5,7 +5,6 @@ extends =
 parts =
     test
     test-jenkins
-    solr
 
 jenkins_python = $PYTHON27
 

--- a/test-solr.cfg
+++ b/test-solr.cfg
@@ -5,7 +5,6 @@ extends =
 parts =
     test
     test-jenkins
-    solr
 
 jenkins_python = $PYTHON27
 

--- a/test-testserver-selftest.cfg
+++ b/test-testserver-selftest.cfg
@@ -9,7 +9,6 @@ parts =
     gems
     bin-test-jenkins
     ${:testserver-parts}
-    solr
 
 jenkins_python = $PYTHON27
 


### PR DESCRIPTION
Run Solr with Docker instead of installing it with Buildout.

This has several advantages:
- The required services for development can be started with one command `docker-compose up -d`.
- No locally installed JDK required.
- Better isolation. Solr for development does not interfere with Solr for running tests.

The Solr image has been extended to support the creation of multiple cores on startup.
Further the configuration of each core is updated on container startup. Before this change, the configuration of a core was never updated even if there were changes added to the image.

For [CA-XXXX]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)

