### PR TITLE
Order AllGroupsSource groups by title.

### DIFF
--- a/changes/CA-4296.bugfix
+++ b/changes/CA-4296.bugfix
@@ -1,0 +1,1 @@
+Order AllGroupsSource groups by title. [elioschmutz]

--- a/opengever/ogds/base/sources.py
+++ b/opengever/ogds/base/sources.py
@@ -585,6 +585,7 @@ class AssignedUsersSource(AllUsersSource):
 
         return query
 
+
 @implementer(IContextSourceBinder)
 class AssignedUsersSourceBinder(object):
 
@@ -913,7 +914,10 @@ class AllGroupsSource(BaseSQLModelSource):
 
     @property
     def search_query(self):
-        return self.base_query
+        return self.base_query.order_by(
+            asc(func.lower(Group.title)),
+            asc(func.lower(Group.groupid))
+        )
 
 
 class ActualWorkspaceGroupsSource(AllGroupsSource):


### PR DESCRIPTION
This PR properly orders groups from the `AllGroupsSource` by `title` and `groupid`

## Before
<img width="1027" alt="Bildschirmfoto 2022-06-07 um 16 30 57" src="https://user-images.githubusercontent.com/557005/172406455-b61cce9e-81cc-4a2a-9b9b-d31ebb4c12c2.png">

## After
<img width="1034" alt="Bildschirmfoto 2022-06-07 um 16 30 28" src="https://user-images.githubusercontent.com/557005/172406489-f6d16332-13ee-419c-8970-dc23a82f4f64.png">


For [CA-4296]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-4296]: https://4teamwork.atlassian.net/browse/CA-4296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ