### PR TITLE
Do not copy creator and creation date when transporting task documents.

### DIFF
--- a/changes/CA-4069.feature
+++ b/changes/CA-4069.feature
@@ -1,0 +1,1 @@
+Do not copy creator and creation date when transporting task documents. [njohner]

--- a/opengever/base/transport.py
+++ b/opengever/base/transport.py
@@ -165,7 +165,8 @@ class DexterityObjectCreator(object):
         # insert data from collectors
         collectors = getAdapters((obj.__of__(container),), IDataCollector)
         for name, collector in collectors:
-            collector.insert(self.data[name])
+            if name in self.data:
+                collector.insert(self.data[name])
 
         obj = addContentToContainer(container, obj, checkConstraints=True)
         return obj

--- a/opengever/task/tests/test_transporter.py
+++ b/opengever/task/tests/test_transporter.py
@@ -1,122 +1,48 @@
-from ftw.builder import Builder
-from ftw.builder import create
 from opengever.document.versioner import Versioner
 from opengever.task.interfaces import ITaskDocumentsTransporter
 from opengever.task.task import ITask
-from opengever.testing import FunctionalTestCase
-from plone.app.testing import TEST_USER_ID
-from plone.dexterity.utils import createContentInContainer
-from plone.dexterity.utils import iterSchemata
-from z3c.form.interfaces import IValue
+from opengever.testing import IntegrationTestCase
 from z3c.relationfield.relation import RelationValue
 from zope.component import getUtility
-from zope.component import queryMultiAdapter
 from zope.intid.interfaces import IIntIds
-from zope.schema import getFieldsInOrder
-import transaction
 
 
-def set_defaults(obj):
-    for schemata in iterSchemata(obj):
-        for name, field in getFieldsInOrder(schemata):
-            try:
-                value = field.get(field.interface(obj))
-                if value:
-                    # field is present with a truthy value, nothing to do
-                    continue
-            except AttributeError:
-                # Field not present, set default
-                pass
-            default = queryMultiAdapter(
-                (obj, obj.REQUEST, None, field, None),
-                IValue,
-                name='default')
-            if default is not None:
-                default = default.get()
-            if default is None:
-                default = getattr(field, 'default', None)
-            if default is None:
-                try:
-                    default = field.missing_value
-                except AttributeError:
-                    pass
-            field.set(field.interface(obj), default)
-
-    return obj
-
-
-class TestTransporter(FunctionalTestCase):
-
-    def _create_task(self, context, with_docs=False, return_docs=False):
-
-        # task
-        task = create(Builder('task')
-                      .having(title='Task1',
-                              responsible=TEST_USER_ID,
-                              issuer=TEST_USER_ID,
-                              task_type='correction'))
-
-        if not with_docs:
-            return task
-
-        documents = []
-        # containing documents
-        documents.append(set_defaults(createContentInContainer(
-                task, 'opengever.document.document', title=u'Doc 1')))
-        documents.append(set_defaults(createContentInContainer(
-                task, 'opengever.document.document', title=u'Doc 2')))
-
-        # related documents
-        documents.append(set_defaults(createContentInContainer(
-            context, 'opengever.document.document', title=u'Doc 3')))
-
-        documents.append(set_defaults(createContentInContainer(
-            context, 'opengever.document.document', title=u'Doc 4')))
-
-        intids = getUtility(IIntIds)
-        ITask(task).relatedItems = [
-            RelationValue(intids.getId(documents[2]))]
-
-        # commit any pending transaction in order to avoid
-        # StorageTransactionError: Duplicate tpc_begin calls for same transaction
-        # See https://github.com/4teamwork/opengever.core/pull/556
-        transaction.commit()
-
-        if return_docs:
-            return task, documents
-        return task
+class TestTransporter(IntegrationTestCase):
 
     def test_documents_task_transport(self):
-        task = self._create_task(self.portal, with_docs=True)
-        target = self._create_task(self.portal)
+        self.login(self.regular_user)
+
+        self.assertItemsEqual([], self.seq_subtask_1.getFolderContents())
 
         doc_transporter = getUtility(ITaskDocumentsTransporter)
         doc_transporter.copy_documents_from_remote_task(
-            task.get_sql_object(), target)
+            self.task.get_sql_object(), self.seq_subtask_1)
 
-        self.assertEquals(
-            [aa.Title for aa in target.getFolderContents()].sort(),
-            ['Doc 1', 'Doc 2', 'Doc 3', 'Doc 4'].sort())
+        self.assertItemsEqual(
+            [self.taskdocument.Title(), self.document.Title()],
+            [aa.Title for aa in self.seq_subtask_1.getFolderContents()])
 
     def test_documents_task_transport_selected_docs(self):
+        self.login(self.regular_user)
         intids = getUtility(IIntIds)
 
-        task, documents = self._create_task(
-            self.portal, with_docs=True, return_docs=True)
-        target = self._create_task(self.portal)
-        sql_task = task.get_sql_object()
+        ITask(self.task).relatedItems = [
+             RelationValue(intids.getId(self.document)),
+             RelationValue(intids.getId(self.subdocument))]
+
+        self.assertItemsEqual([], self.seq_subtask_1.getFolderContents())
 
         doc_transporter = getUtility(ITaskDocumentsTransporter)
-        ids = [intids.getId(documents[0]), intids.getId(documents[3])]
+        ids = [intids.getId(self.subdocument), intids.getId(self.taskdocument)]
         intids_mapping = doc_transporter.copy_documents_from_remote_task(
-            sql_task, target, documents=ids)
+            self.task.get_sql_object(), self.seq_subtask_1, documents=ids)
 
-        self.assertEquals(
-            [aa.Title for aa in target.getFolderContents()].sort(),
-            ['Doc 1', 'Doc 4'].sort())
+        self.assertItemsEqual(
+            [self.subdocument.Title(), self.taskdocument.Title()],
+            [aa.Title for aa in self.seq_subtask_1.getFolderContents()],
+            )
 
-        pair1 = intids_mapping.items()[0]
-        pair2 = intids_mapping.items()[0]
+        pair1, pair2 = intids_mapping.items()
 
         self.assertEquals(
             intids.getObject(pair1[0]).Title(),
@@ -128,14 +54,16 @@ class TestTransporter(FunctionalTestCase):
             intids.getObject(pair2[1]).Title()
             )
 
-    def test_documents_with_custom_sort(self):
-        task = self._create_task(self.portal, with_docs=True)
-        target = self._create_task(self.portal)
-
+    def test_documents_with_custom_comment(self):
+        self.login(self.regular_user)
         doc_transporter = getUtility(ITaskDocumentsTransporter)
         doc_transporter.copy_documents_from_remote_task(
-            task.get_sql_object(), target, comment=u'Custom initial version')
+            self.task.get_sql_object(),
+            self.seq_subtask_1,
+            comment=u'Custom initial version')
 
-        doc = target.getFolderContents()[0].getObject()
-        self.assertEquals(u'Custom initial version',
-                          Versioner(doc).get_custom_initial_version_comment())
+        for brain in self.seq_subtask_1.getFolderContents():
+            doc = brain.getObject()
+            self.assertEquals(
+                u'Custom initial version',
+                Versioner(doc).get_custom_initial_version_comment())

--- a/opengever/task/transporter.py
+++ b/opengever/task/transporter.py
@@ -259,6 +259,8 @@ class TaskDocumentsTransporter(object):
         intids = getUtility(IIntIds)
 
         for item in data:
+            # Avoid setting creator and created
+            item.pop(u'unicode:dublin-core')
             obj = transporter.create(item, target)
 
             # Set custom initial version comment


### PR DESCRIPTION
When closing a cross-client "information" task, documents can be copied to a dossier on the responsible client. In such cases, we also copied over the "creator" and "created" to the copied document. This is not consistent with normal copy of a document and is a bit confusing as in the journal it says that the document was added by the current user, whereas the creator is still the creator of the original document.

No upgrade step to fix existing such documents. Also I corrected this only for copying documents when closing a task and not generally in the transporter, as I think in most cases it makes sense to copy the Creator and creation date.

For [CA-4096]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-4096]: https://4teamwork.atlassian.net/browse/CA-4096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ