### PR TITLE
Sort group representatives by lastname and allow filtering ogds-user-listing by group membership.

### DIFF
--- a/changes/CA-3754.feature
+++ b/changes/CA-3754.feature
@@ -1,0 +1,1 @@
+Sort group users by last name and allow filtering users by group membership in ogdsuserlisting. [njohner]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -8,12 +8,13 @@ API Changelog
 
 Breaking Changes
 ^^^^^^^^^^^^^^^^
--``@responses``: Responses can no longer be edited if they are not of type comment.
+- ``@responses``: Responses can no longer be edited if they are not of type comment.
 
 Other Changes
 ^^^^^^^^^^^^^
--``@responses``: Add DELETE endpoint.
--``@responses``: Set modifier and modified in PATCH endpoint.
+- ``@responses``: Add DELETE endpoint.
+- ``@responses``: Set modifier and modified in PATCH endpoint.
+- ``@ogds-user-listing`` now supports filtering by group membership.
 
 2022.11.0 (2022-05-24)
 ----------------------

--- a/docs/public/dev-manual/api/listings.rst
+++ b/docs/public/dev-manual/api/listings.rst
@@ -460,7 +460,7 @@ Folgende Parameter werden im Moment unterstützt:
 
 Filtern:
 --------
-Im Moment ist für beide Endpoinst ein Filter nach Status (aktiv/inaktiv) und ein Filter nach dem Zeitpunkt des letzten Logins implementiert.
+Im Moment sind ein Filter nach Status (``filters.state``), ein Filter nach dem Zeitpunkt des letzten Logins ``filters.last_login`` und ein filter nach Gruppenmitgliedschaft ``filters.groupid`` implementiert.
 
 Mit ``filters.state:record:list`` können die gewünschten Status angegeben werden:
 
@@ -479,6 +479,13 @@ Mit ``filters.state:record:list`` können die gewünschten Status angegeben werd
   .. sourcecode:: http
 
     GET /@ogds-user-listing?filters.last_login:record:list=2020-05-27%20TO%20* HTTP/1.1
+    Accept: application/json
+
+**Beispiel: Filtern nach Benutzer welche Teil der Gruppe test-group sind**
+
+  .. sourcecode:: http
+
+    GET /@ogds-user-listing?filters.groupid:record:test-group HTTP/1.1
     Accept: application/json
 
 Auflistung Teams

--- a/opengever/api/ogdsuserlisting.py
+++ b/opengever/api/ogdsuserlisting.py
@@ -34,6 +34,15 @@ class OGDSUserListingGet(OGDSListingBaseService):
     default_state_filter = tuple()
     pattern = re.compile(r"^(\d{4}-\d{2}-\d{2}) TO (\d{4}-\d{2}-\d{2})")
 
+    def extract_params(self):
+        sort_on, sort_order, search, filters = super(OGDSUserListingGet, self).extract_params()
+        if self.needs_join_with_groups_users(filters) and sort_on:
+            sort_on = "users.{}".format(sort_on)
+        return sort_on, sort_order, search, filters
+
+    def needs_join_with_groups_users(self, filters):
+        return bool(filters.get('groupid', False))
+
     def _convert_date_query_to_dates(self, date_query):
         search = self.pattern.search(date_query)
         start, end = search.group(1), search.group(2)
@@ -57,8 +66,8 @@ class OGDSUserListingGet(OGDSListingBaseService):
             start_date, end_date = self._convert_date_query_to_dates(last_login_query[0])
             query = query.filter(User.last_login >= start_date, User.last_login <= end_date)
 
-        groupid = filters.get('groupid', None)
-        if groupid:
+        if self.needs_join_with_groups_users(filters):
+            groupid = filters.get('groupid', None)
             query = query.join(groups_users).filter_by(groupid=groupid)
 
         query = self.extend_query_with_visible_users_and_groups_filter(query)

--- a/opengever/api/ogdsuserlisting.py
+++ b/opengever/api/ogdsuserlisting.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from opengever.api.ogdslistingbase import OGDSListingBaseService
 from opengever.base.visible_users_and_groups_filter import visible_users_and_groups_filter
+from opengever.ogds.models.group import groups_users
 from opengever.ogds.models.user import User
 import re
 
@@ -55,6 +56,10 @@ class OGDSUserListingGet(OGDSListingBaseService):
         if last_login_query:
             start_date, end_date = self._convert_date_query_to_dates(last_login_query[0])
             query = query.filter(User.last_login >= start_date, User.last_login <= end_date)
+
+        groupid = filters.get('groupid', None)
+        if groupid:
+            query = query.join(groups_users).filter_by(groupid=groupid)
 
         query = self.extend_query_with_visible_users_and_groups_filter(query)
 

--- a/opengever/api/tests/test_actors.py
+++ b/opengever/api/tests/test_actors.py
@@ -175,6 +175,7 @@ class TestActorsGet(IntegrationTestCase):
 
     @browsing
     def test_actors_response_for_committee(self, browser):
+        self.maxDiff = None
         self.login(self.regular_user, browser=browser)
 
         actor_id = 'committee:1'
@@ -194,12 +195,12 @@ class TestActorsGet(IntegrationTestCase):
                 u'label': u'Rechnungspr\xfcfungskommission',
                 u'representatives': [
                     {
-                        u'@id': u'http://nohost/plone/@actors/franzi.muller',
-                        u'identifier': u'franzi.muller',
-                    },
-                    {
                         u'@id': u'http://nohost/plone/@actors/nicole.kohler',
                         u'identifier': u'nicole.kohler',
+                    },
+                    {
+                        u'@id': u'http://nohost/plone/@actors/franzi.muller',
+                        u'identifier': u'franzi.muller',
                     },
                 ],
                 u'represents': {

--- a/opengever/api/tests/test_ogdsgroups.py
+++ b/opengever/api/tests/test_ogdsgroups.py
@@ -55,6 +55,27 @@ class TestOGDSGroupsGet(IntegrationTestCase):
             browser.json)
 
     @browsing
+    def test_ogds_groups_users_are_sorted(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(self.portal, view='@ogds-groups/projekt_a',
+                     headers=self.api_headers)
+        self.assertEqual(200, browser.status_code)
+        self.assertEqual(
+            [u'B\xe4rfuss', u'Ziegler'],
+            [each['lastname'] for each in browser.json['items']])
+
+        group = ogds_service().fetch_group("projekt_a")
+        group.users.append(ogds_service().fetch_user(self.workspace_member.getId()))
+
+        browser.open(self.portal, view='@ogds-groups/projekt_a',
+                     headers=self.api_headers)
+        self.assertEqual(200, browser.status_code)
+        self.assertEqual(
+            [u'B\xe4rfuss', u'Schr\xf6dinger', u'Ziegler'],
+            [each['lastname'] for each in browser.json['items']])
+
+    @browsing
     def test_raises_bad_request_when_groupid_is_missing(self, browser):
         self.login(self.regular_user, browser=browser)
         browser.exception_bubbling = True

--- a/opengever/api/tests/test_ogdsuserlisting.py
+++ b/opengever/api/tests/test_ogdsuserlisting.py
@@ -1,5 +1,6 @@
 from datetime import date
 from ftw.testbrowser import browsing
+from opengever.ogds.models.service import ogds_service
 from opengever.ogds.models.user import User
 from opengever.testing import IntegrationTestCase
 from zExceptions import BadRequest
@@ -318,3 +319,18 @@ class TestOGDSUserListingGet(IntegrationTestCase):
              u'userid': u'l\xfccklicher.laser'}],
             browser.json['items'])
         self.assertEqual(1, browser.json['items_total'])
+
+    @browsing
+    def test_filter_by_group_membership(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(self.portal,
+                     view='@ogds-user-listing?filters.groupid:record=projekt_a',
+                     headers=self.api_headers)
+
+        self.assertEqual(2, len(browser.json['items']))
+        self.assertEqual(2, browser.json['items_total'])
+        group = ogds_service().fetch_group("projekt_a")
+        self.assertEqual(
+            [user.userid for user in group.users],
+            [user['userid'] for user in browser.json['items']])

--- a/opengever/base/browser/list_groupmembers.py
+++ b/opengever/base/browser/list_groupmembers.py
@@ -19,7 +19,6 @@ class ListGroupMembers(BrowserView):
 
     def __call__(self):
         self.group_id = self.context.REQUEST.get('group', None)
-        self.members = []
 
         if not self.group_id:
             BadRequest('no group id')
@@ -29,7 +28,6 @@ class ListGroupMembers(BrowserView):
 
         actors = [Actor.user(user.userid)
                   for user in getattr(group, 'users', [])]
-        actors.sort(key=lambda actor: actor.get_label())
         self.members = [each.get_link() for each in actors]
 
         return self.template()

--- a/opengever/ogds/models/group.py
+++ b/opengever/ogds/models/group.py
@@ -14,7 +14,6 @@ from sqlalchemy.orm import backref
 from sqlalchemy.orm import relation
 from sqlalchemy.orm import relationship
 
-
 # association table
 groups_users = Table(
     'groups_users', Base.metadata,
@@ -47,7 +46,7 @@ class Group(Base):
     # allowed to be managed over the @groups endpoint.
     is_local = Column(Boolean, default=False, nullable=True)
 
-    users = relation(User, secondary=groups_users,
+    users = relation(User, secondary=groups_users, order_by='User.lastname',
                      backref=backref('groups', order_by='Group.groupid'))
     teams = relationship(Team, back_populates="group")
 


### PR DESCRIPTION
Group member representation in the gever-ui was unsatisfactory. To improve this we wanted 
1. group representatives to be sorted
2. to show a real user listing in the group detail view.
I therefore sorted the user in the ogds Group model and implemented a new `groupid` filter for the `@ogds-user-listing` endpoint. 

For [CA-3754]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-3754]: https://4teamwork.atlassian.net/browse/CA-3754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ