### PR TITLE
Fix possible watchers query to work for Oracle databases as well

### DIFF
--- a/changes/CA-4179.bugfix
+++ b/changes/CA-4179.bugfix
@@ -1,0 +1,1 @@
+Fix possible watchers query to work for Oracle databases as well. [tinagerber]

--- a/opengever/activity/sources.py
+++ b/opengever/activity/sources.py
@@ -38,7 +38,7 @@ class PossibleWatchersSource(AssignedUsersSource):
         current_user = api.user.get_current()
         return query.order_by(case(
             ((User.userid == current_user.getId(), 1), ),
-            else_='2'))
+            else_=2))
 
     def _filter_not_subscribing_watchers(self, query):
         """This function adds the filter clause to only return users without a


### PR DESCRIPTION
The possible watchers query didn't work for Zug

See also https://sentry.4teamwork.ch/organizations/sentry/issues/75726/events/8c822c0cd82945fab82bd17c9252ee56/?project=17

For [CA-4179]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-4179]: https://4teamwork.atlassian.net/browse/CA-4179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ