### PR TITLE
Journal api refactoring

### DIFF
--- a/changes/CA-4298-2.other
+++ b/changes/CA-4298-2.other
@@ -1,0 +1,1 @@
+Properly deserialize vocabulary values in @journal endpoint. [elioschmutz]

--- a/changes/CA-4298-3.other
+++ b/changes/CA-4298-3.other
@@ -1,0 +1,1 @@
+Rename `comments` attribute for GET @journal entries to `comment` which is the expected naming in the POST request. [elioschmutz]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,6 +11,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- ``@journal``: Properly deserializes category values provided by the vocabulary. We can now send category with ``{ 'token': 'information' }``.
 
 2022.13.0 (2022-07-07)
 ----------------------

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -8,6 +8,7 @@ API Changelog
 
 Breaking Changes
 ^^^^^^^^^^^^^^^^
+- ``@journal``: Rename `comments` attribute for GET @journal entries to `comment` which is the expected naming in the POST request
 
 Other Changes
 ^^^^^^^^^^^^^

--- a/docs/public/dev-manual/api/journal.rst
+++ b/docs/public/dev-manual/api/journal.rst
@@ -21,7 +21,7 @@ Pflicht:
 
 Optional:
 
-``category``: ``String``
+``category``: ``String`` or ``dict with token``
    Journal-Kategory. Mögliche Werte können über den endpoint `@vocabularies/opengever.journal.manual_entry_categories` abgeholt werden.
 
 ``related_documents``: ``String[]``
@@ -37,7 +37,7 @@ Optional:
 
        {
          "comment": "Dossier mit externem Tool archiviert",
-         "category": "phone-call",
+         "category": { "token": "phone-call" },
          "related_documents": [
            "http://localhost:8080/fd/ordnungssystem/fuehrung/kommunikation/allgemeines/dossier-1/document-1",
            "http://localhost:8080/fd/ordnungssystem/fuehrung/gemeinderecht/dossier-14/document-33"

--- a/docs/public/dev-manual/api/journal.rst
+++ b/docs/public/dev-manual/api/journal.rst
@@ -76,7 +76,7 @@ Ein GET Request gibt die Journaleinträge eines Inhalts zurück.
         {
           "actor_fullname": "zopemaster",
           "actor_id": "zopemaster",
-          "comments": "Ich bin ein neuer Journaleintrag",
+          "comment": "Ich bin ein neuer Journaleintrag",
           "related_documents": [
             {
               "@id": "http://localhost:8080/fd/ordnungssystem/fuehrung/gemeinderecht/dossier-1/document-1",
@@ -95,7 +95,7 @@ Ein GET Request gibt die Journaleinträge eines Inhalts zurück.
         {
           "actor_fullname": "zopemaster",
           "actor_id": "zopemaster",
-          "comments": "Ich bin ein neuer Journaleintrag",
+          "comment": "Ich bin ein neuer Journaleintrag",
           "related_documents": [],
           "time": "2019-04-15T13:59:21+00:00",
           "title": "Manueller Eintrag: Telefongespräch"

--- a/opengever/api/journal.py
+++ b/opengever/api/journal.py
@@ -90,7 +90,7 @@ class JournalGet(JournalService):
             item['time'] = json_compatible(entry.get('time'))
             item['actor_id'] = entry.get('actor')
             item['actor_fullname'] = display_name(entry.get('actor'))
-            item['comments'] = entry.get('comments')
+            item['comment'] = entry.get('comments')
             item['related_documents'] = self.get_related_documents(action.get('documents', []))
             items.append(item)
 

--- a/opengever/api/tests/test_journal.py
+++ b/opengever/api/tests/test_journal.py
@@ -120,7 +120,7 @@ class TestJournalGet(IntegrationTestCase):
             headers=http_headers(),
         ).json
 
-        entry_titles = [item.get('comments') for item in response.get('items')]
+        entry_titles = [item.get('comment') for item in response.get('items')]
         self.assertEqual(['second', 'first'], entry_titles)
 
     @browsing
@@ -185,7 +185,7 @@ class TestJournalGet(IntegrationTestCase):
         self.assertDictEqual({
             u'actor_fullname': u'B\xe4rfuss K\xe4thi',
             u'actor_id': u'kathi.barfuss',
-            u'comments': u'is an agent',
+            u'comment': u'is an agent',
             u'related_documents': [{
                 u'@id': self.document.absolute_url(),
                 u'@type': u'opengever.document.document',
@@ -217,7 +217,7 @@ class TestJournalGet(IntegrationTestCase):
 
         self.assertEqual(
             ['Manual entry 2', 'Manual entry 1'],
-            map(lambda item: item.get('comments'), response.json.get('items')))
+            map(lambda item: item.get('comment'), response.json.get('items')))
 
     @browsing
     def test_can_filter_by_categories(self, browser):
@@ -237,7 +237,7 @@ class TestJournalGet(IntegrationTestCase):
 
         self.assertEqual(
             ['my phone call'],
-            map(lambda item: item.get('comments'), response.json.get('items')))
+            map(lambda item: item.get('comment'), response.json.get('items')))
 
     @browsing
     def test_can_search_by_comment(self, browser):
@@ -257,7 +257,7 @@ class TestJournalGet(IntegrationTestCase):
 
         self.assertEqual(
             [u'my phone c\xe4ll'],
-            map(lambda item: item.get('comments'), response.json.get('items')))
+            map(lambda item: item.get('comment'), response.json.get('items')))
 
     @browsing
     def test_can_search_by_title(self, browser):


### PR DESCRIPTION
This PR refactors hand harmonizes the `@journal` endpoint:

- We now use the `IFieldDeserializer` for every `IManualJournalEntry`-field, not only for the documents. This allows us to send the `category` as it comes from the `vocabulary`: `{ "token": "information" }`.
- The `POST` method expects a `comment` attribute, but the `GET` returns a `comments` attribute for each journal entry. The naming is now harmonized and will always be `comment`.

For [CA-4298]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [x] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-4298]: https://4teamwork.atlassian.net/browse/CA-4298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ