### PR TITLE
Increase ClamAV maximal allowed filesize.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,8 @@ services:
       - 3310:3310
     profiles:
       - clamav
+    environment:
+      - CLAMD_CONF_StreamMaxLength=50M
   ogui:
     image: 4teamwork/ogui:latest
     profiles:


### PR DESCRIPTION
This is just for testing, will be closed afterwards. This fixes upload and download of 50MB files in the new and old UI. We should probably set it to something larger though.

For [CA-2373]



[CA-2373]: https://4teamwork.atlassian.net/browse/CA-2373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ