### PR TITLE
Translate error message when trying to copy a checked-out document.

### DIFF
--- a/changes/CA-4021.other
+++ b/changes/CA-4021.other
@@ -1,0 +1,1 @@
+Translate error message when trying to copy a checked-out document. [njohner]

--- a/opengever/api/tests/test_copy_paste.py
+++ b/opengever/api/tests/test_copy_paste.py
@@ -90,9 +90,12 @@ class TestCopyPasteAPI(IntegrationTestCase):
                 method='POST',
                 headers=self.api_headers)
 
-        self.assertEqual({u'message': u'Checked out documents cannot be copied.',
-                          u'type': u'CopyError'},
-                         browser.json)
+        self.assertDictEqual(
+            {u'message': u'error_checked_out_cannot_be_copied',
+             u'translated_message': u'Checked out documents cannot be copied.',
+             u'additional_metadata': {},
+             u'type': u'CopyError'},
+            browser.json)
 
     @browsing
     def test_copy_document_when_not_all_path_elemnts_are_accessible(self, browser):

--- a/opengever/base/monkey/patches/verify_object_paste.py
+++ b/opengever/base/monkey/patches/verify_object_paste.py
@@ -18,6 +18,7 @@ class PatchCopyContainerVerifyObjectPaste(MonkeyPatch):
         from opengever.api.not_reported_exceptions import CopyError as NotReportedCopyError
         from opengever.document.behaviors import IBaseDocument
         from ZODB.POSException import ConflictError
+        from opengever.base import _
 
         def _verifyObjectPaste(self, object, validate_src=1):
             # Verify whether the current user is allowed to paste the
@@ -37,7 +38,9 @@ class PatchCopyContainerVerifyObjectPaste(MonkeyPatch):
             # We also make sure that we are not pasting a checked-out document
 
             if IBaseDocument.providedBy(object) and object.is_checked_out():
-                raise NotReportedCopyError('Checked out documents cannot be copied.')
+                raise NotReportedCopyError(
+                    _(u'error_checked_out_cannot_be_copied',
+                      default=u"Checked out documents cannot be copied."))
 
             if not hasattr(object, 'meta_type'):
                 raise CopyError(MessageDialog(


### PR DESCRIPTION
So that the error can be displayed correctly in the frontend.

See also https://github.com/4teamwork/gever-ui/pull/2230

For [CA-4021]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-4021]: https://4teamwork.atlassian.net/browse/CA-4021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ