### PR TITLE
Add `category` attribute for serialized @journal entry items

### DIFF
--- a/changes/CA-4298-3.feature
+++ b/changes/CA-4298-3.feature
@@ -1,0 +1,1 @@
+Add `category` attribute for serialized @journal entry items (only available for new manual journal entries) . [elioschmutz]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -12,6 +12,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- ``@journal``: Returns a new attribute ``category`` for journal-entries.
 - ``@journal``: Returns a new attribute ``is_editable`` for journal-entries.
 - ``@journal``: Provides PATCH for manual journal entries (only available for new manual journal entries).
 - ``@journal``: Provides removing of manual journal entries with DELETE method (only available for new manual journal entries).

--- a/docs/public/dev-manual/api/journal.rst
+++ b/docs/public/dev-manual/api/journal.rst
@@ -80,6 +80,7 @@ Ein GET Request gibt die Journaleinträge eines Inhalts zurück.
           "actor_fullname": "zopemaster",
           "actor_id": "zopemaster",
           "comment": "Ich bin ein neuer Journaleintrag",
+          "category": { "token": "information", "title": "Information" }
           "related_documents": [
             {
               "@id": "http://localhost:8080/fd/ordnungssystem/fuehrung/gemeinderecht/dossier-1/document-1",
@@ -102,6 +103,7 @@ Ein GET Request gibt die Journaleinträge eines Inhalts zurück.
           "actor_fullname": "zopemaster",
           "actor_id": "zopemaster",
           "comment": "Ich bin ein neuer Journaleintrag",
+          "category": { "token": "information", "title": "Information" }
           "related_documents": [],
           "time": "2019-04-15T13:59:21+00:00",
           "title": "Manueller Eintrag: Telefongespräch"

--- a/opengever/api/tests/test_journal.py
+++ b/opengever/api/tests/test_journal.py
@@ -191,6 +191,7 @@ class TestJournalGet(IntegrationTestCase):
             u'actor_fullname': u'B\xe4rfuss K\xe4thi',
             u'actor_id': u'kathi.barfuss',
             u'comment': u'is an agent',
+            u'category': {'token': 'information', 'title': 'Information' },
             u'related_documents': [{
                 u'@id': self.document.absolute_url(),
                 u'@type': u'opengever.document.document',


### PR DESCRIPTION
Add `category` attribute for serialized @journal entry items.

This information is required to properly display the currently selected category if we want to display an edit form in the frontend.

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-4298]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-4298]: https://4teamwork.atlassian.net/browse/CA-4298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ