### PR TITLE
CA-4363 Add additional_ui_attributes to registry

### DIFF
--- a/changes/CA-4364.feature
+++ b/changes/CA-4364.feature
@@ -1,0 +1,1 @@
+Add additional_ui_attributes to registry. [tinagerber]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -16,6 +16,7 @@ Other Changes
 - ``@journal``: Provides filtering and searching.
 - ``@participations``: Add field ``primary_participation_roles``. (see :ref:`dossier-participations`)
 - ``@participations``: Improve error messages for DELETE endpoint.
+- Include additional_ui_attributes in KuB entity serialization.
 
 
 2022.12.0 (2022-06-21)

--- a/opengever/api/kub.py
+++ b/opengever/api/kub.py
@@ -1,5 +1,7 @@
 from opengever.base.interfaces import IOpengeverBaseLayer
 from opengever.kub.entity import KuBEntity
+from opengever.kub.interfaces import IKuBSettings
+from plone import api
 from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.services import Service
 from zExceptions import BadRequest
@@ -20,7 +22,10 @@ class SerializeKuBEntityToJson(object):
         self.request = request
 
     def __call__(self, full_representation=False):
-        return self.context.serialize()
+        serialization = self.context.serialize()
+        serialization['additional_ui_attributes'] = api.portal.get_registry_record(
+            'additional_ui_attributes', interface=IKuBSettings)
+        return serialization
 
 
 class KuBGet(Service):

--- a/opengever/core/upgrades/20220704143500_add_additional_ui_attributes_setting/registry.xml
+++ b/opengever/core/upgrades/20220704143500_add_additional_ui_attributes_setting/registry.xml
@@ -1,0 +1,5 @@
+<registry>
+  <records interface="opengever.kub.interfaces.IKuBSettings">
+    <value key="additional_ui_attributes"/>
+  </records>
+</registry>

--- a/opengever/core/upgrades/20220704143500_add_additional_ui_attributes_setting/upgrade.py
+++ b/opengever/core/upgrades/20220704143500_add_additional_ui_attributes_setting/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddAdditionalUiAttributesSetting(UpgradeStep):
+    """Add additional ui attributes setting.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/kub/interfaces.py
+++ b/opengever/kub/interfaces.py
@@ -11,3 +11,8 @@ class IKuBSettings(Interface):
     service_token = schema.TextLine(
         title=u'KuB Service token',
         description=u'Authentication service token for the KuB service.')
+
+    additional_ui_attributes = schema.List(title=u"Additional UI attributes",
+                                           default=list(),
+                                           missing_value=list(),
+                                           value_type=schema.TextLine())


### PR DESCRIPTION
This is necessary to display customer-specific additional attributes in the kub info card in the UI.

For [CA-4363]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))

[CA-4363]: https://4teamwork.atlassian.net/browse/CA-4363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ