### PR TITLE
Make closing of main task more fail safe.

### DIFF
--- a/changes/CA-4023.bugfix
+++ b/changes/CA-4023.bugfix
@@ -1,0 +1,1 @@
+Make automatic closing of a main task fail safer. [phgross]

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -679,6 +679,9 @@ class Task(Container, TaskReminderSupport):
         if not parent:
             return
         with elevated_privileges():
+            if api.content.get_state(parent) != 'task-state-in-progress':
+                return
+
             api.content.transition(
                 obj=parent, transition='task-transition-in-progress-tested-and-closed')
 

--- a/opengever/task/tests/test_task_from_template.py
+++ b/opengever/task/tests/test_task_from_template.py
@@ -575,3 +575,17 @@ class TestCloseTaskFromTemplate(IntegrationTestCase):
         last_journal_entry = get_journal_entry(self.dossier, -1)
         self.assertEqual(last_journal_entry['action']['type'], 'Task modified')
         self.assertEqual(last_journal_entry['actor'], self.administrator.getId())
+
+    def test_close_main_task_is_skipped_if_main_task_is_already_closed(self):
+        self.login(self.administrator)
+        self.set_workflow_state(
+            'task-state-tested-and-closed', self.seq_subtask_1)
+        self.set_workflow_state(
+            'task-state-tested-and-closed', self.seq_subtask_2)
+        self.set_workflow_state(
+            'task-state-tested-and-closed', self.sequential_task)
+        self.set_workflow_state('task-state-open', self.seq_subtask_3)
+
+        api.content.transition(
+            obj=self.seq_subtask_3,
+            transition='task-transition-open-tested-and-closed')


### PR DESCRIPTION
The automatic closing of the main task is a comfort function, should never cause problems when closing a subtask.

For [CA-4023] and https://sentry.4teamwork.ch/organizations/sentry/issues/79537

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- Bug fixed:
  - [x] Resolved any Sentry issues caused by this bug


[CA-4023]: https://4teamwork.atlassian.net/browse/CA-4023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ