### PR TITLE
Drastically improve performance of reactivation for highly nested dossiers.

### DIFF
--- a/changes/CA-4382.other
+++ b/changes/CA-4382.other
@@ -1,0 +1,1 @@
+Drastically improve performance of reactivation for highly nested dossiers. [njohner]

--- a/opengever/dossier/reactivate.py
+++ b/opengever/dossier/reactivate.py
@@ -33,7 +33,7 @@ class Reactivator(object):
         self._recursive_reactivate(self.context)
 
     def _recursive_reactivate(self, dossier):
-        for subdossier in dossier.get_subdossiers():
+        for subdossier in dossier.get_subdossiers(depth=1):
             self._recursive_reactivate(subdossier.getObject())
 
         if self.wft.getInfoFor(dossier,

--- a/opengever/dossier/reactivate.py
+++ b/opengever/dossier/reactivate.py
@@ -33,7 +33,7 @@ class Reactivator(object):
         self._recursive_reactivate(self.context)
 
     def _recursive_reactivate(self, dossier):
-        for subdossier in dossier.get_subdossiers(depth=1):
+        for subdossier in dossier.get_subdossiers(depth=1, sort_on=None, sort_order=None):
             self._recursive_reactivate(subdossier.getObject())
 
         if self.wft.getInfoFor(dossier,


### PR DESCRIPTION
`get_subdossiers` is recursive by default, returning all subdossier at any depth. So as we recursively execute `_recursive_reactivate`, we want to limit the subdossiers in the loop to `depth=1`.

I've tested locally for a pretty deep dossier structure containing a total of 176 dossiers and a 8 levels of subdossiers. In that case, most of the time was spent getting the subdossiers and iterating over them (see flamegraph), and reactivation took 363 seconds. When limiting depth to 1, it took 39 seconds, and without sorting it took 38 seconds. 

Of course improvement largely depends on the nesting depth, but can probably be even more drastic in some real cases. Indeed I started looking into this because I could not understand why the customer could not reopen the dossier (see jira story) himself, as reopening only reindexes the dossiers and their security. Security was only reindexed once per dossier and not on the documents, thanks to a Monkey patch in solr (https://github.com/4teamwork/ftw.solr/blob/master/ftw/solr/patches.py#L81-L193), so I figured reopening should be pretty fast...

I'd say that should be back-ported to the stable release.

![flamegraph_before_change](https://user-images.githubusercontent.com/7374243/176186823-f79cfeb8-ce9a-4c17-97e2-8d3732b89c0e.svg)

For [CA-4382]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-4382]: https://4teamwork.atlassian.net/browse/CA-4382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ