### PR TITLE
Allow to move dossiertemplates and tasktemplatefolders

### DIFF
--- a/changes/CA-2808.feature
+++ b/changes/CA-2808.feature
@@ -1,0 +1,1 @@
+Allow to move dossiertemplates and tasktemplatefolders. [tinagerber]

--- a/opengever/dossier/actions.py
+++ b/opengever/dossier/actions.py
@@ -3,6 +3,8 @@ from opengever.base.interfaces import IOpengeverBaseLayer
 from opengever.base.listing_actions import BaseListingActions
 from opengever.docugate import is_docugate_feature_enabled
 from opengever.dossier.behaviors.dossier import IDossierMarker
+from opengever.dossier.dossiertemplate.behaviors import IDossierTemplateMarker
+from opengever.dossier.templatefolder import ITemplateFolder
 from opengever.oneoffixx import is_oneoffixx_feature_enabled
 from opengever.workspaceclient import is_linking_enabled
 from opengever.workspaceclient import is_workspace_client_feature_available
@@ -144,7 +146,15 @@ class DossierContextActions(BaseContextActions):
         return True
 
 
-class TemplateContextActions(BaseContextActions):
+@adapter(ITemplateFolder, IOpengeverBaseLayer)
+class TemplateFolderContextActions(BaseContextActions):
+
+    def is_delete_available(self):
+        return api.user.has_permission('Delete objects', obj=self.context)
+
+
+@adapter(IDossierTemplateMarker, IOpengeverBaseLayer)
+class DossierTemplateContextActions(BaseContextActions):
 
     def is_delete_available(self):
         return api.user.has_permission('Delete objects', obj=self.context)

--- a/opengever/dossier/actions.py
+++ b/opengever/dossier/actions.py
@@ -54,6 +54,9 @@ class DossierTemplateListingActions(BaseListingActions):
     def is_delete_available(self):
         return api.user.has_permission('Delete objects', obj=self.context)
 
+    def is_move_items_available(self):
+        return True
+
 
 @adapter(IDossierMarker, IOpengeverBaseLayer)
 class DossierContextActions(BaseContextActions):
@@ -158,3 +161,6 @@ class DossierTemplateContextActions(BaseContextActions):
 
     def is_delete_available(self):
         return api.user.has_permission('Delete objects', obj=self.context)
+
+    def is_move_item_available(self):
+        return api.user.has_permission('Copy or Move', obj=self.context)

--- a/opengever/dossier/configure.zcml
+++ b/opengever/dossier/configure.zcml
@@ -93,17 +93,8 @@
       />
 
   <adapter factory=".actions.DossierContextActions" />
-  <adapter
-      factory=".actions.TemplateContextActions"
-      for="opengever.dossier.templatefolder.ITemplateFolder
-           opengever.base.interfaces.IOpengeverBaseLayer"
-      />
-
-  <adapter
-      factory=".actions.TemplateContextActions"
-      for="opengever.dossier.dossiertemplate.behaviors.IDossierTemplateMarker
-           opengever.base.interfaces.IOpengeverBaseLayer"
-      />
+  <adapter factory=".actions.TemplateFolderContextActions" />
+  <adapter factory=".actions.DossierTemplateContextActions" />
 
   <!-- JSON endpoint for dossier attributes -->
   <plone:service

--- a/opengever/dossier/configure.zcml
+++ b/opengever/dossier/configure.zcml
@@ -391,5 +391,6 @@
   <adapter factory=".participations.SQLParticipationData" />
 
   <adapter factory=".move_items.DossierMovabiliyChecker" />
+  <adapter factory=".move_items.DossierTemplateMovabilityChecker" />
 
 </configure>

--- a/opengever/dossier/dossiertemplate/dossiertemplate.py
+++ b/opengever/dossier/dossiertemplate/dossiertemplate.py
@@ -145,6 +145,24 @@ class DossierTemplate(Container):
 
         return subdossiers
 
+    def is_dossier_structure_addable(self, additional_depth=1):
+        """Checks if the maximum dossier depth allows additional_depth levels
+        of subdossiers
+        """
+        max_depth = api.portal.get_registry_record(
+            name='maximum_dossier_depth',
+            interface=IDossierContainerTypes,
+            default=100,
+            )
+
+        depth = 0
+        obj = self
+        while IDossierTemplateMarker.providedBy(obj):
+            depth += 1
+            obj = aq_parent(aq_inner(obj))
+
+        return depth + additional_depth <= max_depth + 1
+
     def get_filing_prefix_label(self):
         return voc_term_title(IDossierTemplate['filing_prefix'],
                               IDossierTemplate(self).filing_prefix)

--- a/opengever/dossier/dossiertemplate/dossiertemplate.py
+++ b/opengever/dossier/dossiertemplate/dossiertemplate.py
@@ -122,10 +122,21 @@ class DossierTemplate(Container):
 
     def get_subdossiers(self, sort_on='sortable_title',
                         sort_order='ascending',
+                        unrestricted=False,
                         **kwargs):
 
-        subdossiers = api.content.find(self, object_provides=IDossierTemplateMarker,
-                                       sort_order=sort_order, sort_on=sort_on)
+        dossier_path = '/'.join(self.getPhysicalPath())
+        query = {
+            'path': dict(query=dossier_path),
+            'object_provides': IDossierTemplateMarker.__identifier__,
+            'sort_on': sort_on,
+            'sort_order': sort_order
+            }
+
+        if unrestricted:
+            subdossiers = self.portal_catalog.unrestrictedSearchResults(query)
+        else:
+            subdossiers = self.portal_catalog(query)
 
         # Remove the object itself from the list of subdossiers
         current_uid = self.UID()

--- a/opengever/dossier/move_items.py
+++ b/opengever/dossier/move_items.py
@@ -405,3 +405,17 @@ class DossierMovabiliyChecker(DefaultMovabilityChecker):
             return 1
         max_level = max([len(brain.getPath().split('/')) for brain in subdossiers])
         return max_level - len(self.context.getPhysicalPath()) + 1
+
+
+@adapter(IDossierTemplateMarker)
+class DossierTemplateMovabilityChecker(DossierMovabiliyChecker):
+
+    def validate_movement(self, target):
+        """Avoid exceeding maximum dossier depth
+        """
+        super(DossierTemplateMovabilityChecker, self).validate_movement(target)
+        if not IDossierTemplateMarker.providedBy(target):
+            return
+        if not self.context.is_respect_max_dossier_depth:
+            return
+        self.validate_depth(target)

--- a/opengever/dossier/move_items.py
+++ b/opengever/dossier/move_items.py
@@ -388,6 +388,9 @@ class DossierMovabiliyChecker(DefaultMovabilityChecker):
         if not IDossierMarker.providedBy(target):
             return
 
+        self.validate_depth(target)
+
+    def validate_depth(self, target):
         # determine depth of structure being moved
         substructure_depth = self.dossier_structure_depth()
 

--- a/opengever/dossier/tests/test_actions.py
+++ b/opengever/dossier/tests/test_actions.py
@@ -67,11 +67,11 @@ class TestDossierTemplateListingActions(IntegrationTestCase):
 
     def test_dossiertemplate_actions_for_templatefolder_and_dossiertemplate(self):
         self.login(self.regular_user)
-        self.assertEqual([], self.get_actions(self.templates))
-        self.assertEqual([], self.get_actions(self.dossiertemplate))
+        self.assertEqual([u'move_items'], self.get_actions(self.templates))
+        self.assertEqual([u'move_items'], self.get_actions(self.dossiertemplate))
 
         self.login(self.administrator)
-        expected_actions = [u'delete']
+        expected_actions = [u'move_items', u'delete']
         self.assertEqual(expected_actions, self.get_actions(self.templates))
         self.assertEqual(expected_actions, self.get_actions(self.dossiertemplate))
 
@@ -192,5 +192,5 @@ class TestTemplateContextActions(IntegrationTestCase):
 
     def test_dossier_template_context_actions(self):
         self.login(self.administrator)
-        expected_actions = [u'delete', u'edit', u'local_roles']
+        expected_actions = [u'delete', u'edit', u'local_roles', u'move_item']
         self.assertEqual(expected_actions, self.get_actions(self.dossiertemplate))

--- a/opengever/tasktemplates/actions.py
+++ b/opengever/tasktemplates/actions.py
@@ -1,8 +1,20 @@
 from opengever.base.context_actions import BaseContextActions
 from plone import api
+from opengever.base.interfaces import IOpengeverBaseLayer
+from zope.component import adapter
+from opengever.tasktemplates.content.templatefoldersschema import ITaskTemplateFolderSchema
+from opengever.tasktemplates.content.tasktemplate import ITaskTemplate
 
 
+@adapter(ITaskTemplate, IOpengeverBaseLayer)
 class TaskTemplateContextActions(BaseContextActions):
+
+    def is_delete_available(self):
+        return api.user.has_permission('Delete objects', obj=self.context)
+
+
+@adapter(ITaskTemplateFolderSchema, IOpengeverBaseLayer)
+class TaskTemplateFolderContextActions(BaseContextActions):
 
     def is_delete_available(self):
         return api.user.has_permission('Delete objects', obj=self.context)

--- a/opengever/tasktemplates/actions.py
+++ b/opengever/tasktemplates/actions.py
@@ -1,9 +1,9 @@
 from opengever.base.context_actions import BaseContextActions
-from plone import api
 from opengever.base.interfaces import IOpengeverBaseLayer
-from zope.component import adapter
-from opengever.tasktemplates.content.templatefoldersschema import ITaskTemplateFolderSchema
 from opengever.tasktemplates.content.tasktemplate import ITaskTemplate
+from opengever.tasktemplates.content.templatefoldersschema import ITaskTemplateFolderSchema
+from plone import api
+from zope.component import adapter
 
 
 @adapter(ITaskTemplate, IOpengeverBaseLayer)
@@ -18,3 +18,6 @@ class TaskTemplateFolderContextActions(BaseContextActions):
 
     def is_delete_available(self):
         return api.user.has_permission('Delete objects', obj=self.context)
+
+    def is_move_item_available(self):
+        return api.user.has_permission('Copy or Move', obj=self.context)

--- a/opengever/tasktemplates/configure.zcml
+++ b/opengever/tasktemplates/configure.zcml
@@ -21,17 +21,8 @@
   <include package=".viewlets" />
   <include package=".content" />
 
-  <adapter
-      factory=".actions.TaskTemplateContextActions"
-      for="opengever.tasktemplates.content.templatefoldersschema.ITaskTemplateFolderSchema
-           opengever.base.interfaces.IOpengeverBaseLayer"
-      />
-
-  <adapter
-      factory=".actions.TaskTemplateContextActions"
-      for="opengever.tasktemplates.content.tasktemplate.ITaskTemplate
-           opengever.base.interfaces.IOpengeverBaseLayer"
-      />
+  <adapter factory=".actions.TaskTemplateContextActions" />
+  <adapter factory=".actions.TaskTemplateFolderContextActions" />
 
   <utility
       factory=".vocabularies.ActiveTasktemplatefoldersVocabulary"

--- a/opengever/tasktemplates/configure.zcml
+++ b/opengever/tasktemplates/configure.zcml
@@ -67,6 +67,8 @@
       name="tasktemplatefolder-transition-activ-inactiv"
       />
 
+  <adapter factory=".move.TaskTemplateFolderMovabiliyChecker" />
+
 
 
 

--- a/opengever/tasktemplates/locales/de/LC_MESSAGES/opengever.tasktemplates.po
+++ b/opengever/tasktemplates/locales/de/LC_MESSAGES/opengever.tasktemplates.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2022-04-01 15:20+0000\n"
+"POT-Creation-Date: 2022-05-09 11:00+0000\n"
 "PO-Revision-Date: 2012-02-23 14:39+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -227,6 +227,11 @@ msgstr "Alle Aufgaben aus gewähltem Standardablauf wurden erstellt."
 #: ./opengever/tasktemplates/browser/trigger.py
 msgid "msg_no_active_tasktemplatefolders"
 msgstr "Zurzeit sind keine aktiven Standardabläufe hinterlegt."
+
+#. Default: "It's not allowed to move tasktemplatefolders into tasktemplatefolders."
+#: ./opengever/tasktemplates/move.py
+msgid "msg_tasktemplatefolder_nesting_not_allowed"
+msgstr "Es ist nicht erlaubt, Standardabläufe in Standardabläufe zu verschieben."
 
 #. Default: "Yes"
 #: ./opengever/tasktemplates/browser/tasktemplates.py

--- a/opengever/tasktemplates/locales/en/LC_MESSAGES/opengever.tasktemplates.po
+++ b/opengever/tasktemplates/locales/en/LC_MESSAGES/opengever.tasktemplates.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2022-04-01 15:20+0000\n"
+"POT-Creation-Date: 2022-05-09 11:00+0000\n"
 "PO-Revision-Date: 2012-02-23 14:39+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -274,6 +274,11 @@ msgstr "All tasks from the selected task template have been created."
 #: ./opengever/tasktemplates/browser/trigger.py
 msgid "msg_no_active_tasktemplatefolders"
 msgstr "Currently there are no active task template folders."
+
+#. Default: "It's not allowed to move tasktemplatefolders into tasktemplatefolders."
+#: ./opengever/tasktemplates/move.py
+msgid "msg_tasktemplatefolder_nesting_not_allowed"
+msgstr "It's not allowed to move tasktemplatefolders into tasktemplatefolders."
 
 #. German translation: Ja
 #. Default: "Yes"

--- a/opengever/tasktemplates/locales/fr/LC_MESSAGES/opengever.tasktemplates.po
+++ b/opengever/tasktemplates/locales/fr/LC_MESSAGES/opengever.tasktemplates.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-04-01 15:20+0000\n"
+"POT-Creation-Date: 2022-05-09 11:00+0000\n"
 "PO-Revision-Date: 2017-12-03 11:48+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-tasktemplates/fr/>\n"
@@ -229,6 +229,11 @@ msgstr "Toutes les tâches du procédé standard ont été créées."
 #: ./opengever/tasktemplates/browser/trigger.py
 msgid "msg_no_active_tasktemplatefolders"
 msgstr "Aucun déroulement standard actif n'est enregistré pour le moment."
+
+#. Default: "It's not allowed to move tasktemplatefolders into tasktemplatefolders."
+#: ./opengever/tasktemplates/move.py
+msgid "msg_tasktemplatefolder_nesting_not_allowed"
+msgstr ""
 
 #. Default: "Yes"
 #: ./opengever/tasktemplates/browser/tasktemplates.py

--- a/opengever/tasktemplates/locales/opengever.tasktemplates.pot
+++ b/opengever/tasktemplates/locales/opengever.tasktemplates.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-04-01 15:20+0000\n"
+"POT-Creation-Date: 2022-05-09 11:00+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -229,6 +229,11 @@ msgstr ""
 #. Default: "Currently there are no active task template folders registered."
 #: ./opengever/tasktemplates/browser/trigger.py
 msgid "msg_no_active_tasktemplatefolders"
+msgstr ""
+
+#. Default: "It's not allowed to move tasktemplatefolders into tasktemplatefolders."
+#: ./opengever/tasktemplates/move.py
+msgid "msg_tasktemplatefolder_nesting_not_allowed"
 msgstr ""
 
 #. Default: "Yes"

--- a/opengever/tasktemplates/move.py
+++ b/opengever/tasktemplates/move.py
@@ -1,0 +1,20 @@
+from zope.component import adapter
+from opengever.tasktemplates.content.templatefoldersschema import ITaskTemplateFolderSchema
+from opengever.base.adapters import DefaultMovabilityChecker
+from opengever.tasktemplates import is_tasktemplatefolder_nesting_allowed
+from opengever.api.not_reported_exceptions import Forbidden as NotReportedForbidden
+from opengever.tasktemplates import _
+
+
+@adapter(ITaskTemplateFolderSchema)
+class TaskTemplateFolderMovabiliyChecker(DefaultMovabilityChecker):
+
+    def validate_movement(self, target):
+        super(TaskTemplateFolderMovabiliyChecker, self).validate_movement(target)
+        if not ITaskTemplateFolderSchema.providedBy(target):
+            return
+
+        if not is_tasktemplatefolder_nesting_allowed():
+            raise NotReportedForbidden(
+                _(u"msg_tasktemplatefolder_nesting_not_allowed",
+                  u"It's not allowed to move tasktemplatefolders into tasktemplatefolders."))

--- a/opengever/tasktemplates/tests/test_actions.py
+++ b/opengever/tasktemplates/tests/test_actions.py
@@ -11,7 +11,7 @@ class TestTaskTemplateContextActions(IntegrationTestCase):
 
     def test_task_template_folder_context_actions(self):
         self.login(self.administrator)
-        expected_actions = [u'delete', u'edit']
+        expected_actions = [u'delete', u'edit', u'move_item']
         self.assertEqual(expected_actions, self.get_actions(self.tasktemplatefolder))
 
     def test_task_template_context_actions(self):

--- a/opengever/tasktemplates/tests/test_move.py
+++ b/opengever/tasktemplates/tests/test_move.py
@@ -1,0 +1,20 @@
+from opengever.tasktemplates.move import TaskTemplateFolderMovabiliyChecker
+from opengever.testing import IntegrationTestCase
+from zExceptions import Forbidden
+from ftw.builder import Builder
+from ftw.builder import create
+
+
+class TestTaskTemplateFolderMovabilityChecker(IntegrationTestCase):
+
+    def test_can_only_move_tasktemplatefolder_into_tasktemplatefolder_if_nesting_enabled(self):
+        self.login(self.administrator)
+        tasktemplatefolder = create(Builder('tasktemplatefolder').within(self.templates))
+
+        with self.assertRaises(Forbidden):
+            TaskTemplateFolderMovabiliyChecker(tasktemplatefolder).validate_movement(
+                self.tasktemplatefolder)
+
+        self.activate_feature('tasktemplatefolder_nesting')
+        TaskTemplateFolderMovabiliyChecker(tasktemplatefolder).validate_movement(
+            self.tasktemplatefolder)


### PR DESCRIPTION
This PR enables the `move_item` context action for dossiertemplates and tasktemplatefolders and the `move_items` folder action for dossiertemplate listings. Furthermore I have implemented a MovabilityChecker for both types


For [CA-2808]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-2808]: https://4teamwork.atlassian.net/browse/CA-2808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ