### PR TITLE
Add new API enpoint @sync-ogds to start the OGDS sync manually.

### DIFF
--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -12,6 +12,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- A new ``@ogds-sync`` endpoint allows to start an OGDS synchronisation.
 
 2022.10.0 (2022-05-11)
 ----------------------

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -19,6 +19,7 @@
   <include package="opengever.webactions" file="permissions.zcml" />
   <include package="opengever.workspace" file="permissions.zcml" />
   <include package="opengever.workspaceclient" file="permissions.zcml" />
+  <include package="opengever.ogds.base" file="permissions.zcml" />
 
   <include package=".schema" />
 
@@ -1705,6 +1706,14 @@
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"
       factory=".dashboard.DashboardSettings"
       permission="zope2.View"
+      />
+
+  <plone:service
+      method="POST"
+      name="@ogds-sync"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      factory=".ogdssync.OgdsSync"
+      permission="opengever.ogds.base.SyncOgds"
       />
 
 </configure>

--- a/opengever/api/ogdssync.py
+++ b/opengever/api/ogdssync.py
@@ -1,0 +1,12 @@
+from opengever.ogds.base.sync.ogds_updater import sync_ogds
+from plone.restapi.services import Service
+
+
+class OgdsSync(Service):
+
+    def reply(self):
+        sync_ogds(
+            self.context, users=True, groups=True, local_groups=True)
+
+        self.request.response.setStatus(204)
+        return super(OgdsSync, self).reply()

--- a/opengever/api/tests/test_ogdssync.py
+++ b/opengever/api/tests/test_ogdssync.py
@@ -1,0 +1,33 @@
+from ftw.testbrowser import browsing
+from mock import patch
+from opengever.testing import IntegrationTestCase
+
+
+class TestOGDSSync(IntegrationTestCase):
+
+    @browsing
+    def test_syncs_users_groups_and_local_groups(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        # patch
+        with patch('opengever.api.ogdssync.sync_ogds') as mock_sync:
+            url = "{}/@ogds-sync".format(self.portal.absolute_url())
+            browser.open(url, method="POST", headers=self.api_headers)
+
+        mock_sync.assert_called_once_with(
+            self.portal, users=True, groups=True, local_groups=True)
+
+        self.assertEqual(204, browser.status_code)
+
+    @browsing
+    def test_sync_is_only_allowed_for_administrators(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        with browser.expect_http_error(401):
+            url = "{}/@ogds-sync".format(self.portal.absolute_url())
+            browser.open(url, method="POST", headers=self.api_headers)
+
+        self.assertEqual(
+            {u'message': u'You are not authorized to access this resource.',
+             u'type': u'Unauthorized'},
+            browser.json)

--- a/opengever/base/monkey/patches/readonly.py
+++ b/opengever/base/monkey/patches/readonly.py
@@ -212,6 +212,7 @@ WRITE_PERMISSIONS = [
     'opengever.meeting: Add Proposal Comment',
     'opengever.meeting: Add Proposal Template',
     'opengever.meeting: Add Sablon Template',
+    'opengever.ogds.base: Sync the OGDS',
     'opengever.private: Add private dossier',
     'opengever.private: Add private folder',
     'opengever.private: Add private root',

--- a/opengever/core/lawgiver.zcml
+++ b/opengever/core/lawgiver.zcml
@@ -228,6 +228,7 @@
                    opengever.meeting: Add Meeting Template,
                    opengever.meeting: Add Paragraph Template,
                    opengever.meeting: Add Proposal Comment,
+                   opengever.ogds.base: Sync the OGDS,
                    opengever.propertysheets: Manage PropertySheets,
                    opengever.repository: Export repository,
                    opengever.sharing: List Protected Objects,

--- a/opengever/core/profiles/default/rolemap.xml
+++ b/opengever/core/profiles/default/rolemap.xml
@@ -417,6 +417,11 @@
       <role name="WorkspacesCreator" />
     </permission>
 
+    <permission name="opengever.ogds.base: Sync the OGDS" acquire="True">
+      <role name="Manager" />
+      <role name="Administrator" />
+    </permission>
+
   </permissions>
 
 </rolemap>

--- a/opengever/core/upgrades/20220518085545_add_new_sync_ogds_permission/rolemap.xml
+++ b/opengever/core/upgrades/20220518085545_add_new_sync_ogds_permission/rolemap.xml
@@ -1,0 +1,12 @@
+<rolemap>
+
+  <permissions>
+
+    <permission name="opengever.ogds.base: Sync the OGDS" acquire="True">
+      <role name="Manager" />
+      <role name="Administrator" />
+    </permission>
+
+  </permissions>
+
+</rolemap>

--- a/opengever/core/upgrades/20220518085545_add_new_sync_ogds_permission/upgrade.py
+++ b/opengever/core/upgrades/20220518085545_add_new_sync_ogds_permission/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddNewSyncOGDSPermission(UpgradeStep):
+    """Add new sync OGDS permission.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/ogds/base/configure.zcml
+++ b/opengever/ogds/base/configure.zcml
@@ -14,6 +14,8 @@
   <include package=".viewlets" />
   <include package=".sync" />
 
+  <include file="permissions.zcml" />
+
   <i18n:registerTranslations directory="locales" />
 
   <adapter

--- a/opengever/ogds/base/permissions.zcml
+++ b/opengever/ogds/base/permissions.zcml
@@ -1,0 +1,7 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    i18n_domain="opengever.ogds.base">
+
+  <permission id="opengever.ogds.base.SyncOgds" title="opengever.ogds.base: Sync the OGDS" />
+
+</configure>

--- a/opengever/ogds/base/sync/ogds_updater.py
+++ b/opengever/ogds/base/sync/ogds_updater.py
@@ -58,7 +58,13 @@ def sync_ogds(plone, users=True, groups=True, local_groups=False,
     """
     # Set up logging to a rotating ogds-update.log
     if not disable_logfile:
-        setup_ogds_sync_logfile(logger)
+        try:
+            setup_ogds_sync_logfile(logger)
+        except RuntimeError:
+            # in some cases (testserver and other test builds), the specific
+            # logger cannot be setupped. We can ignore this case and use the
+            # default logfile
+            pass
 
     # We check that the group management is setup correctly. This is not
     # strictly necessary but ensures that this configuration is checked


### PR DESCRIPTION
The endpoint is protected with a separate permission, assigned only to the roles administrator and manager.

For [CA-4103]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- Upgrade-Steps:
  - only profile changes
- API change:
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))


[CA-4103]: https://4teamwork.atlassian.net/browse/CA-4103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ