### PR TITLE
Allow saving journal entry comments as HTML structure

### DIFF
--- a/changes/CA-4299.feature
+++ b/changes/CA-4299.feature
@@ -1,0 +1,1 @@
+Allow saving journal entry comments as HTML structure. [tinagerber]

--- a/opengever/api/tests/test_journal.py
+++ b/opengever/api/tests/test_journal.py
@@ -103,6 +103,18 @@ class TestJournalPost(IntegrationTestCase):
              u'type': u'ValueError'},
             browser.json)
 
+    @browsing
+    def test_add_journal_entry_via_api_is_xss_safe(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.dossier, view='@journal', method='POST',
+                     headers=self.api_headers,
+                     data=json.dumps({
+                         'comment': u'<p>Danger<script>alert("foo")</script> text</p>',
+                         'category': u'information'}))
+
+        entry = self.journal_entries(self.dossier)[-1]
+        self.assertEqual('<p>Danger text</p>', entry['comments'])
+
 
 class TestJournalGet(IntegrationTestCase):
 

--- a/opengever/journal/tests/test_journal_tab.py
+++ b/opengever/journal/tests/test_journal_tab.py
@@ -127,7 +127,7 @@ class TestJournalTab(FunctionalTestCase):
 
         browser.open(dossier, view=u'tabbedview_view-journal')
         self.assertIn(
-            '&lt;img src="http://not.found/" onerror="script:alert(\'XSS\');" /&gt;',
+            '<img src="http://not.found/" />',
             browser.contents)
 
 


### PR DESCRIPTION
This provides the ability to format journal entry comments.

<img width="726" alt="Bildschirmfoto 2022-06-23 um 13 43 13" src="https://user-images.githubusercontent.com/50165195/175291068-9a8d9d33-b65e-4348-974c-f2c16737a6fb.png">

For [CA-4299]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-4299]: https://4teamwork.atlassian.net/browse/CA-4299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ