### PR TITLE
Improve perfomance in KuB contact source.

### DIFF
--- a/changes/CA-3978.bugfix
+++ b/changes/CA-3978.bugfix
@@ -1,0 +1,1 @@
+Improve perfomance in KuB contact source. [phgross]

--- a/opengever/api/tests/test_dossier_participations.py
+++ b/opengever/api/tests/test_dossier_participations.py
@@ -103,6 +103,7 @@ class TestParticipationsGetWithKubFeatureEnabled(KuBIntegrationTestCase):
         handler = IParticipationAware(self.dossier)
 
         self.mock_get_by_id(mocker, self.person_jean)
+        self.mock_labels(mocker)
         handler.add_participation(
             self.person_jean, ['regard', 'participation', 'final-drawing'])
 
@@ -165,6 +166,7 @@ class TestParticipationsGetWithKubFeatureEnabled(KuBIntegrationTestCase):
         self.login(self.regular_user, browser=browser)
         handler = IParticipationAware(self.dossier)
 
+        self.mock_labels(mocker)
         self.mock_get_by_id(mocker, self.person_jean)
         handler.add_participation(
             self.person_jean, ['regard', 'participation', 'final-drawing'])
@@ -420,15 +422,18 @@ class TestParticipationsPostWithKubFeatureEnabled(KuBIntegrationTestCase, TestPa
         self.valid_participant_id2 = self.org_ftw
 
     def test_post_participation(self, mocker):
+        self.mock_labels(mocker)
         self.mock_get_by_id(mocker, self.valid_participant_id)
         self.mock_get_by_id(mocker, self.valid_participant_id2)
         super(TestParticipationsPostWithKubFeatureEnabled, self).test_post_participation()
 
     def test_post_participations_without_roles_raises_bad_request(self, mocker):
+        self.mock_labels(mocker)
         self.mock_get_by_id(mocker, self.valid_participant_id)
         super(TestParticipationsPostWithKubFeatureEnabled, self).test_post_participations_without_roles_raises_bad_request()
 
     def test_post_participations_with_invalid_role_raises_bad_request(self, mocker):
+        self.mock_labels(mocker)
         self.mock_get_by_id(mocker, self.valid_participant_id)
         super(TestParticipationsPostWithKubFeatureEnabled, self).test_post_participations_with_invalid_role_raises_bad_request()
 
@@ -440,6 +445,7 @@ class TestParticipationsPostWithKubFeatureEnabled(KuBIntegrationTestCase, TestPa
         super(TestParticipationsPostWithKubFeatureEnabled, self).test_post_participations_with_invalid_participant_id_raises_bad_request()
 
     def test_post_participation_with_existing_participant_raises_bad_request(self, mocker):
+        self.mock_labels(mocker)
         self.mock_get_by_id(mocker, self.valid_participant_id)
         super(TestParticipationsPostWithKubFeatureEnabled, self).test_post_participation_with_existing_participant_raises_bad_request()
 
@@ -596,33 +602,41 @@ class TestParticipationsPatchWithKuBFeatureEnabled(KuBIntegrationTestCase, TestP
         self.participant_id = self.person_jean
 
     def test_patch_participation(self, mocker):
+        self.mock_labels(mocker)
         self.mock_get_by_id(mocker, self.participant_id)
         super(TestParticipationsPatchWithKuBFeatureEnabled, self).test_patch_participation()
 
     def test_patch_participation_without_participant_id_raises_bad_request(self, mocker):
+        self.mock_labels(mocker)
         super(TestParticipationsPatchWithKuBFeatureEnabled, self).test_patch_participation_without_participant_id_raises_bad_request()
 
     def test_patch_participation_when_particpant_has_no_participation_raises_bad_request(self,
                                                                                          mocker):
         self.mock_get_by_id(mocker, self.participant_id)
+        self.mock_labels(mocker)
         super(TestParticipationsPatchWithKuBFeatureEnabled, self).test_patch_participation_when_particpant_has_no_participation_raises_bad_request()
 
     def test_patch_participations_with_invalid_participant_id_raises_bad_request(self, mocker):
         self.mock_get_by_id(mocker, "invalid-id")
+        self.mock_labels(mocker)
         super(TestParticipationsPatchWithKuBFeatureEnabled, self).test_patch_participations_with_invalid_participant_id_raises_bad_request()
 
     def test_patch_participations_without_roles_raises_bad_request(self, mocker):
         self.mock_get_by_id(mocker, self.participant_id)
+        self.mock_labels(mocker)
         super(TestParticipationsPatchWithKuBFeatureEnabled, self).test_patch_participations_without_roles_raises_bad_request()
 
     def test_patch_participations_with_invalid_role_raises_bad_request(self, mocker):
+        self.mock_labels(mocker)
         self.mock_get_by_id(mocker, self.participant_id)
         super(TestParticipationsPatchWithKuBFeatureEnabled, self).test_patch_participations_with_invalid_role_raises_bad_request()
 
     def test_patch_participation_for_resolved_dossier_raises_unauthorized(self, mocker):
+        self.mock_labels(mocker)
         super(TestParticipationsPatchWithKuBFeatureEnabled, self).test_patch_participation_for_resolved_dossier_raises_unauthorized()
 
     def test_patch_participation_for_inactive_dossier_raises_unauthorized(self, mocker):
+        self.mock_labels(mocker)
         super(TestParticipationsPatchWithKuBFeatureEnabled, self).test_patch_participation_for_inactive_dossier_raises_unauthorized()
 
 
@@ -725,15 +739,18 @@ class TestParticipationsDeleteWithKuBFeatureEnabled(KuBIntegrationTestCase, Test
 
     def test_delete_participation(self, mocker):
         self.mock_get_by_id(mocker, self.participant_id)
+        self.mock_labels(mocker)
         super(TestParticipationsDeleteWithKuBFeatureEnabled, self).test_delete_participation()
 
     def test_delete_participation_when_participant_has_no_participation_raises_bad_request(
             self, mocker):
         self.mock_get_by_id(mocker, self.participant_id)
+        self.mock_labels(mocker)
         super(TestParticipationsDeleteWithKuBFeatureEnabled, self).test_delete_participation_when_participant_has_no_participation_raises_bad_request()
 
     def test_can_delete_participations_with_invalid_participant_id(self, mocker):
         self.mock_get_by_id(mocker, "invalid-id")
+        self.mock_labels(mocker)
         super(TestParticipationsDeleteWithKuBFeatureEnabled, self).test_can_delete_participations_with_invalid_participant_id()
 
     def test_delete_participation_for_resolved_dossier_raises_unauthorized(self, mocker):
@@ -780,8 +797,11 @@ class TestPossibleParticipantsGetWithContactFeatureEnabled(SolrIntegrationTestCa
     @browsing
     def test_get_possible_participants(self, browser):
         self.login(self.regular_user, browser=browser)
-        url = self.dossier.absolute_url() + '/@possible-participants?query=mei'
 
+        # features not working
+        self.activate_feature('contact')
+
+        url = self.dossier.absolute_url() + '/@possible-participants?query=mei'
         browser.open(url, method='GET', headers=self.api_headers)
 
         expected_json = {u'@id': url,

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -1781,6 +1781,7 @@ class TestKuBDossierParticipationsInListingWithRealSolr(SolrIntegrationTestCase,
     def test_dossier_participations_fields(self, mocker, browser):
         self.login(self.regular_user, browser=browser)
 
+        self.mock_labels(mocker)
         self.mock_get_by_id(mocker, self.person_jean)
         self.mock_get_by_id(mocker, self.org_ftw)
         handler = IParticipationAware(self.dossier)
@@ -1826,6 +1827,7 @@ class TestKuBDossierParticipationsInListingWithRealSolr(SolrIntegrationTestCase,
     def test_dossier_participant_and_roles_filters(self, mocker, browser):
         self.login(self.regular_user, browser=browser)
 
+        self.mock_labels(mocker)
         self.mock_get_by_id(mocker, self.person_jean)
         self.mock_get_by_id(mocker, self.org_ftw)
         handler = IParticipationAware(self.dossier)

--- a/opengever/contact/tests/test_participation.py
+++ b/opengever/contact/tests/test_participation.py
@@ -622,6 +622,7 @@ class TestRemoveKubParticipation(KuBIntegrationTestCase):
     @browsing
     def test_deleting_kub_participation_is_not_supported(self, mocker, browser):
         self.login(self.regular_user, browser)
+        self.mock_labels(mocker)
         self.mock_get_by_id(mocker, self.person_jean)
         handler = IParticipationAware(self.empty_dossier)
         handler.add_participation(self.person_jean, roles=['participation'])

--- a/opengever/dossier/tests/test_indexer.py
+++ b/opengever/dossier/tests/test_indexer.py
@@ -480,6 +480,7 @@ class TestDossierParticipationsIndexerWithKuB(SolrIntegrationTestCase, KuBIntegr
     def test_kub_participations_are_indexed_in_solr(self, mocker):
         self.login(self.regular_user)
 
+        self.mock_labels(mocker)
         self.mock_get_by_id(mocker, self.person_jean)
         handler = IParticipationAware(self.dossier)
         handler.add_participation(

--- a/opengever/dossier/tests/test_participation.py
+++ b/opengever/dossier/tests/test_participation.py
@@ -198,50 +198,61 @@ class TestKuBParticipationHanlder(KuBIntegrationTestCase, TestPloneParticipation
     valid_id = 'person:9af7d7cc-b948-423f-979f-587158c6bc65'
 
     def test_handler_delegates_to_correct_handler_class(self, mocker):
-        self.mock_get_by_id(mocker, self.valid_id)
+        self.mock_labels(mocker)
         super(TestKuBParticipationHanlder, self).test_handler_delegates_to_correct_handler_class()
 
     def test_adding_participation(self, mocker):
+        self.mock_labels(mocker)
         self.mock_get_by_id(mocker, self.valid_id)
         super(TestKuBParticipationHanlder, self).test_adding_participation()
 
     def test_updating_participation(self, mocker):
+        self.mock_labels(mocker)
         self.mock_get_by_id(mocker, self.valid_id)
         super(TestKuBParticipationHanlder, self).test_updating_participation()
 
     def test_deleting_participation(self, mocker):
+        self.mock_labels(mocker)
         self.mock_get_by_id(mocker, self.valid_id)
         super(TestKuBParticipationHanlder, self).test_deleting_participation()
 
     def test_only_one_participation_per_participant_is_allowed(self, mocker):
+        self.mock_labels(mocker)
         self.mock_get_by_id(mocker, self.valid_id)
         super(TestKuBParticipationHanlder, self).test_only_one_participation_per_participant_is_allowed()
 
     def test_cannot_add_participation_for_invalid_participant(self, mocker):
+        self.mock_labels(mocker)
         self.mock_get_by_id(mocker, "invalid-id")
         super(TestKuBParticipationHanlder, self).test_cannot_add_participation_for_invalid_participant()
 
     def test_cannot_delete_missing_participation(self, mocker):
+        self.mock_labels(mocker)
         self.mock_get_by_id(mocker, self.valid_id)
         super(TestKuBParticipationHanlder, self).test_cannot_delete_missing_participation()
 
     def test_cannot_update_missing_participation(self, mocker):
+        self.mock_labels(mocker)
         self.mock_get_by_id(mocker, self.valid_id)
         super(TestKuBParticipationHanlder, self).test_cannot_update_missing_participation()
 
     def test_cannot_add_participation_with_invalid_role(self, mocker):
+        self.mock_labels(mocker)
         self.mock_get_by_id(mocker, self.valid_id)
         super(TestKuBParticipationHanlder, self).test_cannot_add_participation_with_invalid_role()
 
     def test_cannot_add_participation_without_role(self, mocker):
+        self.mock_labels(mocker)
         self.mock_get_by_id(mocker, self.valid_id)
         super(TestKuBParticipationHanlder, self).test_cannot_add_participation_without_role()
 
     def test_cannot_update_participation_with_invalid_role(self, mocker):
+        self.mock_labels(mocker)
         self.mock_get_by_id(mocker, self.valid_id)
         super(TestKuBParticipationHanlder, self).test_cannot_update_participation_with_invalid_role()
 
     def test_cannot_update_participation_without_role(self, mocker):
+        self.mock_labels(mocker)
         self.mock_get_by_id(mocker, self.valid_id)
         super(TestKuBParticipationHanlder, self).test_cannot_update_participation_without_role()
 

--- a/opengever/kub/client.py
+++ b/opengever/kub/client.py
@@ -1,6 +1,8 @@
 from opengever.base.sentry import log_msg_to_sentry
 from opengever.kub.interfaces import IKuBSettings
 from plone import api
+from plone.memoize import ram
+from time import time
 import requests
 
 
@@ -51,3 +53,18 @@ class KuBClient(object):
 
     def get_resolve_url(self, _id):
         return u'{}resolve/{}'.format(self.kub_api_url, _id)
+
+    # Cache kub labels for an hour
+    @ram.cache(lambda *args: time() // (60 * 60))
+    def get_kub_id_label_mapping(self):
+        return self._prepare_kub_label_mapping()
+
+    def _prepare_kub_label_mapping(self):
+        resp = self.session.get(u'{}labels'.format(self.kub_api_url))
+        try:
+            resp.raise_for_status()
+        except requests.HTTPError as exc:
+            log_msg_to_sentry(exc.message)
+            raise LookupError
+        return {
+            item['typedId']: item['label'] for item in resp.json()['results']}

--- a/opengever/kub/sources.py
+++ b/opengever/kub/sources.py
@@ -35,8 +35,8 @@ class KuBContactsSource(object):
             raise LookupError()
 
         if ActorLookup(token).is_kub_contact():
-            item = self.client.get_by_id(token)
-            return self._kub_term(item)
+            mapping = self.client.get_kub_id_label_mapping()
+            return SimpleTerm(value=token, title=mapping.get(token, token))
 
         # it's an ogds user
         try:

--- a/opengever/kub/testing.py
+++ b/opengever/kub/testing.py
@@ -29,6 +29,11 @@ class KuBIntegrationTestCase(IntegrationTestCase):
         mocker.get(url, json=KUB_RESPONSES[url], **kwargs)
         return url
 
+    def mock_labels(self, mocker):
+        url = u'{}labels'.format(self.client.kub_api_url)
+        mocker.get(url, json=KUB_RESPONSES[url])
+        return url
+
 
 # These responses are taken from performing these exact requests against
 # the database defined in "fixtures/gever-testing.json" in the KUB repository.
@@ -786,5 +791,40 @@ KUB_RESPONSES = {
         "url": "http://localhost:8000/api/v1/people/9af7d7cc-b948-423f-979f-587158c6bc65",
         "typedId": "person:9af7d7cc-b948-423f-979f-587158c6bc65",
         "type": "person"
+    },
+
+    "http://localhost:8000/api/v1/labels": {
+        "results": [
+            {
+                "id": "0e623708-2d0d-436a-82c6-c1a9c27b65dc",
+                "typedId": "person:0e623708-2d0d-436a-82c6-c1a9c27b65dc",
+                "label": "Dupont Julie"
+            },
+            {
+                "id": "1193d423-ce13-4dd9-aa8d-1f224f6a2b96",
+                "typedId": "person:1193d423-ce13-4dd9-aa8d-1f224f6a2b96",
+                "label": "Peter Hans"
+            },
+            {
+                "id": "5db3e407-7fc3-4093-a6cf-96030044285a",
+                "typedId": "person:5db3e407-7fc3-4093-a6cf-96030044285a",
+                "label": "Schaudi Julia"
+            },
+            {
+                "id": "9af7d7cc-b948-423f-979f-587158c6bc65",
+                "typedId": "person:9af7d7cc-b948-423f-979f-587158c6bc65",
+                "label": "Dupont Jean"
+            },
+            {
+                "id": "30bab83d-300a-4886-97d4-ff592e88a56a",
+                "typedId": "organization:30bab83d-300a-4886-97d4-ff592e88a56a",
+                "label": "4Teamwork"
+            },
+            {
+                "id": "8345fcfe-2d67-4b75-af46-c25b2f387448",
+                "typedId": "membership:8345fcfe-2d67-4b75-af46-c25b2f387448",
+                "label": "Dupont Jean - 4Teamwork (CEO)"
+            }
+        ]
     }
 }

--- a/opengever/kub/tests/test_kub_contact_source.py
+++ b/opengever/kub/tests/test_kub_contact_source.py
@@ -50,27 +50,28 @@ class TestKubContactSource(KuBIntegrationTestCase):
                               [term.title for term in terms])
 
     def test_get_term_by_token_handles_persons(self, mocker):
-        self.mock_get_by_id(mocker, self.person_jean)
+        self.mock_labels(mocker)
         term = self.source.getTermByToken(self.person_jean)
         self.assertEqual(self.person_jean, term.token)
         self.assertEqual(self.person_jean, term.value)
         self.assertEqual('Dupont Jean', term.title)
 
     def test_get_by_id_handles_organizations(self, mocker):
-        self.mock_get_by_id(mocker, self.org_ftw)
+        self.mock_labels(mocker)
         term = self.source.getTermByToken(self.org_ftw)
         self.assertEqual(self.org_ftw, term.token)
         self.assertEqual(self.org_ftw, term.value)
         self.assertEqual('4Teamwork', term.title)
 
     def test_get_by_id_handles_memberships(self, mocker):
-        self.mock_get_by_id(mocker, self.memb_jean_ftw)
+        self.mock_labels(mocker)
         term = self.source.getTermByToken(self.memb_jean_ftw)
         self.assertEqual(self.memb_jean_ftw, term.token)
         self.assertEqual(self.memb_jean_ftw, term.value)
         self.assertEqual('Dupont Jean - 4Teamwork (CEO)', term.title)
 
     def test_get_by_id_handles_ogds_users(self, mocker):
+        self.mock_labels(mocker)
         term = self.source.getTermByToken(self.regular_user.getId())
         ogds_user = ogds_service().fetch_user(self.regular_user.getId())
         self.assertEqual(self.regular_user.getId(), term.token)
@@ -78,6 +79,7 @@ class TestKubContactSource(KuBIntegrationTestCase):
         self.assertEqual(u'B\xe4rfuss K\xe4thi (kathi.barfuss)', term.title)
 
     def test_get_by_id_raises_lookup_error_for_invalid_token(self, mocker):
+        self.mock_labels(mocker)
         contact_id = "invalid-id"
         self.mock_get_by_id(mocker, contact_id)
         with self.assertRaises(LookupError):

--- a/opengever/latex/tests/test_dossierdetails.py
+++ b/opengever/latex/tests/test_dossierdetails.py
@@ -201,6 +201,7 @@ class TestDossierDetailsWithKuB(KuBIntegrationTestCase, TestDossierDetailsBase):
 
         self.login(self.regular_user)
 
+        self.mock_labels(mocker)
         self.mock_get_by_id(mocker, 'person:9af7d7cc-b948-423f-979f-587158c6bc65')
         handler = IParticipationAware(self.dossier)
         handler.add_participation(


### PR DESCRIPTION
With the current implementation, we had some serious performance issues, when accessing a large dossier listing with thousands of KuB-participations. Because the participation facet has led to thousands of separate kub-reqest (one separate request for each participations).

We solve the issue by using a separated, newly introduced KuB endpoint called `labels` (needs https://github.com/4teamwork/kub/pull/130), which returns the label for all contacts (people, organization and memberships) and create a mapping of those. This mapping will be cached for one hour.

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-3978]

Needs  backport to LTS `2022.4` and `2022.11`

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-3978]: https://4teamwork.atlassian.net/browse/CA-3978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ