### PR TITLE
Set Accept-Language header when requesting KuB

### DIFF
--- a/changes/CA-4363.other
+++ b/changes/CA-4363.other
@@ -1,0 +1,1 @@
+Set Accept-Language header when requesting KuB. [tinagerber]

--- a/opengever/kub/client.py
+++ b/opengever/kub/client.py
@@ -29,9 +29,11 @@ class KuBClient(object):
     @property
     def session(self):
         session = requests.Session()
+        language_tool = api.portal.get_tool('portal_languages')
+        language = language_tool.getPreferredLanguage()
         session.headers.update(
-            {'Authorization': 'Token {}'.format(self.kub_service_token)})
-
+            {'Accept-Language': language,
+             'Authorization': 'Token {}'.format(self.kub_service_token)})
         return session
 
     def query(self, query_str):

--- a/opengever/kub/tests/test_kub_client.py
+++ b/opengever/kub/tests/test_kub_client.py
@@ -11,6 +11,10 @@ class TestKubClient(KuBIntegrationTestCase):
         self.assertIn('Authorization', self.client.session.headers)
         self.assertEqual(u'Token secret', self.client.session.headers['Authorization'])
 
+    def test_sets_accept_language_header(self, mocker):
+        self.assertIn('Accept-Language', self.client.session.headers)
+        self.assertEqual(u'en', self.client.session.headers['Accept-Language'])
+
     def test_kub_api_url(self, mocker):
         self.assertEqual(u'http://localhost:8000/api/v1/',
                          self.client.kub_api_url)


### PR DESCRIPTION
Otherwise, the KuB attributes are not translated in the correct language.

For [CA-4363]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-4363]: https://4teamwork.atlassian.net/browse/CA-4363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ