### PR TITLE
Support importing dossier participations in bundle import.

### DIFF
--- a/changes/CA-4037.feature
+++ b/changes/CA-4037.feature
@@ -1,0 +1,1 @@
+Support importing dossier participations in bundle import. [phgross]

--- a/opengever/base/schemadump/schema.py
+++ b/opengever/base/schemadump/schema.py
@@ -304,6 +304,7 @@ class OGGBundleJSONSchemaBuilder(object):
         # Tweak the content type schema for use in OGGBundles
         self._add_review_state_property()
         self._add_guid_properties()
+        self._add_participation_property()
         self._add_permissions_property()
         self._add_file_properties()
         self._add_sequence_number_property()
@@ -358,6 +359,27 @@ class OGGBundleJSONSchemaBuilder(object):
             self.schema._schema['definitions'][self.short_name] = None
 
             self.schema.add_definition('permission', permissions_schema)
+
+    def _add_participation_property(self):
+        if self.portal_type == 'opengever.dossier.businesscasedossier':
+            self.ct_schema.add_property('_participations', {
+                'type': 'array',
+                "items": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {
+                        "participant_id": {
+                            "type": "string"
+                        },
+                        "roles": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            })
 
     def _build_permission_subschema(self):
         subschema = JSONSchema(additional_properties=False)

--- a/opengever/bundle/cfgs/oggbundle.cfg
+++ b/opengever/bundle/cfgs/oggbundle.cfg
@@ -27,6 +27,7 @@ pipeline =
     assignreporootnavigation
     redirect
     set-dates
+    participations
     reindexobject
     savepoint
     progress
@@ -77,6 +78,9 @@ old-paths-key = _old_paths
 
 [set-dates]
 blueprint = opengever.bundle.set_dates
+
+[participations]
+blueprint = opengever.bundle.participations
 
 [savepoint]
 blueprint = collective.transmogrifier.sections.savepoint

--- a/opengever/bundle/schemas/dossiers.schema.json
+++ b/opengever/bundle/schemas/dossiers.schema.json
@@ -377,6 +377,27 @@
                         "type": "array"
                     }
                 },
+                "_participations": {
+                    "type": [
+                        "null",
+                        "array"
+                    ],
+                    "items": {
+                        "additionalProperties": false,
+                        "type": "object",
+                        "properties": {
+                            "roles": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "participant_id": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
                 "_permissions": {
                     "$ref": "#/definitions/permission"
                 },

--- a/opengever/bundle/sections/participations.py
+++ b/opengever/bundle/sections/participations.py
@@ -1,0 +1,61 @@
+from collective.transmogrifier.interfaces import ISection
+from collective.transmogrifier.interfaces import ISectionBlueprint
+from collective.transmogrifier.utils import defaultMatcher
+from opengever.dossier.behaviors.participation import IParticipationAware
+from opengever.dossier.behaviors.participation import IParticipationAwareMarker
+from zope.interface import classProvides
+from zope.interface import implements
+import logging
+
+
+logger = logging.getLogger('opengever.setup.sections.set_dates')
+PARTICIPATIONS_KEY = '_participations'
+
+
+class ParticipationSection(object):
+    """Transmogrifier section which adds dossier participations.
+    """
+
+    implements(ISection)
+    classProvides(ISectionBlueprint)
+
+    def __init__(self, transmogrifier, name, options, previous):
+        self.transmogrifier = transmogrifier
+        self.name = name
+        self.options = options
+        self.previous = previous
+        self.context = transmogrifier.context
+        self.pathkey = defaultMatcher(options, 'path-key', name, 'path')
+
+    def __iter__(self):
+        for item in self.previous:
+            obj = self._get_obj(item)
+            participations = item.get(PARTICIPATIONS_KEY, [])
+            if participations:
+                self.create_participations(obj, participations)
+            yield item
+
+    def create_participations(self, obj, participations):
+        if not IParticipationAwareMarker.providedBy(obj):
+            logger.warn(u'Participations for object {} ignored, participation '
+                        'not supported for this type.'.format(obj))
+            return
+
+        handler = IParticipationAware(obj)
+
+        for participation in participations:
+            handler.add_participation(
+                participation.get('participant_id'),
+                participation.get('roles'),
+                validate=False)
+
+    def _get_obj(self, item):
+        path = item.get(self.pathkey(*item.keys())[0], None)
+        # Skip the Plone site object itself
+        if not path:
+            return None
+
+        obj = self.context.unrestrictedTraverse(
+            path.encode('utf-8').lstrip('/'), None)
+
+        return obj

--- a/opengever/bundle/tests/assets/basic.oggbundle/dossiers.json
+++ b/opengever/bundle/tests/assets/basic.oggbundle/dossiers.json
@@ -8,7 +8,13 @@
     "responsible": "lukas.graf",
     "review_state": "dossier-state-active",
     "start": "2010-11-11",
-    "title": "Dossier Peter Schneider"
+    "title": "Dossier Peter Schneider",
+      "_participations": [
+          {"participant_id": "person:c2a9c298-a769-4c52-affe-0803c11cb571",
+           "roles": ["regard", "participation"]},
+          {"participant_id": "organization:e66b4572-5244-491c-bbe8-32295f8da070",
+           "roles": ["regard"]}
+      ]
   },  {
     "guid": "4ed93561c4004c668feb8124b55897fc",
     "parent_reference": [

--- a/opengever/bundle/tests/test_oggbundle_pipeline.py
+++ b/opengever/bundle/tests/test_oggbundle_pipeline.py
@@ -16,6 +16,7 @@ from opengever.bundle.sections.bundlesource import BUNDLE_KEY
 from opengever.bundle.sections.bundlesource import BUNDLE_PATH_KEY
 from opengever.bundle.sections.constructor import BUNDLE_GUID_KEY
 from opengever.dossier.behaviors.dossier import IDossier
+from opengever.dossier.behaviors.participation import IParticipationAware
 from opengever.propertysheets.utils import get_custom_properties
 from opengever.repository.behaviors.referenceprefix import IReferenceNumberPrefix  # noqa
 from opengever.testing import index_data_for
@@ -407,6 +408,20 @@ class TestOggBundlePipeline(IntegrationTestCase):
         self.assertEqual(
             IAnnotations(dossier)[BUNDLE_GUID_KEY],
             index_data_for(dossier)[GUID_INDEX_NAME])
+
+        participations = IAnnotations(dossier)['participations']
+        self.assertEqual(
+            ['person:c2a9c298-a769-4c52-affe-0803c11cb571',
+             'organization:e66b4572-5244-491c-bbe8-32295f8da070'],
+            participations.keys())
+
+        self.assertEqual(
+            [['regard', 'participation'], ['regard']],
+            [particpation.roles for particpation in participations.values()])
+        self.assertEqual(
+            ['person:c2a9c298-a769-4c52-affe-0803c11cb571',
+             'organization:e66b4572-5244-491c-bbe8-32295f8da070'],
+            [particpation.contact for particpation in participations.values()])
 
     def assert_dossier2_created(self):
         dossier = self.find_by_title(

--- a/opengever/bundle/transmogrifier.zcml
+++ b/opengever/bundle/transmogrifier.zcml
@@ -88,4 +88,9 @@
       name="opengever.bundle.reindex_containers"
       />
 
+  <utility
+      component=".sections.participations.ParticipationSection"
+      name="opengever.bundle.participations"
+      />
+
 </configure>

--- a/opengever/dossier/participations.py
+++ b/opengever/dossier/participations.py
@@ -87,9 +87,10 @@ class PloneParticipationHandler(ParticipationHandlerBase):
             raise InvalidParticipantId(
                 u"{} is not a valid id".format(participant_id))
 
-    def add_participation(self, participant_id, roles):
-        self.validate_participant(participant_id)
-        self.validate_roles(roles)
+    def add_participation(self, participant_id, roles, validate=True):
+        if validate:
+            self.validate_participant(participant_id)
+            self.validate_roles(roles)
         if self.has_participation(participant_id):
             raise DupplicateParticipation(
                 u"There is already a participation for {}".format(participant_id))
@@ -202,8 +203,9 @@ class SQLParticipationHandler(ParticipationHandlerBase):
                 u"{} is not a valid id".format(participant_id))
         return term.value
 
-    def add_participation(self, participant_id, roles):
-        self.validate_roles(roles)
+    def add_participation(self, participant_id, roles, validate=True):
+        if validate:
+            self.validate_roles(roles)
         if self.has_participation(participant_id):
             raise DupplicateParticipation(
                 u"There is already a participation for {}".format(participant_id))


### PR DESCRIPTION
This adds support for an additional key `_participations` in the dossier bundle import which allows to import dossier participations. The participant ids and roles are not validated, this gives us more flexibility during migrations. Moreover, GEVER can handle Ids that no longer exist or are incorrect. 

For [CA-4037]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-4037]: https://4teamwork.atlassian.net/browse/CA-4037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ