### PR TITLE
Excel mass export for documents and dossiers

### DIFF
--- a/changes/CA-2609-2.feature
+++ b/changes/CA-2609-2.feature
@@ -1,0 +1,1 @@
+Excel export: Items to export can be addressed by a listing-name and filters. [elioschmutz]

--- a/changes/CA-2609.feature
+++ b/changes/CA-2609.feature
@@ -1,0 +1,1 @@
+Excel export: Remove limit of 1000 items. [elioschmutz]

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -344,7 +344,8 @@ class ListingGet(SolrQueryBaseService):
                 "Unknown listing {}. Available listings are: {}".format(
                     self.name, ",".join(FILTERS.keys())))
 
-        query, filters, start, rows, sort, field_list, params = self.prepare_solr_query()
+        query, filters, start, rows, sort, field_list, params = \
+            self.prepare_solr_query(self.request_payload)
 
         resp = self.solr.search(
             query=query, filters=filters, start=start, rows=rows, sort=sort,

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -39,10 +39,10 @@ class SolrQueryBaseService(Service):
             # to utf-8 to get the same encoding as with a GET reqeust.
             return recursive_encode(json_body(self.request))
 
-    def prepare_solr_query(self):
+    def prepare_solr_query(self, params):
         """ Extract the requested parameters and prepare the solr query
         """
-        params = self.request_payload.copy()
+        params = params.copy()
         query = self.extract_query(params)
         filters = self.extract_filters(params)
         start = self.extract_start(params)

--- a/opengever/api/solrsearch.py
+++ b/opengever/api/solrsearch.py
@@ -266,7 +266,8 @@ class SolrSearchGet(SolrQueryBaseService):
                 'use_solr', interface=ISearchSettings):
             raise BadRequest('Solr is not enabled on this GEVER installation.')
 
-        query, filters, start, rows, sort, field_list, params = self.prepare_solr_query()
+        query, filters, start, rows, sort, field_list, params = \
+            self.prepare_solr_query(self.request_payload)
 
         resp = self.solr.search(
             query=query, filters=filters, start=start, rows=rows, sort=sort,

--- a/opengever/base/browser/reporting_view.py
+++ b/opengever/base/browser/reporting_view.py
@@ -111,7 +111,7 @@ class SolrReporterView(BaseReporterView):
     def get_selected_items(self):
         paths = self.request.get('paths')
         if not paths:
-            return []
+            return
 
         fields = [col['id'] for col in self.columns()]
 
@@ -129,11 +129,9 @@ class SolrReporterView(BaseReporterView):
             sort=sort,
             fl=self.fields.get_query_fields(fields) + ['path'])
 
-        return [
-            IContentListingObject(
-                OGSolrDocument(doc, fields=self.solr.manager.schema.fields))
-            for doc in resp.docs
-        ]
+        for doc in resp.docs:
+            doc = OGSolrDocument(doc, fields=self.solr.manager.schema.fields)
+            yield IContentListingObject(doc)
 
     @property
     def is_frontend_request(self):

--- a/opengever/base/solr/__init__.py
+++ b/opengever/base/solr/__init__.py
@@ -21,7 +21,7 @@ def batched_solr_results(**kwargs):
     start = 0
     rows = kwargs.get('rows', 1000)
     while not last_batch:
-        resp = solr.unrestricted_search(start=start, **kwargs)
+        resp = solr.search(start=start, **kwargs)
         yield resp.docs
         if start + len(resp.docs) >= resp.num_found or not resp.docs:
             last_batch = True

--- a/opengever/document/browser/report.py
+++ b/opengever/document/browser/report.py
@@ -94,7 +94,7 @@ class DocumentReporter(SolrReporterView):
     ]
 
     def __call__(self):
-        if not self.request.get('paths'):
+        if not self.request.get('paths') and not self.request.get('listing_name'):
             msg = _(
                 u'error_no_items', default=u'You have not selected any Items')
             IStatusMessage(self.request).addStatusMessage(msg, type='error')

--- a/opengever/dossier/browser/report.py
+++ b/opengever/dossier/browser/report.py
@@ -65,7 +65,7 @@ class DossierReporter(SolrReporterView):
     )
 
     def __call__(self):
-        if not self.request.get('paths'):
+        if not self.request.get('paths') and not self.request.get('listing_name'):
             msg = _(
                 u'error_no_items', default=u'You have not selected any items.')
             IStatusMessage(self.request).addStatusMessage(msg, type='error')


### PR DESCRIPTION
This PR changes the report-view:

- it can now export more than 1000 objects. We do no longer define a limit
- it is now possible to choose selected items by passing a listing-name and the corresponding filter/sorting params instead of explicitly define them by paths

![Bildschirmfoto 2022-05-11 um 21 21 19](https://user-images.githubusercontent.com/557005/167929226-c7dc164c-c175-44f0-beb5-10d9ebcc72c3.png)

- no longer sort the results locally when using paths. Use term-boosting to directly sort the results in solr instead: https://solr.apache.org/guide/6_6/the-standard-query-parser.html since we use a generator for the selected_items.

For [CA-2609]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-2609]: https://4teamwork.atlassian.net/browse/CA-2609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ