### PR TITLE
Return creator in task serialization.

### DIFF
--- a/changes/CA-4108.feature
+++ b/changes/CA-4108.feature
@@ -1,0 +1,1 @@
+Return creator in task serialization. [njohner]

--- a/opengever/api/task.py
+++ b/opengever/api/task.py
@@ -44,7 +44,7 @@ class SerializeTaskToJson(GeverSerializeFolderToJson):
         result[u'containing_dossier'] = self._get_containing_dossier_summary()
         result[u'sequence_type'] = self._get_sequence_type()
         result[u'is_completed'] = self.context.is_in_final_state
-
+        result[u'creator'] = serialize_actor_id_to_json_summary(self.context.Creator())
         model = self.context.get_sql_object()
         result[u'is_remote_task'] = model.is_remote_task
         result[u'has_remote_predecessor'] = model.has_remote_predecessor

--- a/opengever/api/tests/test_forwarding.py
+++ b/opengever/api/tests/test_forwarding.py
@@ -69,6 +69,16 @@ class TestForwardingSerialization(SolrIntegrationTestCase):
             browser.json['task_type']
         )
 
+    @browsing
+    def test_fowarding_contains_creator(self, browser):
+        self.login(self.secretariat_user, browser=browser)
+
+        browser.open(
+            self.inbox_forwarding, method="GET", headers=self.api_headers)
+
+        self.assertEqual(self.administrator.getId(),
+                         browser.json['creator']['identifier'])
+
 
 class TestForwardingTransitions(IntegrationTestCase):
 

--- a/opengever/api/tests/test_task.py
+++ b/opengever/api/tests/test_task.py
@@ -265,6 +265,13 @@ class TestTaskSerialization(SolrIntegrationTestCase):
                          browser.json['sequence_type'])
 
     @browsing
+    def test_contains_creator(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.task, method="GET", headers=self.api_headers)
+        self.assertEqual(self.dossier_responsible.getId(),
+                         browser.json['creator']['identifier'])
+
+    @browsing
     def test_contains_is_remote_task(self, browser):
         self.login(self.regular_user, browser=browser)
         browser.open(self.task, method="GET", headers=self.api_headers)


### PR DESCRIPTION
We need the creator to display him in the task responses (see https://github.com/4teamwork/gever-ui/pull/2242).

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-4069]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- New functionality:
  - [ ] for `document` also works for `mail`
  - [x] for `task` also works for `forwarding`

[CA-4069]: https://4teamwork.atlassian.net/browse/CA-4069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ