### PR TITLE
Enabled zipexport for workspaces and workspacefolders.

### DIFF
--- a/changes/CA-4132.feature
+++ b/changes/CA-4132.feature
@@ -1,0 +1,1 @@
+Enabled zipexport for workspaces and workspacefolders. [phgross]

--- a/opengever/core/profiles/default/registry.xml
+++ b/opengever/core/profiles/default/registry.xml
@@ -144,6 +144,8 @@
       <element>opengever.dossier.behaviors.dossier.IDossierMarker</element>
       <element>opengever.dossier.templatefolder.interfaces.ITemplateFolder</element>
       <element>opengever.task.task.ITask</element>
+      <element>opengever.workspace.interfaces.IWorkspace</element>
+      <element>opengever.workspace.interfaces.IWorkspaceFolder</element>
     </value>
   </records>
 

--- a/opengever/core/upgrades/20220624115904_enable_zip_export_for_workspace_and_workspacefolders/registry.xml
+++ b/opengever/core/upgrades/20220624115904_enable_zip_export_for_workspace_and_workspacefolders/registry.xml
@@ -1,0 +1,10 @@
+<registry>
+
+  <records interface="ftw.zipexport.interfaces.IZipExportSettings">
+    <value key="enabled_dotted_names" purge="False">
+      <element>opengever.workspace.interfaces.IWorkspace</element>
+      <element>opengever.workspace.interfaces.IWorkspaceFolder</element>
+    </value>
+  </records>
+
+</registry>

--- a/opengever/core/upgrades/20220624115904_enable_zip_export_for_workspace_and_workspacefolders/upgrade.py
+++ b/opengever/core/upgrades/20220624115904_enable_zip_export_for_workspace_and_workspacefolders/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class EnableZipExportForWorkspaceAndWorkspacefolders(UpgradeStep):
+    """Enable Zip export for workspace and workspacefolders.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/workspace/actions.py
+++ b/opengever/workspace/actions.py
@@ -62,6 +62,9 @@ class WorkspaceContextActions(BaseContextActions):
     def is_share_content_available(self):
         return True
 
+    def is_zipexport_available(self):
+        return True
+
 
 @adapter(IWorkspaceFolder, IOpengeverBaseLayer)
 class WorkspaceFolderContextActions(BaseContextActions):
@@ -86,3 +89,6 @@ class WorkspaceFolderContextActions(BaseContextActions):
 
     def is_untrash_context_available(self):
         return ITrasher(self.context).verify_may_untrash(raise_on_violations=False)
+
+    def is_zipexport_available(self):
+        return True

--- a/opengever/workspace/configure.zcml
+++ b/opengever/workspace/configure.zcml
@@ -126,4 +126,22 @@
   <adapter factory=".delete.WorkspaceFolderDeleter" />
   <adapter factory=".delete.WorkspaceDeleter" />
 
+  <adapter
+      factory="ftw.zipexport.representations.general.NullZipRepresentation"
+      for="opengever.workspace.interfaces.IWorkspaceMeeting
+           zope.interface.Interface"
+      />
+
+  <adapter
+      factory="ftw.zipexport.representations.general.NullZipRepresentation"
+      for="opengever.workspace.interfaces.IToDo
+           zope.interface.Interface"
+      />
+
+  <adapter
+      factory="ftw.zipexport.representations.general.NullZipRepresentation"
+      for="opengever.workspace.interfaces.IToDoList
+           zope.interface.Interface"
+      />
+
 </configure>

--- a/opengever/workspace/tests/test_actions.py
+++ b/opengever/workspace/tests/test_actions.py
@@ -53,12 +53,12 @@ class TestWorkspaceContextActions(IntegrationTestCase):
 
     def test_workspace_context_actions(self):
         self.login(self.workspace_member)
-        expected_actions = [u'edit', u'share_content']
+        expected_actions = [u'edit', u'share_content', 'zipexport']
         self.assertEqual(expected_actions, self.get_actions(self.workspace))
 
     def test_workspace_context_actions_for_workspace_admins(self):
         self.login(self.workspace_admin)
-        expected_actions = [u'add_invitation', u'edit', u'local_roles', u'share_content']
+        expected_actions = [u'add_invitation', u'edit', u'local_roles', u'share_content', 'zipexport']
         self.assertEqual(expected_actions, self.get_actions(self.workspace))
 
     def test_delete_action_only_available_for_deactivated_workspaces(self):
@@ -82,16 +82,16 @@ class TestWorkspaceFolderContextActions(IntegrationTestCase):
 
     def test_workspace_folder_context_actions(self):
         self.login(self.workspace_member)
-        expected_actions = [u'edit', u'share_content', u'trash_context']
+        expected_actions = [u'edit', u'share_content', u'trash_context', 'zipexport']
         self.assertEqual(expected_actions, self.get_actions(self.workspace_folder))
 
     def test_workspace_folder_context_actions_for_workspace_admins(self):
         self.login(self.workspace_admin)
-        expected_actions = [u'edit', u'local_roles', u'share_content', u'trash_context']
+        expected_actions = [u'edit', u'local_roles', u'share_content', u'trash_context', 'zipexport']
         self.assertEqual(expected_actions, self.get_actions(self.workspace_folder))
 
     def test_context_action_for_trashed_workspace_folder(self):
         self.login(self.workspace_member)
         ITrasher(self.workspace_folder).trash()
-        expected_actions = [u'delete_workspace_context', u'share_content', u'untrash_context']
+        expected_actions = [u'delete_workspace_context', u'share_content', u'untrash_context', 'zipexport']
         self.assertEqual(expected_actions, self.get_actions(self.workspace_folder))

--- a/opengever/workspace/tests/test_zipexport.py
+++ b/opengever/workspace/tests/test_zipexport.py
@@ -1,0 +1,36 @@
+from ftw.zipexport.interfaces import IZipRepresentation
+from opengever.testing import IntegrationTestCase
+from zope.component import getMultiAdapter
+
+
+class TestWorkspaceZipExport(IntegrationTestCase):
+
+    def test_workspace_zip_export(self):
+        self.login(self.workspace_member)
+        zip_adapter = getMultiAdapter((self.workspace, self.request),
+                                      interface=IZipRepresentation)
+        paths = [
+            path_and_file[0]
+            for path_and_file in zip_adapter.get_files()
+        ]
+
+        self.assertEqual(
+            [u'/WS F\xc3lder/Ordnerdokument.txt',
+             u'/Teamraumdokument.txt',
+             u'/Die Buergschaft.eml',
+             u'/Allgemeine Informationen',
+             u'/Projekteinf\xfchrung/Go live',
+             u'/Projekteinf\xfchrung/Cleanup installation',
+             u'/Fix user login'],
+            paths)
+
+    def test_workspacefolder_zip_export(self):
+        self.login(self.workspace_member)
+        zip_adapter = getMultiAdapter((self.workspace_folder, self.request),
+                                      interface=IZipRepresentation)
+        paths = [
+            path_and_file[0]
+            for path_and_file in zip_adapter.get_files()
+        ]
+
+        self.assertEqual([u'/Ordnerdokument.txt'], paths)

--- a/opengever/workspace/tests/test_zipexport.py
+++ b/opengever/workspace/tests/test_zipexport.py
@@ -17,11 +17,7 @@ class TestWorkspaceZipExport(IntegrationTestCase):
         self.assertEqual(
             [u'/WS F\xc3lder/Ordnerdokument.txt',
              u'/Teamraumdokument.txt',
-             u'/Die Buergschaft.eml',
-             u'/Allgemeine Informationen',
-             u'/Projekteinf\xfchrung/Go live',
-             u'/Projekteinf\xfchrung/Cleanup installation',
-             u'/Fix user login'],
+             u'/Die Buergschaft.eml'],
             paths)
 
     def test_workspacefolder_zip_export(self):


### PR DESCRIPTION
workspace-meetings, todos and todolists are excluded from the zip.

For [CA-4132]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- Upgrade-Steps:
 -  only profile change

[CA-4132]: https://4teamwork.atlassian.net/browse/CA-4132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ