### PR TITLE
Enable all languages by default for Teamraum policies.

### DIFF
--- a/changes/CA-4151.other
+++ b/changes/CA-4151.other
@@ -1,0 +1,1 @@
+Enable all languages by default for Teamraum policies. [njohner]

--- a/opengever/core/upgrades/20220707162158_enable_all_languages_for_teamraum/portal_languages.xml
+++ b/opengever/core/upgrades/20220707162158_enable_all_languages_for_teamraum/portal_languages.xml
@@ -1,0 +1,11 @@
+<object>
+
+  <default_language value="de-ch" />
+
+  <supported_langs>
+    <element value="fr-ch" />
+    <element value="de-ch" />
+    <element value="en-us" />
+  </supported_langs>
+
+</object>

--- a/opengever/core/upgrades/20220707162158_enable_all_languages_for_teamraum/upgrade.py
+++ b/opengever/core/upgrades/20220707162158_enable_all_languages_for_teamraum/upgrade.py
@@ -1,0 +1,37 @@
+from ftw.upgrade import UpgradeStep
+from opengever.workspace import is_workspace_feature_enabled
+from plone import api
+
+
+class EnableAllLanguagesForTeamraum(UpgradeStep):
+    """Enable all languages for teamraum.
+    """
+    language_mapping = {
+        'de': 'de-ch',
+        'fr': 'fr-ch',
+        'en': 'en-us',
+    }
+
+    def __call__(self):
+        if is_workspace_feature_enabled():
+            return
+
+        lang_tool = api.portal.get_tool('portal_languages')
+
+        # Before installing the new profile we remember the current default
+        # language to set it back after.
+        default = lang_tool.getDefaultLanguage()
+        default = self.language_mapping.get(default, default)
+        self.install_upgrade_profile()
+        if default:
+            lang_tool.setDefaultLanguage(default)
+
+        self.set_titles()
+
+    def set_titles(self):
+        catalog = api.portal.get_tool('portal_catalog')
+        for brain in catalog.unrestrictedSearchResults(portal_type="opengever.workspace.root"):
+            obj = brain.getObject()
+            obj.title_en = u"Workspaces"
+            obj.title_fr = u"Espaces de travail"
+            obj.reindexObject(idxs=["UID", "title_en", "title_fr"])

--- a/opengever/policytemplates/hooks.py
+++ b/opengever/policytemplates/hooks.py
@@ -60,7 +60,7 @@ IGNORED_DIRECTORIES = {
 
 IGNORED_FILES = {
     'teamraum': ['hooks.py.bob'],
-    'gever': []
+    'gever': ['portal_languages.xml']
 }
 
 VARIABLE_VALUES = {

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/profiles/default/portal_languages.xml
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/profiles/default/portal_languages.xml
@@ -1,0 +1,11 @@
+<object>
+
+  <default_language value="de-ch" />
+
+  <supported_langs>
+    <element value="fr-ch" />
+    <element value="de-ch" />
+    <element value="en-us" />
+  </supported_langs>
+
+</object>


### PR DESCRIPTION
We update the policy templates to enable all languages by default for Teamraum policies.

There is also an upgrade step to enable the languages for all Teamraum deployments. We try to maintain the default language.

For [CA-4151]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-4151]: https://4teamwork.atlassian.net/browse/CA-4151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ