### PR TITLE
Re add dossier comments to the searchable text.

### DIFF
--- a/opengever/core/upgrades/20220421180133_reindex_dossier_comments/upgrade.py
+++ b/opengever/core/upgrades/20220421180133_reindex_dossier_comments/upgrade.py
@@ -1,0 +1,19 @@
+from ftw.upgrade import UpgradeStep
+from opengever.core.upgrade import NightlyDossierCommentIndexer
+from opengever.dossier.interfaces import IDossierMarker
+
+
+class ReindexDossierComments(UpgradeStep):
+    """Reindex dossier comments.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()
+
+        query = {'object_provides': [IDossierMarker.__identifier__]}
+
+        with NightlyDossierCommentIndexer(
+                idxs=["SearchableText"], index_in_solr_only=True) as indexer:
+            for brain in self.brains(
+                    query, 'Index SearchableText for all dossiers'):
+                indexer.add_by_brain(brain)

--- a/opengever/dossier/indexers.py
+++ b/opengever/dossier/indexers.py
@@ -3,6 +3,7 @@ from Acquisition import aq_parent
 from collective import dexteritytextindexer
 from opengever.base.interfaces import IReferenceNumber
 from opengever.base.interfaces import ISequenceNumber
+from opengever.base.response import IResponseContainer
 from opengever.base.utils import ensure_str
 from opengever.contact.sources import PloneSqlOrKubContactSourceBinder
 from opengever.document.behaviors.name_from_title import DOCUMENT_NAME_PREFIX
@@ -230,6 +231,10 @@ class SearchableTextExtender(object):
         searchable_external_reference = IDossier(self.context).external_reference
         if searchable_external_reference:
             searchable.append(searchable_external_reference.encode('utf-8'))
+
+        # comments stored in the response container
+        for response in IResponseContainer(self.context):
+            searchable.append(response.text.encode('utf-8'))
 
         # custom properties
         custom_properties = IDossierCustomProperties(self.context).custom_properties

--- a/opengever/dossier/tests/test_indexer.py
+++ b/opengever/dossier/tests/test_indexer.py
@@ -2,6 +2,9 @@ from ftw.builder import Builder
 from ftw.builder import create
 from opengever.base.behaviors.base import IOpenGeverBase
 from opengever.base.model import CONTENT_TITLE_LENGTH
+from opengever.base.response import COMMENT_RESPONSE_TYPE
+from opengever.base.response import IResponseContainer
+from opengever.base.response import Response
 from opengever.dossier.behaviors.customproperties import IDossierCustomProperties
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.behaviors.filing import IFilingNumber
@@ -248,6 +251,24 @@ class TestDossierIndexers(SolrIntegrationTestCase):
         self.assertIn(u"Kr\xe4he", indexed_value)
         self.assertIn(u"rot", indexed_value)
         self.assertIn(u"blau", indexed_value)
+
+    def test_dossier_searchable_text_contains_comments(self):
+        self.login(self.regular_user)
+
+        response1 = Response(COMMENT_RESPONSE_TYPE)
+        response1.text = u'Telefongespr\xe4ch mit Herr Meier'
+        IResponseContainer(self.dossier).add(response1)
+
+        response2 = Response(COMMENT_RESPONSE_TYPE)
+        response2.text = u'Abschlussnummer DDD2837'
+        IResponseContainer(self.dossier).add(response2)
+
+        self.dossier.reindexObject()
+        self.commit_solr()
+
+        indexed_value = solr_data_for(self.dossier, 'SearchableText')
+        self.assertIn(u'Meier', indexed_value)
+        self.assertIn(u'DDD2837', indexed_value)
 
     def test_dossiertemplate_searchable_text_contains_keywords(self):
         self.login(self.regular_user)


### PR DESCRIPTION
With the rebuild of the dossier comments from a simple field to a response container, the dossier comments has been dropped from the searchableText by mistake. This PR re adds the dossier comments to the searchableText and provides a nightly upgradestep to reindex dossiers with a comment.

For [CA-3970]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- Upgrade-Steps:
  - [x] Make it deferrable if possible
  - [x] Execute as much as possible conditionally


[CA-3970]: https://4teamwork.atlassian.net/browse/CA-3970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ