### PR TITLE
Support foreign zip codes in document properties

### DIFF
--- a/changes/CA-4489.bugfix
+++ b/changes/CA-4489.bugfix
@@ -1,0 +1,1 @@
+Support foreign zip codes in document properties. [tinagerber]

--- a/opengever/kub/docprops.py
+++ b/opengever/kub/docprops.py
@@ -134,7 +134,7 @@ class KuBAddressDocPropertyProvider(BaseDocPropertyProvider):
         address = self.context.get("primaryAddress") or {}
         return {
             'street': address.get("street"),
-            'zip_code': address.get("swissZipCode"),
+            'zip_code': address.get("swissZipCode") or address.get('foreignZipCode'),
             'city': address.get("town"),
             'country': address.get("countryName"),
         }

--- a/opengever/kub/tests/test_docprops.py
+++ b/opengever/kub/tests/test_docprops.py
@@ -1,5 +1,6 @@
 from opengever.kub.docprops import KuBEntityDocPropertyProvider
 from opengever.kub.entity import KuBEntity
+from opengever.kub.testing import KUB_RESPONSES
 from opengever.kub.testing import KuBIntegrationTestCase
 import requests_mock
 
@@ -26,6 +27,19 @@ class TestKuBEntityDocPropertyProvider(KuBIntegrationTestCase):
              'ogg.phone.number': None,
              'ogg.url.url': None},
             properties)
+
+    def test_zip_code_docproperty_is_swiss_or_foreign_zip_code(self, mocker):
+        url = self.mock_get_by_id(mocker, self.person_jean)
+        entity = KuBEntity(self.person_jean)
+        properties = KuBEntityDocPropertyProvider(entity).get_properties()
+        self.assertEqual(u'9999', properties['ogg.address.zip_code'])
+
+        KUB_RESPONSES[url]['primaryAddress']['swissZipCode'] = ""
+        KUB_RESPONSES[url]['primaryAddress']['foreignZipCode'] = "12345"
+        self.mock_get_by_id(mocker, self.person_jean)
+        entity = KuBEntity(self.person_jean)
+        properties = KuBEntityDocPropertyProvider(entity).get_properties()
+        self.assertEqual(u'12345', properties['ogg.address.zip_code'])
 
     def test_docproperties_for_kub_organization(self, mocker):
         self.mock_get_by_id(mocker, self.org_ftw)


### PR DESCRIPTION
KuB distinguishes between Swiss zip code and foreign zip code. Therefore the DocPropertyProvider must be able to handle both.

For [CA-4489]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-4489]: https://4teamwork.atlassian.net/browse/CA-4489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ