### PR TITLE
Add param to share content with all authorized participants in @share-content endpoint

### DIFF
--- a/changes/CA-4125.feature
+++ b/changes/CA-4125.feature
@@ -1,0 +1,1 @@
+Add param ``notify_all` to share content with all authorized participants in @share-content endpoint. [tinagerber]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -15,6 +15,7 @@ Other Changes
 - ``@responses``: Add DELETE endpoint.
 - ``@responses``: Set modifier and modified in PATCH endpoint.
 - ``@ogds-user-listing`` now supports filtering by group membership.
+- ``@share-content``: Add `notify_all` param to share content with all authorized participants.
 
 2022.11.0 (2022-05-24)
 ----------------------

--- a/docs/public/dev-manual/api/workspace/share_content.rst
+++ b/docs/public/dev-manual/api/workspace/share_content.rst
@@ -34,3 +34,24 @@ Mit dem ``@share-content`` Endpoint können Teamräume und Inhalte von Teamräum
   .. sourcecode:: http
 
     HTTP/1.1 204 No Content
+
+
+Wenn der Parameter ``notify_all`` gesetzt, wird, wird an alle berechtigten Teilnehmer eine E-Mail geschickt.
+
+**Beispiel-Request**:
+
+  .. sourcecode:: http
+
+    POST /workspaces/workspace-1/todo-1/@share-content HTTP/1.1
+    Accept: application/json
+
+    {
+      "notify_all": true,
+      "comment": "Have you seen this ToDo yet?"
+    }
+
+**Beispiel-Response**:
+
+  .. sourcecode:: http
+
+    HTTP/1.1 204 No Content


### PR DESCRIPTION
This eliminates the need to select them all individually.

For [CA-4125]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))

[CA-4125]: https://4teamwork.atlassian.net/browse/CA-4125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ