### PR TITLE
Handle inactive users in the @accessible-workspaces endpoint.

### DIFF
--- a/changes/CA-4164.bugfix
+++ b/changes/CA-4164.bugfix
@@ -1,0 +1,1 @@
+Handle inactive users in the @accessible-workspaces endpoint. [njohner]

--- a/opengever/api/accessible_workspaces.py
+++ b/opengever/api/accessible_workspaces.py
@@ -1,5 +1,6 @@
 from ftw.solr.interfaces import ISolrSearch
 from opengever.api.solr_query_service import SolrQueryBaseService
+from opengever.ogds.models.service import ogds_service
 from plone import api
 from zExceptions import BadRequest
 from zope.component import getUtility
@@ -26,13 +27,17 @@ class AccessibleWorkspacesGet(SolrQueryBaseService):
 
     def reply(self):
         userid = self.read_params().decode('utf-8')
-        user = api.user.get(userid)
-        if not user:
+        ogds_user = ogds_service().fetch_user(userid)
+
+        if not ogds_user:
             raise BadRequest(u'Invalid userid "{}".'.format(userid))
 
         allowed_roles_and_users = [u'user:{}'.format(userid)]
-        allowed_roles_and_users.extend([u'user:{}'.format(group) for group in user.getGroups()])
-        allowed_roles_and_users.extend(user.getRoles())
+
+        user = api.user.get(userid)
+        if user:
+            allowed_roles_and_users.extend([u'user:{}'.format(group) for group in user.getGroups()])
+            allowed_roles_and_users.extend(user.getRoles())
 
         query = u'object_provides:opengever.workspace.interfaces.IWorkspace'
 

--- a/opengever/api/tests/test_accessible_workspaces.py
+++ b/opengever/api/tests/test_accessible_workspaces.py
@@ -53,6 +53,30 @@ class TestAccessibleWorkspacesGet(SolrIntegrationTestCase):
                          u'title': u'A Workspace'}]}, browser.json)
 
     @browsing
+    def test_accessible_workspaces_handles_inactive_users(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        # create an inactive user with no member data
+        inactive_user = create(
+            Builder('ogds_user')
+            .id('inactive_user')
+            .having(active=False)
+        )
+
+        self.set_roles(self.workspace, 'inactive_user', ['WorkspaceMember'])
+        self.commit_solr()
+
+        url = '{}/@accessible-workspaces/{}'.format(self.portal.absolute_url(),
+                                                    inactive_user.userid)
+        browser.open(url, headers=self.api_headers)
+        self.assertEqual(
+            {u'@id': u'http://nohost/plone/@accessible-workspaces/inactive_user',
+             u'items': [{u'@id': self.workspace.absolute_url(),
+                         u'@type': u'opengever.workspace.workspace',
+                         u'review_state': u'opengever_workspace--STATUS--active',
+                         u'title': u'A Workspace'}]}, browser.json)
+
+    @browsing
     def test_raises_bad_request_when_userid_is_missing(self, browser):
         self.login(self.administrator, browser=browser)
         url = '{}/@accessible-workspaces'.format(self.portal.absolute_url())


### PR DESCRIPTION
When a user is deleted from the LDAP, set inactive in the OGDS, it does not have a member data anymore, which leads to raising an error in the @accessible-workspaces endpoint. This is fixed here by checking whether the user is in the OGDS instead, and then adding groups and the users'roles only if he has memberdata.

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-4164]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug

[CA-4164]: https://4teamwork.atlassian.net/browse/CA-4164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ