### PR TITLE
No longer sync groups with names containing non-ascii characters into the OGDS

### DIFF
--- a/changes/CA-4449.bugfix
+++ b/changes/CA-4449.bugfix
@@ -1,0 +1,1 @@
+No longer sync groups with names containing non-ascii characters into the OGDS. [tinagerber]

--- a/opengever/ogds/base/sync/ogds_updater.py
+++ b/opengever/ogds/base/sync/ogds_updater.py
@@ -447,6 +447,12 @@ class OGDSUpdater(object):
                     groupid = info['fullname']
 
                 groupid = groupid.decode('utf-8')
+                try:
+                    groupid.encode('ascii')
+                except UnicodeEncodeError:
+                    logger.warn(
+                        u"Skipping group '{}' - contains non-ascii characters".format(groupid))
+                    continue
                 info['groupid'] = groupid
 
                 # Skip groups with groupid longer than SQL 'groupid' column


### PR DESCRIPTION
Since these groups cannot be authorised in GEVER anyway, we do not need to synchronise them.

For [CA-4449]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-4449]: https://4teamwork.atlassian.net/browse/CA-4449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ