### PR TITLE
TUS upload: Only clean up file system data after successful commit:

### DIFF
--- a/changes/CA-3909.bugfix
+++ b/changes/CA-3909.bugfix
@@ -1,0 +1,1 @@
+TUS upload: Only clean up file system data after successful commit. [lgraf]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,6 +11,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- ``@tus-upload``: Only clean up file system data after successful commit.
 - ``@tus-upload``: Allow uploading a file if the document has no file yet.
 
 2022.8.0 (2022-04-12)

--- a/opengever/base/monkey/patches/__init__.py
+++ b/opengever/base/monkey/patches/__init__.py
@@ -34,6 +34,7 @@ from .resource_registries_url_regex import PatchResourceRegistriesURLRegex
 from .rolemanager import PatchOFSRoleManager
 from .scrub_bobo_exceptions import ScrubBoboExceptions
 from .session import PatchSessionCookie
+from .tus_upload import PatchTUSUploadCleanup
 from .tz_for_log import PatchZ2LogTimezone
 from .verify_object_paste import PatchCopyContainerVerifyObjectPaste
 from .webdav_lock_timeout import PatchWebDAVLockTimeout
@@ -73,6 +74,7 @@ PatchRelationFieldEventHandlers()()
 PatchResourceRegistriesURLRegex()()
 PatchSessionCookie()()
 PatchTransmogrifyDXSchemaUpdater()()
+PatchTUSUploadCleanup()()
 PatchWebDAVLockTimeout()()
 PatchWorkflowTool()()
 PatchZ2LogTimezone()()

--- a/opengever/base/monkey/patches/tus_upload.py
+++ b/opengever/base/monkey/patches/tus_upload.py
@@ -1,0 +1,47 @@
+from opengever.base.monkey.patching import MonkeyPatch
+
+
+class PatchTUSUploadCleanup(MonkeyPatch):
+    """Monkeypatch for plone.restapi.services.content.tus.TUSUpload
+
+    This patches TUSUpload.cleanup() so that file system data for TUS uploads
+    doesn't get cleaned up immediately during a running transaction, but
+    instead is done in an afterCommmitHook, and only if the transaction was
+    successful.
+
+    This prevents the following bug that otherwise can occur:
+
+    - A file is uploaded in the 2nd stage of a TUS upload using @tus-upload
+    - The blob is added to the ZODB and file system data is cleaned up
+    - But a write conflict happens when trying to commit the transaction
+      - Changes to the ZODB are rolled back
+      - But not the changes on the file system
+      - The request is retried as part of the conflict resolution
+    - On the 2nd request, the @tus-upload will not find the file system data
+      for the prepared upload, and reject the upload with a 404
+    """
+
+    def __call__(self):
+        import os
+        import transaction
+
+        def cleanup(self):
+            """Remove temporary upload files after successful commit."""
+
+            def cleanup_hook(commit_successful, filepath, metadata_path):
+                if not commit_successful:
+                    return
+
+                if os.path.exists(filepath):
+                    os.remove(filepath)
+                if os.path.exists(metadata_path):
+                    os.remove(metadata_path)
+
+            txn = transaction.get()
+            txn.addAfterCommitHook(
+                cleanup_hook, args=(self.filepath, self.metadata_path)
+            )
+
+        from plone.restapi.services.content.tus import TUSUpload
+
+        self.patch_refs(TUSUpload, "cleanup", cleanup)


### PR DESCRIPTION
This patches [`TUSUpload.cleanup()`](https://github.com/plone/plone.restapi/blob/6.14.0/src/plone/restapi/services/content/tus.py#L372-L377) so that file system data for TUS uploads doesn't get cleaned up immediately during a running transaction, but instead is done in an **afterCommmitHook**, and only if the transaction was successful.

This prevents the following bug that otherwise can occur:

- A file is uploaded in the 2nd stage of a TUS upload using `@tus-upload`
- The blob is added to the ZODB and file system data is cleaned up
- But a write conflict happens when trying to commit the transaction
  - Changes to the ZODB are rolled back
  - But not the changes on the file system
  - The request is retried as part of the conflict resolution
- On the 2nd request, the `@tus-upload` will not find the file system data for the prepared upload, and reject the upload with a 404

I was able to reconstruct the behavior described in [CA-3909](https://4teamwork.atlassian.net/browse/CA-3909) using a barrage of concurrent request that upload a new file to the same, checked out document. This resulted in a different type of conflict (conflicted on the document object itself, instead of what seemed like a catalog index in production), but the effect was the same:

During that barrage of requests, `@tus-upload` often rejected the upload with a 404. After the fix, I was able to confirm that all requests were accepted with `204`, including ones that got retried because of write conflicts, and all the file system data for TUS uploads still got cleaned up in the end.

For [CA-3909](https://4teamwork.atlassian.net/browse/CA-3909)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- API change:
  - [x] API Changelog entry
