### PR TITLE
Allow current value in single or multiple choice fields for custom properties.

### DIFF
--- a/changes/CA-4012.bugfix
+++ b/changes/CA-4012.bugfix
@@ -1,0 +1,1 @@
+Fix multiple choice field validation for custom properties. [njohner]

--- a/changes/CA-4012.feature
+++ b/changes/CA-4012.feature
@@ -1,0 +1,1 @@
+Support serialization of invalid values for custom choice fields. [njohner]

--- a/changes/CA-4012.feature
+++ b/changes/CA-4012.feature
@@ -1,1 +1,1 @@
-Support serialization of invalid values for custom choice fields. [njohner]
+Allow current value in single or multiple choice fields. [njohner]

--- a/opengever/propertysheets/definition.py
+++ b/opengever/propertysheets/definition.py
@@ -5,6 +5,10 @@ from opengever.propertysheets.default_from_member import attach_member_property_
 from opengever.propertysheets.exceptions import InvalidFieldType
 from opengever.propertysheets.exceptions import InvalidFieldTypeDefinition
 from opengever.propertysheets.exceptions import InvalidSchemaAssignment
+from opengever.propertysheets.helpers import add_current_value_to_allowed_terms
+from opengever.propertysheets.helpers import is_choice_field
+from opengever.propertysheets.helpers import is_multiple_choice_field
+from opengever.propertysheets.interfaces import IDuringPropertySheetFieldDeserialization
 from opengever.propertysheets.schema import get_property_sheet_schema
 from persistent.list import PersistentList
 from persistent.mapping import PersistentMapping
@@ -389,6 +393,11 @@ class PropertySheetSchemaDefinition(object):
 
         for name, field in self.get_fields():
             value = data_to_validate.pop(name, None)
+            if is_choice_field(field) or is_multiple_choice_field(field):
+                request = getRequest()
+                if IDuringPropertySheetFieldDeserialization.providedBy(request):
+                    add_current_value_to_allowed_terms(field, request.context)
+
             field.validate(value)
 
         # prevent setting arbitrary properties, don't allow remainders

--- a/opengever/propertysheets/definition.py
+++ b/opengever/propertysheets/definition.py
@@ -160,6 +160,9 @@ class PropertySheetSchemaDefinition(object):
         """
         if isinstance(field, Choice):
             field._init_field = False
+        elif isinstance(field, Set) and isinstance(field.value_type, Choice):
+            # For multiple choice fields
+            field.value_type._init_field = False
 
     def __eq__(self, other):
         if isinstance(other, PropertySheetSchemaDefinition):

--- a/opengever/propertysheets/deserializer.py
+++ b/opengever/propertysheets/deserializer.py
@@ -1,11 +1,17 @@
 from opengever.propertysheets.field import IPropertySheetField
+from opengever.propertysheets.helpers import add_current_value_to_allowed_terms
+from opengever.propertysheets.helpers import is_choice_field
+from opengever.propertysheets.helpers import is_multiple_choice_field
+from opengever.propertysheets.interfaces import IDuringPropertySheetFieldDeserialization
 from opengever.propertysheets.storage import PropertySheetSchemaStorage
 from plone.dexterity.interfaces import IDexterityContent
 from plone.restapi.deserializer.dxfields import DefaultFieldDeserializer
 from plone.restapi.interfaces import IFieldDeserializer
 from zope.component import adapter
 from zope.component import getMultiAdapter
+from zope.interface import alsoProvides
 from zope.interface import implementer
+from zope.interface import noLongerProvides
 from zope.publisher.interfaces.browser import IBrowserRequest
 from zope.schema import Set
 
@@ -16,8 +22,12 @@ class PropertySheetFieldDeserializer(DefaultFieldDeserializer):
     """Delegate deserialization to property sheet fields."""
 
     def __call__(self, value):
+        alsoProvides(self.request, IDuringPropertySheetFieldDeserialization)
+        self.request.context = self.context
         value = self.deserialize_custom_properties(value)
-        return super(PropertySheetFieldDeserializer, self).__call__(value)
+        resp = super(PropertySheetFieldDeserializer, self).__call__(value)
+        noLongerProvides(self.request, IDuringPropertySheetFieldDeserialization)
+        return resp
 
     def deserialize_custom_properties(self, value):
         """Use property sheet schema fields for deserialization, if a property
@@ -52,6 +62,9 @@ class PropertySheetFieldDeserializer(DefaultFieldDeserializer):
                 # We therefore replace it with an empty list.
                 if isinstance(field, Set) and field_value is None:
                     field_value = []
+
+                if is_choice_field(field) or is_multiple_choice_field(field):
+                    add_current_value_to_allowed_terms(field, self.context)
 
                 data[name] = deserializer(field_value)
 

--- a/opengever/propertysheets/helpers.py
+++ b/opengever/propertysheets/helpers.py
@@ -1,0 +1,31 @@
+from zope.schema import Choice
+from zope.schema import Set
+
+
+def is_choice_field(field):
+    return isinstance(field, Choice)
+
+
+def is_multiple_choice_field(field):
+    return isinstance(field, Set) and isinstance(field.value_type, Choice)
+
+
+def _add_value_to_vocabulary(vocab, value):
+    term = vocab.createTerm(value)
+    vocab._terms.append(term)
+    vocab.by_value[term.value] = term
+    vocab.by_token[term.value] = term
+
+
+def add_current_value_to_allowed_terms(field, context):
+    from opengever.propertysheets.utils import get_custom_properties
+    current_value = get_custom_properties(context).get(field.getName())
+    if not current_value:
+        return
+    if is_choice_field(field):
+        _add_value_to_vocabulary(field.vocabulary, current_value)
+    elif is_multiple_choice_field(field):
+        vocab = field.value_type.vocabulary
+        for value in current_value:
+            if value not in vocab:
+                _add_value_to_vocabulary(vocab, value)

--- a/opengever/propertysheets/interfaces.py
+++ b/opengever/propertysheets/interfaces.py
@@ -1,0 +1,7 @@
+from zope.interface import Interface
+
+
+class IDuringPropertySheetFieldDeserialization(Interface):
+    """Request layer to indicate that we are currently deserializing
+    a property sheet field.
+    """

--- a/opengever/propertysheets/serializer.py
+++ b/opengever/propertysheets/serializer.py
@@ -57,9 +57,9 @@ class PropertySheetFieldSerializer(DefaultFieldSerializer):
                         term = field.vocabulary.getTerm(field_value)
                         data[name] = {"token": term.token, "title": term.title}
                     except LookupError:
-                        # in case of invalid terms we pretend that there is no
-                        # value in storage and drop the field from serialization
-                        del data[name]
+                        # invalid value, but that value was valid sometime in
+                        # the past and should therefore still be serialized.
+                        data[name] = {"token": field_value, "title": field_value}
 
                 elif hasattr(field, 'value_type') and IChoice.providedBy(
                         field.value_type):
@@ -68,11 +68,13 @@ class PropertySheetFieldSerializer(DefaultFieldSerializer):
                     for field_value in field_values:
                         try:
                             term = field.value_type.vocabulary.getTerm(field_value)
-                            tokenized_values.append({"token": term.token, "title": term.title})
+                            tokenized_values.append({"token": term.token,
+                                                     "title": term.title})
                         except LookupError:
-                            # In case of invalid terms we skip them and pretend there
-                            # is no such value
-                            pass
+                            # invalid value, but that value was valid sometime in
+                            # the past and should therefore still be serialized
+                            tokenized_values.append({"token": field_value,
+                                                     "title": field_value})
 
                     data[name] = tokenized_values
 

--- a/opengever/propertysheets/serializer.py
+++ b/opengever/propertysheets/serializer.py
@@ -48,7 +48,7 @@ class PropertySheetFieldSerializer(DefaultFieldSerializer):
                 continue
 
             for name, field in definition.get_fields():
-                if name not in data:
+                if data.get(name) is None:
                     continue
 
                 if IChoice.providedBy(field):

--- a/opengever/propertysheets/tests/test_field.py
+++ b/opengever/propertysheets/tests/test_field.py
@@ -229,6 +229,44 @@ class TestPropertySheetField(FunctionalTestCase):
             }
         )
 
+    def test_multiple_choice_validation_fails_for_invalid_field_data(self):
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field(
+                "multiple_choice", "choose", u"Choose", u"", False, values=['xx']
+            )
+        )
+        self.request["some_request_key"] = [u"question"]
+
+        with self.assertRaises(ValidationError):
+            self.field.validate(
+                {
+                    "IDocumentMetadata.document_type.question": {
+                        "choose": set(['yy']),
+                    }
+                }
+            )
+
+    def test_multiple_choice_validation_with_good_data(self):
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field(
+                "multiple_choice", "choose", u"Choose", u"", True, values=['xx']
+            )
+        )
+        self.request["some_request_key"] = [u"question"]
+        self.field.validate(
+            {
+                "IDocumentMetadata.document_type.question": {
+                    "choose": set(['xx']),
+                }
+            }
+        )
+
     def test_successful_field_validation_with_active_slot_from_request_key(
         self,
     ):

--- a/opengever/propertysheets/tests/test_serializer.py
+++ b/opengever/propertysheets/tests/test_serializer.py
@@ -192,6 +192,34 @@ class TestPropertySheetFieldSerializer(IntegrationTestCase):
             self.serializer(),
         )
 
+    def test_correctly_serializes_none_values_for_choice_fields(self):
+        self.login(self.regular_user)
+
+        choices = ["just one"]
+        create(
+            Builder("property_sheet_schema")
+            .named("schema1")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field(
+                "choice", u"choose", u"Choose", u"", True, values=choices
+            )
+        )
+        self.document.document_type = u"question"
+        IDocumentCustomProperties(self.document).custom_properties = {
+            "IDocumentMetadata.document_type.question": {
+                "choose": None,
+            }
+        }
+
+        self.assertEqual(
+            {
+                "IDocumentMetadata.document_type.question": {
+                    "choose": None,
+                }
+            },
+            self.serializer(),
+        )
+
     def test_greafcully_returns_incorrect_toplevel_data_structure(self):
         self.login(self.regular_user)
 

--- a/opengever/propertysheets/tests/test_serializer.py
+++ b/opengever/propertysheets/tests/test_serializer.py
@@ -147,7 +147,7 @@ class TestPropertySheetFieldSerializer(IntegrationTestCase):
             self.serializer(),
         )
 
-    def test_skips_invalid_vocabulary_values_during_serialization(self):
+    def test_does_not_skip_invalid_vocabulary_values_during_serialization(self):
         self.login(self.regular_user)
 
         choices = ["just one"]
@@ -158,16 +158,38 @@ class TestPropertySheetFieldSerializer(IntegrationTestCase):
             .with_field(
                 "choice", u"choose", u"Choose", u"", True, values=choices
             )
+            .with_field(
+                "multiple_choice", u"multichoose", u"Multi Choose", u"", True, values=choices
+            )
         )
         self.document.document_type = u"question"
         IDocumentCustomProperties(self.document).custom_properties = {
             "IDocumentMetadata.document_type.question": {
                 "choose": "invalid choice",
+                "multichoose": ["just one", "invalid choice"]
             }
         }
 
         self.assertEqual(
-            {"IDocumentMetadata.document_type.question": {}}, self.serializer()
+            {
+                "IDocumentMetadata.document_type.question": {
+                    "choose": {
+                        "title": u"invalid choice",
+                        "token": u"invalid choice"
+                    },
+                    "multichoose": [
+                        {
+                            "title": u"just one",
+                            "token": u"just one"
+                        },
+                        {
+                            "title": u"invalid choice",
+                            "token": u"invalid choice"
+                        },
+                    ]
+                }
+            },
+            self.serializer(),
         )
 
     def test_greafcully_returns_incorrect_toplevel_data_structure(self):


### PR DESCRIPTION
With this PR we modify the behaviour of choice and multiple choice fields for custom properties, ensuring that the current value for such a field remains valid if the list of valid choices is modified. Both serialization and deserialization of the `PropertySheetField` now supports the current value of the field as valid. Moreover I fixed an issue leading to multiple choice fields never being validated.

For [CA-4012]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-4012]: https://4teamwork.atlassian.net/browse/CA-4012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ