### PR TITLE
Add chair, secretary and attendees presence state to workspace meeting

### DIFF
--- a/changes/CA-4154.feature
+++ b/changes/CA-4154.feature
@@ -1,0 +1,1 @@
+Add chair, secretary and attendees presence state to workspace meeting. [tinagerber]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -17,6 +17,7 @@ Other Changes
 - ``@responses``: Set modifier and modified in PATCH endpoint.
 - ``@ogds-user-listing`` now supports filtering by group membership.
 - ``@share-content``: Add `notify_all` param to share content with all authorized participants.
+- A new endpoint ``@attendees-presence-states`` is added (see :ref:`docs <attendees_presence_states>`).
 
 2022.11.0 (2022-05-24)
 ----------------------

--- a/docs/public/dev-manual/api/schemas/opengever.workspace.meeting.inc
+++ b/docs/public/dev-manual/api/schemas/opengever.workspace.meeting.inc
@@ -14,6 +14,26 @@
        :Wertebereich: <Gültige User-ID>
 
 
+   .. py:attribute:: chair
+
+       :Feldname: :field-title:`Sitzungsleitung`
+       :Datentyp: ``Choice``
+       
+       
+       
+       :Wertebereich: <Gültige User-ID>
+
+
+   .. py:attribute:: secretary
+
+       :Feldname: :field-title:`Protokollführung`
+       :Datentyp: ``Choice``
+       
+       
+       
+       :Wertebereich: <Gültige User-ID>
+
+
    .. py:attribute:: start
 
        :Feldname: :field-title:`Beginn`

--- a/docs/public/dev-manual/api/workspace/attendees_presence_states.rst
+++ b/docs/public/dev-manual/api/workspace/attendees_presence_states.rst
@@ -1,0 +1,24 @@
+.. _attendees_presence_states:
+
+Anwesenheitsstatus von Meeting-Teilnehmern bearbeiten
+=====================================================
+
+Mit dem ``@attendees-presence-states`` Endpoint kann der Anwesenheitsstatus von Meeting-Teilnehmern bearbeitet werden. Es stehen drei verschiedene Status zur Verfügung: ``present``, ``excused`` und ``absent``.
+
+**Beispiel-Request**:
+
+  .. sourcecode:: http
+
+    PATCH /workspaces/workspace-1/workspace-meeting-1/@attendees-presences-states HTTP/1.1
+    Accept: application/json
+
+    {
+      "kathi.barfuss": "excused",
+      "robert.ziegler": "absent",
+    }
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 204 No Content

--- a/docs/public/dev-manual/api/workspace/index.rst
+++ b/docs/public/dev-manual/api/workspace/index.rst
@@ -17,3 +17,4 @@ Hier werden alle Teamraum-Schnittstellen beschrieben, welche von OneGov GEVER un
    workspace_content_members
    share_content
    accessible_workspaces
+   attendees_presence_states

--- a/docs/schema-dumps/opengever.workspace.meeting.schema.json
+++ b/docs/schema-dumps/opengever.workspace.meeting.schema.json
@@ -11,6 +11,20 @@
             "_zope_schema_type": "Choice",
             "_vocabulary": "<G\u00fcltige User-ID>"
         },
+        "chair": {
+            "type": "string",
+            "title": "Sitzungsleitung",
+            "description": "",
+            "_zope_schema_type": "Choice",
+            "_vocabulary": "<G\u00fcltige User-ID>"
+        },
+        "secretary": {
+            "type": "string",
+            "title": "Protokollf\u00fchrung",
+            "description": "",
+            "_zope_schema_type": "Choice",
+            "_vocabulary": "<G\u00fcltige User-ID>"
+        },
         "start": {
             "type": "string",
             "title": "Beginn",
@@ -71,6 +85,8 @@
     ],
     "field_order": [
         "responsible",
+        "chair",
+        "secretary",
         "start",
         "end",
         "location",

--- a/opengever/api/attendees_presence_states.py
+++ b/opengever/api/attendees_presence_states.py
@@ -1,0 +1,34 @@
+from opengever.api import _
+from opengever.api.not_reported_exceptions import BadRequest as NotReportedBadRequest
+from opengever.workspace.interfaces import IWorkspaceMeetingAttendeesPresenceStateStorage
+from opengever.workspace.workspace_meeting import ALLOWED_ATTENDEES_PRESENCE_STATES
+from plone.protect.interfaces import IDisableCSRFProtection
+from plone.restapi.deserializer import json_body
+from plone.restapi.services import Service
+from zope.interface import alsoProvides
+from zope.interface import implementer
+from zope.publisher.interfaces import IPublishTraverse
+
+
+@implementer(IPublishTraverse)
+class AttendeesPreseneceStatesPatch(Service):
+    """Edit presence states of workspace meeting attendees.
+    """
+
+    def reply(self):
+        # Disable CSRF protection
+        alsoProvides(self.request, IDisableCSRFProtection)
+        data = json_body(self.request)
+        for userid, state in data.items():
+            if userid not in self.context.attendees:
+                raise NotReportedBadRequest(
+                    _(u'userid_not_in_attendees',
+                      default=u'User with userid ${userid} is not a participant in this meeting.',
+                      mapping={'userid': userid}))
+            if state not in ALLOWED_ATTENDEES_PRESENCE_STATES.keys():
+                raise NotReportedBadRequest(
+                    _(u'invalid_presence_state',
+                      default=u'State ${state} does not exist.',
+                      mapping={'state': state}))
+            IWorkspaceMeetingAttendeesPresenceStateStorage(self.context).add_or_update(userid, state)
+        return self.reply_no_content()

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -1725,4 +1725,12 @@
       permission="opengever.ogds.base.SyncOgds"
       />
 
+  <plone:service
+      method="PATCH"
+      name="@attendees-presence-states"
+      for="opengever.workspace.interfaces.IWorkspaceMeeting"
+      factory=".attendees_presence_states.AttendeesPreseneceStatesPatch"
+      permission="cmf.ModifyPortalContent"
+      />
+
 </configure>

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -53,6 +53,7 @@
   <adapter factory=".kub.SerializeKuBEntityToJson" />
   <adapter factory=".mail.SerializeMailToJson" />
   <adapter factory=".workspace.SerializeWorkspaceToJson" />
+  <adapter factory=".workspace_meeting.SerializeWorkspaceMeetingToJson" />
   <adapter factory=".response.ResponseDefaultFieldSerializer" />
   <adapter factory=".response.SerializeResponseToJson" />
   <adapter factory=".substitutes.SerializeSubstituteToJson" />

--- a/opengever/api/locales/de/LC_MESSAGES/opengever.api.po
+++ b/opengever/api/locales/de/LC_MESSAGES/opengever.api.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-05-30 09:50+0000\n"
+"POT-Creation-Date: 2022-06-16 14:08+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -46,6 +46,11 @@ msgstr "${actorid} ist schon Teilnehmer"
 #: ./opengever/api/tus.py
 msgid "error_proposal_document_type"
 msgstr "Es ist nicht möglich, Dokumente, die nicht im Format docx vorliegen, als Antragsdokumente zu verwenden."
+
+#. Default: "State ${state} does not exist."
+#: ./opengever/api/attendees_presence_states.py
+msgid "invalid_presence_state"
+msgstr "Status ${state} existiert nicht."
 
 #. Default: "Role ${role} is not available. Available roles are: ${allowed_roles}"
 #: ./opengever/api/participations.py
@@ -181,6 +186,11 @@ msgstr "Nur Antworten vom Typ \"Kommentar\" können gelöscht werden."
 #: ./opengever/api/linked_workspaces.py
 msgid "participant_required"
 msgstr "Parameter 'participants' ist erforderlich"
+
+#. Default: "User with userid ${userid} is not a participant in this meeting."
+#: ./opengever/api/attendees_presence_states.py
+msgid "userid_not_in_attendees"
+msgstr "Der Benutzer mit der Benutzer-ID ${userid} ist kein Teilnehmer in diesem Meeting."
 
 #. Default: "Property 'workspace_uid' is required"
 #: ./opengever/api/linked_workspaces.py

--- a/opengever/api/locales/en/LC_MESSAGES/opengever.api.po
+++ b/opengever/api/locales/en/LC_MESSAGES/opengever.api.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-05-30 09:50+0000\n"
+"POT-Creation-Date: 2022-06-16 14:08+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -46,6 +46,11 @@ msgstr "The participant ${actorid} already exists"
 #: ./opengever/api/tus.py
 msgid "error_proposal_document_type"
 msgstr "Only docx documents are allowed as proposal documents."
+
+#. Default: "State ${state} does not exist."
+#: ./opengever/api/attendees_presence_states.py
+msgid "invalid_presence_state"
+msgstr "State ${state} does not exist."
 
 #. Default: "Role ${role} is not available. Available roles are: ${allowed_roles}"
 #: ./opengever/api/participations.py
@@ -181,6 +186,11 @@ msgstr "Only responses of type \"Comment\" can be edited."
 #: ./opengever/api/linked_workspaces.py
 msgid "participant_required"
 msgstr "Property 'participants' is required"
+
+#. Default: "User with userid ${userid} is not a participant in this meeting."
+#: ./opengever/api/attendees_presence_states.py
+msgid "userid_not_in_attendees"
+msgstr "User with userid ${userid} is not a participant in this meeting."
 
 #. Default: "Property 'workspace_uid' is required"
 #: ./opengever/api/linked_workspaces.py

--- a/opengever/api/locales/fr/LC_MESSAGES/opengever.api.po
+++ b/opengever/api/locales/fr/LC_MESSAGES/opengever.api.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-05-30 09:50+0000\n"
+"POT-Creation-Date: 2022-06-16 14:08+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -46,6 +46,11 @@ msgstr "${actorid} est déjà participant"
 #: ./opengever/api/tus.py
 msgid "error_proposal_document_type"
 msgstr "Seuls les fichiers docx sont autorisés comme documents de requête."
+
+#. Default: "State ${state} does not exist."
+#: ./opengever/api/attendees_presence_states.py
+msgid "invalid_presence_state"
+msgstr ""
 
 #. Default: "Role ${role} is not available. Available roles are: ${allowed_roles}"
 #: ./opengever/api/participations.py
@@ -181,6 +186,11 @@ msgstr ""
 #: ./opengever/api/linked_workspaces.py
 msgid "participant_required"
 msgstr "Le paramètre 'participants' est requis"
+
+#. Default: "User with userid ${userid} is not a participant in this meeting."
+#: ./opengever/api/attendees_presence_states.py
+msgid "userid_not_in_attendees"
+msgstr ""
 
 #. Default: "Property 'workspace_uid' is required"
 #: ./opengever/api/linked_workspaces.py

--- a/opengever/api/locales/opengever.api.pot
+++ b/opengever/api/locales/opengever.api.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-05-30 09:50+0000\n"
+"POT-Creation-Date: 2022-06-16 14:08+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -48,6 +48,11 @@ msgstr ""
 #. Default: "It's not possible to have non-.docx documents as proposal documents."
 #: ./opengever/api/tus.py
 msgid "error_proposal_document_type"
+msgstr ""
+
+#. Default: "State ${state} does not exist."
+#: ./opengever/api/attendees_presence_states.py
+msgid "invalid_presence_state"
 msgstr ""
 
 #. Default: "Role ${role} is not available. Available roles are: ${allowed_roles}"
@@ -183,6 +188,11 @@ msgstr ""
 #. Default: "Property 'participants' is required"
 #: ./opengever/api/linked_workspaces.py
 msgid "participant_required"
+msgstr ""
+
+#. Default: "User with userid ${userid} is not a participant in this meeting."
+#: ./opengever/api/attendees_presence_states.py
+msgid "userid_not_in_attendees"
 msgstr ""
 
 #. Default: "Property 'workspace_uid' is required"

--- a/opengever/api/tests/test_attendees_presence_states.py
+++ b/opengever/api/tests/test_attendees_presence_states.py
@@ -1,0 +1,64 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+import json
+
+
+class TestAttendeesPresenceStatesPatch(IntegrationTestCase):
+
+    @browsing
+    def test_patch_attendees_presence_states(self, browser):
+        self.login(self.workspace_member, browser)
+        browser.open(self.workspace_meeting, method='PATCH', headers=self.api_headers,
+                     data=json.dumps({'attendees': [self.workspace_guest.id,
+                                                    self.workspace_admin.id,
+                                                    self.workspace_owner.id]}))
+
+        browser.open(self.workspace_meeting, method='GET', headers=self.api_headers)
+        self.assertEqual({self.workspace_admin.id: u'present',
+                          self.workspace_guest.id: u'present',
+                          self.workspace_owner.id: u'present'},
+                         browser.json['attendees_presence_states'])
+
+        browser.open(self.workspace_meeting, view='@attendees-presence-states', method='PATCH',
+                     headers=self.api_headers, data=json.dumps(
+                         {self.workspace_owner.id: u'absent', self.workspace_admin.id: u'excused'}))
+        self.assertEqual(204, browser.status_code)
+
+        browser.open(self.workspace_meeting, method='GET', headers=self.api_headers)
+        self.assertEqual({self.workspace_admin.id: u'excused',
+                          self.workspace_guest.id: u'present',
+                          self.workspace_owner.id: u'absent'},
+                         browser.json['attendees_presence_states'])
+
+    @browsing
+    def test_cannot_patch_state_of_user_who_is_not_an_attendee(self, browser):
+        self.login(self.workspace_member, browser)
+        browser.open(self.workspace_meeting, method='PATCH', headers=self.api_headers,
+                     data=json.dumps({'attendees': [self.workspace_guest.id,
+                                                    self.workspace_owner.id]}))
+
+        with browser.expect_http_error(400):
+            browser.open(self.workspace_meeting, view='@attendees-presence-states',
+                         method='PATCH', headers=self.api_headers,
+                         data=json.dumps({self.workspace_admin.id: u'excused'}))
+
+        self.assertEqual({u'type': u'BadRequest', u'additional_metadata': {},
+                          u'translated_message': u'User with userid fridolin.hugentobler '
+                                                 u'is not a participant in this meeting.',
+                          u'message': u'userid_not_in_attendees'}, browser.json)
+
+    @browsing
+    def test_cannot_patch_invalid_presence_state_raises_bad_request(self, browser):
+        self.login(self.workspace_member, browser)
+        browser.open(self.workspace_meeting, method='PATCH', headers=self.api_headers,
+                     data=json.dumps({'attendees': [self.workspace_guest.id,
+                                                    self.workspace_owner.id]}))
+
+        with browser.expect_http_error(400):
+            browser.open(self.workspace_meeting, view='@attendees-presence-states',
+                         method='PATCH', headers=self.api_headers,
+                         data=json.dumps({self.workspace_guest.id: u'too late'}))
+
+        self.assertEqual({u'type': u'BadRequest', u'additional_metadata': {},
+                          u'translated_message': u'State too late does not exist.',
+                          u'message': u'invalid_presence_state'}, browser.json)

--- a/opengever/api/workspace_meeting.py
+++ b/opengever/api/workspace_meeting.py
@@ -1,0 +1,18 @@
+from opengever.api.serializer import GeverSerializeFolderToJson
+from opengever.workspace.interfaces import IWorkspaceMeeting
+from opengever.workspace.interfaces import IWorkspaceMeetingAttendeesPresenceStateStorage
+from plone.restapi.interfaces import ISerializeToJson
+from zope.component import adapter
+from zope.interface import implementer
+from zope.interface import Interface
+
+
+@implementer(ISerializeToJson)
+@adapter(IWorkspaceMeeting, Interface)
+class SerializeWorkspaceMeetingToJson(GeverSerializeFolderToJson):
+
+    def __call__(self, *args, **kwargs):
+        result = super(SerializeWorkspaceMeetingToJson, self).__call__(*args, **kwargs)
+        storage = IWorkspaceMeetingAttendeesPresenceStateStorage(self.context)
+        result['attendees_presence_states'] = storage.get_all()
+        return result

--- a/opengever/base/schemadump/config.py
+++ b/opengever/base/schemadump/config.py
@@ -154,7 +154,9 @@ VOCAB_OVERRIDES = {
         'language': u'<Ein g\xfcltiger Sprach-Code (de, en, fr...)>'
     },
     'opengever.workspace.workspace_meeting.IWorkspaceMeetingSchema': {
+        'chair': u'<G\xfcltige User-ID>',
         'responsible': u'<G\xfcltige User-ID>',
+        'secretary': u'<G\xfcltige User-ID>',
     },
     'opengever.workspace.workspace.IWorkspaceSchema': {
         'responsible': u'<G\xfcltige ID eines Teamraum Teilnehmers>',

--- a/opengever/workspace/browser/templates/meeting_minutes.pt
+++ b/opengever/workspace/browser/templates/meeting_minutes.pt
@@ -102,6 +102,14 @@ a {
       <th><span i18n:translate="label_responsible">Responsible</span>:</th>
       <td tal:content="options/responsible"></td>
     </tr>
+    <tr tal:condition="options/chair">
+      <th><span i18n:translate="label_chair">Chair</span>:</th>
+      <td tal:content="options/chair"></td>
+    </tr>
+    <tr tal:condition="options/secretary">
+      <th><span i18n:translate="label_secretary">Secretary</span>:</th>
+      <td tal:content="options/secretary"></td>
+    </tr>
     <tr tal:condition="options/attendees" class="attendees">
       <th><span i18n:translate="label_attendees">Attendees</span>:</th>
       <td>

--- a/opengever/workspace/configure.zcml
+++ b/opengever/workspace/configure.zcml
@@ -16,6 +16,7 @@
   <adapter factory=".sequence.TodoListSequenceNumberGenerator" />
   <adapter factory=".sequence.TodoSequenceNumberGenerator" />
   <adapter factory=".sequence.WorkspaceMeetingSequenceNumberGenerator" />
+  <adapter factory=".workspace_meeting.WorkspaceMeetingAttendeesPresenceStateStorage" />
 
   <adapter
       factory=".actions.WorkspaceFolderListingActions"

--- a/opengever/workspace/interfaces.py
+++ b/opengever/workspace/interfaces.py
@@ -84,3 +84,20 @@ class IWorkspaceMeetingAgendaItem(Interface):
 class IDeleter(Interface):
     """Interface for the Deleter adapter.
     """
+
+
+class IWorkspaceMeetingAttendeesPresenceStateStorage(Interface):
+    """Attendees presence state storage adapter.
+    """
+
+    def add_or_update(self, userid, state):
+        """ Add or update the presence state of the attendee with the given userid
+        """
+
+    def delete(self, userid):
+        """ Delete the presence state of the attendee with the given userid
+        """
+
+    def get_all(self):
+        """ Get the presence states of all attendees
+        """

--- a/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-03-22 12:17+0000\n"
+"POT-Creation-Date: 2022-06-17 09:57+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -150,6 +150,12 @@ msgstr ""
 msgid "label_attendees"
 msgstr "Teilnehmer"
 
+#. Default: "Chair"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
+#: ./opengever/workspace/workspace_meeting.py
+msgid "label_chair"
+msgstr "Sitzungsleitung"
+
 #. Default: "Date"
 #: ./opengever/workspace/browser/templates/meeting_minutes.pt
 msgid "label_date"
@@ -228,6 +234,12 @@ msgstr "Verweise"
 #: ./opengever/workspace/todo.py
 msgid "label_responsible"
 msgstr "Verantwortlich"
+
+#. Default: "Secretary"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
+#: ./opengever/workspace/workspace_meeting.py
+msgid "label_secretary"
+msgstr "Protokollführung"
 
 #. Default: "Start"
 #: ./opengever/workspace/workspace_meeting.py

--- a/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
@@ -93,6 +93,16 @@ msgstr "Gast"
 msgid "WorkspaceMember"
 msgstr "Teammitglied"
 
+#. Default: "absent"
+#: ./opengever/workspace/workspace_meeting.py
+msgid "absent"
+msgstr "abwesend"
+
+#. Default: "excused"
+#: ./opengever/workspace/workspace_meeting.py
+msgid "excused"
+msgstr "entschuldigt"
+
 #. Default: "Common"
 #: ./opengever/workspace/workspace_meeting.py
 msgid "fieldset_common"
@@ -308,6 +318,11 @@ msgstr "Teamräume"
 #: ./opengever/workspace/participation/browser/manage_participants.py
 msgid "msg_one_must_remain_admin"
 msgstr "Mindestens ein Teilnehmer muss Administrator bleiben."
+
+#. Default: "present"
+#: ./opengever/workspace/workspace_meeting.py
+msgid "present"
+msgstr "anwesend"
 
 #. Default: "Comment"
 #: ./opengever/workspace/content_sharing_mailer.py

--- a/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
@@ -112,6 +112,16 @@ msgstr "Guest"
 msgid "WorkspaceMember"
 msgstr "Member"
 
+#. Default: "absent"
+#: ./opengever/workspace/workspace_meeting.py
+msgid "absent"
+msgstr "absent"
+
+#. Default: "excused"
+#: ./opengever/workspace/workspace_meeting.py
+msgid "excused"
+msgstr "excused"
+
 #. German translation: Allgemein
 #. Default: "Common"
 #: ./opengever/workspace/workspace_meeting.py
@@ -356,6 +366,11 @@ msgstr "Workspaces"
 #: ./opengever/workspace/participation/browser/manage_participants.py
 msgid "msg_one_must_remain_admin"
 msgstr "At least one principal must remain admin."
+
+#. Default: "present"
+#: ./opengever/workspace/workspace_meeting.py
+msgid "present"
+msgstr "present"
 
 #. German translation: Kommentar
 #. Default: "Comment"

--- a/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-03-22 12:17+0000\n"
+"POT-Creation-Date: 2022-06-17 09:57+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -176,6 +176,12 @@ msgstr ""
 msgid "label_attendees"
 msgstr "Attendees"
 
+#. Default: "Chair"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
+#: ./opengever/workspace/workspace_meeting.py
+msgid "label_chair"
+msgstr "Chair"
+
 #. Default: "Date"
 #: ./opengever/workspace/browser/templates/meeting_minutes.pt
 msgid "label_date"
@@ -264,6 +270,12 @@ msgstr "Related items"
 #: ./opengever/workspace/todo.py
 msgid "label_responsible"
 msgstr "Responsible"
+
+#. Default: "Secretary"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
+#: ./opengever/workspace/workspace_meeting.py
+msgid "label_secretary"
+msgstr "Secretary"
 
 #. German translation: Beginn
 #. Default: "Start"

--- a/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
@@ -93,6 +93,16 @@ msgstr "Invité"
 msgid "WorkspaceMember"
 msgstr "Membre du team"
 
+#. Default: "absent"
+#: ./opengever/workspace/workspace_meeting.py
+msgid "absent"
+msgstr "absent"
+
+#. Default: "excused"
+#: ./opengever/workspace/workspace_meeting.py
+msgid "excused"
+msgstr "excusé"
+
 #. Default: "Common"
 #: ./opengever/workspace/workspace_meeting.py
 msgid "fieldset_common"
@@ -308,6 +318,11 @@ msgstr "Teamraüme"
 #: ./opengever/workspace/participation/browser/manage_participants.py
 msgid "msg_one_must_remain_admin"
 msgstr "Au moins un participant doit être admin."
+
+#. Default: "present"
+#: ./opengever/workspace/workspace_meeting.py
+msgid "present"
+msgstr "présent"
 
 #. Default: "Comment"
 #: ./opengever/workspace/content_sharing_mailer.py

--- a/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-03-22 12:17+0000\n"
+"POT-Creation-Date: 2022-06-17 09:57+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -150,6 +150,12 @@ msgstr ""
 msgid "label_attendees"
 msgstr "Participants"
 
+#. Default: "Chair"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
+#: ./opengever/workspace/workspace_meeting.py
+msgid "label_chair"
+msgstr ""
+
 #. Default: "Date"
 #: ./opengever/workspace/browser/templates/meeting_minutes.pt
 msgid "label_date"
@@ -228,6 +234,12 @@ msgstr "Renvois"
 #: ./opengever/workspace/todo.py
 msgid "label_responsible"
 msgstr "Responsable"
+
+#. Default: "Secretary"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
+#: ./opengever/workspace/workspace_meeting.py
+msgid "label_secretary"
+msgstr ""
 
 #. Default: "Start"
 #: ./opengever/workspace/workspace_meeting.py

--- a/opengever/workspace/locales/opengever.workspace.pot
+++ b/opengever/workspace/locales/opengever.workspace.pot
@@ -96,6 +96,16 @@ msgstr ""
 msgid "WorkspaceMember"
 msgstr ""
 
+#. Default: "absent"
+#: ./opengever/workspace/workspace_meeting.py
+msgid "absent"
+msgstr ""
+
+#. Default: "excused"
+#: ./opengever/workspace/workspace_meeting.py
+msgid "excused"
+msgstr ""
+
 #. Default: "Common"
 #: ./opengever/workspace/workspace_meeting.py
 msgid "fieldset_common"
@@ -304,6 +314,11 @@ msgstr ""
 #. Default: "At least one principal must remain admin."
 #: ./opengever/workspace/participation/browser/manage_participants.py
 msgid "msg_one_must_remain_admin"
+msgstr ""
+
+#. Default: "present"
+#: ./opengever/workspace/workspace_meeting.py
+msgid "present"
 msgstr ""
 
 #. Default: "Comment"

--- a/opengever/workspace/locales/opengever.workspace.pot
+++ b/opengever/workspace/locales/opengever.workspace.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-03-22 12:17+0000\n"
+"POT-Creation-Date: 2022-06-17 09:57+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -147,6 +147,12 @@ msgstr ""
 msgid "label_attendees"
 msgstr ""
 
+#. Default: "Chair"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
+#: ./opengever/workspace/workspace_meeting.py
+msgid "label_chair"
+msgstr ""
+
 #. Default: "Date"
 #: ./opengever/workspace/browser/templates/meeting_minutes.pt
 msgid "label_date"
@@ -224,6 +230,12 @@ msgstr ""
 #: ./opengever/workspace/browser/templates/meeting_minutes.pt
 #: ./opengever/workspace/todo.py
 msgid "label_responsible"
+msgstr ""
+
+#. Default: "Secretary"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
+#: ./opengever/workspace/workspace_meeting.py
+msgid "label_secretary"
 msgstr ""
 
 #. Default: "Start"

--- a/opengever/workspace/tests/test_workspace_meeting.py
+++ b/opengever/workspace/tests/test_workspace_meeting.py
@@ -213,6 +213,9 @@ class TestAPISupportForWorkspaceMeeting(IntegrationTestCase):
         expected_states = {u'hans.peter': u'present', u'fridolin.hugentobler': u'present'}
         self.assertEqual(expected_states, storage.get_all())
 
+        browser.open(meeting, method='GET', headers=self.api_headers)
+        self.assertEqual(expected_states, browser.json['attendees_presence_states'])
+
     @browsing
     def test_presence_states_after_modifying_attendees(self, browser):
         self.login(self.workspace_member, browser)

--- a/opengever/workspace/tests/test_workspace_meeting.py
+++ b/opengever/workspace/tests/test_workspace_meeting.py
@@ -4,6 +4,7 @@ from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages.statusmessages import assert_no_error_messages
 from ftw.testing.freezer import freeze
 from opengever.testing import IntegrationTestCase
+from opengever.workspace.interfaces import IWorkspaceMeetingAttendeesPresenceStateStorage
 import json
 import pytz
 
@@ -189,21 +190,47 @@ class TestAPISupportForWorkspaceMeeting(IntegrationTestCase):
         self.assertEqual(u'\xc4 new title', self.workspace_meeting.title)
 
     @browsing
-    def test_workspace_meeting_can_have_attendees(self, browser):
+    def test_create_workspace_meeting_with_attendees(self, browser):
         self.login(self.workspace_member, browser)
-        browser.open(
-            self.workspace, method='POST', headers=self.api_headers,
-            data=json.dumps({'title': 'Ein Meeting',
-                             'responsible': self.workspace_member.getId(),
-                             'attendees': [self.workspace_guest.getId(), self.workspace_admin.getId()],
-                             'start': '2020-10-10T23:56:00',
-                             '@type': 'opengever.workspace.meeting'}))
+        with self.observe_children(self.workspace) as children:
+            browser.open(
+                self.workspace, method='POST', headers=self.api_headers,
+                data=json.dumps({'title': 'Ein Meeting',
+                                 'responsible': self.workspace_member.getId(),
+                                 'attendees': [self.workspace_guest.getId(),
+                                               self.workspace_admin.getId()],
+                                 'start': '2020-10-10T23:56:00',
+                                 '@type': 'opengever.workspace.meeting'}))
 
         self.assertEqual(
             [
                 {u'token': u'hans.peter', u'title': u'Peter Hans'},
                 {u'token': u'fridolin.hugentobler', u'title': u'Hugentobler Fridolin'}
             ], browser.json.get('attendees'))
+
+        meeting = children['added'].pop()
+        storage = IWorkspaceMeetingAttendeesPresenceStateStorage(meeting)
+        expected_states = {u'hans.peter': u'present', u'fridolin.hugentobler': u'present'}
+        self.assertEqual(expected_states, storage.get_all())
+
+    @browsing
+    def test_presence_states_after_modifying_attendees(self, browser):
+        self.login(self.workspace_member, browser)
+        storage = IWorkspaceMeetingAttendeesPresenceStateStorage(self.workspace_meeting)
+        browser.open(self.workspace_meeting, method='PATCH', headers=self.api_headers,
+                     data=json.dumps({'attendees': [
+                         self.workspace_guest.getId(), self.workspace_admin.getId()]}))
+
+        storage.add_or_update(self.workspace_guest.getId(), u'excused')
+        self.assertEqual({u'hans.peter': u'excused', u'fridolin.hugentobler': u'present'},
+                         storage.get_all())
+
+        browser.open(self.workspace_meeting, method='PATCH', headers=self.api_headers,
+                     data=json.dumps({'attendees': [
+                         self.workspace_member.getId(), self.workspace_guest.getId()]}))
+
+        self.assertEqual({u'hans.peter': u'excused', u'beatrice.schrodinger': u'present'},
+                         storage.get_all())
 
     @browsing
     def test_only_actual_workspace_members_can_participate_to_a_workspace_meeting(self, browser):

--- a/opengever/workspace/workspace_meeting.py
+++ b/opengever/workspace/workspace_meeting.py
@@ -32,6 +32,16 @@ class IWorkspaceMeetingSchema(model.Schema):
         vocabulary='opengever.workspace.WorkspaceContentMembersVocabulary',
         required=True)
 
+    chair = schema.Choice(
+        title=_('label_chair', default='Chair'),
+        vocabulary='opengever.workspace.WorkspaceContentMembersVocabulary',
+        required=False)
+
+    secretary = schema.Choice(
+        title=_('label_secretary', default='Secretary'),
+        vocabulary='opengever.workspace.WorkspaceContentMembersVocabulary',
+        required=False)
+
     form.widget('start', DatePickerFieldWidget)
     form.order_after(start='responsible')
     start = UTCDatetime(


### PR DESCRIPTION
Some additional fields are needed for workspace meetings. The fields are also included in the PDF protocol.

<img width="944" alt="Bildschirmfoto 2022-06-17 um 15 37 25" src="https://user-images.githubusercontent.com/50165195/174312786-bb2cbd33-7fb2-4b9e-a2d4-88e963b78c36.png">

For [CA-4154]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [x] Execute as much as possible conditionally
- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
- New translations
  - [x] All msg-strings are unicode

[CA-4154]: https://4teamwork.atlassian.net/browse/CA-4154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ