### PR TITLE
Add possibility to bundle import to set obj creator and actor for journal entries 

### DIFF
--- a/changes/CA-4039.feature
+++ b/changes/CA-4039.feature
@@ -1,0 +1,1 @@
+Set creator during bundle import and use creator as journal entry actor. [phgross]

--- a/docs/public/dev-manual/oggbundle/index.rst
+++ b/docs/public/dev-manual/oggbundle/index.rst
@@ -11,6 +11,8 @@ Changelog:
 +---------------+--------------+-------------+--------------------------------------------------------+
 | **Version**   | **Datum**    | **Autor**   | **Kommentar**                                          |
 +===============+==============+=============+========================================================+
+| 1.3           | 20.06.2022   | PG          | Ergänzt: Ersteller                                     |
++---------------+--------------+-------------+--------------------------------------------------------+
 | 1.2           | 16.06.2022   | PG          | Import von OGDS Usern                                  |
 +---------------+--------------+-------------+--------------------------------------------------------+
 | 1.1           | 10.08.2020   | LG          | Import von Teamräumen                                  |
@@ -389,6 +391,13 @@ Dokumente
 Initial-Zustand: ``document-state-draft``
 
 JSON Schema: :ref:`documents.schema.json <documents_schema_json>`
+
+
+Ersteller
+---------
+
+Der Ersteller eines Objekts lässt sich für alle Inhalte mit dem Property ``_creator`` setzen. Auch die entsprechenden Journaleinträge, werden im Namen des Erstellers eines jeweiligen Objektes erfasst.
+
 
 Redirects zu früheren Pfäden
 ----------------------------

--- a/opengever/base/schemadump/schema.py
+++ b/opengever/base/schemadump/schema.py
@@ -304,6 +304,7 @@ class OGGBundleJSONSchemaBuilder(object):
 
         # Tweak the content type schema for use in OGGBundles
         self._add_review_state_property()
+        self._add_creator_property()
         self._add_guid_properties()
         self._add_participation_property()
         self._add_permissions_property()
@@ -327,6 +328,13 @@ class OGGBundleJSONSchemaBuilder(object):
             {'type': 'string',
              'enum': ALLOWED_REVIEW_STATES[self.portal_type]},
             required=True,
+        )
+
+    def _add_creator_property(self):
+        self.ct_schema.add_property(
+            '_creator',
+            {'type': 'string'},
+            required=False,
         )
 
     def _add_guid_properties(self, with_parent_reference=True):

--- a/opengever/bundle/cfgs/oggbundle.cfg
+++ b/opengever/bundle/cfgs/oggbundle.cfg
@@ -9,6 +9,7 @@ pipeline =
     manual-journal-actor
     garbage-collect
     constructor
+    set-creator
     resolvetree
     fileinserter
     criterions
@@ -46,6 +47,9 @@ blueprint = opengever.bundle.disabled_indexing
 
 [manual-journal-actor]
 blueprint = opengever.bundle.manual_journal_actor
+
+[set-creator]
+blueprint = opengever.bundle.set_creator
 
 [resolveguid]
 blueprint = opengever.bundle.resolveguid

--- a/opengever/bundle/cfgs/oggbundle.cfg
+++ b/opengever/bundle/cfgs/oggbundle.cfg
@@ -6,6 +6,7 @@ pipeline =
     bundlesource
     resolveguid
     disabled-catalog-indexing
+    manual-journal-actor
     garbage-collect
     constructor
     resolvetree
@@ -42,6 +43,9 @@ blueprint = opengever.bundle.bundlesource
 
 [disabled-catalog-indexing]
 blueprint = opengever.bundle.disabled_indexing
+
+[manual-journal-actor]
+blueprint = opengever.bundle.manual_journal_actor
 
 [resolveguid]
 blueprint = opengever.bundle.resolveguid

--- a/opengever/bundle/schemas/documents.schema.json
+++ b/opengever/bundle/schemas/documents.schema.json
@@ -216,6 +216,12 @@
                         "document-state-draft"
                     ]
                 },
+                "_creator": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
                 "guid": {
                     "type": "string"
                 },

--- a/opengever/bundle/schemas/dossiers.schema.json
+++ b/opengever/bundle/schemas/dossiers.schema.json
@@ -356,6 +356,12 @@
                         "dossier-state-resolved"
                     ]
                 },
+                "_creator": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
                 "guid": {
                     "type": "string"
                 },

--- a/opengever/bundle/schemas/repofolders.schema.json
+++ b/opengever/bundle/schemas/repofolders.schema.json
@@ -306,6 +306,12 @@
                         "repositoryfolder-state-active"
                     ]
                 },
+                "_creator": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
                 "guid": {
                     "type": "string"
                 },

--- a/opengever/bundle/schemas/reporoots.schema.json
+++ b/opengever/bundle/schemas/reporoots.schema.json
@@ -81,6 +81,12 @@
                         "repositoryroot-state-active"
                     ]
                 },
+                "_creator": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
                 "guid": {
                     "type": "string"
                 },

--- a/opengever/bundle/schemas/workspacefolders.schema.json
+++ b/opengever/bundle/schemas/workspacefolders.schema.json
@@ -41,6 +41,12 @@
                         "opengever_workspace_folder--STATUS--active"
                     ]
                 },
+                "_creator": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
                 "guid": {
                     "type": "string"
                 },

--- a/opengever/bundle/schemas/workspaceroots.schema.json
+++ b/opengever/bundle/schemas/workspaceroots.schema.json
@@ -43,6 +43,12 @@
                         "opengever_workspace_root--STATUS--active"
                     ]
                 },
+                "_creator": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
                 "guid": {
                     "type": "string"
                 },

--- a/opengever/bundle/schemas/workspaces.schema.json
+++ b/opengever/bundle/schemas/workspaces.schema.json
@@ -79,6 +79,12 @@
                         "opengever_workspace--STATUS--active"
                     ]
                 },
+                "_creator": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
                 "guid": {
                     "type": "string"
                 },

--- a/opengever/bundle/sections/constructor.py
+++ b/opengever/bundle/sections/constructor.py
@@ -11,6 +11,7 @@ from opengever.base.schemadump.config import PARENTABLE_TYPES
 from opengever.base.schemadump.config import ROOT_TYPES
 from opengever.bundle.sections.bundlesource import BUNDLE_KEY
 from opengever.dossier.behaviors.dossier import IDossierMarker
+from opengever.journal import ManualJournalActor
 from opengever.ogds.models.user import User
 from plone import api
 from plone.dexterity.utils import createContentInContainer
@@ -272,7 +273,12 @@ class ConstructorSection(object):
 
             container, parent_path = parent
             try:
-                obj = self._construct_object(container, item)
+                if item.get('_creator'):
+                    with ManualJournalActor(item.get('_creator')):
+                        obj = self._construct_object(container, item)
+                else:
+                    obj = self._construct_object(container, item)
+
                 self.bundle.constructed_guids.add(item['guid'])
                 self.bundle.containers_to_reindex.add(parent_path)
                 logger.info(u'Constructed %r' % obj)

--- a/opengever/bundle/sections/constructor.py
+++ b/opengever/bundle/sections/constructor.py
@@ -11,7 +11,6 @@ from opengever.base.schemadump.config import PARENTABLE_TYPES
 from opengever.base.schemadump.config import ROOT_TYPES
 from opengever.bundle.sections.bundlesource import BUNDLE_KEY
 from opengever.dossier.behaviors.dossier import IDossierMarker
-from opengever.journal import ManualJournalActor
 from opengever.ogds.models.user import User
 from plone import api
 from plone.dexterity.utils import createContentInContainer
@@ -273,12 +272,7 @@ class ConstructorSection(object):
 
             container, parent_path = parent
             try:
-                if item.get('_creator'):
-                    with ManualJournalActor(item.get('_creator')):
-                        obj = self._construct_object(container, item)
-                else:
-                    obj = self._construct_object(container, item)
-
+                obj = self._construct_object(container, item)
                 self.bundle.constructed_guids.add(item['guid'])
                 self.bundle.containers_to_reindex.add(parent_path)
                 logger.info(u'Constructed %r' % obj)

--- a/opengever/bundle/sections/creator.py
+++ b/opengever/bundle/sections/creator.py
@@ -1,0 +1,46 @@
+from collective.transmogrifier.interfaces import ISection
+from collective.transmogrifier.interfaces import ISectionBlueprint
+from collective.transmogrifier.utils import traverse
+from zope.interface import classProvides
+from zope.interface import implements
+import logging
+
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.INFO)
+
+
+class SetCreatorSection(object):
+    """Section that sets the creator for the object if creator is given.
+    """
+
+    classProvides(ISectionBlueprint)
+    implements(ISection)
+
+    def __init__(self, transmogrifier, name, options, previous):
+        self.previous = previous
+        self.context = transmogrifier.context
+
+    def __iter__(self):
+        for item in self.previous:
+            path = item.get('_path')
+            if not path:
+                yield item
+                continue
+
+            obj = traverse(self.context, path, None)
+            if obj is None:
+                log.warning("Cannot set creator for {}. "
+                            "Object doesn't exist".format(path))
+                yield item
+                continue
+
+            self.set_creator(obj, item)
+
+            yield item
+
+    def set_creator(self, obj, item):
+        creator = item.get('_creator')
+
+        if creator:
+            obj.setCreators((creator,))

--- a/opengever/bundle/sections/manual_journal_entries.py
+++ b/opengever/bundle/sections/manual_journal_entries.py
@@ -1,0 +1,25 @@
+from collective.transmogrifier.interfaces import ISection
+from collective.transmogrifier.interfaces import ISectionBlueprint
+from opengever.journal import ManualJournalActor
+from zope.interface import classProvides
+from zope.interface import implements
+
+
+class ManualJournalEntrySection(object):
+    """Add request flag to create journal entries with the items creator
+    if given in the bundle.
+    """
+
+    classProvides(ISectionBlueprint)
+    implements(ISection)
+
+    def __init__(self, transmogrifier, name, options, previous):
+        self.previous = previous
+
+    def __iter__(self):
+        for item in self.previous:
+            if item.get('_creator'):
+                with ManualJournalActor(item.get('_creator')):
+                    yield item
+            else:
+                yield item

--- a/opengever/bundle/tests/assets/basic.oggbundle/documents.json
+++ b/opengever/bundle/tests/assets/basic.oggbundle/documents.json
@@ -10,7 +10,8 @@
     "preserved_as_paper": true,
     "relatedItems": [],
     "review_state": "document-state-draft",
-    "title": "Bewerbung Hanspeter Müller"
+    "title": "Bewerbung Hanspeter Müller",
+    "_creator": "elio.schmutz"
   },  {
     "guid": "1d94ce18d336490f84ace260a87712d0",
     "parent_guid": "659645aec58d48a9b9663399ea2ec069",

--- a/opengever/bundle/tests/assets/basic.oggbundle/dossiers.json
+++ b/opengever/bundle/tests/assets/basic.oggbundle/dossiers.json
@@ -8,6 +8,7 @@
     "responsible": "lukas.graf",
     "review_state": "dossier-state-active",
     "start": "2010-11-11",
+    "_creator": "philippe.gross",
     "title": "Dossier Peter Schneider",
       "_participations": [
           {"participant_id": "person:c2a9c298-a769-4c52-affe-0803c11cb571",

--- a/opengever/bundle/tests/test_oggbundle_pipeline.py
+++ b/opengever/bundle/tests/test_oggbundle_pipeline.py
@@ -16,7 +16,7 @@ from opengever.bundle.sections.bundlesource import BUNDLE_KEY
 from opengever.bundle.sections.bundlesource import BUNDLE_PATH_KEY
 from opengever.bundle.sections.constructor import BUNDLE_GUID_KEY
 from opengever.dossier.behaviors.dossier import IDossier
-from opengever.dossier.behaviors.participation import IParticipationAware
+from opengever.journal.tests.utils import get_journal_entry
 from opengever.ogds.models.user import User
 from opengever.propertysheets.utils import get_custom_properties
 from opengever.repository.behaviors.referenceprefix import IReferenceNumberPrefix  # noqa
@@ -425,6 +425,9 @@ class TestOggBundlePipeline(IntegrationTestCase):
              'organization:e66b4572-5244-491c-bbe8-32295f8da070'],
             [particpation.contact for particpation in participations.values()])
 
+        entry = get_journal_entry(dossier)
+        self.assertEqual('philippe.gross', entry['actor'])
+
     def assert_dossier2_created(self):
         dossier = self.find_by_title(
             self.leaf_repofolder,
@@ -538,6 +541,10 @@ class TestOggBundlePipeline(IntegrationTestCase):
         # customproperty with default
         self.assertEqual(
             {'portal': u'plone'}, get_custom_properties(document1))
+
+        # journal entry
+        entry = get_journal_entry(document1)
+        self.assertEqual('elio.schmutz', entry['actor'])
 
     def assert_document2_created(self, parent):
         document2 = self.find_by_title(parent, u'Entlassung Hanspeter M\xfcller')

--- a/opengever/bundle/tests/test_oggbundle_pipeline.py
+++ b/opengever/bundle/tests/test_oggbundle_pipeline.py
@@ -425,6 +425,8 @@ class TestOggBundlePipeline(IntegrationTestCase):
              'organization:e66b4572-5244-491c-bbe8-32295f8da070'],
             [particpation.contact for particpation in participations.values()])
 
+        # creator is journal actor
+        self.assertEqual('philippe.gross', dossier.Creator())
         entry = get_journal_entry(dossier)
         self.assertEqual('philippe.gross', entry['actor'])
 
@@ -541,6 +543,9 @@ class TestOggBundlePipeline(IntegrationTestCase):
         # customproperty with default
         self.assertEqual(
             {'portal': u'plone'}, get_custom_properties(document1))
+
+        # creator
+        self.assertEqual('elio.schmutz', document1.Creator())
 
         # journal entry
         entry = get_journal_entry(document1)

--- a/opengever/bundle/tests/test_section_constructor.py
+++ b/opengever/bundle/tests/test_section_constructor.py
@@ -7,7 +7,6 @@ from opengever.bundle.sections.constructor import ConstructorSection
 from opengever.bundle.sections.constructor import InvalidType
 from opengever.bundle.tests import MockBundle
 from opengever.bundle.tests import MockTransmogrifier
-from opengever.journal.tests.utils import get_journal_entry
 from opengever.testing import IntegrationTestCase
 from plone import api
 from zope.annotation import IAnnotations
@@ -249,27 +248,3 @@ class TestConstructor(IntegrationTestCase):
 
         self.assertEqual(u'My Mail', content.title)
         self.assertEqual('ftw.mail.mail', content.portal_type)
-
-    def test_journal_entry_made_as_creator(self):
-        item = {
-            u"guid": "12345xy",
-            u"parent_guid": "123_parent",
-            u"_type": u"opengever.dossier.businesscasedossier",
-            u"_creator": self.regular_user.id,
-            u"title": u"Dossier",
-        }
-
-        section = self.setup_section(previous=[item])
-        section.bundle.item_by_guid['123_parent'] = {
-            '_path': '/'.join(self.leaf_repofolder.getPhysicalPath()[2:])
-        }
-        list(section)
-
-        portal = api.portal.get()
-        content = portal.restrictedTraverse(item['_path'])
-
-        entry = get_journal_entry(content)
-
-        self.assertEqual(u'Dossier', content.title)
-        self.assertEqual('Dossier added', entry['action']['type'])
-        self.assertEqual(self.regular_user.id, entry['actor'])

--- a/opengever/bundle/transmogrifier.zcml
+++ b/opengever/bundle/transmogrifier.zcml
@@ -93,4 +93,9 @@
       name="opengever.bundle.participations"
       />
 
+  <utility
+      component=".sections.manual_journal_entries.ManualJournalEntrySection"
+      name="opengever.bundle.manual_journal_actor"
+      />
+
 </configure>

--- a/opengever/bundle/transmogrifier.zcml
+++ b/opengever/bundle/transmogrifier.zcml
@@ -98,4 +98,9 @@
       name="opengever.bundle.manual_journal_actor"
       />
 
+  <utility
+      component=".sections.creator.SetCreatorSection"
+      name="opengever.bundle.set_creator"
+      />
+
 </configure>

--- a/opengever/journal/__init__.py
+++ b/opengever/journal/__init__.py
@@ -1,4 +1,27 @@
+from opengever.journal.interfaces import IManualJournalActor
+from zope.globalrequest import getRequest
 from zope.i18nmessageid import MessageFactory
+from zope.interface import alsoProvides
+from zope.interface import noLongerProvides
 
 
 _ = MessageFactory('opengever.journal')
+
+
+class ManualJournalActor(object):
+    """Contextmanager that temporarily creates journal entry for the given
+    actor, instaed of the current user.
+    """
+
+    def __init__(self, actor):
+        self.actor = actor
+
+    def __enter__(self):
+        request = getRequest()
+        alsoProvides(request, IManualJournalActor)
+        request.set('_manual_journal_actor', self.actor)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        request = getRequest()
+        noLongerProvides(request, IManualJournalActor)
+        request.other.pop('_manual_journal_actor')

--- a/opengever/journal/handlers.py
+++ b/opengever/journal/handlers.py
@@ -10,6 +10,7 @@ from opengever.base.oguid import Oguid
 from opengever.document.document import IDocumentSchema
 from opengever.dossier.browser.participants import role_list_helper
 from opengever.journal import _
+from opengever.journal.interfaces import IManualJournalActor
 from opengever.readonly import is_in_readonly_mode
 from opengever.repository.repositoryroot import IRepositoryRoot
 from opengever.sharing.browser.sharing import ROLE_MAPPING
@@ -51,10 +52,15 @@ def propper_string(value):
 def journal_entry_factory(context, action, title,
                           visible=True, comment='', actor=None,
                           documents=None):
+
+    request = getRequest()
+    if IManualJournalActor.providedBy(request):
+        actor = request.get('_manual_journal_actor')
+
     if actor is None:
         actor = api.user.get_current().getId()
 
-    comment = comment == '' and get_change_note(getRequest(), '') or comment
+    comment = comment == '' and get_change_note(request, '') or comment
     title = propper_string(title)
     action = propper_string(action)
     comment = propper_string(comment)

--- a/opengever/journal/interfaces.py
+++ b/opengever/journal/interfaces.py
@@ -1,0 +1,6 @@
+from zope.interface import Interface
+
+
+class IManualJournalActor(Interface):
+    """Request layer to indicate that manual journal actor should be used.
+    """


### PR DESCRIPTION
The original goal of the story was to be able to define the creator of journal entries during a bundle import. We decided to extend this, so that the creator can also be set. It would be confusing if the listing under creator would say something different than in the journal.

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-4039]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-4039]: https://4teamwork.atlassian.net/browse/CA-4039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ