### PR TITLE
No longer clear task permissions when protecting a dossier.

### DIFF
--- a/changes/CA-4245.bugfix
+++ b/changes/CA-4245.bugfix
@@ -1,0 +1,1 @@
+No longer clear task permissions when protecting a dossier. [phgross]

--- a/opengever/base/role_assignments.py
+++ b/opengever/base/role_assignments.py
@@ -341,6 +341,12 @@ class RoleAssignmentManager(object):
         self.storage.clear_all()
         self._update_local_roles()
 
+    def clear_by_causes(self, causes):
+        for cause in causes:
+            self.storage.clear_by_cause(cause)
+
+        self._update_local_roles()
+
     def clear_by_cause_and_principals(self, cause, principals):
         """Remove all assignments of the given cause and principals.
         """

--- a/opengever/dossier/behaviors/protect_dossier.py
+++ b/opengever/dossier/behaviors/protect_dossier.py
@@ -1,4 +1,6 @@
 from ftw.keywordwidget.widget import KeywordFieldWidget
+from opengever.base.role_assignments import ASSIGNMENT_VIA_PROTECT_DOSSIER
+from opengever.base.role_assignments import ASSIGNMENT_VIA_SHARING
 from opengever.base.role_assignments import ProtectDossierRoleAssignment
 from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.dossier import _
@@ -230,7 +232,9 @@ class DossierProtection(AnnotationsFactoryImpl):
             manager.reset(assignments)
 
     def clear_local_roles(self):
-        RoleAssignmentManager(self.context).clear_all()
+        manager = RoleAssignmentManager(self.context)
+        manager.clear_by_causes(
+            [ASSIGNMENT_VIA_SHARING, ASSIGNMENT_VIA_PROTECT_DOSSIER])
 
     def generate_role_settings(self):
         role_settings = {}

--- a/opengever/dossier/tests/test_protect_dossier.py
+++ b/opengever/dossier/tests/test_protect_dossier.py
@@ -134,13 +134,13 @@ class TestProtectDossier(SolrIntegrationTestCase):
         factoriesmenu.add(u'Business Case Dossier')
         browser.fill({'Title': 'My Dossier'})
         form = browser.find_form_by_field('Read only access')
-        form.find_widget('Read/Write access').fill(self.regular_user.getId())
+        form.find_widget('Read/Write access').fill(self.secretariat_user.getId())
         browser.click_on('Save')
 
         new_dossier = browser.context
         self.assert_local_roles(
             IProtectDossier(new_dossier).READING_AND_WRITING_ROLES,
-            self.regular_user.getId(), new_dossier)
+            self.secretariat_user.getId(), new_dossier)
 
         dossier_manager_roles = ['Owner']
         dossier_manager_roles.extend(IProtectDossier(new_dossier).DOSSIER_MANAGER_ROLES)
@@ -152,7 +152,8 @@ class TestProtectDossier(SolrIntegrationTestCase):
         form.find_widget('Read/Write access').fill([])
         form.find_widget('Dossier manager').fill('')
         browser.click_on('Save')
-        self.assert_local_roles([], self.regular_user.getId(), new_dossier)
+
+        self.assert_local_roles([], self.secretariat_user.getId(), new_dossier)
         self.assert_local_roles(['Owner'], self.dossier_manager.getId(), new_dossier)
 
     @browsing
@@ -286,7 +287,7 @@ class TestProtectDossier(SolrIntegrationTestCase):
         browser.click_on('Save')
 
         self.assert_local_roles(
-            IProtectDossier(self.dossier).READING_ROLES,
+            IProtectDossier(self.dossier).READING_ROLES + ['Contributor'],  # assignment via task
             self.regular_user.getId(), browser.context)
 
     def test_protect_dossier_will_disable_role_inheritance(self):
@@ -315,8 +316,25 @@ class TestProtectDossier(SolrIntegrationTestCase):
         dossier_protector.protect()
 
         self.assert_local_roles(
-            dossier_protector.READING_ROLES,
+            dossier_protector.READING_ROLES + ['Contributor'],  # assignment via task
             self.regular_user.getId(), self.dossier)
+
+    def test_protect_dossier_does_not_change_task_permissions(self):
+        self.login(self.dossier_manager)
+
+        dossier_protector = IProtectDossier(self.dossier)
+        dossier_protector.dossier_manager = self.dossier_manager.getId()
+        dossier_protector.reading = [self.regular_user.getId()]
+        dossier_protector.protect()
+
+        # Assignement via task
+        self.assert_local_roles(
+            dossier_protector.READING_ROLES + ['Contributor'],
+            self.regular_user.getId(), self.dossier)
+
+        # Assignement via task agency
+        self.assert_local_roles(
+            ['Contributor'], 'fa_inbox_users', self.dossier)
 
     def test_protect_dossier_will_add_selected_reading_and_writing_users_to_localroles(self):
         self.login(self.dossier_manager)
@@ -341,7 +359,7 @@ class TestProtectDossier(SolrIntegrationTestCase):
         dossier_protector.protect()
 
         self.assert_local_roles(
-            dossier_protector.READING_ROLES,
+            dossier_protector.READING_ROLES + ['Contributor'], #  assignment via task
             self.regular_user.getId(), self.dossier)
 
         self.assert_local_roles(
@@ -389,6 +407,7 @@ class TestProtectDossier(SolrIntegrationTestCase):
 
         self.assertItemsEqual(
             ['Administrator', 'Contributor', 'Editor', 'LimitedAdmin', 'Manager', 'Reader',
+             'user:fa_inbox_users',  # task agency role assignments
              'user:{}'.format(self.dossier_manager.getId()),
              'user:{}'.format(self.regular_user.getId())],
             self.get_allowed_roles_and_users_for(self.dossier))


### PR DESCRIPTION
Currently when a dossier, with tasks, gets protected, all temporary role assignments for tasks are deleted. This should not be the case, because task role assignments are should not be touched by dossiers protect functionality otherwise its not guaranteed that the responsible is able to access the task.


Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-4245]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-4245]: https://4teamwork.atlassian.net/browse/CA-4245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ