### PR TITLE
Retrieve comment from event for DocumenVersionCreatedActivity.

### DIFF
--- a/opengever/document/activities.py
+++ b/opengever/document/activities.py
@@ -52,6 +52,10 @@ class DocumenVersionCreatedActivity(BaseActivity):
     """
     kind = 'document-version-created'
 
+    def __init__(self, context, request, comment):
+        super(DocumenVersionCreatedActivity, self).__init__(context, request)
+        self.comment = comment
+
     @property
     def summary(self):
         return self.translate_to_all_languages(
@@ -65,16 +69,11 @@ class DocumenVersionCreatedActivity(BaseActivity):
 
     @property
     def description(self):
-        versioner = Versioner(self.context)
-        version_id = versioner.get_current_version_id()
-        if version_id is None:
-            return {}
-        comment = versioner.retrieve_version(version_id).comment
-        if comment:
+        if self.comment:
             return self.translate_to_all_languages(
                 _(u'label_prefixed_journal_comment',
                   default=u'Comment: ${comment}',
-                  mapping={'comment': comment}))
+                  mapping={'comment': self.comment}))
         else:
             return {}
 

--- a/opengever/document/checkout/manager.py
+++ b/opengever/document/checkout/manager.py
@@ -358,10 +358,12 @@ class CheckinCheckoutManager(object):
             comment = translate(msg, context=self.request)
             # This will also update the approval_state index in Solr
             self.versioner.create_version(comment)
+        else:
+            comment = ''
 
         # event
         notify(ObjectRevertedToVersion(self.context, version_id,
-                                       create_version))
+                                       create_version, comment))
 
     def is_locked(self):
         """Returns True if a user has a WebDAV lock on the adapted

--- a/opengever/document/events.py
+++ b/opengever/document/events.py
@@ -49,10 +49,11 @@ class ObjectCheckoutCanceledEvent(ObjectEvent):
 class ObjectRevertedToVersion(ObjectEvent):
     """The document was reverted back to a specific version."""
 
-    def __init__(self, obj, version_id, create_version):
+    def __init__(self, obj, version_id, create_version, comment):
         self.object = obj
         self.version_id = version_id
         self.create_version = create_version
+        self.comment = comment
 
 
 @implementer(interfaces.IFileCopyDownloadedEvent)

--- a/opengever/document/handlers.py
+++ b/opengever/document/handlers.py
@@ -138,7 +138,8 @@ def document_reverted_to_version(context, event):
 
 
 def document_version_created(context, event):
-    DocumenVersionCreatedActivity(context, getRequest()).record()
+    DocumenVersionCreatedActivity(
+        context, getRequest(), getattr(event, "comment", None)).record()
 
 
 def author_or_title_changed(context, event):

--- a/opengever/document/interfaces.py
+++ b/opengever/document/interfaces.py
@@ -31,6 +31,8 @@ class IObjectCheckoutCanceledEvent(IObjectEvent):
 class IObjectRevertedToVersion(IObjectEvent):
     """The object was reverted back to a specific version."""
 
+    comment = schema.Text(title=u'journal comment')
+
 
 class IFileCopyDownloadedEvent(IObjectEvent):
     """Event interface for event.FileDownloadedEvent."""

--- a/opengever/journal/tests/test_integration.py
+++ b/opengever/journal/tests/test_integration.py
@@ -201,11 +201,11 @@ class TestOpengeverJournalGeneral(unittest.TestCase):
 
         # Object Reverted-To-Version-Event with fail
         length = get_journal_length(document)
-        notify(ObjectRevertedToVersion(document, '', ''))
+        notify(ObjectRevertedToVersion(document, '', '', ''))
         self.assertTrue(length == get_journal_length(document))
 
         # Object Reverted-To-Version-Event
-        notify(ObjectRevertedToVersion(document, 'v1', 'v1'))
+        notify(ObjectRevertedToVersion(document, 'v1', 'v1', ''))
         self.check_document_revertedtoversion(document)
 
         # Object Sent Document Event


### PR DESCRIPTION
The comment is already stored on the corresponding event (`ObjectCheckedInEvent`), so we can avoid retrieving the latest version of the document in the activity by simply getting the comment from the event. This is more efficient and fixes issues with testing, as retrieving a version makes a transaction savepoint which is not supported by the testserver.

So to be clear, this fixes the failing gever-ui tests...

For [CA-4235]

## Checklist
- [ ] Changelog entry -> no cl entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-4235]: https://4teamwork.atlassian.net/browse/CA-4235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ