### PR TITLE
`@tasktree` endpoint properly handles nested tasks

### DIFF
--- a/changes/CA-3725-6.feature
+++ b/changes/CA-3725-6.feature
@@ -1,0 +1,1 @@
+`@tasktree` endpoint properly handles nested tasks by adding a `is_task_addable` and `is_task_addable_before` attribute for each item. [elioschmutz]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -7,7 +7,7 @@ API Changelog
 ---------------------
 Breaking Changes
 ^^^^^^^^^^^^^^^^
-
+- ``@tasktree``: Endpoint does no longer return the ``is_task_addable_in_main_task`` but provides a ``is_task_addable`` and ``is_task_addable_before`` attribute for each item.
 
 Other Changes
 ^^^^^^^^^^^^^

--- a/docs/public/dev-manual/api/tasks.rst
+++ b/docs/public/dev-manual/api/tasks.rst
@@ -531,14 +531,17 @@ Dazu steht ein spezifischer Endpoint `@tasktree` zur Verfügung. Die Aufgaben we
                 "@type": "opengever.task.task",
                 "children": [],
                 "review_state": "task-state-resolved",
+                "is_task_addable": false
+                "is_task_addable_before": false
                 "title": "Eine Unteraufgabe"
               },
             ],
             "review_state": "task-state-in-progress",
+            "is_task_addable": true
+            "is_task_addable_before": false
             "title": "Eine Aufgabe"
           }
         ],
-        "is_task_addable_in_main_task": true
       }
 
 Die Aufgabenhierarchie kann auch direkt über den GET-Request eines Tasks mittels Expansion angefordert werden.


### PR DESCRIPTION
This PR updates the `@tasktree` endpoint to properly handle nested tasks.

The previous implementation expected to have the main-task as the context and only one nesting level. This is no longer the case since we provide multi-nesting for by using the `@process` endpoint.

This PR removes the main-task specific attribute `is_task_addable_in_main_task` and adds two attributes: `is_task_addable` and `is_task_addable_before` in a consistent way for each item within the task-tree.

For [CA-3725]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [x] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-3725]: https://4teamwork.atlassian.net/browse/CA-3725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ