### PR TITLE
Optimize resolve GUID section in bundle import

### DIFF
--- a/changes/CA-4240.other
+++ b/changes/CA-4240.other
@@ -1,0 +1,1 @@
+Optimize resolve GUID section in bundle import. [buchi]

--- a/opengever/bundle/sections/resolveguid.py
+++ b/opengever/bundle/sections/resolveguid.py
@@ -73,9 +73,9 @@ class ResolveGUIDSection(object):
         self.bundle.item_by_guid = OrderedDict()
 
         # Table of formatted refnums that exist in Plone
-        self.bundle.existing_refnums = ()
+        self.bundle.existing_refnums = set()
         # Table of bundle GUIDs that exist in Plone
-        self.bundle.existing_guids = ()
+        self.bundle.existing_guids = set()
 
         # Current reference number formatter
         self.formatter = None
@@ -105,7 +105,7 @@ class ResolveGUIDSection(object):
 
     def get_existing_refnums(self):
         index = self.catalog._catalog.indexes['reference']
-        return tuple(index.uniqueValues())
+        return set(index.uniqueValues())
 
     def register_items_by_guid(self):
         """Register all items by their guid."""
@@ -158,8 +158,7 @@ class ResolveGUIDSection(object):
 
     def get_all_existing_guids(self):
         index = self.catalog._catalog.indexes['bundle_guid']
-        guids = tuple(index.uniqueValues())
-        return guids
+        return set(index.uniqueValues())
 
     def track_actual_item_stats(self, item):
         portal_type = item['_type']


### PR DESCRIPTION
If the site already contains a large amount of items the resolve GUID section can take several hours. By using sets for containment checks, this is reduced to a few seconds.

For [CA-4240](https://4teamwork.atlassian.net/browse/CA-4240)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

