### PR TITLE
Support importing OGDS Users in a bundle import

### DIFF
--- a/docs/public/dev-manual/oggbundle/index.rst
+++ b/docs/public/dev-manual/oggbundle/index.rst
@@ -11,6 +11,8 @@ Changelog:
 +---------------+--------------+-------------+--------------------------------------------------------+
 | **Version**   | **Datum**    | **Autor**   | **Kommentar**                                          |
 +===============+==============+=============+========================================================+
+| 1.2           | 16.06.2022   | PG          | Import von OGDS Usern                                  |
++---------------+--------------+-------------+--------------------------------------------------------+
 | 1.1           | 10.08.2020   | LG          | Import von Teamräumen                                  |
 +---------------+--------------+-------------+--------------------------------------------------------+
 | 1.0           | 16.10.2017   | LG, PG      | Referenzierung von bestehendem Inhalt via Aktenzeichen |
@@ -47,6 +49,8 @@ Importierbare Inhaltstypen
 | **Dokumente**                | Ja          |
 +------------------------------+-------------+
 | **Mails**                    | Ja          |
++------------------------------+-------------+
+| **OGDS Users**               | Ja          |
 +------------------------------+-------------+
 | Kontakte                     | Nein \*     |
 +------------------------------+-------------+
@@ -160,6 +164,16 @@ Siehe untenstehende Erläuterungen im Abschnitt :ref:`files/ <files>` zu Details
 JSON Schema: :ref:`documents.schema.json <documents_schema_json>`
 
 .. _files:
+
+ogds_users.json
+~~~~~~~~~~~~~~~~
+
+Diese Datei beinhaltet die Benutzer welche ins OGDS importiert werden sollen. In der Regel sind es ehemalige, nicht mehr aktive Benutzer welche so importiert werden können.
+
+Der Wert ``guid`` muss der ``userid`` entsprechen.
+
+JSON Schema: :ref:`ogds_users.schema.json <ogds_users_schema_json>`
+
 
 files/
 ~~~~~~
@@ -596,6 +610,22 @@ Die JSON-Schemas, welche die Struktur der JSON-Dateien für die Metadaten defini
        Schema anzeigen
 
     .. literalinclude:: ../../../../opengever/bundle/schemas/workspacefolders.schema.json
+       :language: json
+
+----------
+
+.. _ogds_users_schema_json:
+
+:download:`ogds_users.schema.json <../../../../opengever/bundle/schemas/ogds_users.schema.json>`
+
+
+.. container:: collapsible
+
+    .. container:: header
+
+       Schema anzeigen
+
+    .. literalinclude:: ../../../../opengever/bundle/schemas/ogds_users.schema.json
        :language: json
 
 

--- a/opengever/base/schemadump/config.py
+++ b/opengever/base/schemadump/config.py
@@ -133,6 +133,11 @@ GEVER_SQL_TYPES = [
     '_opengever.ogds.models.group.Group',
 ]
 
+GEVER_SQL_TYPES_TO_OGGBUNDLE_TYPES = {
+    '_opengever.ogds.models.user.User': 'ogds_user',
+}
+
+
 SEQUENCE_NUMBER_LABELS = {
     'opengever.document.document': u'Fortlaufend gez\xe4hlte Nummer eines Dokumentes.',  # noqa
     'opengever.dossier.businesscasedossier': u'Fortlaufend gez\xe4hlte Nummer eines Dossiers.',  # noqa

--- a/opengever/bundle/loader.py
+++ b/opengever/bundle/loader.py
@@ -24,6 +24,7 @@ BUNDLE_JSON_TYPES = OrderedDict([
     ('workspacefolders.json', 'opengever.workspace.folder'),
     ('dossiers.json', 'opengever.dossier.businesscasedossier'),
     ('documents.json', 'opengever.document.document'),   # document or mail
+    ('ogds_users.json', '_opengever.ogds.models.user.User'),   # ogds user
 ])
 
 # This (almost) inverted dict is used in rare cases where we've already lost
@@ -37,6 +38,7 @@ PORTAL_TYPES_TO_JSON_NAME = OrderedDict([
     ('opengever.dossier.businesscasedossier', 'dossiers.json'),
     ('opengever.document.document', 'documents.json'),
     ('ftw.mail.mail', 'documents.json'),
+    ('_opengever.ogds.models.user.User', 'ogds_users.json'),
 ])
 
 GUID_INDEX_NAME = 'bundle_guid'

--- a/opengever/bundle/schemas/ogds_users.schema.json
+++ b/opengever/bundle/schemas/ogds_users.schema.json
@@ -1,0 +1,302 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "array",
+    "items": {
+        "$ref": "#/definitions/ogds_user"
+    },
+    "definitions": {
+        "ogds_user": {
+            "type": "object",
+            "title": "User",
+            "additionalProperties": false,
+            "properties": {
+                "userid": {
+                    "type": "string",
+                    "title": "userid",
+                    "maxLength": 255,
+                    "description": "",
+                    "_zope_schema_type": "Text"
+                },
+                "active": {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "title": "active",
+                    "description": "",
+                    "_zope_schema_type": "Bool",
+                    "default": true
+                },
+                "firstname": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "title": "firstname",
+                    "maxLength": 255,
+                    "description": "",
+                    "_zope_schema_type": "Text"
+                },
+                "lastname": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "title": "lastname",
+                    "maxLength": 255,
+                    "description": "",
+                    "_zope_schema_type": "Text"
+                },
+                "directorate": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "title": "directorate",
+                    "maxLength": 255,
+                    "description": "",
+                    "_zope_schema_type": "Text"
+                },
+                "directorate_abbr": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "title": "directorate_abbr",
+                    "maxLength": 50,
+                    "description": "",
+                    "_zope_schema_type": "Text"
+                },
+                "department": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "title": "department",
+                    "maxLength": 255,
+                    "description": "",
+                    "_zope_schema_type": "Text"
+                },
+                "department_abbr": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "title": "department_abbr",
+                    "maxLength": 50,
+                    "description": "",
+                    "_zope_schema_type": "Text"
+                },
+                "email": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "title": "email",
+                    "maxLength": 255,
+                    "description": "",
+                    "_zope_schema_type": "Text"
+                },
+                "email2": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "title": "email2",
+                    "maxLength": 255,
+                    "description": "",
+                    "_zope_schema_type": "Text"
+                },
+                "url": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "title": "url",
+                    "maxLength": 100,
+                    "description": "",
+                    "_zope_schema_type": "Text"
+                },
+                "phone_office": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "title": "phone_office",
+                    "maxLength": 30,
+                    "description": "",
+                    "_zope_schema_type": "Text"
+                },
+                "phone_fax": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "title": "phone_fax",
+                    "maxLength": 30,
+                    "description": "",
+                    "_zope_schema_type": "Text"
+                },
+                "phone_mobile": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "title": "phone_mobile",
+                    "maxLength": 30,
+                    "description": "",
+                    "_zope_schema_type": "Text"
+                },
+                "salutation": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "title": "salutation",
+                    "maxLength": 30,
+                    "description": "",
+                    "_zope_schema_type": "Text"
+                },
+                "description": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "title": "description",
+                    "description": "",
+                    "_zope_schema_type": "Text"
+                },
+                "address1": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "title": "address1",
+                    "maxLength": 100,
+                    "description": "",
+                    "_zope_schema_type": "Text"
+                },
+                "address2": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "title": "address2",
+                    "maxLength": 100,
+                    "description": "",
+                    "_zope_schema_type": "Text"
+                },
+                "zip_code": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "title": "zip_code",
+                    "maxLength": 10,
+                    "description": "",
+                    "_zope_schema_type": "Text"
+                },
+                "city": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "title": "city",
+                    "maxLength": 100,
+                    "description": "",
+                    "_zope_schema_type": "Text"
+                },
+                "country": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "title": "country",
+                    "maxLength": 20,
+                    "description": "",
+                    "_zope_schema_type": "Text"
+                },
+                "last_login": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "title": "last_login",
+                    "format": "date",
+                    "description": "",
+                    "_zope_schema_type": "Date"
+                },
+                "absent": {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "title": "absent",
+                    "description": "",
+                    "_zope_schema_type": "Bool",
+                    "default": false
+                },
+                "absent_from": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "title": "absent_from",
+                    "format": "date",
+                    "description": "",
+                    "_zope_schema_type": "Date"
+                },
+                "absent_to": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "title": "absent_to",
+                    "format": "date",
+                    "description": "",
+                    "_zope_schema_type": "Date"
+                },
+                "guid": {
+                    "type": "string"
+                },
+                "parent_guid": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            },
+            "required": [
+                "userid",
+                "guid"
+            ],
+            "field_order": [
+                "userid",
+                "active",
+                "firstname",
+                "lastname",
+                "directorate",
+                "directorate_abbr",
+                "department",
+                "department_abbr",
+                "email",
+                "email2",
+                "url",
+                "phone_office",
+                "phone_fax",
+                "phone_mobile",
+                "salutation",
+                "description",
+                "address1",
+                "address2",
+                "zip_code",
+                "city",
+                "country",
+                "last_login",
+                "absent",
+                "absent_from",
+                "absent_to"
+            ]
+        }
+    }
+}

--- a/opengever/bundle/sections/constructor.py
+++ b/opengever/bundle/sections/constructor.py
@@ -258,8 +258,9 @@ class ConstructorSection(object):
         for item in self.previous:
             if item['_type'] in GEVER_SQL_TYPES:
                 obj = self._construct_sql_object(item)
-                self.bundle.constructed_guids.add(item['guid'])
-                logger.info(u'Constructed %r' % obj)
+                if obj:
+                    self.bundle.constructed_guids.add(item['guid'])
+                    logger.info(u'Constructed %r' % obj)
 
                 yield item
                 continue
@@ -290,6 +291,12 @@ class ConstructorSection(object):
         model, primary_key = GEVER_SQL_TYPES_TO_MODEL[item['_type']]
         data = {k: v for (k, v) in item.items()
                 if not k.startswith('_') and k != 'guid'}
+
+        if model.get(item['guid']):
+            logger.warning(
+                u'Could not create object with guid {}. Object already '
+                'exists'.format(item['guid']))
+            return
 
         obj = model(**data)
         session = create_session()

--- a/opengever/bundle/sections/constructor.py
+++ b/opengever/bundle/sections/constructor.py
@@ -38,7 +38,7 @@ TYPES_WITHOUT_REFERENCE_NUMBER = (
 
 
 GEVER_SQL_TYPES_TO_MODEL = {
-    '_opengever.ogds.models.user.User': User,
+    '_opengever.ogds.models.user.User': (User, 'userid'),
 }
 
 
@@ -287,7 +287,7 @@ class ConstructorSection(object):
             yield item
 
     def _construct_sql_object(self, item):
-        model = GEVER_SQL_TYPES_TO_MODEL[item['_type']]
+        model, primary_key = GEVER_SQL_TYPES_TO_MODEL[item['_type']]
         data = {k: v for (k, v) in item.items()
                 if not k.startswith('_') and k != 'guid'}
 

--- a/opengever/bundle/sections/resolveguid.py
+++ b/opengever/bundle/sections/resolveguid.py
@@ -3,6 +3,7 @@ from collective.transmogrifier.interfaces import ISection
 from collective.transmogrifier.interfaces import ISectionBlueprint
 from opengever.base.interfaces import IReferenceNumberFormatter
 from opengever.base.interfaces import IReferenceNumberSettings
+from opengever.base.schemadump.config import GEVER_SQL_TYPES
 from opengever.base.schemadump.config import PARENTABLE_TYPES
 from opengever.base.schemadump.config import ROOT_TYPES
 from opengever.bundle.loader import PORTAL_TYPES_TO_JSON_NAME
@@ -212,9 +213,10 @@ class ResolveGUIDSection(object):
             elif parent_reference is not None:
                 roots.append(item)
 
-            elif item['_type'] in ROOT_TYPES:
+            elif item['_type'] in ROOT_TYPES or item['_type'] in GEVER_SQL_TYPES:
                 # Repo roots and workspace roots are the only types
-                # without a parent pointer
+                # without a parent pointer. Also SQL objects are not part of
+                # the repo tree and must therefore be treated as "roots".
                 roots.append(item)
 
             elif item['_type'] in PARENTABLE_TYPES:

--- a/opengever/bundle/tests/assets/basic.oggbundle/ogds_users.json
+++ b/opengever/bundle/tests/assets/basic.oggbundle/ogds_users.json
@@ -1,0 +1,22 @@
+[
+  {
+    "guid": "peter.muster",
+    "userid": "peter.muster",
+    "firstname": "Peter",
+    "lastname": "Muster",
+    "active": false,
+    "phone_office": "012 345 67 89",
+    "email": "peter.muster@example.com",
+    "description": "Lorem ipsum."
+  },
+  {
+    "guid": "james.green",
+    "userid": "james.green",
+    "firstname": "James",
+    "lastname": "Green",
+    "active": false,
+    "phone_office": "+41 XXX XX XX",
+    "email": "james.green@example.com",
+    "description": "Lorem ipsum."
+  }
+]

--- a/opengever/bundle/tests/helpers.py
+++ b/opengever/bundle/tests/helpers.py
@@ -3,9 +3,11 @@
 
 
 def get_title(item):
-    title = item.get('title_de')
+    title = item.get('title_de', item.get('title'))
     if not title:
-        title = item['title']
+        # fallback for ogds_users
+        title = item.get('userid')
+
     return title
 
 

--- a/opengever/bundle/tests/test_bundle_loader.py
+++ b/opengever/bundle/tests/test_bundle_loader.py
@@ -30,7 +30,7 @@ class TestBundleLoader(TestCase):
 
     def test_loads_correct_number_of_items(self):
         bundle = self.load_bundle()
-        self.assertEqual(16, len(list(bundle)))
+        self.assertEqual(18, len(list(bundle)))
 
     def test_loads_items_in_correct_order(self):
         bundle = self.load_bundle()
@@ -46,7 +46,7 @@ class TestBundleLoader(TestCase):
              ('document', 'Bewerbung Hanspeter M\xc3\xbcller'),
              ('document', 'Entlassung Hanspeter M\xc3\xbcller'),
              ('mail', 'Ein Mail'),
-             ('mail', ''),
+             ('mail', None),
              ('document', 'Document referenced via UNC-Path'),
              ('document', 'Nonexistent document referenced via UNC-Path with Umlaut'),
              ('document', 'Dokument in bestehendem Examplecontent Dossier'),
@@ -73,6 +73,8 @@ class TestBundleLoader(TestCase):
     def test_inserts_portal_type(self):
         bundle = self.load_bundle()
         self.assertEqual([
+            ('User', 'james.green'),
+            ('User', 'peter.muster'),
             ('businesscasedossier', 'Dossier Peter Schneider'),
             ('businesscasedossier',
              'Dossier in bestehendem Examplecontent Repository'),
@@ -82,7 +84,7 @@ class TestBundleLoader(TestCase):
             ('document', 'Dokument in bestehendem Examplecontent Dossier'),
             ('document', 'Entlassung Hanspeter M\xc3\xbcller'),
             ('document', 'Nonexistent document referenced via UNC-Path with Umlaut'),
-            ('mail', ''),
+            ('mail', None),
             ('mail', 'Ein Mail'),
             ('mail', 'Mail in bestehendem Examplecontent Dossier'),
             ('mail', 'Signiertes Mail.'),

--- a/opengever/bundle/tests/test_bundle_loader.py
+++ b/opengever/bundle/tests/test_bundle_loader.py
@@ -51,7 +51,9 @@ class TestBundleLoader(TestCase):
              ('document', 'Nonexistent document referenced via UNC-Path with Umlaut'),
              ('document', 'Dokument in bestehendem Examplecontent Dossier'),
              ('mail', 'Mail in bestehendem Examplecontent Dossier'),
-             ('mail', 'Signiertes Mail.')],
+             ('mail', 'Signiertes Mail.'),
+             ('User', 'peter.muster'),
+             ('User', 'james.green')],
             [(get_portal_type(i), get_title(i)) for i in list(bundle)])
 
     def test_loaded_items_contain_bytestrings(self):

--- a/opengever/bundle/tests/test_oggbundle_pipeline.py
+++ b/opengever/bundle/tests/test_oggbundle_pipeline.py
@@ -17,6 +17,7 @@ from opengever.bundle.sections.bundlesource import BUNDLE_PATH_KEY
 from opengever.bundle.sections.constructor import BUNDLE_GUID_KEY
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.behaviors.participation import IParticipationAware
+from opengever.ogds.models.user import User
 from opengever.propertysheets.utils import get_custom_properties
 from opengever.repository.behaviors.referenceprefix import IReferenceNumberPrefix  # noqa
 from opengever.testing import index_data_for
@@ -186,6 +187,7 @@ class TestOggBundlePipeline(IntegrationTestCase):
         self.assert_document4_created(dossier)
         self.assert_document5_created()
         self.assert_mail3_created()
+        self.assert_ogds_users_created()
 
         self.assert_report_data_collected(bundle)
         self.assert_redirects_registered(dossier)
@@ -706,6 +708,23 @@ class TestOggBundlePipeline(IntegrationTestCase):
             IAnnotations(mail)[BUNDLE_GUID_KEY],
             index_data_for(mail)[GUID_INDEX_NAME])
 
+    def assert_ogds_users_created(self):
+        peter = User.query.get('peter.muster')
+        self.assertFalse(peter.active)
+        self.assertEqual('Peter', peter.firstname)
+        self.assertEqual('Muster', peter.lastname)
+        self.assertEqual('peter.muster@example.com', peter.email)
+        self.assertEqual('Lorem ipsum.', peter.description)
+        self.assertEqual('012 345 67 89', peter.phone_office)
+
+        james = User.query.get('james.green')
+        self.assertFalse(james.active)
+        self.assertEqual('James', james.firstname)
+        self.assertEqual('Green', james.lastname)
+        self.assertEqual('james.green@example.com', james.email)
+        self.assertEqual('Lorem ipsum.', james.description)
+        self.assertEqual('+41 XXX XX XX', james.phone_office)
+
     def assert_report_data_collected(self, bundle):
         report_data = bundle.report_data
         metadata = report_data['metadata']
@@ -719,7 +738,8 @@ class TestOggBundlePipeline(IntegrationTestCase):
                 'opengever.workspace.folder',
                 'opengever.dossier.businesscasedossier',
                 'opengever.document.document',
-                'ftw.mail.mail']),
+                'ftw.mail.mail',
+                '_opengever.ogds.models.user.User']),
             set(metadata.keys()))
 
         reporoots = metadata['opengever.repository.repositoryroot']
@@ -730,6 +750,7 @@ class TestOggBundlePipeline(IntegrationTestCase):
         dossiers = metadata['opengever.dossier.businesscasedossier']
         documents = metadata['opengever.document.document']
         mails = metadata['ftw.mail.mail']
+        ogds_users = metadata['_opengever.ogds.models.user.User']
 
         self.assertEqual(1, len(reporoots))
         self.assertEqual(3, len(repofolders))
@@ -739,6 +760,7 @@ class TestOggBundlePipeline(IntegrationTestCase):
         self.assertEqual(3, len(dossiers))
         self.assertEqual(5, len(documents))
         self.assertEqual(4, len(mails))
+        self.assertEqual(2, len(ogds_users))
 
     def assert_navigation_portlet_assigned(self, root):
         manager = getUtility(

--- a/opengever/bundle/tests/test_section_bundlesource.py
+++ b/opengever/bundle/tests/test_section_bundlesource.py
@@ -34,7 +34,7 @@ class TestBundleSource(FunctionalTestCase):
 
     def test_yields_items_from_bundle(self):
         source = self.setup_source({})
-        self.assertEqual(16, len(list(source)))
+        self.assertEqual(18, len(list(source)))
 
     def test_raises_if_bundle_path_missing(self):
         transmogrifier = MockTransmogrifier()

--- a/opengever/bundle/tests/test_teamraum_oggbundle_pipeline.py
+++ b/opengever/bundle/tests/test_teamraum_oggbundle_pipeline.py
@@ -280,7 +280,8 @@ class TestTeamraumOggBundlePipeline(IntegrationTestCase):
                 'opengever.workspace.folder',
                 'opengever.dossier.businesscasedossier',
                 'opengever.document.document',
-                'ftw.mail.mail']),
+                'ftw.mail.mail',
+                '_opengever.ogds.models.user.User']),
             set(metadata.keys()))
 
         workspaceroots = metadata['opengever.workspace.root']
@@ -291,6 +292,7 @@ class TestTeamraumOggBundlePipeline(IntegrationTestCase):
         dossiers = metadata['opengever.dossier.businesscasedossier']
         documents = metadata['opengever.document.document']
         mails = metadata['ftw.mail.mail']
+        ogds_users = metadata['_opengever.ogds.models.user.User']
 
         self.assertEqual(1, len(workspaceroots))
         self.assertEqual(1, len(workspaces))
@@ -300,3 +302,4 @@ class TestTeamraumOggBundlePipeline(IntegrationTestCase):
         self.assertEqual(0, len(dossiers))
         self.assertEqual(1, len(documents))
         self.assertEqual(1, len(mails))
+        self.assertEqual(0, len(ogds_users))

--- a/opengever/bundle/tests/test_teamraum_oggbundle_rootless_pipeline.py
+++ b/opengever/bundle/tests/test_teamraum_oggbundle_rootless_pipeline.py
@@ -138,7 +138,8 @@ class TestTeamraumOggBundleRootlessPipeline(IntegrationTestCase):
                 'opengever.workspace.folder',
                 'opengever.dossier.businesscasedossier',
                 'opengever.document.document',
-                'ftw.mail.mail']),
+                'ftw.mail.mail',
+                '_opengever.ogds.models.user.User']),
             set(metadata.keys()))
 
         workspaceroots = metadata['opengever.workspace.root']
@@ -149,6 +150,7 @@ class TestTeamraumOggBundleRootlessPipeline(IntegrationTestCase):
         dossiers = metadata['opengever.dossier.businesscasedossier']
         documents = metadata['opengever.document.document']
         mails = metadata['ftw.mail.mail']
+        ogds_users = metadata['_opengever.ogds.models.user.User']
 
         self.assertEqual(0, len(workspaceroots))
         self.assertEqual(1, len(workspaces))
@@ -158,3 +160,4 @@ class TestTeamraumOggBundleRootlessPipeline(IntegrationTestCase):
         self.assertEqual(0, len(dossiers))
         self.assertEqual(0, len(documents))
         self.assertEqual(0, len(mails))
+        self.assertEqual(0, len(ogds_users))


### PR DESCRIPTION
With this PR the bunde import now also provide the possibility to import SQL objects, currently only OGDS Users are supported. But I implemented a generic way, so that support for other SQL Objects could be easily added.

Used for [CA-4038], where the goal is to import old, inactive users into the ogds.

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-4038]: https://4teamwork.atlassian.net/browse/CA-4038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ