### PR TITLE
Readd accidentally removed return movability checker.

### DIFF
--- a/opengever/document/move.py
+++ b/opengever/document/move.py
@@ -44,6 +44,7 @@ class DocumentMovabiliyChecker(DefaultMovabilityChecker):
                 raise Forbidden(
                     _(u'msg_docs_cant_be_moved_from_repo_to_private_repo',
                       u'Documents within the repository cannot be moved to the private repository.'))
+            return
 
         if is_within_inbox(self.context):
             if is_within_templates(target):


### PR DESCRIPTION
Return statement was accidentally removed in commit dd219d53ae4d696f621f78a7bc620271c85dc5e9. The return statement is not really necessary, it's just for performance.

For [CA-3292]

## Checklist
- [ ] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-3292]: https://4teamwork.atlassian.net/browse/CA-3292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ