### PR TITLE
Add @ui-actions endpoint

### DIFF
--- a/changes/CA-2438.feature
+++ b/changes/CA-2438.feature
@@ -1,0 +1,1 @@
+Add @ui-actions endpoint. [tinagerber]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,6 +11,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- A new endpoint ``@ui-actions`` is added (see :ref:`ui_actions`).
 
 2022.9.0 (2022-04-26)
 ---------------------

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -40,6 +40,7 @@ Inhalt:
    external_activities.rst
    recently_touched.rst
    preview.rst
+   ui_actions.rst
    webactions.rst
    users.rst
    actors.rst

--- a/docs/public/dev-manual/api/ui_actions.rst
+++ b/docs/public/dev-manual/api/ui_actions.rst
@@ -1,0 +1,72 @@
+.. _ui_actions:
+
+UI-Actions
+==========
+
+Es gibt drei Kategorien von UI-Actions, ``context_actions``, ``listing_actions`` und ``webactions``. Mit dem ``categories`` Parameter kann bestimmt werden, welche Kategorien der Endpoint zurückgeben soll.
+
+
+**Beispiel-Request**:
+
+  .. sourcecode:: http
+
+    GET /ordnungssystem/fuehrung/dossier-1/@ui-actions?categories:list=context_actions&categories:list=webactions HTTP/1.1
+    Accept: application/json
+
+**Beispiel-Response**:
+
+  .. sourcecode:: http
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    {
+      "@id": "http://localhost:8080/fd/ordnungssystem/fuehrung/@ui-actions?categories:list=context_actions&categories:list=webactions",
+      "context_actions": [
+        {"id": "edit"},
+        "..."
+      ],
+      "webactions": [
+        {
+          "action_id": 0,
+          "title": "Open in ExternalApp",
+          "target_url": "http://example.org/endpoint",
+          "mode": "self",
+          "display": "actions-menu"
+        },
+        "..."
+      ]
+    }
+
+Für die ``listing_actions`` Kategorie gibts zusätzlich den Parameter ``listings``, mit dem festgelegt werden muss, für welches Listing die Actions zurückgeben werden sollen. Falls mehrere Listings angegeben werden, wird die Schnittmenge zurückgegeben.
+Zur Verfügung stehen folgende Listings:
+
+- documents
+- dossiers
+- dossiertempates
+- proposals
+- tasks
+- trash
+- workspace_folders
+
+**Beispiel-Request**:
+
+.. sourcecode:: http
+
+    GET /ordnungssystem/fuehrung/dossier-1/@ui-actions?categories:list=listing_actions&listings:list=documents HTTP/1.1
+    Accept: application/json
+
+**Beispiel-Response**:
+
+.. sourcecode:: http
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    {
+      "@id": "http://localhost:8080/fd/ordnungssystem/fuehrung/@ui-actions?categories:list=listing_actions&listings:list=documents",
+      "listing_actions": [
+        {"id": "edit_items"},
+        "..."
+      ]
+    }

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -104,6 +104,15 @@
       />
 
   <plone:service
+      method="GET"
+      for="zope.interface.Interface"
+      factory=".ui_actions.UIActionsGet"
+      name="@ui-actions"
+      layer="opengever.base.interfaces.IOpengeverBaseLayer"
+      permission="zope2.View"
+      />
+
+  <plone:service
       method="PATCH"
       for="opengever.document.document.IDocumentSchema"
       factory=".document.DocumentPatch"

--- a/opengever/api/tests/test_ui_actions.py
+++ b/opengever/api/tests/test_ui_actions.py
@@ -1,0 +1,129 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+
+
+class TestUIActionsGET(IntegrationTestCase):
+
+    @browsing
+    def test_ui_actions_without_categories_param(self, browser):
+        self.login(self.regular_user, browser)
+        url = u'{}/@ui-actions'.format(self.dossier.absolute_url())
+        browser.open(url, method='GET', headers=self.api_headers)
+        self.assertEqual({u'@id': url}, browser.json)
+
+    @browsing
+    def test_ui_actions_includes_all_categories(self, browser):
+        self.login(self.regular_user, browser)
+        url = u'{}/@ui-actions?categories:list=context_actions&categories:list=listing_actions'\
+              u'&categories:list=webactions'.format(self.dossier.absolute_url())
+        browser.open(url, method='GET', headers=self.api_headers)
+        self.assertEqual([u'context_actions', u'listing_actions', u'@id', u'webactions'],
+                         browser.json.keys())
+
+    @browsing
+    def test_ui_actions_includes_context_actions(self, browser):
+        self.login(self.regular_user, browser)
+        url = '{}/@ui-actions?categories:list=context_actions'.format(self.dossier.absolute_url())
+        browser.open(url, method='GET', headers=self.api_headers)
+
+        self.assertEqual(
+            {u'@id': url,
+             u'context_actions': [
+                {u'id': u'document_with_template'},
+                {u'id': u'edit'},
+                {u'id': u'export_pdf'},
+                {u'id': u'pdf_dossierdetails'},
+                {u'id': u'zipexport'}]}, browser.json)
+
+    @browsing
+    def test_ui_actions_includes_listing_actions(self, browser):
+        self.login(self.regular_user, browser)
+        url = u'{}/@ui-actions?categories:list=listing_actions'\
+              u'&listings:list=proposals'.format(self.dossier.absolute_url())
+        browser.open(url, method='GET', headers=self.api_headers)
+
+        self.assertEqual(
+            {u'@id': url,
+             u'listing_actions': [{u'id': u'export_proposals'}]}, browser.json)
+
+    @browsing
+    def test_listing_actions_with_multiple_listings_returns_intersection(self, browser):
+        self.login(self.regular_user, browser)
+        task_url = u'{}/@ui-actions?categories:list=listing_actions'\
+                   u'&listings:list=tasks'.format(self.dossier.absolute_url())
+        browser.open(task_url, method='GET', headers=self.api_headers)
+        self.assertEqual([u'move_items', u'export_tasks', u'pdf_taskslisting'],
+                         [action['id'] for action in browser.json['listing_actions']])
+        dossier_url = u'{}/@ui-actions?categories:list=listing_actions'\
+                      u'&listings:list=dossiers'.format(self.dossier.absolute_url())
+        browser.open(dossier_url, method='GET', headers=self.api_headers)
+        self.assertEqual([u'edit_items', u'copy_items', u'move_items', u'export_dossiers',
+                          u'pdf_dossierlisting'],
+                         [action['id'] for action in browser.json['listing_actions']])
+        combined_url = u'{}/@ui-actions?categories:list=listing_actions'\
+                       u'&listings:list=tasks&listings:list=dossiers'.format(
+                        self.dossier.absolute_url())
+        browser.open(combined_url, method='GET', headers=self.api_headers)
+        self.assertEqual([u'move_items'],
+                         [action['id'] for action in browser.json['listing_actions']])
+
+    @browsing
+    def test_listing_actions_without_listings_param_returns_empty_list(self, browser):
+        self.login(self.regular_user, browser)
+        url = '{}/@ui-actions?categories:list=listing_actions'.format(self.dossier.absolute_url())
+        browser.open(url, method='GET', headers=self.api_headers)
+        self.assertEqual([], browser.json['listing_actions'])
+
+    @browsing
+    def test_ui_actions_includes_webactions(self, browser):
+        self.login(self.webaction_manager, browser)
+        create(Builder('webaction')
+               .having(
+                   title=u'Open in ExternalApp',
+                   enabled=True,
+            ))
+        create(Builder('webaction')
+               .having(
+                   title=u'Open in InternalApp',
+                   enabled=True,
+        ))
+        create(Builder('webaction')
+               .having(
+                   title=u'Open in BrokenApp',
+                   enabled=False,
+            ))
+
+        self.login(self.regular_user, browser)
+        browser.open(self.dossier, view='/@ui-actions?categories:list=webactions',
+                     method='GET', headers=self.api_headers)
+
+        self.assertEqual(
+            [u'Open in ExternalApp', u'Open in InternalApp'],
+            [action.get('title') for action in browser.json.get('webactions')])
+
+    @browsing
+    def test_webaction_serialization_in_ui_actions_endpoint(self, browser):
+        self.login(self.webaction_manager, browser)
+        create(Builder('webaction').having(
+            target_url='http://localhost/foo?location={path}'))
+
+        self.login(self.regular_user, browser)
+        browser.open(self.dossier, view='/@ui-actions?categories:list=webactions',
+                     method='GET', headers=self.api_headers)
+
+        self.assertEqual([
+            {
+                u'action_id': 0,
+                u'display': u'actions-menu',
+                u'mode': u'self',
+                u'icon_data': None,
+                u'icon_name': None,
+                u'target_url': u'http://localhost/foo?location=%2Fplone%2Fordnungssystem%2F'
+                               u'fuhrung%2Fvertrage-und-vereinbarungen%2Fdossier-1&'
+                               u'context=http%3A%2F%2Fnohost%2Fplone%2Fordnungssystem%2Ffuhrung'
+                               u'%2Fvertrage-und-vereinbarungen%2Fdossier-1&orgunit=fa',
+                u'title': u'Open in ExternalApp'
+            }],
+            browser.json.get('webactions'))

--- a/opengever/api/ui_actions.py
+++ b/opengever/api/ui_actions.py
@@ -1,0 +1,65 @@
+from opengever.webactions.renderer import WebActionsSafeDataGetter
+from plone.restapi.serializer.converters import json_compatible
+from plone.restapi.services import Service
+from zope.component import queryMultiAdapter
+from opengever.base.interfaces import IListingActions
+from opengever.base.interfaces import IContextActions
+
+
+class UIActionsGet(Service):
+
+    def extract_params(self):
+        params = self.request.form.copy()
+
+        categories = params.get("categories", [])
+        if not isinstance(categories, list):
+            categories = [categories]
+        listings = params.get("listings", [])
+        if not isinstance(listings, list):
+            listings = [listings]
+
+        return categories, listings
+
+    def _get_listing_actions(self, name):
+        adapter = queryMultiAdapter((self.context, self.request),
+                                    interface=IListingActions,
+                                    name=name)
+        return adapter.get_actions() if adapter else []
+
+    def serialize_actions(self, actions):
+        return [{'id': action} for action in actions]
+
+    def extend_with_context_actions(self, response):
+        adapter = queryMultiAdapter((self.context, self.request),
+                                    interface=IContextActions)
+        context_actions = adapter.get_actions() if adapter else []
+        response['context_actions'] = self.serialize_actions(context_actions)
+
+    def extend_with_listing_actions(self, response, listings):
+        all_actions = [self._get_listing_actions(listing) for listing in listings]
+        intersection = set(*all_actions[:1]).intersection(*all_actions[1:])
+        if intersection:
+            sorted_actions = [action for action in all_actions[0] if action in intersection]
+            response['listing_actions'] = self.serialize_actions(sorted_actions)
+        else:
+            response['listing_actions'] = []
+
+    def extend_with_webactions(self, response):
+        data_getter = WebActionsSafeDataGetter(self.context, self.request, None)
+        webactions = data_getter.get_webactions_data(flat=True)
+        response['webactions'] = json_compatible(webactions)
+
+    def reply(self):
+        categories, listings = self.extract_params()
+        url = self.request['ACTUAL_URL']
+        qs = self.request['QUERY_STRING']
+        if qs:
+            url = '?'.join((url, qs))
+        response = {'@id': url}
+        if 'context_actions' in categories:
+            self.extend_with_context_actions(response)
+        if 'listing_actions' in categories:
+            self.extend_with_listing_actions(response, listings)
+        if 'webactions' in categories:
+            self.extend_with_webactions(response)
+        return response

--- a/opengever/base/browser/edit_public_trial.py
+++ b/opengever/base/browser/edit_public_trial.py
@@ -14,6 +14,23 @@ from z3c.form.field import Fields
 from zExceptions import Unauthorized
 
 
+def is_edit_public_trial_status_available(context):
+    if not IBaseDocument.providedBy(context):
+        return False
+
+    parent_dossier = context.get_parent_dossier()
+    if not parent_dossier:
+        # Document inside a workspace
+        return False
+
+    state = api.content.get_state(parent_dossier, default=None)
+    if state not in DOSSIER_STATES_CLOSED:
+        return False
+
+    return can_access_public_trial_edit_form(
+        api.user.get_current(), context)
+
+
 def can_access_public_trial_edit_form(user, content):
     """Returns True if the user has 'Modify portal content' permission in any
     open dossier state. And the containing dossier is
@@ -79,17 +96,4 @@ class EditPublicTrialForm(DefaultEditForm):
 class IsEditPublicTrialStatusAvailable(BrowserView):
 
     def __call__(self):
-        if not IBaseDocument.providedBy(self.context):
-            return False
-
-        parent_dossier = self.context.get_parent_dossier()
-        if not parent_dossier:
-            # Document inside a workspace
-            return False
-
-        state = api.content.get_state(parent_dossier, default=None)
-        if state not in DOSSIER_STATES_CLOSED:
-            return False
-
-        return can_access_public_trial_edit_form(
-            api.user.get_current(), self.context)
+        return is_edit_public_trial_status_available(self.context)

--- a/opengever/base/configure.zcml
+++ b/opengever/base/configure.zcml
@@ -47,6 +47,12 @@
   <adapter factory=".storage.RoleAssignmentReportsStorage" />
 
   <adapter
+      factory=".context_actions.BaseContextActions"
+      for="opengever.inbox.forwarding.IForwarding
+           opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
+  <adapter
       factory=".contentlisting.OpengeverCatalogContentListingObject"
       for="opengever.base.interfaces.IOpengeverCatalogBrain"
       />

--- a/opengever/base/context_actions.py
+++ b/opengever/base/context_actions.py
@@ -1,0 +1,445 @@
+from opengever.base.interfaces import IContextActions
+from plone import api
+from zope.interface import implementer
+
+
+@implementer(IContextActions)
+class BaseContextActions(object):
+
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+
+    def get_actions(self):
+        self.actions = []
+        self.maybe_add_add_invitation()
+        self.maybe_add_attach_to_email()
+        self.maybe_add_cancel_checkout()
+        self.maybe_add_checkin_with_comment()
+        self.maybe_add_checkin_without_comment()
+        self.maybe_add_checkout_document()
+        self.maybe_add_copy_documents_from_workspace()
+        self.maybe_add_copy_documents_to_workspace()
+        self.maybe_add_copy_item()
+        self.maybe_add_create_forwarding()
+        self.maybe_add_create_linked_workspace()
+        self.maybe_add_create_task_from_proposal()
+        self.maybe_add_delete()
+        self.maybe_add_delete_repository()
+        self.maybe_add_delete_workspace()
+        self.maybe_add_delete_workspace_context()
+        self.maybe_add_docugate_retry()
+        self.maybe_add_document_from_docugate()
+        self.maybe_add_document_with_oneoffixx_template()
+        self.maybe_add_document_with_template()
+        self.maybe_add_dossier_with_template()
+        self.maybe_add_download_appraisal_list()
+        self.maybe_add_download_copy()
+        self.maybe_add_download_excel()
+        self.maybe_add_download_removal_protocol()
+        self.maybe_add_download_sip()
+        self.maybe_add_edit()
+        self.maybe_add_edit_public_trial_status()
+        self.maybe_add_export_pdf()
+        self.maybe_add_link_to_workspace()
+        self.maybe_add_list_workspaces()
+        self.maybe_add_local_roles()
+        self.maybe_add_meeting_ical_download()
+        self.maybe_add_meeting_minutes_pdf()
+        self.maybe_add_move_item()
+        self.maybe_add_new_task_from_document()
+        self.maybe_add_oc_direct_checkout()
+        self.maybe_add_oc_direct_edit()
+        self.maybe_add_office_online_edit()
+        self.maybe_add_oneoffixx_retry()
+        self.maybe_add_open_as_pdf()
+        self.maybe_add_pdf_dossierdetails()
+        self.maybe_add_prefix_manager()
+        self.maybe_add_protect_dossier()
+        self.maybe_add_revive_bumblebee_preview()
+        self.maybe_add_save_document_as_pdf()
+        self.maybe_add_share_content()
+        self.maybe_add_submit_additional_documents()
+        self.maybe_add_trash_context()
+        self.maybe_add_unlink_workspace()
+        self.maybe_add_unlock()
+        self.maybe_add_untrash_context()
+        self.maybe_add_zipexport()
+        return self.actions
+
+    def add_action(self, action):
+        self.actions.append(action)
+
+    def is_add_invitation_available(self):
+        return False
+
+    def is_attach_to_email_available(self):
+        return False
+
+    def is_cancel_checkout_available(self):
+        return False
+
+    def is_checkin_with_comment_available(self):
+        return False
+
+    def is_checkin_without_comment_available(self):
+        return False
+
+    def is_checkout_document_available(self):
+        return False
+
+    def is_copy_documents_from_workspace_available(self):
+        return False
+
+    def is_copy_documents_to_workspace_available(self):
+        return False
+
+    def is_copy_item_available(self):
+        return False
+
+    def is_create_forwarding_available(self):
+        return False
+
+    def is_create_linked_workspace_available(self):
+        return False
+
+    def is_create_task_from_proposal_available(self):
+        return False
+
+    def is_delete_repository_available(self):
+        return False
+
+    def is_delete_available(self):
+        return False
+
+    def is_delete_workspace_available(self):
+        return False
+
+    def is_delete_workspace_context_available(self):
+        return False
+
+    def is_docugate_retry_available(self):
+        return False
+
+    def is_document_from_docugate_available(self):
+        return False
+
+    def is_document_with_oneoffixx_template_available(self):
+        return False
+
+    def is_document_with_template_available(self):
+        return False
+
+    def is_dossier_with_template_available(self):
+        return False
+
+    def is_download_appraisal_list_available(self):
+        return False
+
+    def is_download_copy_available(self):
+        return False
+
+    def is_download_excel_available(self):
+        return False
+
+    def is_download_removal_protocol_available(self):
+        return False
+
+    def is_download_sip_available(self):
+        return False
+
+    def is_edit_available(self):
+        is_locked_for_current_user = self.context.restrictedTraverse(
+            '@@plone_lock_info').is_locked_for_current_user()
+        has_modify_permission = api.user.has_permission('Modify portal content', obj=self.context)
+        return has_modify_permission and not is_locked_for_current_user
+
+    def is_edit_public_trial_status_available(self):
+        return False
+
+    def is_export_pdf_available(self):
+        return False
+
+    def is_link_to_workspace_available(self):
+        return False
+
+    def is_list_workspaces_available(self):
+        return False
+
+    def is_local_roles_available(self):
+        return api.user.has_permission('Sharing page: Delegate roles', obj=self.context)
+
+    def is_meeting_ical_download_available(self):
+        return False
+
+    def is_meeting_minutes_pdf_available(self):
+        return False
+
+    def is_move_item_available(self):
+        return False
+
+    def is_new_task_from_document_available(self):
+        return False
+
+    def is_oc_direct_checkout_available(self):
+        return False
+
+    def is_oc_direct_edit_available(self):
+        return False
+
+    def is_office_online_edit_available(self):
+        return False
+
+    def is_oneoffixx_retry_available(self):
+        return False
+
+    def is_open_as_pdf_available(self):
+        return False
+
+    def is_pdf_dossierdetails_available(self):
+        return False
+
+    def is_prefix_manager_available(self):
+        return False
+
+    def is_protect_dossier_available(self):
+        return False
+
+    def is_revive_bumblebee_preview_available(self):
+        return False
+
+    def is_save_document_as_pdf_available(self):
+        return False
+
+    def is_share_content_available(self):
+        return False
+
+    def is_submit_additional_documents_available(self):
+        return False
+
+    def is_trash_context_available(self):
+        return False
+
+    def is_unlink_workspace_available(self):
+        return False
+
+    def is_unlock_available(self):
+        return False
+
+    def is_untrash_context_available(self):
+        return False
+
+    def is_zipexport_available(self):
+        return False
+
+    def maybe_add_add_invitation(self):
+        if self.is_add_invitation_available():
+            self.add_action(u'add_invitation')
+
+    def maybe_add_attach_to_email(self):
+        if self.is_attach_to_email_available():
+            self.add_action(u'attach_to_email')
+
+    def maybe_add_cancel_checkout(self):
+        if self.is_cancel_checkout_available():
+            self.add_action(u'cancel_checkout')
+
+    def maybe_add_checkin_with_comment(self):
+        if self.is_checkin_with_comment_available():
+            self.add_action(u'checkin_with_comment')
+
+    def maybe_add_checkin_without_comment(self):
+        if self.is_checkin_without_comment_available():
+            self.add_action(u'checkin_without_comment')
+
+    def maybe_add_checkout_document(self):
+        if self.is_checkout_document_available():
+            self.add_action(u'checkout_document')
+
+    def maybe_add_copy_documents_from_workspace(self):
+        if self.is_copy_documents_from_workspace_available():
+            self.add_action(u'copy_documents_from_workspace')
+
+    def maybe_add_copy_documents_to_workspace(self):
+        if self.is_copy_documents_to_workspace_available():
+            self.add_action(u'copy_documents_to_workspace')
+
+    def maybe_add_copy_item(self):
+        if self.is_copy_item_available():
+            self.add_action(u'copy_item')
+
+    def maybe_add_create_forwarding(self):
+        if self.is_create_forwarding_available():
+            self.add_action(u'create_forwarding')
+
+    def maybe_add_create_linked_workspace(self):
+        if self.is_create_linked_workspace_available():
+            self.add_action(u'create_linked_workspace')
+
+    def maybe_add_create_task_from_proposal(self):
+        if self.is_create_task_from_proposal_available():
+            self.add_action(u'create_task_from_proposal')
+
+    def maybe_add_document_from_docugate(self):
+        if self.is_document_from_docugate_available():
+            self.add_action(u'document_from_docugate')
+
+    def maybe_add_document_with_oneoffixx_template(self):
+        if self.is_document_with_oneoffixx_template_available():
+            self.add_action(u'document_with_oneoffixx_template')
+
+    def maybe_add_document_with_template(self):
+        if self.is_document_with_template_available():
+            self.add_action(u'document_with_template')
+
+    def maybe_add_delete(self):
+        if self.is_delete_available():
+            self.add_action(u'delete')
+
+    def maybe_add_delete_repository(self):
+        if self.is_delete_repository_available():
+            self.add_action(u'delete_repository')
+
+    def maybe_add_delete_workspace(self):
+        if self.is_delete_workspace_available():
+            self.add_action(u'delete_workspace')
+
+    def maybe_add_delete_workspace_context(self):
+        if self.is_delete_workspace_context_available():
+            self.add_action(u'delete_workspace_context')
+
+    def maybe_add_docugate_retry(self):
+        if self.is_docugate_retry_available():
+            self.add_action(u'docugate_retry')
+
+    def maybe_add_dossier_with_template(self):
+        if self.is_dossier_with_template_available():
+            self.add_action(u'dossier_with_template')
+
+    def maybe_add_download_appraisal_list(self):
+        if self.is_download_appraisal_list_available():
+            self.add_action(u'download-appraisal-list')
+
+    def maybe_add_download_copy(self):
+        if self.is_download_copy_available():
+            self.add_action(u'download_copy')
+
+    def maybe_add_download_excel(self):
+        if self.is_download_excel_available():
+            self.add_action(u'download_excel')
+
+    def maybe_add_download_removal_protocol(self):
+        if self.is_download_removal_protocol_available():
+            self.add_action(u'download-removal-protocol')
+
+    def maybe_add_download_sip(self):
+        if self.is_download_sip_available():
+            self.add_action(u'download-sip')
+
+    def maybe_add_edit(self):
+        if self.is_edit_available():
+            self.add_action(u'edit')
+
+    def maybe_add_edit_public_trial_status(self):
+        if self.is_edit_public_trial_status_available():
+            self.add_action(u'edit-public-trial-status')
+
+    def maybe_add_export_pdf(self):
+        if self.is_export_pdf_available():
+            self.add_action(u'export_pdf')
+
+    def maybe_add_link_to_workspace(self):
+        if self.is_link_to_workspace_available():
+            self.add_action(u'link_to_workspace')
+
+    def maybe_add_list_workspaces(self):
+        if self.is_list_workspaces_available():
+            self.add_action(u'list_workspaces')
+
+    def maybe_add_local_roles(self):
+        if self.is_local_roles_available():
+            self.add_action(u'local_roles')
+
+    def maybe_add_meeting_ical_download(self):
+        if self.is_meeting_ical_download_available():
+            self.add_action(u'meeting_ical_download')
+
+    def maybe_add_meeting_minutes_pdf(self):
+        if self.is_meeting_minutes_pdf_available():
+            self.add_action(u'meeting_minutes_pdf')
+
+    def maybe_add_move_item(self):
+        if self.is_move_item_available():
+            self.add_action(u'move_item')
+
+    def maybe_add_new_task_from_document(self):
+        if self.is_new_task_from_document_available():
+            self.add_action(u'new_task_from_document')
+
+    def maybe_add_oc_direct_checkout(self):
+        if self.is_oc_direct_checkout_available():
+            self.add_action(u'oc_direct_checkout')
+
+    def maybe_add_oc_direct_edit(self):
+        if self.is_oc_direct_edit_available():
+            self.add_action(u'oc_direct_edit')
+
+    def maybe_add_office_online_edit(self):
+        if self.is_office_online_edit_available():
+            self.add_action(u'office_online_edit')
+
+    def maybe_add_oneoffixx_retry(self):
+        if self.is_oneoffixx_retry_available():
+            self.add_action(u'oneoffixx_retry')
+
+    def maybe_add_open_as_pdf(self):
+        if self.is_open_as_pdf_available():
+            self.add_action(u'open_as_pdf')
+
+    def maybe_add_pdf_dossierdetails(self):
+        if self.is_pdf_dossierdetails_available():
+            self.add_action(u'pdf_dossierdetails')
+
+    def maybe_add_prefix_manager(self):
+        if self.is_prefix_manager_available():
+            self.add_action(u'prefix_manager')
+
+    def maybe_add_protect_dossier(self):
+        if self.is_protect_dossier_available():
+            self.add_action(u'protect_dossier')
+
+    def maybe_add_share_content(self):
+        if self.is_share_content_available():
+            self.add_action(u'share_content')
+
+    def maybe_add_submit_additional_documents(self):
+        if self.is_submit_additional_documents_available():
+            self.add_action(u'submit_additional_documents')
+
+    def maybe_add_trash_context(self):
+        if self.is_trash_context_available():
+            self.add_action(u'trash_context')
+
+    def maybe_add_unlink_workspace(self):
+        if self.is_unlink_workspace_available():
+            self.add_action(u'unlink_workspace')
+
+    def maybe_add_untrash_context(self):
+        if self.is_untrash_context_available():
+            self.add_action(u'untrash_context')
+
+    def maybe_add_revive_bumblebee_preview(self):
+        if self.is_revive_bumblebee_preview_available():
+            self.add_action(u'revive_bumblebee_preview')
+
+    def maybe_add_save_document_as_pdf(self):
+        if self.is_save_document_as_pdf_available():
+            self.add_action(u'save_document_as_pdf')
+
+    def maybe_add_unlock(self):
+        if self.is_unlock_available():
+            self.add_action(u'unlock')
+
+    def maybe_add_zipexport(self):
+        if self.is_zipexport_available():
+            self.add_action(u'zipexport')

--- a/opengever/base/interfaces.py
+++ b/opengever/base/interfaces.py
@@ -577,3 +577,10 @@ class IListingActions(Interface):
 
     def get_actions():
         """Return listing actions"""
+
+
+class IContextActions(Interface):
+    """Adapter to determine context actions"""
+
+    def get_actions():
+        """Return context actions"""

--- a/opengever/base/interfaces.py
+++ b/opengever/base/interfaces.py
@@ -570,3 +570,10 @@ class IActorSettings(Interface):
         source=get_user_avatar_image_sources(),
         default=AVATAR_SOURCE_PLONE_ONLY,
     )
+
+
+class IListingActions(Interface):
+    """Adapter to determine listing actions"""
+
+    def get_actions():
+        """Return listing actions"""

--- a/opengever/base/listing_actions.py
+++ b/opengever/base/listing_actions.py
@@ -1,0 +1,184 @@
+from opengever.base.interfaces import IListingActions
+from zope.interface import implementer
+
+
+@implementer(IListingActions)
+class BaseListingActions(object):
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+
+    def get_actions(self):
+        self.actions = []
+        self.maybe_add_edit_items()
+        self.maybe_add_attach_documents()
+        self.maybe_add_copy_items()
+        self.maybe_add_move_items()
+        self.maybe_add_create_task()
+        self.maybe_add_create_proposal()
+        self.maybe_add_create_forwarding()
+        self.maybe_add_zip_selected()
+        self.maybe_add_export_documents()
+        self.maybe_add_export_dossiers()
+        self.maybe_add_export_tasks()
+        self.maybe_add_export_proposals()
+        self.maybe_add_pdf_dossierlisting()
+        self.maybe_add_pdf_taskslisting()
+        self.maybe_add_create_disposition()
+        self.maybe_add_copy_documents_to_workspace()
+        self.maybe_add_trash_content()
+        self.maybe_add_untrash_content()
+        self.maybe_add_remove()
+        self.maybe_add_delete_workspace_content()
+        self.maybe_add_delete()
+        return self.actions
+
+    def add_action(self, action):
+        self.actions.append(action)
+
+    def is_attach_documents_available(self):
+        return False
+
+    def is_copy_documents_to_workspace_available(self):
+        return False
+
+    def is_copy_items_available(self):
+        return False
+
+    def is_create_disposition_available(self):
+        return False
+
+    def is_create_forwarding_available(self):
+        return False
+
+    def is_create_proposal_available(self):
+        return False
+
+    def is_create_task_available(self):
+        return False
+
+    def is_delete_available(self):
+        return False
+
+    def is_delete_workspace_content_available(self):
+        return False
+
+    def is_edit_items_available(self):
+        return False
+
+    def is_export_documents_available(self):
+        return False
+
+    def is_export_dossiers_available(self):
+        return False
+
+    def is_export_proposals_available(self):
+        return False
+
+    def is_export_tasks_available(self):
+        return False
+
+    def is_move_items_available(self):
+        return False
+
+    def is_pdf_dossierlisting_available(self):
+        return False
+
+    def is_pdf_taskslisting_available(self):
+        return False
+
+    def is_remove_available(self):
+        return False
+
+    def is_trash_content_available(self):
+        return False
+
+    def is_untrash_content_available(self):
+        return False
+
+    def is_zip_selected_available(self):
+        return False
+
+    def maybe_add_attach_documents(self):
+        if self.is_attach_documents_available():
+            self.add_action(u'attach_documents')
+
+    def maybe_add_copy_documents_to_workspace(self):
+        if self.is_copy_documents_to_workspace_available():
+            self.add_action(u'copy_documents_to_workspace')
+
+    def maybe_add_copy_items(self):
+        if self.is_copy_items_available():
+            self.add_action(u'copy_items')
+
+    def maybe_add_create_disposition(self):
+        if self.is_create_disposition_available():
+            self.add_action(u'create_disposition')
+
+    def maybe_add_create_forwarding(self):
+        if self.is_create_forwarding_available():
+            self.add_action(u'create_forwarding')
+
+    def maybe_add_create_proposal(self):
+        if self.is_create_proposal_available():
+            self.add_action(u'create_proposal')
+
+    def maybe_add_create_task(self):
+        if self.is_create_task_available():
+            self.add_action(u'create_task')
+
+    def maybe_add_delete(self):
+        if self.is_delete_available():
+            self.add_action(u'delete')
+
+    def maybe_add_delete_workspace_content(self):
+        if self.is_delete_workspace_content_available():
+            self.add_action(u'delete_workspace_content')
+
+    def maybe_add_edit_items(self):
+        if self.is_edit_items_available():
+            self.add_action(u'edit_items')
+
+    def maybe_add_export_documents(self):
+        if self.is_export_documents_available():
+            self.add_action(u'export_documents')
+
+    def maybe_add_export_dossiers(self):
+        if self.is_export_dossiers_available():
+            self.add_action(u'export_dossiers')
+
+    def maybe_add_export_proposals(self):
+        if self.is_export_proposals_available():
+            self.add_action(u'export_proposals')
+
+    def maybe_add_export_tasks(self):
+        if self.is_export_tasks_available():
+            self.add_action(u'export_tasks')
+
+    def maybe_add_move_items(self):
+        if self.is_move_items_available():
+            self.add_action(u'move_items')
+
+    def maybe_add_pdf_dossierlisting(self):
+        if self.is_pdf_dossierlisting_available():
+            self.add_action(u'pdf_dossierlisting')
+
+    def maybe_add_pdf_taskslisting(self):
+        if self.is_pdf_taskslisting_available():
+            self.add_action(u'pdf_taskslisting')
+
+    def maybe_add_remove(self):
+        if self.is_remove_available():
+            self.add_action(u'remove')
+
+    def maybe_add_trash_content(self):
+        if self.is_trash_content_available():
+            self.add_action(u'trash_content')
+
+    def maybe_add_untrash_content(self):
+        if self.is_untrash_content_available():
+            self.add_action(u'untrash_content')
+
+    def maybe_add_zip_selected(self):
+        if self.is_zip_selected_available():
+            self.add_action(u'zip_selected')

--- a/opengever/disposition/actions.py
+++ b/opengever/disposition/actions.py
@@ -1,0 +1,17 @@
+from opengever.base.context_actions import BaseContextActions
+from opengever.base.interfaces import IOpengeverBaseLayer
+from opengever.disposition.interfaces import IDisposition
+from zope.component import adapter
+
+
+@adapter(IDisposition, IOpengeverBaseLayer)
+class DispositionContextActions(BaseContextActions):
+
+    def is_download_appraisal_list_available(self):
+        return True
+
+    def is_download_removal_protocol_available(self):
+        return self.context.removal_protocol_available()
+
+    def is_download_sip_available(self):
+        return self.context.sip_download_available()

--- a/opengever/disposition/configure.zcml
+++ b/opengever/disposition/configure.zcml
@@ -14,6 +14,7 @@
 
   <adapter factory=".appraisal.Appraisal" />
   <adapter factory=".validators.OfferedDossiersValidator" />
+  <adapter factory=".actions.DispositionContextActions" />
 
   <adapter
       factory=".transports.FilesystemTransport"

--- a/opengever/document/actions.py
+++ b/opengever/document/actions.py
@@ -1,15 +1,26 @@
+from ftw.bumblebee.interfaces import IBumblebeeable
+from ftw.bumblebee.interfaces import IBumblebeeServiceV3
+from opengever.base.browser.edit_public_trial import is_edit_public_trial_status_available
+from opengever.base.context_actions import BaseContextActions
 from opengever.base.interfaces import IOpengeverBaseLayer
 from opengever.base.listing_actions import BaseListingActions
+from opengever.bumblebee import is_bumblebee_feature_enabled
+from opengever.document.behaviors import IBaseDocument
+from opengever.document.document import IDocumentSchema
+from opengever.document.interfaces import ICheckinCheckoutManager
+from opengever.document.interfaces import IFileActions
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.inbox.inbox import IInbox
 from opengever.meeting import is_meeting_feature_enabled
 from opengever.private.dossier import IPrivateDossier
 from opengever.private.folder import IPrivateFolder
 from opengever.trash.trash import ITrasher
+from opengever.workspace.utils import is_within_workspace
 from opengever.workspaceclient import is_workspace_client_feature_available
 from opengever.workspaceclient.interfaces import ILinkedWorkspaces
 from plone import api
 from zope.component import adapter
+from zope.component import getMultiAdapter
 
 
 class BaseDocumentListingActions(BaseListingActions):
@@ -118,3 +129,128 @@ class WorkspaceDocumentListingActions(BaseDocumentListingActions):
 
     def is_delete_available(self):
         return False
+
+
+@adapter(IBaseDocument, IOpengeverBaseLayer)
+class BaseDocumentContextActions(BaseContextActions):
+
+    def __init__(self, context, request):
+        super(BaseDocumentContextActions, self).__init__(context, request)
+        self.file_actions = getMultiAdapter((self.context, self.request), IFileActions)
+        self.is_trashed = ITrasher(self.context).is_trashed()
+
+    def is_attach_to_email_available(self):
+        if self.is_trashed:
+            return False
+        return self.file_actions.is_attach_to_email_action_available()
+
+    def is_copy_item_available(self):
+        if self.is_trashed:
+            return False
+        if self.context.is_checked_out():
+            return False
+        return api.user.has_permission('Copy or Move', obj=self.context)
+
+    def is_create_forwarding_available(self):
+        if self.is_trashed:
+            return False
+        return api.user.has_permission('opengever.inbox: Add Forwarding', obj=self.context)
+
+    def is_delete_available(self):
+        return api.user.has_permission('Delete objects', obj=self.context)
+
+    def is_delete_workspace_context_available(self):
+        return self.file_actions.is_delete_workspace_context_action_available()
+
+    def is_download_copy_available(self):
+        if self.is_trashed:
+            return False
+        return self.file_actions.is_download_copy_action_available()
+
+    def is_edit_available(self):
+        if self.is_trashed:
+            return False
+        return super(BaseDocumentContextActions, self).is_edit_available()
+
+    def is_edit_public_trial_status_available(self):
+        if self.is_trashed:
+            return False
+        return is_edit_public_trial_status_available(self.context)
+
+    def is_move_item_available(self):
+        if self.is_trashed:
+            return False
+        if self.context.is_checked_out():
+            return False
+        if not api.user.has_permission('Copy or Move', obj=self.context):
+            return False
+        return self.context.is_movable()
+
+    def is_new_task_from_document_available(self):
+        if self.is_trashed:
+            return False
+        return self.file_actions.is_new_task_from_document_available()
+
+    def is_open_as_pdf_available(self):
+        if self.is_trashed:
+            return False
+        return self.file_actions.is_open_as_pdf_action_available()
+
+    def is_revive_bumblebee_preview_available(self):
+        if not is_bumblebee_feature_enabled():
+            return False
+        if not api.user.has_permission('opengever.bumblebee: Revive Preview'):
+            return False
+        return IBumblebeeable.providedBy(self.context)
+
+    def is_share_content_available(self):
+        return is_within_workspace(self.context)
+
+    def is_trash_context_available(self):
+        return self.file_actions.is_trash_context_action_available()
+
+    def is_untrash_context_available(self):
+        return self.file_actions.is_untrash_context_action_available()
+
+    def is_unlock_available(self):
+        return self.file_actions.is_unlock_available()
+
+
+@adapter(IDocumentSchema, IOpengeverBaseLayer)
+class DocumentSchemaContextActions(BaseDocumentContextActions):
+
+    def is_cancel_checkout_available(self):
+        return self.file_actions.is_cancel_checkout_action_available()
+
+    def is_checkin_with_comment_available(self):
+        return self.file_actions.is_checkin_with_comment_available()
+
+    def is_checkin_without_comment_available(self):
+        return self.file_actions.is_checkin_without_comment_available()
+
+    def is_checkout_document_available(self):
+        if self.context.digitally_available:
+            manager = getMultiAdapter((self.context, self.request), ICheckinCheckoutManager)
+            return manager.is_checkout_allowed()
+        return False
+
+    def is_docugate_retry_available(self):
+        return self.file_actions.is_docugate_retry_action_available()
+
+    def is_oc_direct_checkout_available(self):
+        return self.file_actions.is_oc_direct_checkout_action_available()
+
+    def is_oc_direct_edit_available(self):
+        return self.file_actions.is_oc_direct_edit_action_available()
+
+    def is_office_online_edit_available(self):
+        return self.file_actions.is_office_online_edit_action_available()
+
+    def is_oneoffixx_retry_available(self):
+        return self.file_actions.is_oneoffixx_retry_action_available()
+
+    def is_save_document_as_pdf_available(self):
+        if self.is_trashed:
+            return False
+        is_convertable = IBumblebeeServiceV3(self.request).is_convertable(self.context)
+        return not self.context.is_checked_out() and is_convertable

--- a/opengever/document/actions.py
+++ b/opengever/document/actions.py
@@ -1,0 +1,120 @@
+from opengever.base.interfaces import IOpengeverBaseLayer
+from opengever.base.listing_actions import BaseListingActions
+from opengever.dossier.behaviors.dossier import IDossierMarker
+from opengever.inbox.inbox import IInbox
+from opengever.meeting import is_meeting_feature_enabled
+from opengever.private.dossier import IPrivateDossier
+from opengever.private.folder import IPrivateFolder
+from opengever.trash.trash import ITrasher
+from opengever.workspaceclient import is_workspace_client_feature_available
+from opengever.workspaceclient.interfaces import ILinkedWorkspaces
+from plone import api
+from zope.component import adapter
+
+
+class BaseDocumentListingActions(BaseListingActions):
+
+    def is_attach_documents_available(self):
+        return True
+
+    def is_copy_items_available(self):
+        return True
+
+    def is_delete_available(self):
+        return api.user.has_permission('Delete objects', obj=self.context)
+
+    def is_edit_items_available(self):
+        return True
+
+    def is_export_documents_available(self):
+        return True
+
+    def is_move_items_available(self):
+        return True
+
+    def is_trash_content_available(self):
+        if not api.user.has_permission('opengever.trash: Trash content', obj=self.context):
+            return False
+        return not ITrasher(self.context).is_trashed()
+
+    def is_zip_selected_available(self):
+        return True
+
+
+class RepositoryDocumentListingActions(BaseDocumentListingActions):
+
+    def is_delete_available(self):
+        return False
+
+    def is_trash_content_available(self):
+        return False
+
+
+@adapter(IDossierMarker, IOpengeverBaseLayer)
+class DossierDocumentListingActions(BaseDocumentListingActions):
+
+    def is_copy_documents_to_workspace_available(self):
+        if not self.context.is_open():
+            return False
+        if not is_workspace_client_feature_available():
+            return False
+        if not api.user.has_permission('Modify portal content', obj=self.context):
+            return False
+        if not api.user.has_permission('opengever.workspaceclient: Use Workspace Client'):
+            return False
+
+        linked_workspaces_manager = ILinkedWorkspaces(self.context.get_main_dossier())
+        return linked_workspaces_manager.has_linked_workspaces()
+
+    def is_create_task_available(self):
+        return api.user.has_permission('opengever.task: Add task', obj=self.context)
+
+    def is_create_proposal_available(self):
+        return is_meeting_feature_enabled() and api.user.has_permission(
+            'opengever.meeting: Add Proposal', obj=self.context)
+
+    def is_delete_available(self):
+        return False
+
+    def is_edit_items_available(self):
+        return self.context.is_open()
+
+    def is_move_items_available(self):
+        return self.context.is_open()
+
+
+@adapter(IPrivateDossier, IOpengeverBaseLayer)
+class PrivateDossierDocumentListingActions(BaseDocumentListingActions):
+    pass
+
+
+@adapter(IPrivateFolder, IOpengeverBaseLayer)
+class PrivateFolderDocumentListingActions(BaseDocumentListingActions):
+
+    def is_trash_content_available(self):
+        return False
+
+
+@adapter(IInbox, IOpengeverBaseLayer)
+class InboxDocumentListingActions(BaseDocumentListingActions):
+
+    def is_create_forwarding_available(self):
+        return api.user.has_permission('opengever.inbox: Add Forwarding', obj=self.context)
+
+    def is_delete_available(self):
+        return False
+
+
+class TemplateDocumentListingActions(BaseDocumentListingActions):
+
+    def is_attach_documents_available(self):
+        return False
+
+    def is_trash_content_available(self):
+        return False
+
+
+class WorkspaceDocumentListingActions(BaseDocumentListingActions):
+
+    def is_delete_available(self):
+        return False

--- a/opengever/document/configure.zcml
+++ b/opengever/document/configure.zcml
@@ -421,4 +421,7 @@
            opengever.base.interfaces.IOpengeverBaseLayer"
       />
 
+  <adapter factory=".actions.BaseDocumentContextActions" />
+  <adapter factory=".actions.DocumentSchemaContextActions" />
+
 </configure>

--- a/opengever/document/configure.zcml
+++ b/opengever/document/configure.zcml
@@ -358,4 +358,67 @@
 
   <adapter factory=".approvals.ApprovalList" />
 
+
+  <adapter
+      factory=".actions.DossierDocumentListingActions"
+      name="documents"
+      />
+
+  <adapter
+      factory=".actions.PrivateDossierDocumentListingActions"
+      name="documents"
+      />
+
+  <adapter
+      factory=".actions.PrivateFolderDocumentListingActions"
+      name="documents"
+      />
+
+  <adapter
+      factory=".actions.InboxDocumentListingActions"
+      name="documents"
+      />
+
+  <adapter
+      factory=".actions.RepositoryDocumentListingActions"
+      name="documents"
+      for="opengever.repository.interfaces.IRepositoryFolder
+           opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
+  <adapter
+      factory=".actions.RepositoryDocumentListingActions"
+      name="documents"
+      for="opengever.repository.repositoryroot.IRepositoryRoot
+           opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
+  <adapter
+      factory=".actions.WorkspaceDocumentListingActions"
+      name="documents"
+      for="opengever.workspace.interfaces.IWorkspace
+           opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
+  <adapter
+      factory=".actions.WorkspaceDocumentListingActions"
+      name="documents"
+      for="opengever.workspace.interfaces.IWorkspaceFolder
+           opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
+  <adapter
+      factory=".actions.TemplateDocumentListingActions"
+      name="documents"
+      for="opengever.dossier.templatefolder.ITemplateFolder
+           opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
+  <adapter
+      factory=".actions.TemplateDocumentListingActions"
+      name="documents"
+      for="opengever.dossier.dossiertemplate.behaviors.IDossierTemplateMarker
+           opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
 </configure>

--- a/opengever/document/tests/test_actions.py
+++ b/opengever/document/tests/test_actions.py
@@ -1,0 +1,100 @@
+from opengever.base.interfaces import IListingActions
+from opengever.testing import IntegrationTestCase
+from opengever.workspaceclient.interfaces import ILinkedWorkspaces
+from opengever.workspaceclient.tests import FunctionalWorkspaceClientTestCase
+from zope.component import queryMultiAdapter
+import transaction
+
+
+class TestDocumentListingActions(IntegrationTestCase):
+
+    def get_actions(self, context):
+        adapter = queryMultiAdapter((context, self.request),
+                                    interface=IListingActions,
+                                    name='documents')
+        return adapter.get_actions() if adapter else []
+
+    def test_document_actions_for_reporoot_and_repofolder(self):
+        self.login(self.regular_user)
+        expected_actions = [u'edit_items', u'attach_documents', u'copy_items', u'move_items',
+                            u'zip_selected', u'export_documents']
+        self.assertEqual(expected_actions, self.get_actions(self.repository_root))
+        self.assertEqual(expected_actions, self.get_actions(self.branch_repofolder))
+
+    def test_document_actions_for_open_dossier(self):
+        self.login(self.regular_user)
+        expected_actions = [u'edit_items', u'attach_documents', u'copy_items', u'move_items',
+                            u'create_task', u'zip_selected', u'export_documents', u'trash_content']
+        self.assertEqual(expected_actions, self.get_actions(self.dossier))
+        self.assertEqual(expected_actions, self.get_actions(self.meeting_dossier))
+
+    def test_document_actions_for_closed_dossier(self):
+        self.login(self.regular_user)
+        expected_actions = [u'attach_documents', u'copy_items', u'zip_selected',
+                            u'export_documents']
+        self.assertEqual(expected_actions, self.get_actions(self.expired_dossier))
+
+    def test_document_actions_for_dossier_with_meeting_feature(self):
+        self.login(self.regular_user)
+        self.activate_feature('meeting')
+        expected_actions = [u'edit_items', u'attach_documents', u'copy_items', u'move_items',
+                            u'create_task', u'create_proposal', u'zip_selected',
+                            u'export_documents', u'trash_content']
+        self.assertEqual(expected_actions, self.get_actions(self.dossier))
+        self.assertEqual(expected_actions, self.get_actions(self.meeting_dossier))
+
+    def test_document_actions_for_private_dossier(self):
+        self.login(self.regular_user)
+        expected_actions = [u'edit_items', u'attach_documents', u'copy_items', u'move_items',
+                            u'zip_selected', u'export_documents', u'trash_content', u'delete']
+        self.assertEqual(expected_actions, self.get_actions(self.private_dossier))
+
+    def test_document_actions_for_private_folder(self):
+        self.login(self.regular_user)
+        expected_actions = [u'edit_items', u'attach_documents', u'copy_items', u'move_items',
+                            u'zip_selected', u'export_documents', u'delete']
+        self.assertEqual(expected_actions, self.get_actions(self.private_folder))
+
+    def test_document_actions_for_inbox(self):
+        self.login(self.secretariat_user)
+        expected_actions = [u'edit_items', u'attach_documents', u'copy_items',
+                            u'move_items', u'create_forwarding', u'zip_selected',
+                            u'export_documents', u'trash_content']
+        self.assertEqual(expected_actions, self.get_actions(self.inbox))
+
+    def test_document_actions_for_template_folder_and_dossier_template(self):
+        self.login(self.regular_user)
+        expected_actions = [u'edit_items', u'copy_items', u'move_items', u'zip_selected',
+                            u'export_documents']
+        self.assertEqual(expected_actions, self.get_actions(self.templates))
+        self.assertEqual(expected_actions, self.get_actions(self.dossiertemplate))
+
+    def test_delete_action_available_for_admins_in_template_area(self):
+        self.login(self.administrator)
+        self.assertIn(u'delete', self.get_actions(self.templates))
+        self.assertIn(u'delete', self.get_actions(self.dossiertemplate))
+
+    def test_document_actions_for_workspace_and_workspace_folder(self):
+        self.login(self.workspace_member)
+        expected_actions = [u'edit_items', u'attach_documents', u'copy_items', u'move_items',
+                            u'zip_selected', u'export_documents', u'trash_content']
+        self.assertEqual(expected_actions, self.get_actions(self.workspace))
+        self.assertEqual(expected_actions, self.get_actions(self.workspace_folder))
+
+
+class TestWorkspaceClientDocumentListingActions(FunctionalWorkspaceClientTestCase):
+
+    def get_actions(self, context):
+        adapter = queryMultiAdapter((context, self.request),
+                                    interface=IListingActions,
+                                    name='documents')
+        return adapter.get_actions() if adapter else []
+
+    def test_copy_documents_to_workspace_action_available_in_dossier_with_linked_workspaces(self):
+
+        with self.workspace_client_env():
+            self.assertNotIn(u'copy_documents_to_workspace', self.get_actions(self.dossier))
+            manager = ILinkedWorkspaces(self.dossier)
+            manager.storage.add(self.workspace.UID())
+            transaction.commit()
+            self.assertIn(u'copy_documents_to_workspace', self.get_actions(self.dossier))

--- a/opengever/dossier/actions.py
+++ b/opengever/dossier/actions.py
@@ -1,0 +1,39 @@
+from opengever.base.interfaces import IOpengeverBaseLayer
+from opengever.base.listing_actions import BaseListingActions
+from plone import api
+
+
+class DossierListingActions(BaseListingActions):
+
+    def is_copy_items_available(self):
+        return True
+
+    def is_create_disposition_available(self):
+        return api.user.has_permission('opengever.disposition: Add disposition')
+
+    def is_edit_items_available(self):
+        return True
+
+    def is_export_dossiers_available(self):
+        return True
+
+    def is_move_items_available(self):
+        return True
+
+    def is_pdf_dossierlisting_available(self):
+        return True
+
+
+class PrivateDossierListingActions(BaseListingActions):
+
+    def is_edit_items_available(self):
+        return True
+
+    def is_export_dossiers_available(self):
+        return True
+
+    def is_delete_available(self):
+        return api.user.has_permission('Delete objects', obj=self.context)
+
+    def is_pdf_dossierlisting_available(self):
+        return True

--- a/opengever/dossier/actions.py
+++ b/opengever/dossier/actions.py
@@ -1,6 +1,14 @@
+from opengever.base.context_actions import BaseContextActions
 from opengever.base.interfaces import IOpengeverBaseLayer
 from opengever.base.listing_actions import BaseListingActions
+from opengever.docugate import is_docugate_feature_enabled
+from opengever.dossier.behaviors.dossier import IDossierMarker
+from opengever.oneoffixx import is_oneoffixx_feature_enabled
+from opengever.workspaceclient import is_linking_enabled
+from opengever.workspaceclient import is_workspace_client_feature_available
+from opengever.workspaceclient.interfaces import ILinkedWorkspaces
 from plone import api
+from zope.component import adapter
 
 
 class DossierListingActions(BaseListingActions):
@@ -43,3 +51,94 @@ class DossierTemplateListingActions(BaseListingActions):
 
     def is_delete_available(self):
         return api.user.has_permission('Delete objects', obj=self.context)
+
+
+@adapter(IDossierMarker, IOpengeverBaseLayer)
+class DossierContextActions(BaseContextActions):
+
+    def __init__(self, context, request):
+        super(DossierContextActions, self).__init__(context, request)
+        self.can_use_workspace_client = self._can_use_workspace_client()
+
+    def _can_use_workspace_client(self):
+        return is_workspace_client_feature_available() and \
+                api.user.has_permission('opengever.workspaceclient: Use Workspace Client')
+
+    def is_copy_documents_from_workspace_available(self):
+        if not self.can_use_workspace_client:
+            return False
+        if not api.user.has_permission('Add portal content', obj=self.context):
+            return False
+        if self.context.is_subdossier():
+            return False
+        if not self.context.is_open():
+            return False
+        linked_workspaces_manager = ILinkedWorkspaces(self.context.get_main_dossier())
+        return linked_workspaces_manager.has_linked_workspaces()
+
+    def is_copy_documents_to_workspace_available(self):
+        if not self.can_use_workspace_client:
+            return False
+        if not api.user.has_permission('Modify portal content', obj=self.context):
+            return False
+        if not self.context.is_open():
+            return False
+        linked_workspaces_manager = ILinkedWorkspaces(self.context.get_main_dossier())
+        return linked_workspaces_manager.has_linked_workspaces()
+
+    def is_create_linked_workspace_available(self):
+        if not self.can_use_workspace_client:
+            return False
+        if self.context.is_subdossier():
+            return False
+        if not self.context.is_open():
+            return False
+        return api.user.has_permission('Modify portal content', obj=self.context)
+
+    def is_document_from_docugate_available(self):
+        return api.user.has_permission('Add portal content', obj=self.context) \
+            and is_docugate_feature_enabled()
+
+    def is_document_with_oneoffixx_template_available(self):
+        return api.user.has_permission('Add portal content', obj=self.context) \
+            and is_oneoffixx_feature_enabled()
+
+    def is_document_with_template_available(self):
+        return api.user.has_permission('Add portal content', obj=self.context)
+
+    def is_export_pdf_available(self):
+        return True
+
+    def is_link_to_workspace_available(self):
+        if not self.can_use_workspace_client:
+            return False
+        if self.context.is_subdossier():
+            return False
+        if not self.context.is_open():
+            return False
+        if not api.user.has_permission('Modify portal content', obj=self.context):
+            return False
+        return is_linking_enabled()
+
+    def is_list_workspaces_available(self):
+        return self.can_use_workspace_client
+
+    def is_pdf_dossierdetails_available(self):
+        return True
+
+    def is_protect_dossier_available(self):
+        return api.user.has_permission('opengever.dossier: Protect dossier', obj=self.context)
+
+    def is_unlink_workspace_available(self):
+        if not self.can_use_workspace_client:
+            return False
+        if self.context.is_subdossier():
+            return False
+        if not api.user.has_permission('opengever.workspaceclient: Unlink Workspace',
+                                       obj=self.context):
+            return False
+        linked_workspaces_manager = ILinkedWorkspaces(self.context.get_main_dossier())
+        return linked_workspaces_manager.has_linked_workspaces()
+
+    def is_zipexport_available(self):
+        return True

--- a/opengever/dossier/actions.py
+++ b/opengever/dossier/actions.py
@@ -37,3 +37,9 @@ class PrivateDossierListingActions(BaseListingActions):
 
     def is_pdf_dossierlisting_available(self):
         return True
+
+
+class DossierTemplateListingActions(BaseListingActions):
+
+    def is_delete_available(self):
+        return api.user.has_permission('Delete objects', obj=self.context)

--- a/opengever/dossier/actions.py
+++ b/opengever/dossier/actions.py
@@ -142,3 +142,9 @@ class DossierContextActions(BaseContextActions):
 
     def is_zipexport_available(self):
         return True
+
+
+class TemplateContextActions(BaseContextActions):
+
+    def is_delete_available(self):
+        return api.user.has_permission('Delete objects', obj=self.context)

--- a/opengever/dossier/configure.zcml
+++ b/opengever/dossier/configure.zcml
@@ -92,6 +92,8 @@
            opengever.base.interfaces.IOpengeverBaseLayer"
       />
 
+  <adapter factory=".actions.DossierContextActions" />
+
   <!-- JSON endpoint for dossier attributes -->
   <plone:service
       method="GET"

--- a/opengever/dossier/configure.zcml
+++ b/opengever/dossier/configure.zcml
@@ -78,6 +78,20 @@
            opengever.base.interfaces.IOpengeverBaseLayer"
       />
 
+  <adapter
+      factory=".actions.DossierTemplateListingActions"
+      name="dossiertemplates"
+      for="opengever.dossier.templatefolder.ITemplateFolder
+           opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
+  <adapter
+      factory=".actions.DossierTemplateListingActions"
+      name="dossiertemplates"
+      for="opengever.dossier.dossiertemplate.behaviors.IDossierTemplateMarker
+           opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
   <!-- JSON endpoint for dossier attributes -->
   <plone:service
       method="GET"

--- a/opengever/dossier/configure.zcml
+++ b/opengever/dossier/configure.zcml
@@ -50,6 +50,34 @@
       name="opengever.dossier.ValidResolverNamesVocabulary"
       />
 
+  <adapter
+      factory=".actions.DossierListingActions"
+      name="dossiers"
+      for="plone.dexterity.interfaces.IDexterityContainer
+           opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
+  <adapter
+      factory=".actions.DossierListingActions"
+      name="dossiers"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot
+           opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
+  <adapter
+      factory=".actions.PrivateDossierListingActions"
+      name="dossiers"
+      for="opengever.private.folder.IPrivateFolder
+           opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
+  <adapter
+      factory=".actions.PrivateDossierListingActions"
+      name="dossiers"
+      for="opengever.private.dossier.IPrivateDossier
+           opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
   <!-- JSON endpoint for dossier attributes -->
   <plone:service
       method="GET"

--- a/opengever/dossier/configure.zcml
+++ b/opengever/dossier/configure.zcml
@@ -93,6 +93,17 @@
       />
 
   <adapter factory=".actions.DossierContextActions" />
+  <adapter
+      factory=".actions.TemplateContextActions"
+      for="opengever.dossier.templatefolder.ITemplateFolder
+           opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
+  <adapter
+      factory=".actions.TemplateContextActions"
+      for="opengever.dossier.dossiertemplate.behaviors.IDossierTemplateMarker
+           opengever.base.interfaces.IOpengeverBaseLayer"
+      />
 
   <!-- JSON endpoint for dossier attributes -->
   <plone:service

--- a/opengever/dossier/tests/test_actions.py
+++ b/opengever/dossier/tests/test_actions.py
@@ -1,0 +1,50 @@
+from opengever.base.interfaces import IListingActions
+from opengever.testing import IntegrationTestCase
+from zope.component import queryMultiAdapter
+
+
+class TestDossierListingActions(IntegrationTestCase):
+
+    def get_actions(self, context):
+        adapter = queryMultiAdapter((context, self.request),
+                                    interface=IListingActions,
+                                    name='dossiers')
+        return adapter.get_actions() if adapter else []
+
+    def test_dossier_actions_for_reporoot_and_repofolder(self):
+        self.login(self.regular_user)
+        expected_actions = [u'edit_items', u'copy_items', u'move_items', u'export_dossiers',
+                            u'pdf_dossierlisting']
+        self.assertEqual(expected_actions, self.get_actions(self.repository_root))
+        self.assertEqual(expected_actions, self.get_actions(self.branch_repofolder))
+
+    def test_dossier_actions_for_plone_site(self):
+        self.login(self.regular_user)
+        expected_actions = [u'edit_items', u'copy_items', u'move_items', u'export_dossiers',
+                            u'pdf_dossierlisting']
+        self.assertEqual(expected_actions, self.get_actions(self.portal))
+
+    def test_dossier_actions_for_dossier(self):
+        self.login(self.regular_user)
+        expected_actions = [u'edit_items', u'copy_items', u'move_items', u'export_dossiers',
+                            u'pdf_dossierlisting']
+        self.assertEqual(expected_actions, self.get_actions(self.dossier))
+        self.assertEqual(expected_actions, self.get_actions(self.meeting_dossier))
+
+    def test_create_disposition_available_for_archivist(self):
+        self.login(self.archivist)
+        self.assertIn(u'create_disposition', self.get_actions(self.repository_root))
+        self.assertIn(u'create_disposition', self.get_actions(self.branch_repofolder))
+        self.assertIn(u'create_disposition', self.get_actions(self.dossier))
+
+    def test_create_disposition_available_for_records_manager(self):
+        self.login(self.records_manager)
+        self.assertIn(u'create_disposition', self.get_actions(self.repository_root))
+        self.assertIn(u'create_disposition', self.get_actions(self.branch_repofolder))
+        self.assertIn(u'create_disposition', self.get_actions(self.dossier))
+
+    def test_dossier_actions_for_private_dossier_and_private_folder(self):
+        self.login(self.regular_user)
+        expected_actions = [u'edit_items', u'export_dossiers', u'pdf_dossierlisting', u'delete']
+        self.assertEqual(expected_actions, self.get_actions(self.private_dossier))
+        self.assertEqual(expected_actions, self.get_actions(self.private_folder))

--- a/opengever/dossier/tests/test_actions.py
+++ b/opengever/dossier/tests/test_actions.py
@@ -177,3 +177,20 @@ class TestWorkspaceClientDossierContextActions(FunctionalWorkspaceClientTestCase
             expected_actions = [u'export_pdf', u'list_workspaces', u'pdf_dossierdetails',
                                 u'unlink_workspace', u'zipexport']
             self.assertEqual(expected_actions, self.get_actions(self.dossier))
+
+
+class TestTemplateContextActions(IntegrationTestCase):
+
+    def get_actions(self, context):
+        adapter = queryMultiAdapter((context, self.request), interface=IContextActions)
+        return adapter.get_actions() if adapter else []
+
+    def test_template_folder_context_actions(self):
+        self.login(self.administrator)
+        expected_actions = [u'delete', u'edit', u'local_roles']
+        self.assertEqual(expected_actions, self.get_actions(self.templates))
+
+    def test_dossier_template_context_actions(self):
+        self.login(self.administrator)
+        expected_actions = [u'delete', u'edit', u'local_roles']
+        self.assertEqual(expected_actions, self.get_actions(self.dossiertemplate))

--- a/opengever/dossier/tests/test_actions.py
+++ b/opengever/dossier/tests/test_actions.py
@@ -48,3 +48,22 @@ class TestDossierListingActions(IntegrationTestCase):
         expected_actions = [u'edit_items', u'export_dossiers', u'pdf_dossierlisting', u'delete']
         self.assertEqual(expected_actions, self.get_actions(self.private_dossier))
         self.assertEqual(expected_actions, self.get_actions(self.private_folder))
+
+
+class TestDossierTemplateListingActions(IntegrationTestCase):
+
+    def get_actions(self, context):
+        adapter = queryMultiAdapter((context, self.request),
+                                    interface=IListingActions,
+                                    name='dossiertemplates')
+        return adapter.get_actions() if adapter else []
+
+    def test_dossiertemplate_actions_for_templatefolder_and_dossiertemplate(self):
+        self.login(self.regular_user)
+        self.assertEqual([], self.get_actions(self.templates))
+        self.assertEqual([], self.get_actions(self.dossiertemplate))
+
+        self.login(self.administrator)
+        expected_actions = [u'delete']
+        self.assertEqual(expected_actions, self.get_actions(self.templates))
+        self.assertEqual(expected_actions, self.get_actions(self.dossiertemplate))

--- a/opengever/meeting/actions.py
+++ b/opengever/meeting/actions.py
@@ -1,0 +1,8 @@
+from opengever.base.interfaces import IOpengeverBaseLayer
+from opengever.base.listing_actions import BaseListingActions
+
+
+class ProposalListingActions(BaseListingActions):
+
+    def is_export_proposals_available(self):
+        return True

--- a/opengever/meeting/actions.py
+++ b/opengever/meeting/actions.py
@@ -1,8 +1,30 @@
+from opengever.base.context_actions import BaseContextActions
 from opengever.base.interfaces import IOpengeverBaseLayer
 from opengever.base.listing_actions import BaseListingActions
+from opengever.meeting import is_meeting_feature_enabled
+from opengever.meeting.proposal import IProposal
+from opengever.meeting.proposal import ISubmittedProposal
+from plone import api
+from zope.component import adapter
 
 
 class ProposalListingActions(BaseListingActions):
 
     def is_export_proposals_available(self):
         return True
+
+
+@adapter(IProposal, IOpengeverBaseLayer)
+class ProposalContextActions(BaseContextActions):
+
+    def is_create_task_from_proposal_available(self):
+        if ISubmittedProposal.providedBy(self.context):
+            return False
+        return api.user.has_permission('opengever.task: Add task',
+                                       obj=self.context)
+
+    def is_submit_additional_documents_available(self):
+        if not api.user.has_permission('opengever.meeting: Add Proposal', obj=self.context):
+            return False
+        return is_meeting_feature_enabled() and \
+            self.context.is_submit_additional_documents_allowed()

--- a/opengever/meeting/configure.zcml
+++ b/opengever/meeting/configure.zcml
@@ -220,6 +220,8 @@
            opengever.base.interfaces.IOpengeverBaseLayer"
       />
 
+  <adapter factory=".actions.ProposalContextActions" />
+
   <adapter
       factory="opengever.meeting.proposaltransition.CancelTransitionExtender"
       name="proposal-transition-cancel"

--- a/opengever/meeting/configure.zcml
+++ b/opengever/meeting/configure.zcml
@@ -207,6 +207,20 @@
   <adapter factory=".committee.RepositoryfolderValidator" />
 
   <adapter
+      factory=".actions.ProposalListingActions"
+      name="proposals"
+      for="plone.dexterity.interfaces.IDexterityContainer
+           opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
+  <adapter
+      factory=".actions.ProposalListingActions"
+      name="proposals"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot
+           opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
+  <adapter
       factory="opengever.meeting.proposaltransition.CancelTransitionExtender"
       name="proposal-transition-cancel"
       />

--- a/opengever/meeting/tests/test_actions.py
+++ b/opengever/meeting/tests/test_actions.py
@@ -1,0 +1,25 @@
+from opengever.base.interfaces import IListingActions
+from opengever.testing import IntegrationTestCase
+from zope.component import queryMultiAdapter
+
+
+class TestProposalListingActions(IntegrationTestCase):
+
+    def get_actions(self, context):
+        adapter = queryMultiAdapter((context, self.request),
+                                    interface=IListingActions,
+                                    name='proposals')
+        return adapter.get_actions() if adapter else []
+
+    def test_proposal_actions_for_reporoot_repofolder_and_dossier(self):
+        self.login(self.regular_user)
+        expected_actions = [u'export_proposals']
+        self.assertEqual(expected_actions, self.get_actions(self.repository_root))
+        self.assertEqual(expected_actions, self.get_actions(self.branch_repofolder))
+        self.assertEqual(expected_actions, self.get_actions(self.dossier))
+        self.assertEqual(expected_actions, self.get_actions(self.meeting_dossier))
+
+    def test_proposal_actions_for_plone_site(self):
+        self.login(self.regular_user)
+        expected_actions = [u'export_proposals']
+        self.assertEqual(expected_actions, self.get_actions(self.portal))

--- a/opengever/meeting/tests/test_actions.py
+++ b/opengever/meeting/tests/test_actions.py
@@ -1,3 +1,4 @@
+from opengever.base.interfaces import IContextActions
 from opengever.base.interfaces import IListingActions
 from opengever.testing import IntegrationTestCase
 from zope.component import queryMultiAdapter
@@ -23,3 +24,16 @@ class TestProposalListingActions(IntegrationTestCase):
         self.login(self.regular_user)
         expected_actions = [u'export_proposals']
         self.assertEqual(expected_actions, self.get_actions(self.portal))
+
+
+class TestProposalContextActions(IntegrationTestCase):
+
+    def get_actions(self, context):
+        adapter = queryMultiAdapter((context, self.request), interface=IContextActions)
+        return adapter.get_actions() if adapter else []
+
+    def test_proposal_context_actions(self):
+        self.activate_feature('meeting')
+        self.login(self.regular_user)
+        expected_actions = [u'create_task_from_proposal', u'submit_additional_documents']
+        self.assertEqual(expected_actions, self.get_actions(self.proposal))

--- a/opengever/private/actions.py
+++ b/opengever/private/actions.py
@@ -1,0 +1,28 @@
+from opengever.base.context_actions import BaseContextActions
+from opengever.base.interfaces import IOpengeverBaseLayer
+from opengever.docugate import is_docugate_feature_enabled
+from opengever.oneoffixx import is_oneoffixx_feature_enabled
+from opengever.private.dossier import IPrivateDossier
+from plone import api
+from zope.component import adapter
+
+
+@adapter(IPrivateDossier, IOpengeverBaseLayer)
+class PrivateDossierContextActions(BaseContextActions):
+
+    def is_delete_available(self):
+        return api.user.has_permission('Delete objects', obj=self.context)
+
+    def is_document_from_docugate_available(self):
+        return api.user.has_permission('Add portal content', obj=self.context) \
+            and is_docugate_feature_enabled()
+
+    def is_document_with_oneoffixx_template_available(self):
+        return api.user.has_permission('Add portal content', obj=self.context) \
+            and is_oneoffixx_feature_enabled()
+
+    def is_document_with_template_available(self):
+        return api.user.has_permission('Add portal content', obj=self.context)
+
+    def is_zipexport_available(self):
+        return True

--- a/opengever/private/configure.zcml
+++ b/opengever/private/configure.zcml
@@ -19,6 +19,7 @@
   <include package=".browser" />
   <include package=".viewlets" />
 
+  <adapter factory=".actions.PrivateDossierContextActions" />
 
   <!-- permissions -->
   <permission id="opengever.private.AddPrivateRoot" title="opengever.private: Add private root" />

--- a/opengever/private/tests/test_actions.py
+++ b/opengever/private/tests/test_actions.py
@@ -1,0 +1,28 @@
+from opengever.base.interfaces import IContextActions
+from opengever.testing import IntegrationTestCase
+from zope.component import queryMultiAdapter
+
+
+class TestPrivateDossierContextActions(IntegrationTestCase):
+
+    def get_actions(self, context):
+        adapter = queryMultiAdapter((context, self.request), interface=IContextActions)
+        return adapter.get_actions() if adapter else []
+
+    def test_private_dossier_context_actions(self):
+        self.login(self.regular_user)
+        expected_actions = [u'delete', u'document_with_template', u'edit', u'zipexport']
+        self.assertEqual(expected_actions, self.get_actions(self.private_dossier))
+
+    def test_document_from_docugate_available_if_feature_enabled(self):
+        self.login(self.regular_user)
+        self.assertNotIn(u'document_from_docugate', self.get_actions(self.private_dossier))
+        self.activate_feature('docugate')
+        self.assertIn(u'document_from_docugate', self.get_actions(self.private_dossier))
+
+    def test_document_with_oneoffixx_template_available_if_feature_enabled(self):
+        self.login(self.regular_user)
+        self.assertNotIn(u'document_with_oneoffixx_template',
+                         self.get_actions(self.private_dossier))
+        self.activate_feature('oneoffixx')
+        self.assertIn(u'document_with_oneoffixx_template', self.get_actions(self.private_dossier))

--- a/opengever/repository/actions.py
+++ b/opengever/repository/actions.py
@@ -1,5 +1,8 @@
 from opengever.base.context_actions import BaseContextActions
 from opengever.base.interfaces import IOpengeverBaseLayer
+from opengever.dossier.dossiertemplate import is_create_dossier_from_template_available
+from opengever.repository.deleter import RepositoryDeleter
+from opengever.repository.interfaces import IRepositoryFolder
 from opengever.repository.repositoryroot import IRepositoryRoot
 from plone import api
 from zope.component import adapter
@@ -10,6 +13,21 @@ class RepositoryRootContextActions(BaseContextActions):
 
     def is_download_excel_available(self):
         return api.user.has_permission('opengever.repository: Export repository', obj=self.context)
+
+    def is_prefix_manager_available(self):
+        return api.user.has_permission('opengever.repository: Unlock Reference Prefix',
+                                       obj=self.context)
+
+
+@adapter(IRepositoryFolder, IOpengeverBaseLayer)
+class RepositoryFolderContextActions(BaseContextActions):
+
+    def is_delete_repository_available(self):
+        deletion_check = RepositoryDeleter(self.context).is_deletion_allowed
+        return api.user.has_permission('Delete objects', obj=self.context) and deletion_check()
+
+    def is_dossier_with_template_available(self):
+        return is_create_dossier_from_template_available(self.context)
 
     def is_prefix_manager_available(self):
         return api.user.has_permission('opengever.repository: Unlock Reference Prefix',

--- a/opengever/repository/actions.py
+++ b/opengever/repository/actions.py
@@ -1,0 +1,16 @@
+from opengever.base.context_actions import BaseContextActions
+from opengever.base.interfaces import IOpengeverBaseLayer
+from opengever.repository.repositoryroot import IRepositoryRoot
+from plone import api
+from zope.component import adapter
+
+
+@adapter(IRepositoryRoot, IOpengeverBaseLayer)
+class RepositoryRootContextActions(BaseContextActions):
+
+    def is_download_excel_available(self):
+        return api.user.has_permission('opengever.repository: Export repository', obj=self.context)
+
+    def is_prefix_manager_available(self):
+        return api.user.has_permission('opengever.repository: Unlock Reference Prefix',
+                                       obj=self.context)

--- a/opengever/repository/configure.zcml
+++ b/opengever/repository/configure.zcml
@@ -14,6 +14,7 @@
   <adapter factory=".constrains.RepositoryFolderConstrainTypes" />
 
   <adapter factory=".actions.RepositoryRootContextActions" />
+  <adapter factory=".actions.RepositoryFolderContextActions" />
 
   <adapter
       factory=".indexers.title_de_indexer"

--- a/opengever/repository/configure.zcml
+++ b/opengever/repository/configure.zcml
@@ -13,6 +13,8 @@
 
   <adapter factory=".constrains.RepositoryFolderConstrainTypes" />
 
+  <adapter factory=".actions.RepositoryRootContextActions" />
+
   <adapter
       factory=".indexers.title_de_indexer"
       name="title_de"

--- a/opengever/repository/tests/test_actions.py
+++ b/opengever/repository/tests/test_actions.py
@@ -1,3 +1,5 @@
+from ftw.builder import Builder
+from ftw.builder import create
 from opengever.base.interfaces import IContextActions
 from opengever.testing import IntegrationTestCase
 from zope.component import queryMultiAdapter
@@ -15,3 +17,30 @@ class TestRepositoryRootContextActions(IntegrationTestCase):
         self.login(self.administrator)
         expected_actions = [u'download_excel', u'edit', u'local_roles', u'prefix_manager']
         self.assertEqual(expected_actions, self.get_actions(self.repository_root))
+
+
+class TestRepositoryFolderContextActions(IntegrationTestCase):
+
+    def get_actions(self, context):
+        adapter = queryMultiAdapter((context, self.request), interface=IContextActions)
+        return adapter.get_actions() if adapter else []
+
+    def test_repository_folder_context_actions(self):
+        self.login(self.regular_user)
+        self.assertEqual([], self.get_actions(self.branch_repofolder))
+        self.login(self.administrator)
+        expected_actions = [u'edit', u'local_roles', u'prefix_manager']
+        self.assertEqual(expected_actions, self.get_actions(self.branch_repofolder))
+
+    def test_delete_action_only_available_for_empty_repo_folders(self):
+        self.login(self.administrator)
+        self.assertIn(u'delete_repository', self.get_actions(self.empty_repofolder))
+        create(Builder('dossier').within(self.empty_repofolder))
+        self.assertNotIn(u'delete_repository', self.get_actions(self.empty_repofolder))
+
+    def test_dossier_with_template_only_available_if_repo_folder_is_leafnode(self):
+        self.activate_feature('dossiertemplate')
+        self.login(self.regular_user)
+        self.assertIn(u'dossier_with_template', self.get_actions(self.empty_repofolder))
+        create(Builder('repository').within(self.empty_repofolder))
+        self.assertNotIn(u'dossier_with_template', self.get_actions(self.empty_repofolder))

--- a/opengever/repository/tests/test_actions.py
+++ b/opengever/repository/tests/test_actions.py
@@ -1,0 +1,17 @@
+from opengever.base.interfaces import IContextActions
+from opengever.testing import IntegrationTestCase
+from zope.component import queryMultiAdapter
+
+
+class TestRepositoryRootContextActions(IntegrationTestCase):
+
+    def get_actions(self, context):
+        adapter = queryMultiAdapter((context, self.request), interface=IContextActions)
+        return adapter.get_actions() if adapter else []
+
+    def test_repository_root_context_actions(self):
+        self.login(self.regular_user)
+        self.assertEqual([], self.get_actions(self.repository_root))
+        self.login(self.administrator)
+        expected_actions = [u'download_excel', u'edit', u'local_roles', u'prefix_manager']
+        self.assertEqual(expected_actions, self.get_actions(self.repository_root))

--- a/opengever/task/actions.py
+++ b/opengever/task/actions.py
@@ -1,0 +1,20 @@
+from opengever.base.interfaces import IOpengeverBaseLayer
+from opengever.base.listing_actions import BaseListingActions
+from opengever.dossier.behaviors.dossier import IDossierMarker
+from zope.component import adapter
+
+
+class TaskListingActions(BaseListingActions):
+
+    def is_export_tasks_available(self):
+        return True
+
+    def is_pdf_taskslisting_available(self):
+        return True
+
+
+@adapter(IDossierMarker, IOpengeverBaseLayer)
+class DossierTaskListingActions(TaskListingActions):
+
+    def is_move_items_available(self):
+        return self.context.is_open()

--- a/opengever/task/actions.py
+++ b/opengever/task/actions.py
@@ -1,6 +1,9 @@
+from opengever.base.context_actions import BaseContextActions
 from opengever.base.interfaces import IOpengeverBaseLayer
 from opengever.base.listing_actions import BaseListingActions
 from opengever.dossier.behaviors.dossier import IDossierMarker
+from opengever.task.task import ITask
+from plone import api
 from zope.component import adapter
 
 
@@ -18,3 +21,10 @@ class DossierTaskListingActions(TaskListingActions):
 
     def is_move_items_available(self):
         return self.context.is_open()
+
+
+@adapter(ITask, IOpengeverBaseLayer)
+class TaskContextActions(BaseContextActions):
+
+    def is_move_item_available(self):
+        return api.user.has_permission('Copy or Move', obj=self.context)

--- a/opengever/task/configure.zcml
+++ b/opengever/task/configure.zcml
@@ -28,6 +28,26 @@
   <adapter factory=".transition.NoAdminUnitChangeInProgressStateValidator" />
   <adapter factory=".transition.DeadlineChangedValidator" />
 
+
+  <adapter
+      factory=".actions.TaskListingActions"
+      name="tasks"
+      for="plone.dexterity.interfaces.IDexterityContainer
+           opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
+  <adapter
+      factory=".actions.TaskListingActions"
+      name="tasks"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot
+           opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
+  <adapter
+      factory=".actions.DossierTaskListingActions"
+      name="tasks"
+      />
+
   <browser:page
       name="task_response_delete"
       for="opengever.task.task.ITask"

--- a/opengever/task/configure.zcml
+++ b/opengever/task/configure.zcml
@@ -48,6 +48,8 @@
       name="tasks"
       />
 
+  <adapter factory=".actions.TaskContextActions" />
+
   <browser:page
       name="task_response_delete"
       for="opengever.task.task.ITask"

--- a/opengever/task/tests/test_actions.py
+++ b/opengever/task/tests/test_actions.py
@@ -1,0 +1,39 @@
+from opengever.base.interfaces import IListingActions
+from opengever.testing import IntegrationTestCase
+from zope.component import queryMultiAdapter
+
+
+class TestTaskListingActions(IntegrationTestCase):
+
+    def get_actions(self, context):
+        adapter = queryMultiAdapter((context, self.request),
+                                    interface=IListingActions,
+                                    name='tasks')
+        return adapter.get_actions() if adapter else []
+
+    def test_task_actions_for_reporoot_and_repofolder(self):
+        self.login(self.regular_user)
+        expected_actions = [u'export_tasks', u'pdf_taskslisting']
+        self.assertEqual(expected_actions, self.get_actions(self.repository_root))
+        self.assertEqual(expected_actions, self.get_actions(self.branch_repofolder))
+
+    def test_task_actions_for_plone_site(self):
+        self.login(self.regular_user)
+        expected_actions = [u'export_tasks', u'pdf_taskslisting']
+        self.assertEqual(expected_actions, self.get_actions(self.portal))
+
+    def test_task_actions_open_for_dossier(self):
+        self.login(self.regular_user)
+        expected_actions = [u'move_items', u'export_tasks', u'pdf_taskslisting']
+        self.assertEqual(expected_actions, self.get_actions(self.dossier))
+        self.assertEqual(expected_actions, self.get_actions(self.meeting_dossier))
+
+    def test_task_actions_for_closed_dossier(self):
+        self.login(self.regular_user)
+        expected_actions = [u'export_tasks', u'pdf_taskslisting']
+        self.assertEqual(expected_actions, self.get_actions(self.expired_dossier))
+
+    def test_task_actions_for_inbox(self):
+        self.login(self.secretariat_user)
+        expected_actions = [u'export_tasks', u'pdf_taskslisting']
+        self.assertEqual(expected_actions, self.get_actions(self.inbox))

--- a/opengever/task/tests/test_actions.py
+++ b/opengever/task/tests/test_actions.py
@@ -1,5 +1,7 @@
+from opengever.base.interfaces import IContextActions
 from opengever.base.interfaces import IListingActions
 from opengever.testing import IntegrationTestCase
+from plone import api
 from zope.component import queryMultiAdapter
 
 
@@ -37,3 +39,26 @@ class TestTaskListingActions(IntegrationTestCase):
         self.login(self.secretariat_user)
         expected_actions = [u'export_tasks', u'pdf_taskslisting']
         self.assertEqual(expected_actions, self.get_actions(self.inbox))
+
+
+class TestTaskContextActions(IntegrationTestCase):
+
+    def get_actions(self, context):
+        adapter = queryMultiAdapter((context, self.request), interface=IContextActions)
+        return adapter.get_actions() if adapter else []
+
+    def test_task_context_actions(self):
+        self.login(self.regular_user)
+        expected_actions = [u'edit', u'move_item']
+        self.assertEqual(expected_actions, self.get_actions(self.task))
+
+    def test_move_item_action_only_available_if_user_has_move_permission(self):
+        self.login(self.regular_user)
+        self.assertIn(u'move_item', self.get_actions(self.task))
+        self.task.manage_permission('Copy or Move', roles=[])
+        self.assertNotIn(u'move_item', self.get_actions(self.task))
+
+    def test_move_item_not_available_for_forwarding(self):
+        self.login(self.secretariat_user)
+        self.assertTrue(api.user.has_permission('Copy or Move', obj=self.inbox_forwarding))
+        self.assertNotIn(u'move_item', self.get_actions(self.inbox_forwarding))

--- a/opengever/tasktemplates/actions.py
+++ b/opengever/tasktemplates/actions.py
@@ -1,0 +1,8 @@
+from opengever.base.context_actions import BaseContextActions
+from plone import api
+
+
+class TaskTemplateContextActions(BaseContextActions):
+
+    def is_delete_available(self):
+        return api.user.has_permission('Delete objects', obj=self.context)

--- a/opengever/tasktemplates/configure.zcml
+++ b/opengever/tasktemplates/configure.zcml
@@ -21,6 +21,18 @@
   <include package=".viewlets" />
   <include package=".content" />
 
+  <adapter
+      factory=".actions.TaskTemplateContextActions"
+      for="opengever.tasktemplates.content.templatefoldersschema.ITaskTemplateFolderSchema
+           opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
+  <adapter
+      factory=".actions.TaskTemplateContextActions"
+      for="opengever.tasktemplates.content.tasktemplate.ITaskTemplate
+           opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
   <utility
       factory=".vocabularies.ActiveTasktemplatefoldersVocabulary"
       name="opengever.tasktemplates.active_tasktemplatefolders"

--- a/opengever/tasktemplates/tests/test_actions.py
+++ b/opengever/tasktemplates/tests/test_actions.py
@@ -1,0 +1,20 @@
+from opengever.base.interfaces import IContextActions
+from opengever.testing import IntegrationTestCase
+from zope.component import queryMultiAdapter
+
+
+class TestTaskTemplateContextActions(IntegrationTestCase):
+
+    def get_actions(self, context):
+        adapter = queryMultiAdapter((context, self.request), interface=IContextActions)
+        return adapter.get_actions() if adapter else []
+
+    def test_task_template_folder_context_actions(self):
+        self.login(self.administrator)
+        expected_actions = [u'delete', u'edit']
+        self.assertEqual(expected_actions, self.get_actions(self.tasktemplatefolder))
+
+    def test_task_template_context_actions(self):
+        self.login(self.administrator)
+        expected_actions = [u'delete', u'edit']
+        self.assertEqual(expected_actions, self.get_actions(self.tasktemplate))

--- a/opengever/trash/actions.py
+++ b/opengever/trash/actions.py
@@ -1,0 +1,40 @@
+from opengever.base.interfaces import IOpengeverBaseLayer
+from opengever.base.listing_actions import BaseListingActions
+from opengever.private.dossier import IPrivateDossier
+from opengever.trash.trash import ITrasher
+from plone import api
+from plone.dexterity.interfaces import IDexterityContainer
+from zope.component import adapter
+
+
+@adapter(IDexterityContainer, IOpengeverBaseLayer)
+class TrashListingActions(BaseListingActions):
+
+    def is_remove_available(self):
+        return api.user.has_permission('Remove GEVER content', obj=self.context)
+
+    def is_untrash_content_available(self):
+        if not api.user.has_permission('opengever.trash: Untrash content', obj=self.context):
+            return False
+        return not ITrasher(self.context).is_trashed()
+
+
+@adapter(IPrivateDossier, IOpengeverBaseLayer)
+class PrivateDossierTrashListingActions(TrashListingActions):
+
+    def is_delete_available(self):
+        return api.user.has_permission('Delete objects', obj=self.context)
+
+    def is_remove_available(self):
+        return False
+
+
+class WorkspaceTrashListingActions(TrashListingActions):
+
+    def is_delete_workspace_content_available(self):
+        return (api.user.has_permission('opengever.workspace: Delete Documents', obj=self.context)
+                and api.user.has_permission('opengever.workspace: Delete Workspace Folders',
+                                            obj=self.context))
+
+    def is_remove_available(self):
+        return False

--- a/opengever/trash/configure.zcml
+++ b/opengever/trash/configure.zcml
@@ -28,4 +28,28 @@
   <adapter factory=".trash.DocumentTrasher" />
   <adapter factory=".trash.WorkspaceFolderTrasher" />
 
+  <adapter
+      factory=".actions.TrashListingActions"
+      name="trash"
+      />
+
+  <adapter
+      factory=".actions.PrivateDossierTrashListingActions"
+      name="trash"
+      />
+
+  <adapter
+      factory=".actions.WorkspaceTrashListingActions"
+      name="trash"
+      for="opengever.workspace.interfaces.IWorkspace
+           opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
+  <adapter
+      factory=".actions.WorkspaceTrashListingActions"
+      name="trash"
+      for="opengever.workspace.interfaces.IWorkspaceFolder
+           opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
 </configure>

--- a/opengever/trash/tests/test_actions.py
+++ b/opengever/trash/tests/test_actions.py
@@ -1,0 +1,49 @@
+from opengever.base.interfaces import IListingActions
+from opengever.testing import IntegrationTestCase
+from opengever.trash.trash import ITrasher
+from zope.component import queryMultiAdapter
+
+
+class TestTrashListingActions(IntegrationTestCase):
+
+    def get_actions(self, context):
+        adapter = queryMultiAdapter((context, self.request),
+                                    interface=IListingActions,
+                                    name='trash')
+        return adapter.get_actions() if adapter else []
+
+    def test_trash_actions_for_dossier(self):
+        self.login(self.regular_user)
+        expected_actions = [u'untrash_content']
+        self.assertEqual(expected_actions, self.get_actions(self.dossier))
+        self.assertEqual(expected_actions, self.get_actions(self.meeting_dossier))
+
+    def test_trash_actions_for_closed_dossier(self):
+        self.login(self.regular_user)
+        self.assertEqual([], self.get_actions(self.expired_dossier))
+
+    def test_trash_actions_for_inbox(self):
+        self.login(self.secretariat_user)
+        expected_actions = [u'untrash_content']
+        self.assertEqual(expected_actions, self.get_actions(self.inbox))
+
+    def test_remove_available_for_manager(self):
+        self.login(self.manager)
+        self.assertIn(u'remove', self.get_actions(self.dossier))
+        self.assertIn(u'remove', self.get_actions(self.inbox))
+
+    def test_trash_actions_for_private_dossier(self):
+        self.login(self.regular_user)
+        expected_actions = [u'untrash_content', u'delete']
+        self.assertEqual(expected_actions, self.get_actions(self.private_dossier))
+
+    def test_trash_actions_for_workspace_and_workspace_folder(self):
+        self.login(self.workspace_member)
+        expected_actions = [u'untrash_content', u'delete_workspace_content']
+        self.assertEqual(expected_actions, self.get_actions(self.workspace))
+        self.assertEqual(expected_actions, self.get_actions(self.workspace_folder))
+
+    def test_untrash_content_not_available_if_context_is_trashed(self):
+        self.login(self.workspace_member)
+        ITrasher(self.workspace_folder).trash()
+        self.assertNotIn(u'untrash_content', self.get_actions(self.workspace_folder))

--- a/opengever/workspace/actions.py
+++ b/opengever/workspace/actions.py
@@ -1,5 +1,7 @@
+from opengever.base.context_actions import BaseContextActions
 from opengever.base.interfaces import IOpengeverBaseLayer
 from opengever.base.listing_actions import BaseListingActions
+from opengever.workspace.interfaces import IToDo
 from plone import api
 from plone.dexterity.interfaces import IDexterityContainer
 from zope.component import adapter
@@ -16,3 +18,13 @@ class WorkspaceFolderListingActions(BaseListingActions):
 
     def is_trash_content_available(self):
         return api.user.has_permission('opengever.trash: Trash content', obj=self.context)
+
+
+@adapter(IToDo, IOpengeverBaseLayer)
+class TodoContextActions(BaseContextActions):
+
+    def is_share_content_available(self):
+        return True
+
+    def is_edit_available(self):
+        return api.user.has_permission('Modify portal content', obj=self.context)

--- a/opengever/workspace/actions.py
+++ b/opengever/workspace/actions.py
@@ -1,0 +1,18 @@
+from opengever.base.interfaces import IOpengeverBaseLayer
+from opengever.base.listing_actions import BaseListingActions
+from plone import api
+from plone.dexterity.interfaces import IDexterityContainer
+from zope.component import adapter
+
+
+@adapter(IDexterityContainer, IOpengeverBaseLayer)
+class WorkspaceFolderListingActions(BaseListingActions):
+
+    def is_copy_items_available(self):
+        return True
+
+    def is_move_items_available(self):
+        return True
+
+    def is_trash_content_available(self):
+        return api.user.has_permission('opengever.trash: Trash content', obj=self.context)

--- a/opengever/workspace/actions.py
+++ b/opengever/workspace/actions.py
@@ -2,6 +2,7 @@ from opengever.base.context_actions import BaseContextActions
 from opengever.base.interfaces import IOpengeverBaseLayer
 from opengever.base.listing_actions import BaseListingActions
 from opengever.workspace.interfaces import IToDo
+from opengever.workspace.interfaces import IWorkspace
 from opengever.workspace.interfaces import IWorkspaceMeeting
 from plone import api
 from plone.dexterity.interfaces import IDexterityContainer
@@ -39,6 +40,20 @@ class WorkspaceMeetingContextActions(BaseContextActions):
 
     def is_meeting_minutes_pdf_available(self):
         return True
+
+    def is_share_content_available(self):
+        return True
+
+
+@adapter(IWorkspace, IOpengeverBaseLayer)
+class WorkspaceContextActions(BaseContextActions):
+
+    def is_add_invitation_available(self):
+        return api.user.has_permission('Sharing page: Delegate WorkspaceAdmin role',
+                                       obj=self.context)
+
+    def is_delete_workspace_available(self):
+        return self.context.is_deletion_allowed()
 
     def is_share_content_available(self):
         return True

--- a/opengever/workspace/actions.py
+++ b/opengever/workspace/actions.py
@@ -1,11 +1,15 @@
 from opengever.base.context_actions import BaseContextActions
 from opengever.base.interfaces import IOpengeverBaseLayer
 from opengever.base.listing_actions import BaseListingActions
+from opengever.trash.trash import ITrasher
+from opengever.workspace.interfaces import IDeleter
 from opengever.workspace.interfaces import IToDo
 from opengever.workspace.interfaces import IWorkspace
+from opengever.workspace.interfaces import IWorkspaceFolder
 from opengever.workspace.interfaces import IWorkspaceMeeting
 from plone import api
 from plone.dexterity.interfaces import IDexterityContainer
+from zExceptions import Forbidden
 from zope.component import adapter
 
 
@@ -57,3 +61,28 @@ class WorkspaceContextActions(BaseContextActions):
 
     def is_share_content_available(self):
         return True
+
+
+@adapter(IWorkspaceFolder, IOpengeverBaseLayer)
+class WorkspaceFolderContextActions(BaseContextActions):
+
+    def is_delete_workspace_context_available(self):
+        try:
+            IDeleter(self.context).verify_may_delete()
+            return True
+        except Forbidden:
+            return False
+
+    def is_edit_available(self):
+        if ITrasher(self.context).is_trashed():
+            return False
+        return super(WorkspaceFolderContextActions, self).is_edit_available()
+
+    def is_share_content_available(self):
+        return True
+
+    def is_trash_context_available(self):
+        return ITrasher(self.context).verify_may_trash(raise_on_violations=False)
+
+    def is_untrash_context_available(self):
+        return ITrasher(self.context).verify_may_untrash(raise_on_violations=False)

--- a/opengever/workspace/actions.py
+++ b/opengever/workspace/actions.py
@@ -2,6 +2,7 @@ from opengever.base.context_actions import BaseContextActions
 from opengever.base.interfaces import IOpengeverBaseLayer
 from opengever.base.listing_actions import BaseListingActions
 from opengever.workspace.interfaces import IToDo
+from opengever.workspace.interfaces import IWorkspaceMeeting
 from plone import api
 from plone.dexterity.interfaces import IDexterityContainer
 from zope.component import adapter
@@ -28,3 +29,16 @@ class TodoContextActions(BaseContextActions):
 
     def is_edit_available(self):
         return api.user.has_permission('Modify portal content', obj=self.context)
+
+
+@adapter(IWorkspaceMeeting, IOpengeverBaseLayer)
+class WorkspaceMeetingContextActions(BaseContextActions):
+
+    def is_meeting_ical_download_available(self):
+        return True
+
+    def is_meeting_minutes_pdf_available(self):
+        return True
+
+    def is_share_content_available(self):
+        return True

--- a/opengever/workspace/configure.zcml
+++ b/opengever/workspace/configure.zcml
@@ -17,6 +17,11 @@
   <adapter factory=".sequence.TodoSequenceNumberGenerator" />
   <adapter factory=".sequence.WorkspaceMeetingSequenceNumberGenerator" />
 
+  <adapter
+      factory=".actions.WorkspaceFolderListingActions"
+      name="workspace_folders"
+      />
+
   <subscriber
       for="opengever.workspace.interfaces.IWorkspaceRoot
            zope.lifecycleevent.interfaces.IObjectAddedEvent"

--- a/opengever/workspace/configure.zcml
+++ b/opengever/workspace/configure.zcml
@@ -23,6 +23,7 @@
       />
 
   <adapter factory=".actions.TodoContextActions" />
+  <adapter factory=".actions.WorkspaceContextActions" />
   <adapter factory=".actions.WorkspaceMeetingContextActions" />
 
   <subscriber

--- a/opengever/workspace/configure.zcml
+++ b/opengever/workspace/configure.zcml
@@ -23,6 +23,7 @@
       />
 
   <adapter factory=".actions.TodoContextActions" />
+  <adapter factory=".actions.WorkspaceMeetingContextActions" />
 
   <subscriber
       for="opengever.workspace.interfaces.IWorkspaceRoot

--- a/opengever/workspace/configure.zcml
+++ b/opengever/workspace/configure.zcml
@@ -24,6 +24,7 @@
 
   <adapter factory=".actions.TodoContextActions" />
   <adapter factory=".actions.WorkspaceContextActions" />
+  <adapter factory=".actions.WorkspaceFolderContextActions" />
   <adapter factory=".actions.WorkspaceMeetingContextActions" />
 
   <subscriber

--- a/opengever/workspace/configure.zcml
+++ b/opengever/workspace/configure.zcml
@@ -22,6 +22,8 @@
       name="workspace_folders"
       />
 
+  <adapter factory=".actions.TodoContextActions" />
+
   <subscriber
       for="opengever.workspace.interfaces.IWorkspaceRoot
            zope.lifecycleevent.interfaces.IObjectAddedEvent"

--- a/opengever/workspace/tests/test_actions.py
+++ b/opengever/workspace/tests/test_actions.py
@@ -1,3 +1,4 @@
+from opengever.base.interfaces import IContextActions
 from opengever.base.interfaces import IListingActions
 from opengever.testing import IntegrationTestCase
 from zope.component import queryMultiAdapter
@@ -16,3 +17,15 @@ class TestWorkspaceFolderListingActions(IntegrationTestCase):
         expected_actions = [u'copy_items', u'move_items', u'trash_content']
         self.assertEqual(expected_actions, self.get_actions(self.workspace))
         self.assertEqual(expected_actions, self.get_actions(self.workspace_folder))
+
+
+class TestTodoContextActions(IntegrationTestCase):
+
+    def get_actions(self, context):
+        adapter = queryMultiAdapter((context, self.request), interface=IContextActions)
+        return adapter.get_actions() if adapter else []
+
+    def test_todo_context_actions(self):
+        self.login(self.workspace_member)
+        expected_actions = [u'edit', u'share_content']
+        self.assertEqual(expected_actions, self.get_actions(self.todo))

--- a/opengever/workspace/tests/test_actions.py
+++ b/opengever/workspace/tests/test_actions.py
@@ -1,0 +1,18 @@
+from opengever.base.interfaces import IListingActions
+from opengever.testing import IntegrationTestCase
+from zope.component import queryMultiAdapter
+
+
+class TestWorkspaceFolderListingActions(IntegrationTestCase):
+
+    def get_actions(self, context):
+        adapter = queryMultiAdapter((context, self.request),
+                                    interface=IListingActions,
+                                    name='workspace_folders')
+        return adapter.get_actions() if adapter else []
+
+    def test_workspace_folder_actions_for_workspace_and_workspace_folder(self):
+        self.login(self.workspace_member)
+        expected_actions = [u'copy_items', u'move_items', u'trash_content']
+        self.assertEqual(expected_actions, self.get_actions(self.workspace))
+        self.assertEqual(expected_actions, self.get_actions(self.workspace_folder))

--- a/opengever/workspace/tests/test_actions.py
+++ b/opengever/workspace/tests/test_actions.py
@@ -29,3 +29,16 @@ class TestTodoContextActions(IntegrationTestCase):
         self.login(self.workspace_member)
         expected_actions = [u'edit', u'share_content']
         self.assertEqual(expected_actions, self.get_actions(self.todo))
+
+
+class TestWorkspaceMeetingContextActions(IntegrationTestCase):
+
+    def get_actions(self, context):
+        adapter = queryMultiAdapter((context, self.request), interface=IContextActions)
+        return adapter.get_actions() if adapter else []
+
+    def test_workspace_meeting_context_actions(self):
+        self.login(self.workspace_member)
+        expected_actions = [u'edit', u'meeting_ical_download', u'meeting_minutes_pdf',
+                            u'share_content']
+        self.assertEqual(expected_actions, self.get_actions(self.workspace_meeting))

--- a/opengever/workspace/tests/test_actions.py
+++ b/opengever/workspace/tests/test_actions.py
@@ -42,3 +42,32 @@ class TestWorkspaceMeetingContextActions(IntegrationTestCase):
         expected_actions = [u'edit', u'meeting_ical_download', u'meeting_minutes_pdf',
                             u'share_content']
         self.assertEqual(expected_actions, self.get_actions(self.workspace_meeting))
+
+
+class TestWorkspaceContextActions(IntegrationTestCase):
+
+    def get_actions(self, context):
+        adapter = queryMultiAdapter((context, self.request), interface=IContextActions)
+        return adapter.get_actions() if adapter else []
+
+    def test_workspace_context_actions(self):
+        self.login(self.workspace_member)
+        expected_actions = [u'edit', u'share_content']
+        self.assertEqual(expected_actions, self.get_actions(self.workspace))
+
+    def test_workspace_context_actions_for_workspace_admins(self):
+        self.login(self.workspace_admin)
+        expected_actions = [u'add_invitation', u'edit', u'local_roles', u'share_content']
+        self.assertEqual(expected_actions, self.get_actions(self.workspace))
+
+    def test_delete_action_only_available_for_deactivated_workspaces(self):
+        self.login(self.administrator)
+        self.assertNotIn(u'delete_workspace', self.get_actions(self.workspace))
+        self.set_workflow_state('opengever_workspace--STATUS--inactive', self.workspace)
+        self.assertIn(u'delete_workspace', self.get_actions(self.workspace))
+
+    def test_delete_not_available_for_linked_workspaces(self):
+        self.login(self.administrator)
+        self.workspace.external_reference = u'dossier-UID'
+        self.set_workflow_state('opengever_workspace--STATUS--inactive', self.workspace)
+        self.assertNotIn(u'delete_workspace', self.get_actions(self.workspace))


### PR DESCRIPTION
For the new `@ui-actions` endpoint, all actions are determined by adapters. 
The actions are grouped into 3 categories, `context_actions`, `listing_actions` and `webactions`.

There is now an adapter for each type for which we need the `context_actions` in the new UI, which sets the actions.

Furthermore, there is an adapter for `listing_actions` for each type, per possible listing, for RepositoryFolder these would be adapters for dossiers, documents, tasks and proposals listings.
For `listing_actions` one has to specify what kind of listing it is, so that only actions that are relevant are returned.

In my time measurements, the endpoint was at least 3-4 times faster.
Currently, only the actions that are actually needed by the UI are returned.

Initially, I did not include the title of the action, since we currently maintain the translations of the actions ourselves in the UI. However, I tried to build the whole thing in such a way that the translations could be added without much effort.

For [CA-2438]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))

[CA-2438]: https://4teamwork.atlassian.net/browse/CA-2438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ