### PR TITLE
Include protect-dossier role assignments, in the role-assignment reports.

### DIFF
--- a/changes/CA-3895.feature
+++ b/changes/CA-3895.feature
@@ -1,0 +1,1 @@
+Include protect-dossier role assignments, in the role-assignment reports. [phgross]

--- a/opengever/base/nightly_role_assignment_reports.py
+++ b/opengever/base/nightly_role_assignment_reports.py
@@ -1,4 +1,5 @@
 from opengever.base.interfaces import IRoleAssignmentReportsStorage
+from opengever.base.role_assignments import ASSIGNMENT_VIA_PROTECT_DOSSIER
 from opengever.base.role_assignments import ASSIGNMENT_VIA_SHARING
 from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.base.storage import STATE_IN_PROGRESS
@@ -65,10 +66,12 @@ class NightlyRoleAssignmentReports(NightlyJobProviderBase):
                 self.collect_garbage(self.context)
             obj = brain.getObject()
             assignments = RoleAssignmentManager(obj).get_assignments_by_principal_id(principalid)
-            sharing_assignments = [assignment for assignment in assignments
-                                   if assignment.cause == ASSIGNMENT_VIA_SHARING]
-            if sharing_assignments:
-                roles = filter(lambda r: r != 'Owner', sharing_assignments[0].roles)
+            manual_assignments = [
+                assignment for assignment in assignments
+                if assignment.cause in [ASSIGNMENT_VIA_SHARING,
+                                        ASSIGNMENT_VIA_PROTECT_DOSSIER]]
+            if manual_assignments:
+                roles = filter(lambda r: r != 'Owner', manual_assignments[0].roles)
                 if roles:
                     items.append({'UID': obj.UID(), 'roles': roles})
 

--- a/opengever/base/tests/test_nightly_role_assignment_reports.py
+++ b/opengever/base/tests/test_nightly_role_assignment_reports.py
@@ -1,5 +1,6 @@
 from opengever.base.interfaces import IRoleAssignmentReportsStorage
 from opengever.base.nightly_role_assignment_reports import NightlyRoleAssignmentReports
+from opengever.base.role_assignments import ASSIGNMENT_VIA_PROTECT_DOSSIER
 from opengever.base.role_assignments import ASSIGNMENT_VIA_SHARING
 from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.base.storage import STATE_IN_PROGRESS
@@ -43,6 +44,9 @@ class TestNightlyRoleAssignmentReports(IntegrationTestCase):
         manager = RoleAssignmentManager(self.leaf_repofolder)
         manager.add_or_update(self.meeting_user.getId(), ['Reviewer'],
                               ASSIGNMENT_VIA_SHARING)
+        manager = RoleAssignmentManager(self.resolvable_dossier)
+        manager.add_or_update(self.meeting_user.getId(), ['Reader'],
+                              ASSIGNMENT_VIA_PROTECT_DOSSIER)
 
         storage = IRoleAssignmentReportsStorage(self.portal)
 
@@ -63,4 +67,6 @@ class TestNightlyRoleAssignmentReports(IntegrationTestCase):
              {'UID': IUUID(self.leaf_repofolder),
               'roles': ['Reviewer']},
              {'UID': IUUID(self.empty_dossier),
-              'roles': ['Editor', 'Contributor', 'Reader']}], report['items'])
+              'roles': ['Editor', 'Contributor', 'Reader']},
+             {'UID': IUUID(self.resolvable_dossier),
+              'roles': ['Reader']}], report['items'])


### PR DESCRIPTION
Role-Assignments via the protect dossier functionality, are also of interest in role-assignments-reports, but not part of the export right now.

For [CA-3895]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
