### PR TITLE
Index containing_dossier for document templates

### DIFF
--- a/changes/CA-4286.bugfix
+++ b/changes/CA-4286.bugfix
@@ -1,0 +1,1 @@
+Fix indexing of containing_dossier and containing_subdossier for documents in dossier templates. [tinagerber]

--- a/changes/CA-4286.feature
+++ b/changes/CA-4286.feature
@@ -1,0 +1,1 @@
+Index containing_dossier for document templates. [tinagerber]

--- a/opengever/core/upgrades/20220719160233_index_containing_dossier_and_subdossier_in_template_folder/upgrade.py
+++ b/opengever/core/upgrades/20220719160233_index_containing_dossier_and_subdossier_in_template_folder/upgrade.py
@@ -1,0 +1,26 @@
+from ftw.upgrade import UpgradeStep
+from opengever.core.upgrade import NightlyIndexer
+from plone import api
+
+
+class IndexContainingDossierAndSubdossierInTemplateFolder(UpgradeStep):
+    """Index containing_dossier and subdossier in template folder
+    """
+
+    deferrable = True
+
+    def __call__(self):
+        catalog = api.portal.get_tool('portal_catalog')
+        portal_path = '/'.join(api.portal.get().getPhysicalPath())
+        templatefolder_query = {'path': {'query': portal_path, 'depth': 1},
+                                'portal_type': 'opengever.dossier.templatefolder'}
+        templatefolder_paths = [brain.getPath() for brain in catalog(templatefolder_query)]
+
+        for templatefolder_path in templatefolder_paths:
+            query = {'path': {'query': templatefolder_path},
+                     'portal_type': 'opengever.document.document'}
+
+            with NightlyIndexer(idxs=["containing_dossier", "containing_subdossier"],
+                                index_in_solr_only=True) as indexer:
+                for brain in self.brains(query, "Index containing_dossier and containing_subdossier"):
+                    indexer.add_by_brain(brain)

--- a/opengever/document/configure.zcml
+++ b/opengever/document/configure.zcml
@@ -356,6 +356,11 @@
       name="approval_state"
       />
 
+  <adapter
+      factory=".indexers.containing_dossier_title"
+      name="containing_dossier"
+      />
+
   <adapter factory=".document.UploadValidator" />
 
   <adapter factory=".fileactions.BaseDocumentFileActions" />

--- a/opengever/document/indexers.py
+++ b/opengever/document/indexers.py
@@ -14,6 +14,7 @@ from opengever.document.behaviors.metadata import IDocumentMetadata
 from opengever.document.document import IDocumentSchema
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.document.interfaces import IDocumentIndexer
+from opengever.document.interfaces import ITemplateDocumentMarker
 from opengever.ogds.base.actor import Actor
 from plone import api
 from plone.indexer import indexer
@@ -264,3 +265,13 @@ def approval_state(obj):
     approvals = IApprovalList(obj)
     approval_state = approvals.get_approval_state()
     return approval_state
+
+
+@indexer(ITemplateDocumentMarker)
+def containing_dossier_title(obj):
+    templatefolder = obj.get_parent_dossier()
+    if not templatefolder:
+        return None
+    languages = api.portal.get_tool('portal_languages').getSupportedLanguages()
+    titles = [templatefolder.Title(language.split('-')[0]) for language in languages]
+    return ' / '.join(titles)

--- a/opengever/document/tests/test_indexers.py
+++ b/opengever/document/tests/test_indexers.py
@@ -315,6 +315,12 @@ class SolrDocumentIndexer(SolrIntegrationTestCase):
         self.assertIn(u'Doc One Hugo Boss Client1 1.1 / 1 / 44 44 foo bar',
                       indexed_value)
 
+    def test_containing_subdossier_is_indexed_for_document_in_subdossiertemplate(self):
+        self.login(self.regular_user)
+        document = create(Builder("document").within(self.subdossiertemplate))
+        self.commit_solr()
+        self.assertEqual(u'Anfragen', solr_data_for(document)['containing_subdossier'])
+
     def test_removing_document_type_gets_indexed_correctly(self):
         self.login(self.regular_user)
         self.assertEqual('contract', solr_data_for(self.document, 'document_type'))

--- a/opengever/document/tests/test_indexers.py
+++ b/opengever/document/tests/test_indexers.py
@@ -321,6 +321,19 @@ class SolrDocumentIndexer(SolrIntegrationTestCase):
         self.commit_solr()
         self.assertEqual(u'Anfragen', solr_data_for(document)['containing_subdossier'])
 
+    def test_containing_dossier_is_indexed_for_document_templates(self):
+        self.login(self.regular_user)
+        language_tool = api.portal.get_tool('portal_languages')
+        language_tool.supported_langs = ['fr', 'de-ch']
+        self.normal_template.reindexObject()
+        self.subtemplate.reindexObject()
+        self.commit_solr()
+
+        self.assertEqual(u'Mod\xe8le / Vorlagen',
+                         solr_data_for(self.normal_template)['containing_dossier'])
+        self.assertEqual(u'Mod\xe8les nouveau / Vorlagen neu',
+                         solr_data_for(self.subtemplate)['containing_dossier'])
+
     def test_removing_document_type_gets_indexed_correctly(self):
         self.login(self.regular_user)
         self.assertEqual('contract', solr_data_for(self.document, 'document_type'))

--- a/opengever/dossier/configure.zcml
+++ b/opengever/dossier/configure.zcml
@@ -318,6 +318,12 @@
       />
 
   <subscriber
+      for="opengever.dossier.dossiertemplate.behaviors.IDossierTemplateMarker
+           zope.lifecycleevent.interfaces.IObjectModifiedEvent"
+      handler=".handlers.reindex_contained_objects"
+      />
+
+  <subscriber
       for="opengever.dossier.behaviors.dossier.IDossierMarker
            opengever.sharing.interfaces.ILocalRolesAcquisitionBlocked"
       handler=".handlers.reindex_blocked_local_roles"

--- a/opengever/dossier/indexers.py
+++ b/opengever/dossier/indexers.py
@@ -16,6 +16,7 @@ from opengever.dossier.behaviors.filing import IFilingNumberMarker
 from opengever.dossier.behaviors.participation import IParticipationAware
 from opengever.dossier.behaviors.participation import IParticipationAwareMarker
 from opengever.dossier.browser.participants import translate_participation_role
+from opengever.dossier.dossiertemplate.behaviors import IDossierTemplateMarker
 from opengever.dossier.participations import IParticipationData
 from opengever.dossier.resolve import AfterResolveJobs
 from opengever.dossier.utils import get_main_dossier
@@ -177,12 +178,11 @@ def containing_subdossier(obj):
         if ISiteRoot.providedBy(parent):
             # Shouldn't happen, just to be safe
             break
-        if IDossierMarker.providedBy(parent):
+        if IDossierMarker.providedBy(parent) or IDossierTemplateMarker.providedBy(parent):
             parent_dossier_found = True
             parent_dossier = parent
 
-    if IDossierMarker.providedBy(aq_parent(parent_dossier)):
-        # parent dossier is a subdossier
+    if parent_dossier and parent_dossier.is_subdossier():
         return parent_dossier.Title()
     return ''
 

--- a/opengever/dossier/templatefolder/configure.zcml
+++ b/opengever/dossier/templatefolder/configure.zcml
@@ -114,6 +114,12 @@
       handler=".subscribers.configure_templatefolder_portlets"
       />
 
+  <subscriber
+      for="opengever.dossier.templatefolder.interfaces.ITemplateFolder
+           zope.lifecycleevent.interfaces.IObjectModifiedEvent"
+      handler=".subscribers.reindex_contained_documents"
+      />
+
   <utility
       factory=".vocabulary.DocumentTemplatesVocabulary"
       name="opengever.dossier.DocumentTemplatesVocabulary"

--- a/opengever/dossier/templatefolder/subscribers.py
+++ b/opengever/dossier/templatefolder/subscribers.py
@@ -1,6 +1,14 @@
+from ftw.solr.interfaces import ISolrSearch
+from ftw.solr.query import make_path_filter
 from opengever.base.portlets import add_navigation_portlet_assignment
 from opengever.base.portlets import block_context_portlet_inheritance
+from opengever.base.security import elevated_privileges
+from opengever.base.solr import batched_solr_results
+from opengever.document.interfaces import ITemplateDocumentMarker
 from plone import api
+from plone.app.workflow.interfaces import ILocalrolesModifiedEvent
+from zope.component import queryUtility
+from zope.container.interfaces import IContainerModifiedEvent
 
 
 def configure_templatefolder_portlets(templatefolder, event):
@@ -20,3 +28,37 @@ def configure_templatefolder_portlets(templatefolder, event):
         templatefolder,
         root=u'/'.join(url_tool.getRelativeContentPath(templatefolder)),
         topLevel=0)
+
+
+def reindex_contained_documents(templatefolder, event):
+    """When a templatefolder is modified, if the title has changed we reindex
+    the containing_dossier index in all contained documents
+    """
+    if ILocalrolesModifiedEvent.providedBy(event) or \
+       IContainerModifiedEvent.providedBy(event):
+        return
+
+    attrs = tuple(
+        attr
+        for descr in event.descriptions
+        for attr in descr.attributes
+    )
+    title_attrs = ['ITranslatedTitle.title_de', 'ITranslatedTitle.title_fr',
+                   'ITranslatedTitle.title_en']
+    for attr in title_attrs:
+        if attr in attrs:
+            languages = api.portal.get_tool('portal_languages').getSupportedLanguages()
+            titles = [templatefolder.Title(language.split('-')[0]) for language in languages]
+            containing_dossier_title = ' / '.join(titles)
+            solr = queryUtility(ISolrSearch)
+            filters = make_path_filter('/'.join(templatefolder.getPhysicalPath()), depth=-1)
+            filters.append('object_provides:{}'.format(ITemplateDocumentMarker.__identifier__))
+
+            with elevated_privileges():
+                for batch in batched_solr_results(filters=filters, fl='UID'):
+                    for doc in batch:
+                        solr.manager.connection.add({
+                            "UID": doc['UID'],
+                            "containing_dossier": {"set": containing_dossier_title},
+                        })
+            return

--- a/opengever/dossier/tests/test_dossier_template.py
+++ b/opengever/dossier/tests/test_dossier_template.py
@@ -94,17 +94,6 @@ class TestDossierTemplate(IntegrationTestCase):
         self.assertEquals(['Template'], browser.css('h1').text)
 
     @browsing
-    def test_edit_dossiertemplate_works_properly(self, browser):
-        self.login(self.administrator, browser=browser)
-
-        browser.open(self.dossiertemplate)
-        browser.find('Edit').click()
-        browser.fill({'Title': 'Edited Template'}).submit()
-
-        self.assertEquals(['Changes saved'], info_messages())
-        self.assertEquals(['Edited Template'], browser.css('h1').text)
-
-    @browsing
     def test_addable_types(self, browser):
         self.login(self.administrator, browser=browser)
         browser.open(self.dossiertemplate)
@@ -271,6 +260,17 @@ class TestDossierTemplate(IntegrationTestCase):
 
 
 class TestDossierTemplateWithSolr(SolrIntegrationTestCase):
+
+    @browsing
+    def test_edit_dossiertemplate_works_properly(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        browser.open(self.dossiertemplate)
+        browser.find('Edit').click()
+        browser.fill({'Title': 'Edited Template'}).submit()
+
+        self.assertEquals(['Changes saved'], info_messages())
+        self.assertEquals(['Edited Template'], browser.css('h1').text)
 
     @browsing
     def test_dossiertemplates_tab_lists_only_dossiertemplates_without_subdossiers(self, browser):

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -842,7 +842,10 @@ class OpengeverContentFixture(object):
         subtemplates = self.register('subtemplates', create(
             Builder('templatefolder')
             .titled(u'Vorlagen neu')
-            .having(id='vorlagen-neu')
+            .having(id='vorlagen-neu',
+                    title_de=u'Vorlagen neu',
+                    title_en=u'Templates new',
+                    title_fr=u'Mod\xe8les nouveau')
             .within(self.templates)
         ))
 


### PR DESCRIPTION
We want to provide the containing_dossier column for document templates. Since template folders are multilingual, the index is composed of the titles of all enabled languages.

I noticed that in the UI for documents in dossier templates we provide the containing_subdossier column but the indexer is missing. Also, containing_dossier was not updated when editing the dossier template title. Therefore, I have corrected this as well.

For [CA-4286]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [x] Make it deferrable if possible
  - [x] Execute as much as possible conditionally