### PR TITLE
Always upload blobs to Solr from testserver

### DIFF
--- a/opengever/core/testserver.py
+++ b/opengever/core/testserver.py
@@ -102,23 +102,15 @@ class TestserverLayer(OpengeverFixture):
         # will get the schema from solr and cache it.
         solr.await_ready()
 
-        solr_connection_additional_attributes = ''
-        if SOLR_HOSTNAME != 'localhost':
-            # When the testserver does not run on the same host as solr (such as
-            # when running in docker), we need to upload the blobs over HTTP
-            # since solr cannout access the /tmp of the testserver via disk.
-            solr_connection_additional_attributes = 'upload_blobs="true"'
-
         xmlconfig.string(
             '<configure xmlns:solr="http://namespaces.plone.org/solr">'
             '  <solr:connection host="{SOLR_HOSTNAME}"'
             '                   port="{SOLR_PORT}"'
             '                   base="/solr/{SOLR_CORE}"'
-            '                   {attrs} />'
+            '                   upload_blobs="true"/>'
             '</configure>'.format(SOLR_HOSTNAME=SOLR_HOSTNAME,
                                   SOLR_PORT=SOLR_PORT,
-                                  SOLR_CORE=SOLR_CORE,
-                                  attrs=solr_connection_additional_attributes),
+                                  SOLR_CORE=SOLR_CORE),
             context=configurationContext)
 
         # Clear solr from potential artefacts of the previous run.


### PR DESCRIPTION
Since https://github.com/4teamwork/opengever.core/pull/7427 we run Solr with Docker.
Because of that, blobs always have to be uploaded to Solr. But the testserver did not upload blobs if the Solr hostname was localhost.

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)
