### PR TITLE
Set content type correctly in tus upload

### DIFF
--- a/changes/CA-4108.bugfix
+++ b/changes/CA-4108.bugfix
@@ -1,0 +1,1 @@
+Correctly set content type in tus-upload. [njohner]

--- a/opengever/core/upgrades/20220428110823_correct_content_type_for_cadwork/upgrade.py
+++ b/opengever/core/upgrades/20220428110823_correct_content_type_for_cadwork/upgrade.py
@@ -1,0 +1,48 @@
+from ftw.upgrade import UpgradeStep
+
+CADWORK_EXTENSIONS = [
+    '.2d',
+    '.2dc',
+    '.2dl',
+    '.2dm',
+    '.2dr',
+    '.3d',
+    '.3dc',
+    '.iv',
+    '.ivx',
+    '.ivz',
+    '.l2d',
+    '.lx2d',
+    '.lxz',
+]
+
+
+class AddCadworkMimeTypes(UpgradeStep):
+    """Correct cadwork mimetypes, which were not set correctly by the
+    tus-upload.
+
+    There could be others that were not set correctly, but it's hard to find
+    out which. It would be limited to Cadwork as these mimetypes are not
+    official IANA mimetypes.
+    """
+
+    deferrable = True
+
+    def __call__(self):
+
+        mtr = self.getToolByName('mimetypes_registry')
+
+        for obj in self.objects(
+            {
+                'portal_type': 'opengever.document.document',
+                'file_extension': CADWORK_EXTENSIONS,
+            },
+            'Correct Cadwork mimetypes'
+        ):
+            mt = mtr.lookupExtension(obj.file.filename)
+            content_type = mt.mimetypes[0]
+            if not obj.file.contentType == content_type:
+                obj.file.contentType = content_type
+                # Update catalog metadata (getContentType)
+                # We also need getIcon for solr
+                obj.reindexObject(idxs=['filename', 'getIcon'])


### PR DESCRIPTION
The content type is passed by the frontend to the `tus-upload` endpoint, but this content type comes from the browser or from uppy. This is therefore out of our control and does not work correctly for all content types that we support, notably for Cadwork files. We now set the content type in the backend, using the mimetypes registry, ensuring that content type is at least set correctly for all types supported by OfficeConnector. 

For [CA-4108]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [x] Make it deferrable if possible
  - [x] Execute as much as possible conditionally

[CA-4108]: https://4teamwork.atlassian.net/browse/CA-4108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ