### PR TITLE
Cache get_custom_property_solr_field in SolrFieldMapper to boost mass selection actions

### DIFF
--- a/opengever/base/solr/fields.py
+++ b/opengever/base/solr/fields.py
@@ -19,6 +19,7 @@ from opengever.task.helper import task_type_helper
 from opengever.task.helper import task_type_value_helper
 from opengever.tasktemplates.content.templatefoldersschema import sequence_type_vocabulary
 from plone import api
+from plone.memoize.instance import memoize
 from plone.rfc822.interfaces import IPrimaryFieldInfo
 from Products.CMFPlone.utils import safe_unicode
 from zExceptions import BadRequest
@@ -776,6 +777,7 @@ class SolrFieldMapper(object):
 
         return list(requested_solr_fields & self.all_solr_fields) + dynamic_fields
 
+    @memoize
     def get_custom_property_solr_field(self, field_name):
         """Get a single custom property dynamic field by name.
         """


### PR DESCRIPTION
Looking up the custom property fields is expensive.

Here the flamegraph of an export of 10k documents
![Bildschirmfoto 2022-05-19 um 16 02 13](https://user-images.githubusercontent.com/557005/169312119-6db03494-af25-4752-9fbb-bbc633781626.png)

When performing mass-selection actions, i.e. excel export, we run into massive performance issues:

We can export ~100 documents per second without caching.

**Export of 10k Documents without caching**
![Bildschirmfoto 2022-05-19 um 15 56 32](https://user-images.githubusercontent.com/557005/169314289-8aea9e6d-12ed-457a-9954-de750fa13a80.png)

After the caching, we can export ~1500 documents per second:

**Export of 10k Documents with caching**
![Bildschirmfoto 2022-05-19 um 15 51 51](https://user-images.githubusercontent.com/557005/169314530-c4052aac-5fd1-487f-8b41-c68512ae34e7.png)

## Flamegraph to download
![flamegraph](https://user-images.githubusercontent.com/557005/169312158-da6d3f71-278d-4e2f-8efb-b79b75cb5db6.svg)

For [CA-2609]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry (No cl entry necessary because excel export was introduced within this sprint)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-2609]: https://4teamwork.atlassian.net/browse/CA-2609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ