### PR TITLE
Fix moving an object with the api where not all path elements are accessible.

### DIFF
--- a/changes/CA-4138.bugfix
+++ b/changes/CA-4138.bugfix
@@ -1,0 +1,1 @@
+Fix moving an object with the api where not all path elements are accessible. [phgross]


### PR DESCRIPTION
Use our own `get_obj_by_path` in the `@move` endpoint to fix a traversal bug, when not all path elements are accessible.

For [CA-4138]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-4138]: https://4teamwork.atlassian.net/browse/CA-4138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ