### PR TITLE
Fix search by mailaddress in workspace invitations and mail-in.

### DIFF
--- a/changes/CA-4271.bugfix
+++ b/changes/CA-4271.bugfix
@@ -1,0 +1,1 @@
+Fix search by mailaddress in workspace invitations and mail-in. [phgross]

--- a/opengever/mail/browser/inbound.py
+++ b/opengever/mail/browser/inbound.py
@@ -54,7 +54,7 @@ class GeverMailInbound(MailInbound):
         acl_users = api.portal.get_tool('acl_users')
         pas_search = getMultiAdapter((self.context, self.request),
                                      name='pas_search')
-        users = pas_search.searchUsers(email=sender_email)
+        users = pas_search.searchUsers(email=sender_email, exact_match=True)
         if len(users) > 0:
             user = acl_users.getUserById(users[0].get('userid'))
             if not hasattr(user, 'aq_base'):

--- a/opengever/mail/tests/test_inbound.py
+++ b/opengever/mail/tests/test_inbound.py
@@ -56,6 +56,28 @@ class TestMailInboundSender(IntegrationTestCase):
         self.assertEqual(self.regular_user.getId(), created_mail.Creator())
 
     @browsing
+    def test_sender_email_match_is_exact(self, browser):
+        self.login(self.dossier_responsible)
+
+        # User with similar email adress as regular_user
+        create(Builder('user')
+               .named(u'additional', u'User')
+               .with_email('oo@example.com')
+               .with_userid('additional'))
+
+        msg_txt = (
+            'To: %s\n'
+            'From: %s\n'
+            'Subject: Test' % (self.destination_addr, 'oo@example.com'))
+
+        with self.observe_children(self.dossier) as children:
+            browser.open(self.portal, {'mail': msg_txt}, 'mail-inbound')
+
+        self.assertEqual(
+            '77:Unable to create message. Permission denied.',
+            browser.contents)
+
+    @browsing
     def test_aliases_sender_email_to_user(self, browser):
         self.login(self.dossier_responsible)
 

--- a/opengever/workspace/participation/storage.py
+++ b/opengever/workspace/participation/storage.py
@@ -129,7 +129,7 @@ class InvitationStorage(object):
     def _find_user_id_for_email(self, email):
         pas_search = getMultiAdapter((api.portal.get(), getRequest()),
                                      name='pas_search')
-        users = pas_search.searchUsers(email=email)
+        users = pas_search.searchUsers(email=email, exact_match=True)
         if len(users) > 1:
             raise MultipleUsersFound("Found mulitple users for {}".format(email))
         elif len(users) == 0:

--- a/opengever/workspace/tests/test_participation_storage.py
+++ b/opengever/workspace/tests/test_participation_storage.py
@@ -287,6 +287,27 @@ class TestWorspaceParticipationStorage(IntegrationTestCase):
                         self.workspace_owner.getId(),
                         'WorkspaceGuest')
 
+    def test_user_search_by_mail_match_exact(self):
+        with self.login(self.manager):
+            create(Builder('user')
+                   .named('foo', 'bar')
+                   .with_roles(['Member'])
+                   .in_groups('fa_users')
+                   .with_email('ttwice@example.com'))
+
+            create(Builder('user')
+                   .named('bar', 'qux')
+                   .with_roles(['Member'])
+                   .in_groups('fa_users')
+                   .with_email('twice@example.com'))
+
+        self.login(self.workspace_admin)
+        getUtility(IInvitationStorage).add_invitation(
+            self.workspace,
+            'twice@example.com',
+            self.workspace_owner.getId(),
+            'WorkspaceGuest')
+
     def add_invitation(self, **options):
         options.setdefault('target', self.workspace)
         options.setdefault('recipient_email', self.workspace_guest.getProperty('email'))


### PR DESCRIPTION
Currently when sending a mail to a dossier (mail-in) or inviting a user to a workspace. The search for the user by email address was not exact. This leads to problems when having two users with similar email-adresses like `meier@example.com` and `bergmeier@example.com`. The `exact_match` solves this issue, case insensitivity still works.
 
Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-4271]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-4271]: https://4teamwork.atlassian.net/browse/CA-4271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ