### PR TITLE
Add disposition setting: only attach original if conversion missing.

### DIFF
--- a/changes/CA-3839.feature
+++ b/changes/CA-3839.feature
@@ -1,0 +1,1 @@
+Add disposition setting, to only attach the original file if conversion is missing. [phgross]

--- a/opengever/core/upgrades/20220512150235_add_only_attach_original_if_conversion_is_missing_flag/registry.xml
+++ b/opengever/core/upgrades/20220512150235_add_only_attach_original_if_conversion_is_missing_flag/registry.xml
@@ -1,0 +1,6 @@
+<registry>
+
+  <record interface="opengever.disposition.interfaces.IDispositionSettings"
+          field="only_attach_original_if_conversion_is_missing" />
+
+</registry>

--- a/opengever/core/upgrades/20220512150235_add_only_attach_original_if_conversion_is_missing_flag/upgrade.py
+++ b/opengever/core/upgrades/20220512150235_add_only_attach_original_if_conversion_is_missing_flag/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddOnlyAttachOriginalIfConversionIsMissingFlag(UpgradeStep):
+    """Add only attach original if conversion is missing flag.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/disposition/__init__.py
+++ b/opengever/disposition/__init__.py
@@ -1,3 +1,13 @@
+from opengever.disposition.interfaces import IDispositionSettings
+from plone import api
 from zope.i18nmessageid import MessageFactory
 
 _ = MessageFactory('opengever.disposition')
+
+def only_attach_original_enabled():
+    """checks if the feature flag only_attach_original_if_conversion_is_missing
+    is enabled"""
+
+    return api.portal.get_registry_record(
+        'only_attach_original_if_conversion_is_missing',
+        interface=IDispositionSettings)

--- a/opengever/disposition/ech0160/model/folder.py
+++ b/opengever/disposition/ech0160/model/folder.py
@@ -1,3 +1,4 @@
+from opengever.disposition import only_attach_original_enabled
 from opengever.disposition.ech0160.bindings import arelda
 from opengever.disposition.ech0160.model import File
 import os.path
@@ -18,11 +19,18 @@ class Folder(object):
             self.folders.append(Folder(toc, subdossier, self.path))
 
         for doc in dossier.documents.values():
+            conversion_attached = False
             if doc.obj.archival_file:
                 if not doc.obj.is_archival_file_conversion_skipped():
                     self.files.append(File(toc, doc, doc.obj.archival_file))
+                    conversion_attached = True
+
             if doc.obj.get_file():
+                if conversion_attached and only_attach_original_enabled():
+                    continue
+
                 self.files.append(File(toc, doc, doc.obj.get_file()))
+
 
     def binding(self):
         ordner = arelda.ordnerSIP(self.name)

--- a/opengever/disposition/interfaces.py
+++ b/opengever/disposition/interfaces.py
@@ -61,6 +61,12 @@ class IDispositionSettings(Interface):
                     'period.',
         default=False)
 
+    only_attach_original_if_conversion_is_missing = schema.Bool(
+        title=u'Only attach original in SIP Package if conversion is missing',
+        description=u'Whether the original file of a document should only be '
+        'attached in the SIP package if no conversion file exists.',
+        default=False)
+
 
 class IFilesystemTransportSettings(Interface):
 


### PR DESCRIPTION
For [CA-3839]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- Upgrade-Steps:
- New functionality:
  - [x] for `document` also works for `mail`

[CA-3839]: https://4teamwork.atlassian.net/browse/CA-3839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ