### PR TITLE
The @journal endpoint can now be filtered and searched.

### DIFF
--- a/changes/CA-4301.feature
+++ b/changes/CA-4301.feature
@@ -1,0 +1,1 @@
+The @journal endpoint can now be filtered and searched. [elioschmutz]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,6 +11,8 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- ``@journal``: Provides filtering and searching.
+
 
 2022.12.0 (2022-06-21)
 ----------------------

--- a/docs/public/dev-manual/api/journal.rst
+++ b/docs/public/dev-manual/api/journal.rst
@@ -109,3 +109,36 @@ Ein GET Request gibt die Journaleinträge eines Inhalts zurück.
         Suchresultate werden **paginiert** wenn die Anzahl Resultate die
         voreingestellte Seitengrösse (default: 25) überschreitet. Siehe
         :doc:`batching` zu Details zum Umgang mit paginierten Resultaten.
+
+
+Optionale Parameter:
+--------------------
+
+- ``b_start``: Das erste zurückzugebende Element
+- ``b_size``: Die maximale Anzahl der zurückzugebenden Elemente
+- ``search``: Filterung nach einem beliebigen Suchbegriff im Titel oder Kommentar
+- ``filters``: Einschränkung nach einem bestimmten Wert eines Feldes
+
+
+**Beispiel: Filtern nach Journal-Kategorie:**
+
+  .. sourcecode:: http
+
+    GET /ordnungssystem/fuehrung/dossier-23/@journal?filters.categories:record:list=phone-call HTTP/1.1
+    Accept: application/json
+
+
+**Beispiel: Filtern nach manuellen Journal-Einträgen:**
+
+  .. sourcecode:: http
+
+    GET /ordnungssystem/fuehrung/dossier-23/@journal?filters.manual_entries_only:record:boolean=True HTTP/1.1
+    Accept: application/json
+
+
+**Beispiel: Suchen nach Einträgen mit einem Suchbegriff:**
+
+  .. sourcecode:: http
+
+    GET /ordnungssystem/fuehrung/dossier-23/@journal?search=Important HTTP/1.1
+    Accept: application/json

--- a/opengever/journal/entry.py
+++ b/opengever/journal/entry.py
@@ -36,6 +36,7 @@ class ManualJournalEntry(object):
         entry = {'obj': self.context,
                  'action': PersistentDict({
                      'type': MANUAL_JOURNAL_ENTRY,
+                     'category': self.category,
                      'title': self.get_title(),
                      'visible': True,
                      'documents': self.serialize_documents(),


### PR DESCRIPTION
This PR extends the `@journal` to make it searchable and filterable.

For [CA-4301]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-4301]: https://4teamwork.atlassian.net/browse/CA-4301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ