### PR TITLE
Revoke roles from former task responsibles only when task is completed

### DIFF
--- a/changes/CA-3577-1.feature
+++ b/changes/CA-3577-1.feature
@@ -1,0 +1,1 @@
+When changing the task responsible, the previous responsible's permissions are no longer revoked, but only when the task is completed. [tinagerber]

--- a/changes/CA-3577-2.feature
+++ b/changes/CA-3577-2.feature
@@ -1,0 +1,1 @@
+No longer allow to change task responsible via PATCH request. [tinagerber]

--- a/changes/CA-3577.bugfix
+++ b/changes/CA-3577.bugfix
@@ -1,0 +1,1 @@
+Local roles are correctly set and revoked when accepting and closing a team task. [tinagerber]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -8,6 +8,7 @@ API Changelog
 Breaking Changes
 ^^^^^^^^^^^^^^^^
 - ``@tasktree``: Endpoint does no longer return the ``is_task_addable_in_main_task`` but provides a ``is_task_addable`` and ``is_task_addable_before`` attribute for each item.
+- No longer allow to change task responsible via PATCH request.
 
 Other Changes
 ^^^^^^^^^^^^^

--- a/opengever/api/locales/de/LC_MESSAGES/opengever.api.po
+++ b/opengever/api/locales/de/LC_MESSAGES/opengever.api.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-04-06 19:47+0000\n"
+"POT-Creation-Date: 2022-04-14 06:43+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,6 +21,11 @@ msgstr "Dokument kann nicht zurückgeführt werden, weil das Dokument im Teamrau
 #: ./opengever/api/linked_workspaces.py
 msgid "Document not in linked workspace"
 msgstr "Dokument befindet sich nicht in einem verknüpften Teamraum."
+
+#. Default: "It's not allowed to change responsible here. Use \"Reassign\" instead"
+#: ./opengever/api/task.py
+msgid "change_responsible_not_allowed"
+msgstr "Es ist nicht erlaubt, den Auftragnehmer hier zu ändern. Verwenden Sie stattdessen \"Neu zuweisen\"."
 
 #. Default: "Copy of ${title}"
 #: ./opengever/api/copy_.py

--- a/opengever/api/locales/en/LC_MESSAGES/opengever.api.po
+++ b/opengever/api/locales/en/LC_MESSAGES/opengever.api.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-04-06 19:47+0000\n"
+"POT-Creation-Date: 2022-04-14 06:43+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -20,6 +20,11 @@ msgstr ""
 
 #: ./opengever/api/linked_workspaces.py
 msgid "Document not in linked workspace"
+msgstr ""
+
+#. Default: "It's not allowed to change responsible here. Use \"Reassign\" instead"
+#: ./opengever/api/task.py
+msgid "change_responsible_not_allowed"
 msgstr ""
 
 #. Default: "Copy of ${title}"

--- a/opengever/api/locales/fr/LC_MESSAGES/opengever.api.po
+++ b/opengever/api/locales/fr/LC_MESSAGES/opengever.api.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-04-06 19:47+0000\n"
+"POT-Creation-Date: 2022-04-14 06:43+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,6 +21,11 @@ msgstr "Le document ne peut pas être copié de l’espace de travail car il est
 #: ./opengever/api/linked_workspaces.py
 msgid "Document not in linked workspace"
 msgstr "Document absent de l’espace de travail lié"
+
+#. Default: "It's not allowed to change responsible here. Use \"Reassign\" instead"
+#: ./opengever/api/task.py
+msgid "change_responsible_not_allowed"
+msgstr ""
 
 #. Default: "Copy of ${title}"
 #: ./opengever/api/copy_.py

--- a/opengever/api/locales/opengever.api.pot
+++ b/opengever/api/locales/opengever.api.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-04-06 19:47+0000\n"
+"POT-Creation-Date: 2022-04-14 06:43+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -23,6 +23,11 @@ msgstr ""
 
 #: ./opengever/api/linked_workspaces.py
 msgid "Document not in linked workspace"
+msgstr ""
+
+#. Default: "It's not allowed to change responsible here. Use \"Reassign\" instead"
+#: ./opengever/api/task.py
+msgid "change_responsible_not_allowed"
 msgstr ""
 
 #. Default: "Copy of ${title}"

--- a/opengever/api/task.py
+++ b/opengever/api/task.py
@@ -32,6 +32,7 @@ from zope.component import getMultiAdapter
 from zope.i18n import translate
 from zope.interface import implementer
 from zope.interface import Interface
+from opengever.api import _
 
 
 @implementer(ISerializeToJson)
@@ -315,9 +316,16 @@ class TaskPatch(ContentPatch):
 
     def reply(self):
         current_is_private_value = self.context.is_private
+        current_responsible = self.context.responsible
+        current_responsible_client = self.context.responsible_client
         data = super(TaskPatch, self).reply()
 
         if self.context.is_private != current_is_private_value:
             raise BadRequest("It's not allowed to change the is_private option"
                              " of an existing task.")
+
+        if self.context.responsible != current_responsible or \
+           self.context.responsible_client != current_responsible_client:
+            raise BadRequest(_(u"change_responsible_not_allowed",
+                               default=u"It's not allowed to change responsible here. Use \"Reassign\" instead"))
         return data

--- a/opengever/api/tests/test_task.py
+++ b/opengever/api/tests/test_task.py
@@ -590,6 +590,7 @@ class TestTaskTransitions(IntegrationTestCase):
 
         self.assertEqual('rk', self.task.responsible_client)
         self.assertEqual('james.bond', self.task.responsible)
+        self.assertEqual(['kathi.barfuss'], self.task.get_former_responsibles())
 
     @browsing
     def test_reassign_task_without_combined_responsible_value(self, browser):

--- a/opengever/api/tests/test_task.py
+++ b/opengever/api/tests/test_task.py
@@ -534,22 +534,20 @@ class TestTaskCreation(SolrIntegrationTestCase):
 class TestTaskPatch(IntegrationTestCase):
 
     @browsing
-    def test_edit_responsible_with_responsible_client(self, browser):
+    def test_edit_responsible_raises_bad_request(self, browser):
         self.login(self.regular_user, browser=browser)
 
-        self.add_additional_admin_and_org_unit()
-        data = {
-            "responsible": {
-                'token': "rk:james.bond",
-                'title': u'Ratskanzlei: James Bond'
-            }
-        }
+        data = {"responsible": {'token': "fa:nicole.kohler"}}
+        with browser.expect_http_error(400):
+            browser.open(self.task, json.dumps(data),
+                         method="PATCH", headers=self.api_headers)
 
-        browser.open(self.task, json.dumps(data),
-                     method="PATCH", headers=self.api_headers)
-
-        self.assertEqual('rk', self.task.responsible_client)
-        self.assertEqual('james.bond', self.task.responsible)
+        self.assertEqual(
+            {u'type': u'BadRequest',
+             u'additional_metadata': {},
+             u'translated_message': u'It\'s not allowed to change responsible here.'
+                                    u' Use "Reassign" instead',
+             u'message': u'change_responsible_not_allowed'}, browser.json)
 
     @browsing
     def test_changing_is_private_raise_bad_request(self, browser):

--- a/opengever/api/tests/test_transfer_task.py
+++ b/opengever/api/tests/test_transfer_task.py
@@ -389,7 +389,7 @@ class TestTransferTaskInterAdminUnit(IntegrationTestCase):
                 mgr = RoleAssignmentManager(task)
                 old_user_assignments = mgr.get_assignments_by_principal_id(old_userid)
                 new_user_assignments = mgr.get_assignments_by_principal_id(new_userid)
-                self.assertEqual(0, len(old_user_assignments))
+                self.assertEqual(1, len(old_user_assignments))
                 self.assertEqual(1, len(new_user_assignments))
 
                 new_user_assignment = new_user_assignments[0]

--- a/opengever/inbox/tests/test_api_support.py
+++ b/opengever/inbox/tests/test_api_support.py
@@ -266,6 +266,7 @@ class TestAPITransitions(IntegrationTestCase):
 
         self.assertEqual('inbox:rk', forwarding.responsible)
         self.assertEqual('inbox:fa', copied_forwarding.responsible)
+        self.assertEqual(['inbox:fa'], forwarding.get_former_responsibles())
 
         self.assertEqual('forwarding-state-refused', api.content.get_state(forwarding))
         self.assertEqual('forwarding-state-closed', api.content.get_state(copied_forwarding))

--- a/opengever/inbox/tests/test_workflow.py
+++ b/opengever/inbox/tests/test_workflow.py
@@ -157,11 +157,14 @@ class TestInboxWorkflow(IntegrationTestCase):
 
         assignment_manager = RoleAssignmentManager(self.inbox_forwarding)
         assignments = assignment_manager.storage._storage()
-        self.assertEqual(2, len(assignments))
-        user_assignment, inbox_assignment = assignments
-        self.assertEqual(ASSIGNMENT_VIA_TASK, user_assignment["cause"])
-        self.assertEqual(["Editor"], user_assignment["roles"])
-        self.assertEqual(self.secretariat_user.getId(), user_assignment["principal"])
+        self.assertEqual(3, len(assignments))
+        old_assignment, inbox_assignment, new_assignment = assignments
+        self.assertEqual(ASSIGNMENT_VIA_TASK, old_assignment["cause"])
+        self.assertEqual(["Editor"], old_assignment["roles"])
+        self.assertEqual(self.regular_user.getId(), old_assignment["principal"])
+        self.assertEqual(ASSIGNMENT_VIA_TASK, new_assignment["cause"])
+        self.assertEqual(["Editor"], new_assignment["roles"])
+        self.assertEqual(self.secretariat_user.getId(), new_assignment["principal"])
         self.assertEqual(ASSIGNMENT_VIA_TASK_AGENCY, inbox_assignment["cause"])
         self.assertEqual(["Editor"], inbox_assignment["roles"])
         self.assertEqual(u'fa_inbox_users', inbox_assignment["principal"])
@@ -191,12 +194,12 @@ class TestInboxWorkflow(IntegrationTestCase):
         form.find_widget('Responsible').fill(self.meeting_user)
         browser.click_on('Assign')
 
-        self.assertNotIn("user:{}".format(self.regular_user),
-                         index_data_for(self.inbox_forwarding)['allowedRolesAndUsers'])
-        self.assertNotIn("user:{}".format(self.regular_user),
-                         index_data_for(self.inbox_forwarding_document)['allowedRolesAndUsers'])
-        self.assertNotIn("user:{}".format(self.regular_user),
-                         index_data_for(mail)['allowedRolesAndUsers'])
+        self.assertIn("user:{}".format(self.regular_user),
+                      index_data_for(self.inbox_forwarding)['allowedRolesAndUsers'])
+        self.assertIn("user:{}".format(self.regular_user),
+                      index_data_for(self.inbox_forwarding_document)['allowedRolesAndUsers'])
+        self.assertIn("user:{}".format(self.regular_user),
+                      index_data_for(mail)['allowedRolesAndUsers'])
         self.assertIn("user:{}".format(self.meeting_user),
                       index_data_for(self.inbox_forwarding)['allowedRolesAndUsers'])
         self.assertIn("user:{}".format(self.meeting_user),

--- a/opengever/inbox/transition.py
+++ b/opengever/inbox/transition.py
@@ -74,13 +74,7 @@ class ForwardingRefuseTransitionExtender(ForwardingDefaultTransitionExtender):
         return {'location': copy_url}
 
     def switch_responsible(self):
-        # Revoke local roles for current responsible, except if
-        # revoke_permissions is set to False.
-        # The roles for the new responsible will be assigned afterwards
-        # in set_roles_after_modifying on the ObjectModifiedEvent.
-        if self.context.revoke_permissions:
-            LocalRolesSetter(self.context).revoke_roles()
-
+        self.context.add_former_responsible(self.context.responsible)
         current_org_unit = get_current_org_unit()
         self.context.responsible_client = current_org_unit.id()
         self.context.responsible = current_org_unit.inbox().id()

--- a/opengever/task/browser/assign.py
+++ b/opengever/task/browser/assign.py
@@ -155,8 +155,8 @@ class AssignTaskForm(Form):
                     self.context.absolute_url())
 
             self.reassign_task(**data)
-
-            return self.redirect()
+            msg = _(u'msg_successfully_reassigned', default=u'Task successfully reassigned.')
+            api.portal.show_message(msg, request=self.request, type='info')
 
     def create_watcher_and_commit_if_needed(self, new_responsible):
         """If we don't have an entry in the 'watchers' table for the
@@ -190,22 +190,6 @@ class AssignTaskForm(Form):
             session.add(watcher)
             transaction.commit()
             transaction.begin()
-
-    def redirect(self):
-        """Redirects to task if the current user still has View permission,
-        otherwise it redirects to portal.
-        """
-        if api.user.has_permission('View', obj=self.context):
-            msg = _(u'msg_successfully_reassigned',
-                    default=u'Task successfully reassigned.')
-            api.portal.show_message(msg, request=self.request, type='info')
-            return self.request.RESPONSE.redirect(self.context.absolute_url())
-
-        msg = _(u'msg_successfully_reassigned_no_longer_permission',
-                default=u'Task successfully reassigned. You are no '
-                'longer permitted to access the task.')
-        api.portal.show_message(msg, request=self.request, type='info')
-        return self.request.RESPONSE.redirect(api.portal.get().absolute_url())
 
     def reassign_task(self, **kwargs):
         wftool = api.portal.get_tool('portal_workflow')

--- a/opengever/task/browser/forms.py
+++ b/opengever/task/browser/forms.py
@@ -186,6 +186,7 @@ class TaskEditForm(DefaultEditForm):
         data.pop('is_private', None)
 
         if self.is_reassigned(data):
+            self.context.add_former_responsible(self.context.responsible)
             response = self.add_reassign_response(data)
             changes = super(TaskEditForm, self).applyChanges(data)
             TaskReassignActivity(self.context, self.context.REQUEST, response).record()

--- a/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2022-03-31 17:41+0000\n"
+"POT-Creation-Date: 2022-04-14 11:33+0000\n"
 "PO-Revision-Date: 2015-02-17 18:41+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -755,11 +755,6 @@ msgstr "Die temporäre Berechtigungen für den Auftragnehmer und dessen Stellver
 #: ./opengever/task/browser/assign.py
 msgid "msg_successfully_reassigned"
 msgstr "Aufgabe erfolgreich neu zugewiesen."
-
-#. Default: "Task successfully reassigned. You are no longer permitted to access the task."
-#: ./opengever/task/browser/assign.py
-msgid "msg_successfully_reassigned_no_longer_permission"
-msgstr "Aufgabe erfolgreich neu zugewiesen. Sie sind nicht länger berechtigt auf die Aufgabe zuzugreifen."
 
 #. Default: "Commented by ${user}"
 #: ./opengever/task/response_description.py

--- a/opengever/task/locales/en/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/en/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2022-03-31 17:41+0000\n"
+"POT-Creation-Date: 2022-04-14 11:33+0000\n"
 "PO-Revision-Date: 2015-02-17 18:41+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -902,12 +902,6 @@ msgstr "Temporary permissions for the responsible user (and their deputy) have b
 #: ./opengever/task/browser/assign.py
 msgid "msg_successfully_reassigned"
 msgstr "Task successfully reassigned."
-
-#. German translation: Aufgabe erfolgreich neu zugewiesen. Sie sind nicht länger berechtigt auf die Aufgabe zuzugreifen.
-#. Default: "Task successfully reassigned. You are no longer permitted to access the task."
-#: ./opengever/task/browser/assign.py
-msgid "msg_successfully_reassigned_no_longer_permission"
-msgstr "Task successfully reassigned. You are no longer permitted to access the task."
 
 #. German translation: Kommentiert von ${user}
 #. Default: "Commented by ${user}"

--- a/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-03-31 17:41+0000\n"
+"POT-Creation-Date: 2022-04-14 11:33+0000\n"
 "PO-Revision-Date: 2017-12-03 11:47+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-task/fr/>\n"
@@ -757,11 +757,6 @@ msgstr "Les autorisations temporaires pour le mandataire et ses suppléants ont 
 #: ./opengever/task/browser/assign.py
 msgid "msg_successfully_reassigned"
 msgstr "Tâche réassignée avec succès."
-
-#. Default: "Task successfully reassigned. You are no longer permitted to access the task."
-#: ./opengever/task/browser/assign.py
-msgid "msg_successfully_reassigned_no_longer_permission"
-msgstr "Tâche réassignée avec succès. Vous n’avez désormais plus accès à cette tâche"
 
 #. Default: "Commented by ${user}"
 #: ./opengever/task/response_description.py

--- a/opengever/task/locales/opengever.task.pot
+++ b/opengever/task/locales/opengever.task.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2022-03-31 17:41+0000\n"
+"POT-Creation-Date: 2022-04-14 11:33+0000\n"
 "PO-Revision-Date: 2009-02-25 14:39+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -752,11 +752,6 @@ msgstr ""
 #. Default: "Task successfully reassigned."
 #: ./opengever/task/browser/assign.py
 msgid "msg_successfully_reassigned"
-msgstr ""
-
-#. Default: "Task successfully reassigned. You are no longer permitted to access the task."
-#: ./opengever/task/browser/assign.py
-msgid "msg_successfully_reassigned_no_longer_permission"
 msgstr ""
 
 #. Default: "Commented by ${user}"

--- a/opengever/task/localroles.py
+++ b/opengever/task/localroles.py
@@ -42,6 +42,7 @@ class LocalRolesSetter(object):
         self.globalindex_reindex_task()
         self.revoke_on_related_items()
         self.revoke_on_distinct_parent()
+        self.task.reset_former_responsibles()
 
     def get_permission_identifier(self, actorid):
         actor = Actor.lookup(actorid)
@@ -177,12 +178,18 @@ class LocalRolesSetter(object):
         manager.clear(ASSIGNMENT_VIA_TASK_AGENCY,
                       self.inbox_group_id, self.task, reindex)
 
+        for former_responsible in self.task.get_former_responsibles():
+            manager.clear(ASSIGNMENT_VIA_TASK,
+                          self.get_permission_identifier(former_responsible),
+                          self.task, reindex)
+
     def revoke_roles_on_task(self):
         self._revoke_roles(self.task)
 
     def revoke_on_related_items(self):
         for item in getattr(aq_base(self.task), 'relatedItems', []):
             document = item.to_object
+
             self._revoke_roles(document)
 
             if self._is_inside_a_proposal(document):

--- a/opengever/task/localroles.py
+++ b/opengever/task/localroles.py
@@ -11,6 +11,7 @@ from opengever.document.document import IBaseDocument
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.globalindex.handlers.task import sync_task
 from opengever.meeting.proposal import IBaseProposal
+from opengever.ogds.base.actor import Actor
 from opengever.ogds.base.utils import get_current_org_unit
 from plone import api
 
@@ -42,6 +43,12 @@ class LocalRolesSetter(object):
         self.revoke_on_related_items()
         self.revoke_on_distinct_parent()
 
+    def get_permission_identifier(self, actorid):
+        actor = Actor.lookup(actorid)
+        if isinstance(actor.permission_identifier, unicode):
+            return actor.permission_identifier.encode('utf-8')
+        return actor.permission_identifier
+
     @property
     def responsible_permission_identfier(self):
         """Returns the responsible pricipal. This may be the userid
@@ -50,14 +57,7 @@ class LocalRolesSetter(object):
         """
         # cache information
         if not self._permission_identifier:
-            actor = self.task.get_responsible_actor()
-            self._permission_identifier = actor.permission_identifier
-
-            if isinstance(self._permission_identifier, unicode):
-                self._permission_identifier = (
-                    self._permission_identifier.encode('utf-8')
-                    )
-
+            self._permission_identifier = self.get_permission_identifier(self.task.responsible)
         return self._permission_identifier
 
     @property
@@ -170,30 +170,24 @@ class LocalRolesSetter(object):
 
         return maybe_document.is_inside_a_proposal()
 
-    def revoke_roles_on_task(self):
-        manager = RoleAssignmentManager(self.task)
+    def _revoke_roles(self, obj, reindex=True):
+        manager = RoleAssignmentManager(obj)
         manager.clear(ASSIGNMENT_VIA_TASK,
-                      self.responsible_permission_identfier, self.task)
+                      self.responsible_permission_identfier, self.task, reindex)
         manager.clear(ASSIGNMENT_VIA_TASK_AGENCY,
-                      self.inbox_group_id, self.task)
+                      self.inbox_group_id, self.task, reindex)
+
+    def revoke_roles_on_task(self):
+        self._revoke_roles(self.task)
 
     def revoke_on_related_items(self):
         for item in getattr(aq_base(self.task), 'relatedItems', []):
             document = item.to_object
-
-            manager = RoleAssignmentManager(document)
-            manager.clear(ASSIGNMENT_VIA_TASK,
-                          self.responsible_permission_identfier, self.task)
-            manager.clear(ASSIGNMENT_VIA_TASK_AGENCY,
-                          self.inbox_group_id, self.task)
+            self._revoke_roles(document)
 
             if self._is_inside_a_proposal(document):
                 proposal = document.get_proposal()
-                manager = RoleAssignmentManager(proposal)
-                manager.clear(ASSIGNMENT_VIA_TASK,
-                              self.responsible_permission_identfier, self.task)
-                manager.clear(ASSIGNMENT_VIA_TASK_AGENCY,
-                              self.inbox_group_id, self.task)
+                self._revoke_roles(proposal)
 
     def revoke_on_distinct_parent(self):
         distinct_parent = self.get_distinct_parent()
@@ -208,12 +202,7 @@ class LocalRolesSetter(object):
                              IBaseProposal.__identifier__],
             path='/'.join(distinct_parent.getPhysicalPath()))]
 
-        manager = RoleAssignmentManager(distinct_parent)
-        manager.clear(
-            ASSIGNMENT_VIA_TASK,
-            self.responsible_permission_identfier, self.task, reindex=False)
-        manager.clear(ASSIGNMENT_VIA_TASK_AGENCY,
-                      self.inbox_group_id, self.task, reindex=False)
+        self._revoke_roles(distinct_parent, reindex=False)
 
         for dossier in subdossiers:
             reindex_object_security_without_children(dossier)

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -42,6 +42,7 @@ from opengever.tasktemplates.interfaces import IContainSequentialProcess
 from opengever.tasktemplates.interfaces import IFromTasktemplateGenerated
 from opengever.tasktemplates.interfaces import IPartOfSequentialProcess
 from persistent.dict import PersistentDict
+from persistent.list import PersistentList
 from plone import api
 from plone.autoform import directives as form
 from plone.dexterity.content import Container
@@ -74,6 +75,7 @@ from zope.schema.vocabulary import getVocabularyRegistry
 _marker = object()
 TASKTEMPLATE_PREDECESSOR_KEY = 'tasktemplate_predecessor'
 TASK_PROCESS_ORDER_KEY = 'task_process_order'
+TASK_FORMER_RESPONSIBLES_KEY = 'task_former_responsibles'
 
 
 def deadline_default():
@@ -596,6 +598,18 @@ class Task(Container, TaskReminderSupport):
         term = vocabulary.getTerm(self.task_type)
 
         return term.title
+
+    def get_former_responsibles(self, create_if_missing=False):
+        annotations = IAnnotations(self)
+        if create_if_missing and TASK_FORMER_RESPONSIBLES_KEY not in annotations:
+            annotations[TASK_FORMER_RESPONSIBLES_KEY] = PersistentList()
+
+        return annotations.get(TASK_FORMER_RESPONSIBLES_KEY, [])
+
+    def add_former_responsible(self, respoonsible_id):
+        responsibles = self.get_former_responsibles(create_if_missing=True)
+        if respoonsible_id not in responsibles:
+            responsibles.append(respoonsible_id)
 
     def cancel_subtasks(self):
         for subtask in self.objectValues():

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -611,6 +611,9 @@ class Task(Container, TaskReminderSupport):
         if respoonsible_id not in responsibles:
             responsibles.append(respoonsible_id)
 
+    def reset_former_responsibles(self):
+        IAnnotations(self)[TASK_FORMER_RESPONSIBLES_KEY] = PersistentList()
+
     def cancel_subtasks(self):
         for subtask in self.objectValues():
             if not ITask.providedBy(subtask):

--- a/opengever/task/tests/test_assign.py
+++ b/opengever/task/tests/test_assign.py
@@ -14,7 +14,6 @@ from opengever.task.response_syncer.workflow import WorkflowResponseSyncerReceiv
 from opengever.testing import IntegrationTestCase
 from opengever.testing.event_recorder import get_recorded_events
 from opengever.testing.event_recorder import register_event_recorder
-from plone import api
 from zope.lifecycleevent.interfaces import IObjectModifiedEvent
 
 
@@ -212,31 +211,6 @@ class TestAssignTask(IntegrationTestCase):
               'reference': Oguid.for_object(self.task).id,
               'principal': 'jurgen.konig'}],
             manager.storage._storage())
-
-    @browsing
-    def test_redirects_to_portal_when_current_user_has_no_longer_view_permission(self, browser):
-        self.login(self.regular_user, browser=browser)
-
-        api.content.disable_roles_acquisition(obj=self.dossier)
-        self.assign_task(self.secretariat_user, u'Thats a job for you.')
-
-        manager = RoleAssignmentManager(self.task)
-        self.assertEqual(
-            [{'cause': ASSIGNMENT_VIA_TASK,
-              'roles': ['Editor'],
-              'reference': Oguid.for_object(self.task).id,
-              'principal': 'jurgen.konig'},
-             {'cause': ASSIGNMENT_VIA_TASK_AGENCY,
-              'roles': ['Editor'],
-              'reference': Oguid.for_object(self.task).id,
-              'principal': u'fa_inbox_users'}],
-            manager.storage._storage())
-
-        self.assertEqual(self.portal.absolute_url(), browser.url)
-        self.assertEqual(
-            ['Task successfully reassigned. You are no longer permitted to '
-             'access the task.'],
-            info_messages())
 
 
 class TestAssignTaskWithSuccessors(IntegrationTestCase):

--- a/opengever/task/tests/test_assign.py
+++ b/opengever/task/tests/test_assign.py
@@ -166,6 +166,20 @@ class TestAssignTask(IntegrationTestCase):
         self.assertEquals(self.regular_user.getId(), self.task.responsible)
 
     @browsing
+    def test_reassign_task_stores_former_responsible(self, browser):
+        self.login(self.regular_user, browser=browser)
+        self.assertEqual(self.task.get_former_responsibles(), [])
+
+        self.assign_task(self.secretariat_user, u'Thats a job for you.')
+        self.assign_task(self.administrator, u'Thats a job for you.')
+        self.assign_task(self.limited_admin, u'Thats a job for you.')
+
+        self.assertEqual(self.task.get_former_responsibles(),
+                         [self.regular_user.id,
+                          self.secretariat_user.id,
+                          self.administrator.id])
+
+    @browsing
     def test_modify_event_is_fired_but_only_once(self, browser):
         register_event_recorder(IObjectModifiedEvent)
 
@@ -178,7 +192,7 @@ class TestAssignTask(IntegrationTestCase):
         self.assertEqual(self.task, events[0].object)
 
     @browsing
-    def test_revokes_permission_for_former_responsible(self, browser):
+    def test_does_not_revoke_permission_for_former_responsible(self, browser):
         self.login(self.regular_user, browser=browser)
 
         self.assign_task(self.secretariat_user, u'Thats a job for you.')
@@ -188,11 +202,15 @@ class TestAssignTask(IntegrationTestCase):
             [{'cause': ASSIGNMENT_VIA_TASK,
               'roles': ['Editor'],
               'reference': Oguid.for_object(self.task).id,
-              'principal': 'jurgen.konig'},
+              'principal': 'kathi.barfuss'},
              {'cause': ASSIGNMENT_VIA_TASK_AGENCY,
               'roles': ['Editor'],
               'reference': Oguid.for_object(self.task).id,
-              'principal': u'fa_inbox_users'}],
+              'principal': u'fa_inbox_users'},
+             {'cause': ASSIGNMENT_VIA_TASK,
+              'roles': ['Editor'],
+              'reference': Oguid.for_object(self.task).id,
+              'principal': 'jurgen.konig'}],
             manager.storage._storage())
 
     @browsing
@@ -281,7 +299,7 @@ class TestAssignTaskWithSuccessors(IntegrationTestCase):
             self.secretariat_user.getId(), self.successor.responsible)
 
     @browsing
-    def test_revokes_roles_also_on_predecessor_when_reassigning_successor(self, browser):
+    def test_does_not_revoke_roles_on_predecessor_when_reassigning_successor(self, browser):
         self.login(self.regular_user, browser=browser)
 
         browser.open(self.successor)
@@ -296,15 +314,19 @@ class TestAssignTaskWithSuccessors(IntegrationTestCase):
             [{'cause': ASSIGNMENT_VIA_TASK,
               'roles': ['Editor'],
               'reference': Oguid.for_object(self.task).id,
-              'principal': 'jurgen.konig'},
+              'principal': 'kathi.barfuss'},
              {'cause': ASSIGNMENT_VIA_TASK_AGENCY,
               'roles': ['Editor'],
               'reference': Oguid.for_object(self.task).id,
-              'principal': u'fa_inbox_users'}],
+              'principal': u'fa_inbox_users'},
+             {'cause': ASSIGNMENT_VIA_TASK,
+              'roles': ['Editor'],
+              'reference': Oguid.for_object(self.task).id,
+              'principal': 'jurgen.konig'}],
             manager.storage._storage())
 
     @browsing
-    def test_revokes_roles_also_on_successor_when_reassigning_predecessor(self, browser):
+    def test_does_not_revoke_roles_on_successor_when_reassigning_predecessor(self, browser):
         self.login(self.regular_user, browser=browser)
 
         browser.open(self.task)
@@ -319,9 +341,13 @@ class TestAssignTaskWithSuccessors(IntegrationTestCase):
             [{'cause': ASSIGNMENT_VIA_TASK,
               'roles': ['Editor'],
               'reference': Oguid.for_object(self.successor).id,
-              'principal': 'jurgen.konig'},
+              'principal': 'kathi.barfuss'},
              {'cause': ASSIGNMENT_VIA_TASK_AGENCY,
               'roles': ['Editor'],
               'reference': Oguid.for_object(self.successor).id,
-              'principal': u'fa_inbox_users'}],
+              'principal': u'fa_inbox_users'},
+             {'cause': ASSIGNMENT_VIA_TASK,
+              'roles': ['Editor'],
+              'reference': Oguid.for_object(self.successor).id,
+              'principal': 'jurgen.konig'}],
             manager.storage._storage())

--- a/opengever/task/tests/test_forms.py
+++ b/opengever/task/tests/test_forms.py
@@ -104,6 +104,19 @@ class TestTaskEditForm(IntegrationTestCase):
             answer.css('h3').text)
 
     @browsing
+    def test_edit_responsible_adds_former_responsible(self, browser):
+        self.login(self.administrator, browser=browser)
+        self.set_workflow_state('task-state-open', self.task)
+        self.assertEqual(self.regular_user.id, self.task.responsible)
+        self.assertEqual([], self.task.get_former_responsibles())
+        browser.open(self.task, view='edit')
+
+        form = browser.find_form_by_field('Responsible')
+        form.find_widget('Responsible').fill(self.secretariat_user)
+        browser.find('Save').click()
+        self.assertEqual([self.regular_user.id], self.task.get_former_responsibles())
+
+    @browsing
     def test_edit_responsible_records_activity(self, browser):
         self.activate_feature('activity')
         self.login(self.administrator, browser=browser)

--- a/opengever/task/tests/test_localroles.py
+++ b/opengever/task/tests/test_localroles.py
@@ -243,7 +243,7 @@ class TestLocalRolesRevoking(IntegrationTestCase):
               'principal': 'fa_inbox_users'}], storage._storage())
 
     @browsing
-    def test_reassigning_task_revokes_responsible_roles_on_task(self, browser):
+    def test_reassigning_task_does_not_revoke_responsible_roles_on_task(self, browser):
         self.login(self.regular_user, browser)
 
         roles = self.task.get_local_roles_for_userid(
@@ -262,10 +262,10 @@ class TestLocalRolesRevoking(IntegrationTestCase):
         browser.fill({'Response': 'For you'})
         browser.click_on('Assign')
 
-        # old responsible's permissions were revoked
+        # old responsible's permissions were not revoked
         roles = self.task.get_local_roles_for_userid(
             self.regular_user.id)
-        self.assertEqual(tuple(), roles)
+        self.assertEqual(('Editor', ), roles)
 
         # new responsible was granted permissions
         roles = self.task.get_local_roles_for_userid(
@@ -304,7 +304,7 @@ class TestLocalRolesRevoking(IntegrationTestCase):
         self.assertEqual(('Editor', ), roles)
 
     @browsing
-    def test_reject_task_revokes_responsible_roles_on_task(self, browser):
+    def test_reject_task_does_not_revoke_responsible_roles_on_task(self, browser):
         self.login(self.regular_user, browser)
 
         self.set_workflow_state('task-state-open', self.subtask)
@@ -321,9 +321,11 @@ class TestLocalRolesRevoking(IntegrationTestCase):
         browser.fill({'Response': 'Nope!'})
         browser.click_on('Save')
 
-        # old responsible's permissions were revoked
+        # old responsible's permissions were not revoked
+        # but old responsible is added to former responsibles list
         roles = self.subtask.get_local_roles_for_userid(self.regular_user.id)
-        self.assertEqual(tuple(), roles)
+        self.assertEqual(('Editor',), roles)
+        self.assertEqual([self.regular_user.id], self.subtask.get_former_responsibles())
 
         # The new responsible, which is the issuer was granted permissions
         roles = self.subtask.get_local_roles_for_userid(self.dossier_responsible.id)

--- a/opengever/task/transition.py
+++ b/opengever/task/transition.py
@@ -19,7 +19,6 @@ from opengever.task.browser.delegate.recipients import ISelectRecipientsSchema
 from opengever.task.browser.delegate.utils import create_subtasks
 from opengever.task.browser.modify_deadline import validate_deadline_changed
 from opengever.task.interfaces import IDeadlineModifier
-from opengever.task.localroles import LocalRolesSetter
 from opengever.task.response_syncer import sync_task_response
 from opengever.task.sources import DocumentsFromTaskSourceBinder
 from opengever.task.task import ITask
@@ -246,14 +245,13 @@ class AcceptTransitionExtender(DefaultTransitionExtender):
         center = notification_center()
         center.add_task_responsible(self.context, current_user_id)
         center.remove_task_responsible(self.context, old_responsible)
-
         ITask(self.context).responsible = current_user_id
+        self.context.add_former_responsible(old_responsible)
         response.add_change(
             'responsible',
             old_responsible, ITask(self.context).responsible,
             _(u"label_responsible", default=u"Responsible"))
-        self.context.reindexObject(idxs=["responsible"])
-        self.context.sync()
+        notify(ObjectModifiedEvent(self.context))
 
 
 @implementer(ITransitionExtender)

--- a/opengever/task/transition.py
+++ b/opengever/task/transition.py
@@ -367,13 +367,6 @@ class ReassignTransitionExtender(DefaultTransitionExtender):
     schemas = [IResponse, INewResponsibleSchema]
 
     def after_transition_hook(self, transition, disable_sync, transition_params):
-        # Revoke local roles for current responsible, except if
-        # revoke_permissions is set to False.
-        # the roles for the new responsible will be assigned afterwards
-        # in set_roles_after_modifying on the ObjectModifiedEvent.
-        if self.context.revoke_permissions:
-            LocalRolesSetter(self.context).revoke_roles()
-
         self.context.clear_reminder(self.context.responsible)
 
         responsible_client = transition_params.get('responsible_client')
@@ -399,6 +392,7 @@ class ReassignTransitionExtender(DefaultTransitionExtender):
                 responsible=responsible, responsible_client=responsible_client)
 
     def change_responsible(self, transition_params):
+        self.context.add_former_responsible(self.context.responsible)
         self.context.responsible_client = transition_params.get('responsible_client')
         self.context.responsible = transition_params.get('responsible')
 
@@ -438,13 +432,7 @@ class RejectTransitionExtender(DefaultTransitionExtender):
             self.context.oguid, self.context.issuer, TASK_RESPONSIBLE_ROLE)
 
     def switch_responsible(self):
-        # Revoke local roles for current responsible, except if
-        # revoke_permissions is set to False.
-        # The roles for the new responsible will be assigned afterwards
-        # in set_roles_after_modifying on the ObjectModifiedEvent.
-        if self.context.revoke_permissions:
-            LocalRolesSetter(self.context).revoke_roles()
-
+        self.context.add_former_responsible(self.context.responsible)
         self.context.responsible = ITask(self.context).issuer
 
 


### PR DESCRIPTION
This allows former responsibles to follow up on what is happening with the task.

For [CA-3577]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [x] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New translations
  - [x] All msg-strings are unicode


[CA-3577]: https://4teamwork.atlassian.net/browse/CA-3577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ