### PR TITLE
Optimize groups API

### DIFF
--- a/changes/CA-1039-1.other
+++ b/changes/CA-1039-1.other
@@ -1,0 +1,1 @@
+Optimize performance of groups API. [buchi]

--- a/changes/CA-1039-2.other
+++ b/changes/CA-1039-2.other
@@ -1,0 +1,1 @@
+Allow to recreate deleted local groups. [buchi]

--- a/opengever/api/tests/test_group.py
+++ b/opengever/api/tests/test_group.py
@@ -442,6 +442,7 @@ class TestGeverGroupsPatch(IntegrationTestCase):
 
         self.assertEqual(204, response.status_code)
         self.assertEqual(u'new title', self.ogds_group.title)
+        self.ogds_group.session.expire(self.ogds_group)
         self.assertItemsEqual(
             [self.committee_responsible.id, self.administrator.id, self.workspace_guest.id],
             [user.userid for user in self.ogds_group.users])
@@ -463,6 +464,7 @@ class TestGeverGroupsPatch(IntegrationTestCase):
             method='PATCH',
             headers=self.api_headers)
 
+        self.ogds_group.session.expire(self.ogds_group)
         self.assertEqual(204, response.status_code)
         self.assertEqual([], self.ogds_group.users)
 
@@ -543,7 +545,7 @@ class TestGeverGroupsPatch(IntegrationTestCase):
 
         self.assertEqual(
             browser.json[u'message'],
-            "User {} not found in OGDS.".format(userid))
+            "Users ['{}'] not found in OGDS.".format(userid))
         self.assertEqual(browser.json[u'type'], u'BadRequest')
         self.assertItemsEqual(
             [self.committee_responsible.id, self.administrator.id],
@@ -555,6 +557,7 @@ class TestGeverGroupsPatch(IntegrationTestCase):
             data=json.dumps(payload),
             method='PATCH',
             headers=self.api_headers)
+        self.ogds_group.session.expire(self.ogds_group)
         self.assertItemsEqual(
             [self.committee_responsible.id, self.administrator.id, userid],
             [user.userid for user in self.ogds_group.users])


### PR DESCRIPTION
The previous implementation performed terribly with a large amount of group members (e.g. 10'000 members).
We now avoid fetching the user object for each group member which greatly improves the performance.

Further we also allow to recreate deleted local groups.

For [CA-1039](https://4teamwork.atlassian.net/browse/CA-1039)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


