### PR TITLE
Add parameter to deactivate the workspace in the @unlink-workspace endpoint

### DIFF
--- a/changes/CA-3514.feature
+++ b/changes/CA-3514.feature
@@ -1,0 +1,1 @@
+Add parameter to deactivate the workspace in the @unlink-workspace endpoint. [tinagerber]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,7 +11,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
-
+- ``@unlink-workspace``: Add field ``deactivate_workspace``. (see :ref:`unlink-workspace`)
 
 2022.14.0 (2022-07-20)
 ----------------------

--- a/docs/public/dev-manual/api/linked_workspaces.rst
+++ b/docs/public/dev-manual/api/linked_workspaces.rst
@@ -101,11 +101,12 @@ Ein Dosser kann über den Endpoint ``@link-to-workspace`` mit einem bestehenden 
 
       HTTP/1.1 204 No Content
 
+.. _unlink-workspace:
 
 Teamraum Verknüpfung entfernen
 ------------------------------
 
-Eine bestehende Verknüpfung eines Teamraums kann mit dem ``@unlink-workspace`` Endpoint entfernt werden. Dabei werden auch bestehende Locks auf verlinkten Dokumenten aufgehoben. Der Teamraum bleibt aber bestehen.
+Eine bestehende Verknüpfung eines Teamraums kann mit dem ``@unlink-workspace`` Endpoint entfernt werden. Dabei werden auch bestehende Locks auf verlinkten Dokumenten aufgehoben. Der Teamraum bleibt aber bestehen. Mit dem Parameter ``deactivate_workspace`` kann der Teamraum zusätzlich deaktiviert werden.
 
 **Beispiel-Request**:
 
@@ -116,7 +117,8 @@ Eine bestehende Verknüpfung eines Teamraums kann mit dem ``@unlink-workspace`` 
     Content-Type: application/json
 
     {
-      "workspace_uid": "c11627f492b6447fb61617bb06b9a21a"
+      "workspace_uid": "c11627f492b6447fb61617bb06b9a21a",
+      "deactivate_workspace": true
     }
 
 **Beispiel-Response**:

--- a/opengever/api/linked_workspaces.py
+++ b/opengever/api/linked_workspaces.py
@@ -128,8 +128,8 @@ class UnlinkWorkspacePost(LinkedWorkspacesService):
         if not workspace_uid:
             raise BadRequest(_(u"workspace_uid_required",
                                default=u"Property 'workspace_uid' is required"))
-
-        ILinkedWorkspaces(self.context).unlink_workspace(workspace_uid)
+        deactivate_workspace = data.get('deactivate_workspace', False)
+        ILinkedWorkspaces(self.context).unlink_workspace(workspace_uid, deactivate_workspace)
         return self.reply_no_content()
 
 

--- a/opengever/workspace/__init__.py
+++ b/opengever/workspace/__init__.py
@@ -6,6 +6,8 @@ from zope.i18nmessageid import MessageFactory
 
 _ = MessageFactory('opengever.workspace')
 
+DEACTIVATE_WORKSPACE_TRANSITION = 'opengever_workspace--TRANSITION--deactivate--active_inactive'
+
 WHITELISTED_TEAMRAUM_GLOBAL_SOURCES = set()
 
 WHITELISTED_TEAMRAUM_PORTAL_TYPES = {

--- a/opengever/workspaceclient/client.py
+++ b/opengever/workspaceclient/client.py
@@ -1,3 +1,4 @@
+from opengever.workspace import DEACTIVATE_WORKSPACE_TRANSITION
 from opengever.workspaceclient import is_workspace_client_feature_available
 from opengever.workspaceclient.exceptions import WorkspaceClientFeatureNotEnabled
 from opengever.workspaceclient.exceptions import WorkspaceURLMissing
@@ -102,6 +103,18 @@ class WorkspaceClient(object):
             workspace.get('@id'),
             json={'external_reference': new_dossier_oguid,
                   'gever_url': self.get_gever_url(new_dossier_oguid)})
+
+    def deactivate_workspace(self, workspace_url):
+        """Deactivates workspace"""
+        return self.request.post('{}/@workflow/{}'.format(workspace_url,
+                                                          DEACTIVATE_WORKSPACE_TRANSITION))
+
+    def is_workspace_deactivation_transition_available(self, workspace_url):
+        workflow_url = '{}/@workflow'.format(workspace_url)
+        response = self.request.get(workflow_url).json()
+        transition_url = '{}/{}'.format(workflow_url, DEACTIVATE_WORKSPACE_TRANSITION)
+        transition_ids = [transition['@id'] for transition in response.get('transitions', [])]
+        return transition_url in transition_ids
 
     def unlink_workspace(self, workspace_uid):
         """Removes external_reference on the workspace"""

--- a/opengever/workspaceclient/locales/de/LC_MESSAGES/opengever.workspaceclient.po
+++ b/opengever/workspaceclient/locales/de/LC_MESSAGES/opengever.workspaceclient.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-04-07 13:05+0000\n"
+"POT-Creation-Date: 2022-07-21 07:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,6 +17,11 @@ msgstr ""
 #: ./opengever/workspaceclient/linked_workspaces.py
 msgid "Not moved to trash: Document was retrieved, but workspace document could not be moved to trash."
 msgstr "Nicht in Papierkorb verschoben: Dokument wurde erfolgreich zurückgeführt, aber das Teamraum-Dokument konnte nicht in den Papierkorb verschoben werden."
+
+#. Default: "The workspace was unlinked, but it could not be deactivated."
+#: ./opengever/workspaceclient/linked_workspaces.py
+msgid "deactivate_workspace_failed"
+msgstr "Die Verknüpfung wurde entfernt, aber der Teamraum konnte nicht deaktiviert werden."
 
 #. Default: "Document retrieved from teamraum"
 #: ./opengever/workspaceclient/linked_workspaces.py

--- a/opengever/workspaceclient/locales/en/LC_MESSAGES/opengever.workspaceclient.po
+++ b/opengever/workspaceclient/locales/en/LC_MESSAGES/opengever.workspaceclient.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-04-07 13:05+0000\n"
+"POT-Creation-Date: 2022-07-21 07:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,6 +17,11 @@ msgstr ""
 #: ./opengever/workspaceclient/linked_workspaces.py
 msgid "Not moved to trash: Document was retrieved, but workspace document could not be moved to trash."
 msgstr "Not moved to trash: the document was retrieved, but the workspace document could not be moved to the trash."
+
+#. Default: "The workspace was unlinked, but it could not be deactivated."
+#: ./opengever/workspaceclient/linked_workspaces.py
+msgid "deactivate_workspace_failed"
+msgstr "The workspace was unlinked, but it could not be deactivated."
 
 #. German translation: Dokument aus Teamraum zurückgeführt.
 #. Default: "Document retrieved from teamraum"

--- a/opengever/workspaceclient/locales/fr/LC_MESSAGES/opengever.workspaceclient.po
+++ b/opengever/workspaceclient/locales/fr/LC_MESSAGES/opengever.workspaceclient.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-04-07 13:05+0000\n"
+"POT-Creation-Date: 2022-07-21 07:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,6 +17,11 @@ msgstr ""
 #: ./opengever/workspaceclient/linked_workspaces.py
 msgid "Not moved to trash: Document was retrieved, but workspace document could not be moved to trash."
 msgstr "Pas déplacé vers la corbeille: le document a été rapatrié, mais le document de l’espace de travail n’a pas pu être déplacé vers la corbeille."
+
+#. Default: "The workspace was unlinked, but it could not be deactivated."
+#: ./opengever/workspaceclient/linked_workspaces.py
+msgid "deactivate_workspace_failed"
+msgstr ""
 
 #. Default: "Document retrieved from teamraum"
 #: ./opengever/workspaceclient/linked_workspaces.py

--- a/opengever/workspaceclient/locales/opengever.workspaceclient.pot
+++ b/opengever/workspaceclient/locales/opengever.workspaceclient.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-04-07 13:05+0000\n"
+"POT-Creation-Date: 2022-07-21 07:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,6 +19,11 @@ msgstr ""
 
 #: ./opengever/workspaceclient/linked_workspaces.py
 msgid "Not moved to trash: Document was retrieved, but workspace document could not be moved to trash."
+msgstr ""
+
+#. Default: "The workspace was unlinked, but it could not be deactivated."
+#: ./opengever/workspaceclient/linked_workspaces.py
+msgid "deactivate_workspace_failed"
 msgstr ""
 
 #. Default: "Document retrieved from teamraum"


### PR DESCRIPTION
One can now unlink a workspace and deactivate it at the same time.

For [CA-3514]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))

[CA-3514]: https://4teamwork.atlassian.net/browse/CA-3514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ