### PR TITLE
Remove flaky test.

### DIFF
--- a/changes/CA-3929.other
+++ b/changes/CA-3929.other
@@ -1,0 +1,1 @@
+Remove flaky test. [njohner]

--- a/opengever/api/tests/test_linked_workspaces.py
+++ b/opengever/api/tests/test_linked_workspaces.py
@@ -1100,46 +1100,6 @@ class TestCopyDocumentFromWorkspacePost(FunctionalWorkspaceClientTestCase):
                 browser.json.get('teamraum_connect_retrieval_mode'))
 
     @browsing
-    def test_copy_document_from_second_batch_from_a_workspace(self, browser):
-        for i in range(25):
-            create(Builder('document')
-                   .within(self.workspace)
-                   .with_dummy_content())
-
-        document = create(Builder('document')
-                          .titled('Another document')
-                          .within(self.workspace)
-                          .with_dummy_content())
-
-        payload = {
-            'workspace_uid': self.workspace.UID(),
-            'document_uid': document.UID(),
-        }
-
-        with self.workspace_client_env():
-            manager = ILinkedWorkspaces(self.dossier)
-            manager.storage.add(self.workspace.UID())
-            transaction.commit()
-            documents_first_batch = manager.list_documents_in_linked_workspace(
-                self.workspace.UID())['items']
-            self.assertNotIn(document.UID(), [doc['UID'] for doc in documents_first_batch])
-
-            browser.login()
-            fix_publisher_test_bug(browser, document)
-            with self.observe_children(self.dossier) as children:
-                browser.open(
-                    self.dossier.absolute_url() + '/@copy-document-from-workspace',
-                    data=json.dumps(payload),
-                    method='POST',
-                    headers={'Accept': 'application/json',
-                             'Content-Type': 'application/json'},
-                )
-
-            self.assertEqual(len(children['added']), 1)
-            document_copy = children['added'].pop()
-            self.assertEqual(document_copy.title, document.title)
-
-    @browsing
     def test_copy_document_from_workspace_as_new_version(self, browser):
         gever_doc = create(Builder('document')
                            .within(self.dossier)


### PR DESCRIPTION
The test to copy a document from the second batch from a workspace does not make sense, as there is no such thing as a document from the second batch (the search is not sorted). So this test was flaky and I don't see any way to make a meaningful test for this. See https://ci.4teamwork.ch/builds/498333/tasks/936230

For [CA-3929]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-3929]: https://4teamwork.atlassian.net/browse/CA-3929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ