### PR TITLE
Fix column width in latex subdossier listings.

### DIFF
--- a/changes/CA-4413.bugfix
+++ b/changes/CA-4413.bugfix
@@ -1,0 +1,1 @@
+Fix column width in latex subdossier listings. [phgross]

--- a/opengever/latex/listing.py
+++ b/opengever/latex/listing.py
@@ -206,10 +206,14 @@ class DossiersLaTeXListing(LaTexListing):
 @adapter(Interface, Interface, Interface)
 class SubDossiersLaTeXListing(DossiersLaTeXListing):
 
-    def update_column_dict(self, columns):
-        del columns['reference']
-        del columns['repository_title']
-        self.reset_column_widths(columns)
+    def get_columns(self):
+        columns = [
+            col for col in super(SubDossiersLaTeXListing, self).get_columns()
+            if col.id not in ['reference', 'repository_title']]
+
+        # widen title and responsible columns
+        columns[1].width = '40%'
+        columns[2].width = '35%'
         return columns
 
 

--- a/opengever/latex/tests/test_listing.py
+++ b/opengever/latex/tests/test_listing.py
@@ -194,6 +194,11 @@ class TestSubDossierListing(BaseLatexListingTest):
             ['No.', 'Title', 'Responsible', 'State', 'Start', 'End'],
             [col.text_content().strip() for col in cols])
 
+        cols = table.xpath(CSSSelector('colgroup col').path)
+        self.assertEquals(
+            ['5%', '40%', '35%', '10%', '5%', '5%'],
+            [col.get('width') for col in cols])
+
     def test_drop_reference_from_default_dossier_listings(self):
         self.listing.items = [obj2brain(self.dossier)]
 


### PR DESCRIPTION
Before:
<img width="877" alt="Bildschirmfoto 2022-07-21 um 15 39 13" src="https://user-images.githubusercontent.com/485755/180227731-c0df62a8-01cc-44b5-96c5-519b62535386.png">

After:
<img width="860" alt="Bildschirmfoto 2022-07-21 um 15 39 21" src="https://user-images.githubusercontent.com/485755/180227742-ed094aa2-a24f-464e-a62a-f9afe34b8130.png">

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-4413]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-4413]: https://4teamwork.atlassian.net/browse/CA-4413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ