### PR TITLE
Fix contentType problem when copying mails with teamraum connect.

### DIFF
--- a/changes/CA-4114.bugfix
+++ b/changes/CA-4114.bugfix
@@ -1,0 +1,1 @@
+Fix contentType problem when copying mails with teamraum connect. [phgross]

--- a/opengever/workspaceclient/linked_workspaces.py
+++ b/opengever/workspaceclient/linked_workspaces.py
@@ -237,7 +237,6 @@ class LinkedWorkspaces(object):
 
         document_metadata['gever_url'] = self.client.get_gever_url(Oguid.for_object(document).id)
 
-        content_type = document.content_type()
         filename = document.get_filename()
         gever_document_uid = document.UID()
 
@@ -255,7 +254,7 @@ class LinkedWorkspaces(object):
 
         response = self.client.upload_document_copy(
             workspace_url, file_.open(),
-            content_type, filename,
+            file_.contentType, filename,
             document_metadata, gever_document_uid)
 
         workspace_document_uid = response['UID']

--- a/opengever/workspaceclient/tests/test_linked_workspaces.py
+++ b/opengever/workspaceclient/tests/test_linked_workspaces.py
@@ -285,6 +285,8 @@ class TestLinkedWorkspaces(FunctionalWorkspaceClientTestCase):
             self.assertEqual(workspace_mail.get_file().open().read(),
                              mail.get_file().open().read())
 
+            self.assertEqual('message/rfc822', workspace_mail.message.contentType)
+
             self.assertItemsEqual(
                 manager._serialized_document_schema_fields(mail),
                 manager._serialized_document_schema_fields(workspace_mail))


### PR DESCRIPTION
using `document.content_type` can lead to wrong contentType, because it calls `Format` on the `CMFDefault/DublinCore`, which returns `text/plain` for mails (see CA-4114 for more details).

For [CA-4114]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-4114]: https://4teamwork.atlassian.net/browse/CA-4114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ