### PR TITLE
Add sender docproperties when creating document from template.

### DIFF
--- a/changes/CA-4429.feature
+++ b/changes/CA-4429.feature
@@ -1,0 +1,1 @@
+Add sender docproperties when creating document from template. [njohner]

--- a/docs/public-fr/admin-manual/proprietedocs/list.rst
+++ b/docs/public-fr/admin-manual/proprietedocs/list.rst
@@ -92,6 +92,38 @@ ProriétéDocs pour les coordonnées du destinataire (Adresse/Tel./E-Mail/URL):
 - ``ogg.recipient.email.address``
 - ``ogg.recipient.url.url``
 
+ProriétéDocs pour tous les types de expéditeur:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- ``ogg.sender.contact.title`` - Name der Organisation / zusammengesetzter Name der Person
+- ``ogg.sender.contact.description``
+
+ProriétéDocs d'expéditeurs de type personne:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- ``ogg.sender.person.salutation``
+- ``ogg.sender.person.firstname``
+- ``ogg.sender.person.lastname``
+- ``ogg.sender.person.academic_title``
+
+ProriétéDocs d'expéditeurs de type organisation:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- ``ogg.sender.organization.name``
+
+ProriétéDocs relation organisationnelle de l'expéditeur:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- ``ogg.sender.orgrole.function``
+- ``ogg.sender.orgrole.department``
+- ``ogg.sender.orgrole.description``
+
+ProriétéDocs pour les coordonnées de l'expéditeur (Adresse/Tel./E-Mail/URL):
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- ``ogg.sender.address.street``
+- ``ogg.sender.address.zip_code``
+- ``ogg.sender.address.city``
+- ``ogg.sender.address.country``
+- ``ogg.sender.phone.number``
+- ``ogg.sender.email.address``
+- ``ogg.sender.url.url``
+
 Ces ProriétéDocs sont obsolètes et ne doivent plus être utilisées:
 
 - ``Dossier.ReferenceNumber`` – référence du dossier qui contient le document

--- a/docs/public/admin-manual/docproperties/list.rst
+++ b/docs/public/admin-manual/docproperties/list.rst
@@ -99,6 +99,38 @@ Doc-Properties Empfänger Adresse/Tel./E-Mail/URL:
 - ``ogg.recipient.email.address``
 - ``ogg.recipient.url.url``
 
+Doc-Properties alle Absender:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- ``ogg.sender.contact.title`` - Name der Organisation / zusammengesetzter Name der Person
+- ``ogg.sender.contact.description``
+
+Doc-Properties Absender Person:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- ``ogg.sender.person.salutation``
+- ``ogg.sender.person.firstname``
+- ``ogg.sender.person.lastname``
+- ``ogg.sender.person.academic_title``
+
+Doc-Properties Absender Organisation:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- ``ogg.sender.organization.name``
+
+Doc-Properties Absender Organisationsbeziehung:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- ``ogg.sender.orgrole.function``
+- ``ogg.sender.orgrole.department``
+- ``ogg.sender.orgrole.description``
+
+Doc-Properties Absender Adresse/Tel./E-Mail/URL:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- ``ogg.sender.address.street``
+- ``ogg.sender.address.zip_code``
+- ``ogg.sender.address.city``
+- ``ogg.sender.address.country``
+- ``ogg.sender.phone.number``
+- ``ogg.sender.email.address``
+- ``ogg.sender.url.url``
+
 Die folgenden Doc-Properties sind deprecated, und sollten deshalb nicht mehr verwendet werden:
 
 - ``Dossier.ReferenceNumber`` – Aktenzeichen des Dossiers, welches das Dokument

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -12,6 +12,7 @@ Breaking Changes
 Other Changes
 ^^^^^^^^^^^^^
 - ``@unlink-workspace``: Add field ``deactivate_workspace``. (see :ref:`unlink-workspace`)
+- ``@document-from-template`` now also supports a ``sender`` parameter when KuB is active.
 
 2022.14.0 (2022-07-20)
 ----------------------

--- a/docs/public/dev-manual/api/templatefolder.rst
+++ b/docs/public/dev-manual/api/templatefolder.rst
@@ -35,4 +35,4 @@ siehe :ref:`Inhaltstypen <content-types>`.
 Mit Kontakt- und Behördenverzeichnis
 ------------------------------------
 
-Wenn OneGov GEVER mit der Kontakt- und Behördenverzeichnis Applikation verlinkt ist, kann zusätzlich noch ein ``recipient`` mitgegeben werden, dessen Daten als docproperties verwendet werden. Valide ``recipient`` können von ``@globalsources/contacts`` auf Stufe PloneSiteRoot abgefragt werden.
+Wenn OneGov GEVER mit der Kontakt- und Behördenverzeichnis Applikation verlinkt ist, können zusätzlich noch ein ``recipient`` und ein ``sender`` mitgegeben werden, dessen Daten als docproperties verwendet werden. Valide ``recipient`` und ``sender`` können von ``@globalsources/contacts`` auf Stufe PloneSiteRoot abgefragt werden.

--- a/opengever/api/templatefolder.py
+++ b/opengever/api/templatefolder.py
@@ -71,12 +71,14 @@ class DocumentFromTemplatePost(Service):
             raise BadRequest('Missing parameter title')
 
         recipient_id = data.get('recipient')
-        if recipient_id and not is_kub_feature_enabled():
-            raise BadRequest('recipient is only supported when KuB feature is active')
+        sender_id = data.get('sender')
+        if (recipient_id or sender_id) and not is_kub_feature_enabled():
+            raise BadRequest('recipient and sender are only supported when KuB feature is active')
         recipient = self.get_contact_data(recipient_id)
+        sender = self.get_contact_data(sender_id)
 
         command = CreateDocumentFromTemplateCommand(
-            self.context, template, title, recipient)
+            self.context, template, title, recipient, sender)
         document = command.execute()
 
         serializer = queryMultiAdapter((document, self.request), ISerializeToJson)

--- a/opengever/document/docprops.py
+++ b/opengever/document/docprops.py
@@ -33,7 +33,7 @@ class DocPropertyCollector(object):
 
         return api.user.get(userid=creator_userid)
 
-    def get_properties(self, recipient_data=tuple()):
+    def get_properties(self, recipient_data=tuple(), sender_data=tuple()):
         dossier = self.document.get_parent_dossier()
         member = api.user.get_current()
         proposal = self.document.get_proposal()
@@ -55,6 +55,10 @@ class DocPropertyCollector(object):
         for recipient in recipient_data:
             provider = recipient.get_doc_property_provider()
             properties.update(provider.get_properties(prefix='recipient'))
+
+        for sender in sender_data:
+            provider = sender.get_doc_property_provider()
+            properties.update(provider.get_properties(prefix='sender'))
 
         return properties
 
@@ -84,8 +88,9 @@ class DocPropertyWriter(object):
     providers that are added to the document with a "recipient" prefix.
     """
 
-    def __init__(self, document, recipient_data=tuple()):
+    def __init__(self, document, recipient_data=tuple(), sender_data=tuple()):
         self.recipient_data = recipient_data
+        self.sender_data = sender_data
         self.document = document
         self.request = self.document.REQUEST
         self.date_format = api.portal.get_registry_record(
@@ -100,7 +105,7 @@ class DocPropertyWriter(object):
 
     def get_properties(self):
         return DocPropertyCollector(self.document).get_properties(
-            self.recipient_data)
+            self.recipient_data, self.sender_data)
 
     def is_export_enabled(self):
         registry = getUtility(IRegistry)

--- a/opengever/dossier/command.py
+++ b/opengever/dossier/command.py
@@ -17,12 +17,14 @@ class CreateDocumentFromTemplateCommand(CreateDocumentCommand):
     """Store a copy of the template in the new document's primary file field
     """
 
-    def __init__(self, context, template_doc, title, recipient_data=tuple()):
+    def __init__(self, context, template_doc, title, recipient_data=tuple(),
+                 sender_data=tuple()):
         data = getattr(template_doc.get_file(), "data", None)
         super(CreateDocumentFromTemplateCommand, self).__init__(
             context, template_doc.get_filename(), data,
             title=title)
         self.recipient_data = recipient_data
+        self.sender_data = sender_data
 
         # Grab blocking of role inheritance
         self.block_role_inheritance = getattr(
@@ -45,7 +47,8 @@ class CreateDocumentFromTemplateCommand(CreateDocumentCommand):
         obj = super(CreateDocumentFromTemplateCommand, self).execute()
 
         getRequest().set(DISABLE_DOCPROPERTY_UPDATE_FLAG, False)
-        DocPropertyWriter(obj, recipient_data=self.recipient_data).initialize()
+        DocPropertyWriter(obj, recipient_data=self.recipient_data,
+                          sender_data=self.sender_data).initialize()
 
         # Set blocking of role inheritance based on the template object
         if self.block_role_inheritance is not None:

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2022-05-18 06:23+0000\n"
+"POT-Creation-Date: 2022-07-28 09:06+0000\n"
 "PO-Revision-Date: 2017-05-23 04:53+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -155,6 +155,10 @@ msgstr "Vorlage auswählen"
 #: ./opengever/dossier/templatefolder/form.py
 msgid "Select recipient address"
 msgstr "Empfänger-Adresse auswählen"
+
+#: ./opengever/dossier/templatefolder/form.py
+msgid "Select sender address"
+msgstr "Absender-Adresse auswählen"
 
 #: ./opengever/dossier/dossiertemplate/menu.py
 #: ./opengever/dossier/menu.py
@@ -828,6 +832,11 @@ msgstr "Rollen"
 #: ./opengever/dossier/browser/tabbed.py
 msgid "label_sablon_templates"
 msgstr "Sablon Vorlagen"
+
+#. Default: "Sender"
+#: ./opengever/dossier/templatefolder/form.py
+msgid "label_sender"
+msgstr "Absender"
 
 #. Default: "Sequence Number"
 #: ./opengever/dossier/viewlets/byline.py

--- a/opengever/dossier/locales/en/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/en/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2022-05-18 06:23+0000\n"
+"POT-Creation-Date: 2022-07-28 09:06+0000\n"
 "PO-Revision-Date: 2017-05-23 04:53+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -187,6 +187,10 @@ msgstr "Select dossier template"
 #: ./opengever/dossier/templatefolder/form.py
 msgid "Select recipient address"
 msgstr "Select recipient address"
+
+#: ./opengever/dossier/templatefolder/form.py
+msgid "Select sender address"
+msgstr "Select sender address"
 
 #. German translation: Subdossier
 #: ./opengever/dossier/dossiertemplate/menu.py
@@ -1004,6 +1008,11 @@ msgstr "Roles"
 #: ./opengever/dossier/browser/tabbed.py
 msgid "label_sablon_templates"
 msgstr "Sablon templates"
+
+#. Default: "Sender"
+#: ./opengever/dossier/templatefolder/form.py
+msgid "label_sender"
+msgstr "Sender"
 
 #. German translation: Laufnummer
 #. Default: "Sequence Number"

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-05-18 06:23+0000\n"
+"POT-Creation-Date: 2022-07-28 09:06+0000\n"
 "PO-Revision-Date: 2017-12-03 11:16+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/fr/>\n"
@@ -154,6 +154,10 @@ msgstr "Choisir un modèle"
 #: ./opengever/dossier/templatefolder/form.py
 msgid "Select recipient address"
 msgstr "Choisir l'adresse du destinataire"
+
+#: ./opengever/dossier/templatefolder/form.py
+msgid "Select sender address"
+msgstr "Choisir l'adresse de l'expéditeur"
 
 #: ./opengever/dossier/dossiertemplate/menu.py
 #: ./opengever/dossier/menu.py
@@ -826,6 +830,11 @@ msgstr "Rôles"
 #: ./opengever/dossier/browser/tabbed.py
 msgid "label_sablon_templates"
 msgstr "Modèles Sablon"
+
+#. Default: "Sender"
+#: ./opengever/dossier/templatefolder/form.py
+msgid "label_sender"
+msgstr "Expéditeur"
 
 #. Default: "Sequence Number"
 #: ./opengever/dossier/viewlets/byline.py

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-05-18 06:23+0000\n"
+"POT-Creation-Date: 2022-07-28 09:06+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -154,6 +154,10 @@ msgstr ""
 
 #: ./opengever/dossier/templatefolder/form.py
 msgid "Select recipient address"
+msgstr ""
+
+#: ./opengever/dossier/templatefolder/form.py
+msgid "Select sender address"
 msgstr ""
 
 #: ./opengever/dossier/dossiertemplate/menu.py
@@ -824,6 +828,11 @@ msgstr ""
 #. Default: "Sablon Templates"
 #: ./opengever/dossier/browser/tabbed.py
 msgid "label_sablon_templates"
+msgstr ""
+
+#. Default: "Sender"
+#: ./opengever/dossier/templatefolder/form.py
+msgid "label_sender"
 msgstr ""
 
 #. Default: "Sequence Number"

--- a/opengever/dossier/templatefolder/configure.zcml
+++ b/opengever/dossier/templatefolder/configure.zcml
@@ -12,8 +12,15 @@
 
   <browser:page
       for="*"
-      name="select-address"
-      class=".form.SelectAddressView"
+      name="select-recipient-address"
+      class=".form.SelectRecipientAddressView"
+      permission="zope2.View"
+      />
+
+  <browser:page
+      for="*"
+      name="select-sender-address"
+      class=".form.SelectSenderAddressView"
       permission="zope2.View"
       />
 

--- a/opengever/dossier/templatefolder/form.py
+++ b/opengever/dossier/templatefolder/form.py
@@ -159,15 +159,23 @@ class CreateDocumentMixin(object):
 
         recipient_data = filter(None, [
             data.get('recipient'),
-            data.get('address'),
-            data.get('mail_address'),
-            data.get('phonenumber'),
-            data.get('url'),
+            data.get('recipient_address'),
+            data.get('recipient_mail_address'),
+            data.get('recipient_phonenumber'),
+            data.get('recipient_url'),
+        ])
+
+        sender_data = filter(None, [
+            data.get('sender'),
+            data.get('sender_address'),
+            data.get('sender_mail_address'),
+            data.get('sender_phonenumber'),
+            data.get('sender_url'),
         ])
 
         command = CreateDocumentFromTemplateCommand(
             self.context, data['template'], data['title'],
-            recipient_data=recipient_data)
+            recipient_data=recipient_data, sender_data=sender_data)
         return command.execute()
 
 

--- a/opengever/dossier/templatefolder/form.py
+++ b/opengever/dossier/templatefolder/form.py
@@ -97,6 +97,13 @@ class ICreateDocumentFromTemplate(model.Schema):
         required=False,
     )
 
+    form.widget('sender', KeywordFieldWidget, async=True)
+    sender = schema.Choice(
+        title=_(u'label_sender', default=u'Sender'),
+        source=ContactsSourceBinder(),
+        required=False,
+    )
+
     form.widget(edit_after_creation=SingleCheckBoxFieldWidget)
     edit_after_creation = schema.Bool(
         title=_(u'label_edit_after_creation', default='Edit after creation'),
@@ -122,7 +129,8 @@ class CreateDocumentMixin(object):
         if not is_contact_feature_enabled():
             return []
         return [('select-document', _(u'Select document')),
-                ('select-address', _(u'Select recipient address'))]
+                ('select-recipient-address', _(u'Select recipient address')),
+                ('select-sender-address', _(u'Select sender address'))]
 
     def finish_document_creation(self, data):
         new_doc = self.create_document(data)
@@ -172,6 +180,7 @@ class SelectTemplateDocumentWizardStep(
         super(SelectTemplateDocumentWizardStep, self).updateFieldsFromSchemata()
         if not is_contact_feature_enabled():
             self.fields = self.fields.omit('recipient')
+            self.fields = self.fields.omit('sender')
         if is_client_ip_in_office_connector_disallowed_ip_ranges():
             self.fields = self.fields.omit('edit_after_creation')
         if is_kub_feature_enabled():
@@ -198,7 +207,13 @@ class SelectTemplateDocumentWizardStep(
             dm = getUtility(IWizardDataStorage)
             dm.update(get_dm_key(self.context), data)
             return self.request.RESPONSE.redirect(
-                "{}/select-address".format(self.context.absolute_url()))
+                "{}/select-recipient-address".format(self.context.absolute_url()))
+
+        if data.get('sender'):
+            dm = getUtility(IWizardDataStorage)
+            dm.update(get_dm_key(self.context), data)
+            return self.request.RESPONSE.redirect(
+                "{}/select-sender-address".format(self.context.absolute_url()))
 
         return self.finish_document_creation(data)
 
@@ -212,7 +227,7 @@ class SelectTemplateDocumentView(FormWrapper):
     form = SelectTemplateDocumentWizardStep
 
 
-def get_recipient(context):
+def get_contact(context, key='recipient'):
     """Return the previously selected recipient.
 
     If it is an unpickled/detached mapper merge it into the current session,
@@ -222,66 +237,83 @@ def get_recipient(context):
     dm = getUtility(IWizardDataStorage)
     data = dm.get_data(get_dm_key(context))
 
-    recipient = data['recipient']
+    contact = data[key]
+
     try:
         # merge unpickled recipient into session when it is a mapper
-        if inspect(recipient).detached:
-            recipient = create_session().merge(recipient)
+        if inspect(contact).detached:
+            contact = create_session().merge(contact)
     except NoInspectionAvailable:
         pass
-    return recipient
+    return contact
 
 
-@provider(IContextSourceBinder)
-def make_address_vocabulary(context):
-    recipient = get_recipient(context)
+def make_address_vocabulary_binder(key='recipient'):
 
-    return SimpleVocabulary([
-        SimpleVocabulary.createTerm(
-            address, str(address.address_id))
-        for address in recipient.addresses])
+    @provider(IContextSourceBinder)
+    def make_address_vocabulary(context):
+        contact = get_contact(context, key=key)
+
+        return SimpleVocabulary([
+            SimpleVocabulary.createTerm(
+                address, str(address.address_id))
+            for address in contact.addresses])
+
+    return make_address_vocabulary
 
 
 def address_lines(item, value):
     return u"<br />".join(item.get_lines())
 
 
-@provider(IContextSourceBinder)
-def make_mail_address_vocabulary(context):
-    recipient = get_recipient(context)
+def make_mail_address_vocabulary_binder(key='recipient'):
 
-    return SimpleVocabulary([
-        SimpleVocabulary.createTerm(
-            mail_address, str(mail_address.mailaddress_id))
-        for mail_address in recipient.mail_addresses])
+    @provider(IContextSourceBinder)
+    def make_mail_address_vocabulary(context):
+        contact = get_contact(context, key=key)
 
+        return SimpleVocabulary([
+            SimpleVocabulary.createTerm(
+                mail_address, str(mail_address.mailaddress_id))
+            for mail_address in contact.mail_addresses])
 
-@provider(IContextSourceBinder)
-def make_phonenumber_vocabulary(context):
-    recipient = get_recipient(context)
-
-    return SimpleVocabulary([
-        SimpleVocabulary.createTerm(
-            phone_number, str(phone_number.phone_number_id))
-        for phone_number in recipient.phonenumbers])
+    return make_mail_address_vocabulary
 
 
-@provider(IContextSourceBinder)
-def make_url_vocabulary(context):
-    recipient = get_recipient(context)
+def make_phonenumber_vocabulary_binder(key='recipient'):
 
-    return SimpleVocabulary([
-        SimpleVocabulary.createTerm(
-            url, str(url.url_id))
-        for url in recipient.urls])
+    @provider(IContextSourceBinder)
+    def make_phonenumber_vocabulary(context):
+        contact = get_contact(context, key=key)
+
+        return SimpleVocabulary([
+            SimpleVocabulary.createTerm(
+                phone_number, str(phone_number.phone_number_id))
+            for phone_number in contact.phonenumbers])
+
+    return make_phonenumber_vocabulary
+
+
+def make_url_vocabulary_binder(key='recipient'):
+
+    @provider(IContextSourceBinder)
+    def make_url_vocabulary(context):
+        contact = get_contact(context, key=key)
+
+        return SimpleVocabulary([
+            SimpleVocabulary.createTerm(
+                url, str(url.url_id))
+            for url in contact.urls])
+
+    return make_url_vocabulary
 
 
 class ISelectRecipientAddress(model.Schema):
 
-    address = TableChoice(
+    recipient_address = TableChoice(
         title=_(u"label_address", default=u"Address"),
         required=False,
-        source=make_address_vocabulary,
+        source=make_address_vocabulary_binder(key='recipient'),
         columns=(
             {'column': 'label',
              'column_title': _(u'label_label', default=u'Label')},
@@ -290,10 +322,10 @@ class ISelectRecipientAddress(model.Schema):
              'transform': address_lines},
         ))
 
-    mail_address = TableChoice(
+    recipient_mail_address = TableChoice(
         title=_(u"label_mail_address", default=u"Mail-Address"),
         required=False,
-        source=make_mail_address_vocabulary,
+        source=make_mail_address_vocabulary_binder(key='recipient'),
         columns=(
             {'column': 'label',
              'column_title': _(u'label_label', default=u'Label')},
@@ -301,10 +333,10 @@ class ISelectRecipientAddress(model.Schema):
              'column_title': _(u'label_mail_address', default=u'Mail-Address')},
         ))
 
-    phonenumber = TableChoice(
+    recipient_phonenumber = TableChoice(
         title=_(u"label_phonenumber", default=u"Phonenumber"),
         required=False,
-        source=make_phonenumber_vocabulary,
+        source=make_phonenumber_vocabulary_binder(key='recipient'),
         columns=(
             {'column': 'label',
              'column_title': _(u'label_label', default=u'Label')},
@@ -312,10 +344,10 @@ class ISelectRecipientAddress(model.Schema):
              'column_title': _(u'label_phonenumber', default=u'Phonenumber')},
         ))
 
-    url = TableChoice(
+    recipient_url = TableChoice(
         title=_(u"label_url", default=u"URL"),
         required=False,
-        source=make_url_vocabulary,
+        source=make_url_vocabulary_binder(key='recipient'),
         columns=(
             {'column': 'label',
              'column_title': _(u'label_label', default=u'Label')},
@@ -324,11 +356,88 @@ class ISelectRecipientAddress(model.Schema):
         ))
 
 
-class SelectAddressWizardStep(
+class ISelectSenderAddress(model.Schema):
+
+    sender_address = TableChoice(
+        title=_(u"label_address", default=u"Address"),
+        required=False,
+        source=make_address_vocabulary_binder(key='sender'),
+        columns=(
+            {'column': 'label',
+             'column_title': _(u'label_label', default=u'Label')},
+            {'column': 'address',
+             'column_title': _(u'label_address', default=u'Address'),
+             'transform': address_lines},
+        ))
+
+    sender_mail_address = TableChoice(
+        title=_(u"label_mail_address", default=u"Mail-Address"),
+        required=False,
+        source=make_mail_address_vocabulary_binder(key='sender'),
+        columns=(
+            {'column': 'label',
+             'column_title': _(u'label_label', default=u'Label')},
+            {'column': 'address',
+             'column_title': _(u'label_mail_address', default=u'Mail-Address')},
+        ))
+
+    sender_phonenumber = TableChoice(
+        title=_(u"label_phonenumber", default=u"Phonenumber"),
+        required=False,
+        source=make_phonenumber_vocabulary_binder(key='sender'),
+        columns=(
+            {'column': 'label',
+             'column_title': _(u'label_label', default=u'Label')},
+            {'column': 'phone_number',
+             'column_title': _(u'label_phonenumber', default=u'Phonenumber')},
+        ))
+
+    sender_url = TableChoice(
+        title=_(u"label_url", default=u"URL"),
+        required=False,
+        source=make_url_vocabulary_binder(key='sender'),
+        columns=(
+            {'column': 'label',
+             'column_title': _(u'label_label', default=u'Label')},
+            {'column': 'url',
+             'column_title': _(u'label_url', default=u'URL')},
+        ))
+
+
+class SelectRecipientAddressWizardStep(
         CreateDocumentMixin, AutoExtensibleForm, BaseWizardStepForm, Form):
 
-    step_name = 'select-address'
+    step_name = 'select-recipient-address'
     schema = ISelectRecipientAddress
+
+    @button.buttonAndHandler(_('button_save', default=u'Save'), name='save')
+    def handleApply(self, action):
+        data, errors = self.extractData()
+        if errors:
+            self.status = self.formErrorsMessage
+            return
+
+        dm = getUtility(IWizardDataStorage)
+        data.update(dm.get_data(get_dm_key(self.context)))
+
+        if data.get('sender'):
+            dm = getUtility(IWizardDataStorage)
+            dm.update(get_dm_key(self.context), data)
+            return self.request.RESPONSE.redirect(
+                "{}/select-sender-address".format(self.context.absolute_url()))
+
+        return self.finish_document_creation(data)
+
+    @button.buttonAndHandler(_(u'button_cancel', default=u'Cancel'), name='cancel')
+    def cancel(self, action):
+        return self.request.RESPONSE.redirect(self.context.absolute_url())
+
+
+class SelectSenderAddressWizardStep(
+        CreateDocumentMixin, AutoExtensibleForm, BaseWizardStepForm, Form):
+
+    step_name = 'select-sender-address'
+    schema = ISelectSenderAddress
 
     @button.buttonAndHandler(_('button_save', default=u'Save'), name='save')
     def handleApply(self, action):
@@ -347,6 +456,11 @@ class SelectAddressWizardStep(
         return self.request.RESPONSE.redirect(self.context.absolute_url())
 
 
-class SelectAddressView(FormWrapper):
+class SelectRecipientAddressView(FormWrapper):
 
-    form = SelectAddressWizardStep
+    form = SelectRecipientAddressWizardStep
+
+
+class SelectSenderAddressView(FormWrapper):
+
+    form = SelectSenderAddressWizardStep

--- a/opengever/dossier/tests/test_templatefolder.py
+++ b/opengever/dossier/tests/test_templatefolder.py
@@ -51,7 +51,7 @@ class TestDocumentWithTemplateFormPlain(IntegrationTestCase):
             {'': '', 'Creator': 'nicole.kohler', 'Modified': '31.08.2016', 'Title': u'T\xc3\xb6mpl\xc3\xb6te Normal'},
             {'': '', 'Creator': 'nicole.kohler', 'Modified': '31.08.2016', 'Title': u'T\xc3\xb6mpl\xc3\xb6te Ohne'},
             {'': '', 'Creator': 'nicole.kohler', 'Modified': '29.02.2020', 'Title': u'T\xc3\xb6mpl\xc3\xb6te Sub'},
-            ]
+        ]
 
         self.assertEqual(expected_listing, browser.css('table.listing').first.dicts())
 
@@ -69,7 +69,7 @@ class TestDocumentWithTemplateFormPlain(IntegrationTestCase):
             {'': '', 'Creator': 'nicole.kohler', 'Modified': '31.08.2016', 'Title': u'T\xc3\xb6mpl\xc3\xb6te Normal'},
             {'': '', 'Creator': 'nicole.kohler', 'Modified': '31.08.2016', 'Title': u'T\xc3\xb6mpl\xc3\xb6te Ohne'},
             {'': '', 'Creator': 'nicole.kohler', 'Modified': '29.02.2020', 'Title': u'T\xc3\xb6mpl\xc3\xb6te Sub'},
-            ]
+        ]
 
         self.assertEqual(expected_listing, browser.css('table.listing').first.dicts())
 
@@ -87,7 +87,7 @@ class TestDocumentWithTemplateFormPlain(IntegrationTestCase):
             u'Filter',
             u'Title',
             u'Edit after creation',
-            ]
+        ]
 
         self.assertEqual(expected_labels, browser.css('#form label').text)
 
@@ -110,7 +110,7 @@ class TestDocumentWithTemplateFormPlain(IntegrationTestCase):
             'form.widgets.template': self.normal_template.UID(),
             'Title': 'Test Document',
             'Edit after creation': False,
-            }).save()
+        }).save()
 
         self.assertEqual(self.dossier, browser.context)
         self.assertEqual(self.dossier.absolute_url() + '#documents', browser.url)
@@ -122,7 +122,7 @@ class TestDocumentWithTemplateFormPlain(IntegrationTestCase):
         browser.fill({
             'form.widgets.template': self.normal_template.UID(),
             'Title': 'Test Document',
-            }).save()
+        }).save()
 
         document = self.dossier.listFolderContents()[-1]
         self.assertEqual('Test Document', document.title)
@@ -134,7 +134,7 @@ class TestDocumentWithTemplateFormPlain(IntegrationTestCase):
         browser.fill({
             'form.widgets.template': self.normal_template.UID(),
             'Title': 'Test Document',
-            }).save()
+        }).save()
 
         document = self.dossier.listFolderContents()[-1]
         self.assertEqual(date.today(), document.document_date)
@@ -147,7 +147,7 @@ class TestDocumentWithTemplateFormPlain(IntegrationTestCase):
         browser.fill({
             'form.widgets.template': self.normal_template.UID(),
             'Title': 'Test Document',
-            }).save()
+        }).save()
 
         document = self.dossier.listFolderContents()[-1]
 
@@ -163,7 +163,7 @@ class TestDocumentWithTemplateFormPlain(IntegrationTestCase):
             browser.fill({
                 'form.widgets.template': self.asset_template.UID(),
                 'Title': 'Test Docx',
-                }).save()
+            }).save()
 
         document = self.dossier.listFolderContents()[-1]
         self.assertEqual(u'Test Docx.docx', document.file.filename)
@@ -182,12 +182,12 @@ class TestDocumentWithTemplateFormPlain(IntegrationTestCase):
             u'T\xc3\xb6mpl\xc3\xb6te Normal',
             u'T\xc3\xb6mpl\xc3\xb6te Ohne',
             u'T\xc3\xb6mpl\xc3\xb6te Sub',
-            ]
+        ]
 
         found_documents = [
             row.get('Title')
             for row in browser.css('table.listing').first.dicts()
-            ]
+        ]
 
         self.assertEqual(expected_documents, found_documents)
         self.assertNotIn(u'T\xc3\xb6mpl\xc3\xb6te Leer', found_documents)
@@ -196,7 +196,7 @@ class TestDocumentWithTemplateFormPlain(IntegrationTestCase):
 class TestDocumentWithTemplateFormWithDocProperties(IntegrationTestCase):
     features = (
         'doc-properties',
-        )
+    )
 
     maxDiff = None
 
@@ -216,7 +216,7 @@ class TestDocumentWithTemplateFormWithDocProperties(IntegrationTestCase):
             browser.fill({
                 'form.widgets.template': self.docprops_template.UID(),
                 'Title': 'Test Docx',
-                }).save()
+            }).save()
 
         document = self.dossier.listFolderContents()[-1]
         self.assertEqual(u'Test Docx.docx', document.file.filename)
@@ -297,7 +297,7 @@ class TestDocumentWithTemplateFormWithDocProperties(IntegrationTestCase):
             browser.fill({
                 'form.widgets.template': self.asset_template.UID(),
                 'Title': 'Test Docx',
-                }).save()
+            }).save()
 
         document = self.dossier.listFolderContents()[-1]
         self.assertEqual(u'Test Docx.docx', document.file.filename)
@@ -360,7 +360,7 @@ class TestDocumentWithTemplateFormWithDocProperties(IntegrationTestCase):
             'ogg.document.creator.user.lastname': u'B\xe4rfuss',
             'ogg.document.creator.user.department': 'Staatskanzlei',
             'ogg.document.creator.user.directorate': 'Staatsarchiv',
-            }
+        }
 
         with TemporaryDocFile(document.file) as tmpfile:
             properties = CustomProperties(Document(tmpfile.path)).items()
@@ -414,7 +414,7 @@ class TestDocumentWithTemplateFormWithContacts(FunctionalTestCase):
             .titled('Word Docx template')
             .within(self.templatefolder)
             .with_asset_file('without_custom_properties.docx'),
-            )
+        )
 
         self.dossier = create(Builder('dossier').titled(u'My Dossier'))
         self.peter = create(Builder('person').having(firstname=u'Peter', lastname=u'M\xfcller'))
@@ -437,8 +437,8 @@ class TestDocumentWithTemplateFormWithContacts(FunctionalTestCase):
                 zip_code=u'1234',
                 city=u'Hinterkappelen',
                 country=u'Schweiz',
-                ),
-            )
+            ),
+        )
 
         create(
             Builder('address')
@@ -447,26 +447,26 @@ class TestDocumentWithTemplateFormWithContacts(FunctionalTestCase):
             .having(
                 street=u'Hauptstrasse 1',
                 city=u'Vorkappelen',
-                ),
-            )
+            ),
+        )
 
         mailaddress = create(
             Builder('mailaddress')
             .for_contact(self.peter)
             .having(address=u'foo@example.com'),
-            )
+        )
 
         phonenumber = create(
             Builder('phonenumber')
             .for_contact(self.peter)
             .having(phone_number=u'1234 123 123'),
-            )
+        )
 
         url = create(
             Builder('url')
             .for_contact(self.peter)
             .having(url=u'http://www.example.com'),
-            )
+        )
 
         with freeze(self.document_date):
             # submit first wizard step
@@ -474,17 +474,17 @@ class TestDocumentWithTemplateFormWithContacts(FunctionalTestCase):
             browser.fill({
                 'form.widgets.template': self.template_word.UID(),
                 'Title': 'Test Docx',
-                })
+            })
             form = browser.find_form_by_field('Recipient')
             form.find_widget('Recipient').fill(get_contacts_token(self.peter))
             form.save()
             # submit second wizard step
             browser.fill({
-                'form.widgets.address': str(address1.address_id),
-                'form.widgets.mail_address': str(mailaddress.mailaddress_id),
-                'form.widgets.phonenumber': str(phonenumber.phone_number_id),
-                'form.widgets.url': str(url.url_id),
-                }).save()
+                'form.widgets.recipient_address': str(address1.address_id),
+                'form.widgets.recipient_mail_address': str(mailaddress.mailaddress_id),
+                'form.widgets.recipient_phonenumber': str(phonenumber.phone_number_id),
+                'form.widgets.recipient_url': str(url.url_id),
+            }).save()
 
         document = self.dossier.listFolderContents()[0]
         self.assertEqual(u'Test Docx.docx', document.file.filename)
@@ -500,7 +500,7 @@ class TestDocumentWithTemplateFormWithContacts(FunctionalTestCase):
             'ogg.recipient.email.address': u'foo@example.com',
             'ogg.recipient.phone.number': u'1234 123 123',
             'ogg.recipient.url.url': u'http://www.example.com',
-            }
+        }
         expected_person_properties.update(self.expected_doc_properties)
 
         with TemporaryDocFile(document.file) as tmpfile:
@@ -513,7 +513,7 @@ class TestDocumentWithTemplateFormWithContacts(FunctionalTestCase):
         organization = create(
             Builder('organization')
             .having(name=u'Meier AG'),
-            )
+        )
 
         org_role = create(
             Builder('org_role')
@@ -521,8 +521,8 @@ class TestDocumentWithTemplateFormWithContacts(FunctionalTestCase):
                 person=self.peter,
                 organization=organization,
                 function=u'cheffe',
-                ),
-            )
+            ),
+        )
 
         create(
             Builder('address')
@@ -533,26 +533,26 @@ class TestDocumentWithTemplateFormWithContacts(FunctionalTestCase):
                 zip_code=u'1234',
                 city=u'Hinterkappelen',
                 country=u'Schweiz',
-                ),
-            )
+            ),
+        )
 
         mailaddress = create(
             Builder('mailaddress')
             .for_contact(organization)
             .having(address=u'foo@example.com'),
-            )
+        )
 
         phonenumber = create(
             Builder('phonenumber')
             .for_contact(self.peter)
             .having(phone_number=u'1234 123 123'),
-            )
+        )
 
         url = create(
             Builder('url')
             .for_contact(organization)
             .having(url=u'http://www.example.com'),
-            )
+        )
 
         address_id = org_role.addresses[0].address_id
 
@@ -562,17 +562,17 @@ class TestDocumentWithTemplateFormWithContacts(FunctionalTestCase):
             browser.fill({
                 'form.widgets.template': self.template_word.UID(),
                 'Title': 'Test Docx',
-                })
+            })
             form = browser.find_form_by_field('Recipient')
             form.find_widget('Recipient').fill(get_contacts_token(org_role))
             form.save()
             # submit second wizard step
             browser.fill({
-                'form.widgets.address': address_id,
-                'form.widgets.mail_address': str(mailaddress.mailaddress_id),
-                'form.widgets.phonenumber': str(phonenumber.phone_number_id),
-                'form.widgets.url': str(url.url_id),
-                }).save()
+                'form.widgets.recipient_address': address_id,
+                'form.widgets.recipient_mail_address': str(mailaddress.mailaddress_id),
+                'form.widgets.recipient_phonenumber': str(phonenumber.phone_number_id),
+                'form.widgets.recipient_url': str(url.url_id),
+            }).save()
 
         document = self.dossier.listFolderContents()[0]
         self.assertEqual(u'Test Docx.docx', document.file.filename)
@@ -589,7 +589,7 @@ class TestDocumentWithTemplateFormWithContacts(FunctionalTestCase):
             'ogg.recipient.email.address': u'foo@example.com',
             'ogg.recipient.phone.number': u'1234 123 123',
             'ogg.recipient.url.url': u'http://www.example.com',
-            }
+        }
         expected_org_role_properties.update(self.expected_doc_properties)
 
         with TemporaryDocFile(document.file) as tmpfile:
@@ -604,7 +604,7 @@ class TestDocumentWithTemplateFormWithContacts(FunctionalTestCase):
             .id('ogds-peter')
             .having(**OGDS_USER_ATTRIBUTES)
             .as_contact_adapter(),
-            )
+        )
 
         with freeze(self.document_date):
             # submit first wizard step
@@ -612,17 +612,17 @@ class TestDocumentWithTemplateFormWithContacts(FunctionalTestCase):
             browser.fill({
                 'form.widgets.template': self.template_word.UID(),
                 'Title': 'Test Docx',
-                })
+            })
             form = browser.find_form_by_field('Recipient')
             form.find_widget('Recipient').fill(get_contacts_token(ogds_user))
             form.save()
             # submit second wizard step
             browser.fill({
-                'form.widgets.address': '{}_1'.format(ogds_user.id),
-                'form.widgets.mail_address': '{}_2'.format(ogds_user.id),
-                'form.widgets.phonenumber': '{}_3'.format(ogds_user.id),
-                'form.widgets.url': '{}_1'.format(ogds_user.id),
-                }).save()
+                'form.widgets.recipient_address': '{}_1'.format(ogds_user.id),
+                'form.widgets.recipient_mail_address': '{}_2'.format(ogds_user.id),
+                'form.widgets.recipient_phonenumber': '{}_3'.format(ogds_user.id),
+                'form.widgets.recipient_url': '{}_1'.format(ogds_user.id),
+            }).save()
 
         document = self.dossier.listFolderContents()[0]
         self.assertEqual(u'Test Docx.docx', document.file.filename)
@@ -648,6 +648,313 @@ class TestDocumentWithTemplateFormWithContacts(FunctionalTestCase):
             self.assertItemsEqual(expected_org_role_properties.items(), properties)
         self.assert_doc_properties_updated_journal_entry_generated(document)
 
+    @browsing
+    def test_contact_sender_properties_are_added(self, browser):
+        address1 = create(
+            Builder('address')
+            .for_contact(self.peter)
+            .labeled(u'Home')
+            .having(
+                street=u'Musterstrasse 283',
+                zip_code=u'1234',
+                city=u'Hinterkappelen',
+                country=u'Schweiz',
+            ),
+        )
+
+        create(
+            Builder('address')
+            .for_contact(self.peter)
+            .labeled(u'Home')
+            .having(
+                street=u'Hauptstrasse 1',
+                city=u'Vorkappelen',
+            ),
+        )
+
+        mailaddress = create(
+            Builder('mailaddress')
+            .for_contact(self.peter)
+            .having(address=u'foo@example.com'),
+        )
+
+        phonenumber = create(
+            Builder('phonenumber')
+            .for_contact(self.peter)
+            .having(phone_number=u'1234 123 123'),
+        )
+
+        url = create(
+            Builder('url')
+            .for_contact(self.peter)
+            .having(url=u'http://www.example.com'),
+        )
+
+        with freeze(self.document_date):
+            # submit first wizard step
+            browser.login().open(self.dossier, view='document_with_template')
+            browser.fill({
+                'form.widgets.template': self.template_word.UID(),
+                'Title': 'Test Docx',
+            })
+            form = browser.find_form_by_field('Sender')
+            form.find_widget('Sender').fill(get_contacts_token(self.peter))
+            form.save()
+            # submit second wizard step
+            browser.fill({
+                'form.widgets.sender_address': str(address1.address_id),
+                'form.widgets.sender_mail_address': str(mailaddress.mailaddress_id),
+                'form.widgets.sender_phonenumber': str(phonenumber.phone_number_id),
+                'form.widgets.sender_url': str(url.url_id),
+            }).save()
+
+        document = self.dossier.listFolderContents()[0]
+        self.assertEqual(u'Test Docx.docx', document.file.filename)
+
+        expected_person_properties = {
+            'ogg.sender.contact.title': u'M\xfcller Peter',
+            'ogg.sender.person.firstname': 'Peter',
+            'ogg.sender.person.lastname': u'M\xfcller',
+            'ogg.sender.address.street': u'Musterstrasse 283',
+            'ogg.sender.address.zip_code': '1234',
+            'ogg.sender.address.city': 'Hinterkappelen',
+            'ogg.sender.address.country': 'Schweiz',
+            'ogg.sender.email.address': u'foo@example.com',
+            'ogg.sender.phone.number': u'1234 123 123',
+            'ogg.sender.url.url': u'http://www.example.com',
+        }
+        expected_person_properties.update(self.expected_doc_properties)
+
+        with TemporaryDocFile(document.file) as tmpfile:
+            properties = CustomProperties(Document(tmpfile.path)).items()
+            self.assertItemsEqual(expected_person_properties.items(), properties)
+        self.assert_doc_properties_updated_journal_entry_generated(document)
+
+    @browsing
+    def test_org_role_sender_properties_are_added(self, browser):
+        organization = create(
+            Builder('organization')
+            .having(name=u'Meier AG'),
+        )
+
+        org_role = create(
+            Builder('org_role')
+            .having(
+                person=self.peter,
+                organization=organization,
+                function=u'cheffe',
+            ),
+        )
+
+        create(
+            Builder('address')
+            .for_contact(organization)
+            .labeled(u'Home')
+            .having(
+                street=u'Musterstrasse 283',
+                zip_code=u'1234',
+                city=u'Hinterkappelen',
+                country=u'Schweiz',
+            ),
+        )
+
+        mailaddress = create(
+            Builder('mailaddress')
+            .for_contact(organization)
+            .having(address=u'foo@example.com'),
+        )
+
+        phonenumber = create(
+            Builder('phonenumber')
+            .for_contact(self.peter)
+            .having(phone_number=u'1234 123 123'),
+        )
+
+        url = create(
+            Builder('url')
+            .for_contact(organization)
+            .having(url=u'http://www.example.com'),
+        )
+
+        address_id = org_role.addresses[0].address_id
+
+        with freeze(self.document_date):
+            # submit first wizard step
+            browser.login().open(self.dossier, view='document_with_template')
+            browser.fill({
+                'form.widgets.template': self.template_word.UID(),
+                'Title': 'Test Docx',
+            })
+            form = browser.find_form_by_field('Sender')
+            form.find_widget('Sender').fill(get_contacts_token(org_role))
+            form.save()
+            # submit second wizard step
+            browser.fill({
+                'form.widgets.sender_address': address_id,
+                'form.widgets.sender_mail_address': str(mailaddress.mailaddress_id),
+                'form.widgets.sender_phonenumber': str(phonenumber.phone_number_id),
+                'form.widgets.sender_url': str(url.url_id),
+            }).save()
+
+        document = self.dossier.listFolderContents()[0]
+        self.assertEqual(u'Test Docx.docx', document.file.filename)
+        expected_org_role_properties = {
+            'ogg.sender.contact.title': u'M\xfcller Peter',
+            'ogg.sender.person.firstname': 'Peter',
+            'ogg.sender.person.lastname': u'M\xfcller',
+            'ogg.sender.orgrole.function': u'cheffe',
+            'ogg.sender.organization.name': u'Meier AG',
+            'ogg.sender.address.street': u'Musterstrasse 283',
+            'ogg.sender.address.zip_code': '1234',
+            'ogg.sender.address.city': 'Hinterkappelen',
+            'ogg.sender.address.country': 'Schweiz',
+            'ogg.sender.email.address': u'foo@example.com',
+            'ogg.sender.phone.number': u'1234 123 123',
+            'ogg.sender.url.url': u'http://www.example.com',
+        }
+        expected_org_role_properties.update(self.expected_doc_properties)
+
+        with TemporaryDocFile(document.file) as tmpfile:
+            properties = CustomProperties(Document(tmpfile.path)).items()
+            self.assertItemsEqual(expected_org_role_properties.items(), properties)
+        self.assert_doc_properties_updated_journal_entry_generated(document)
+
+    @browsing
+    def test_ogds_user_sender_properties_are_added(self, browser):
+        ogds_user = create(
+            Builder('ogds_user')
+            .id('ogds-peter')
+            .having(**OGDS_USER_ATTRIBUTES)
+            .as_contact_adapter(),
+        )
+
+        with freeze(self.document_date):
+            # submit first wizard step
+            browser.login().open(self.dossier, view='document_with_template')
+            browser.fill({
+                'form.widgets.template': self.template_word.UID(),
+                'Title': 'Test Docx',
+            })
+            form = browser.find_form_by_field('Sender')
+            form.find_widget('Sender').fill(get_contacts_token(ogds_user))
+            form.save()
+            # submit second wizard step
+            browser.fill({
+                'form.widgets.sender_address': '{}_1'.format(ogds_user.id),
+                'form.widgets.sender_mail_address': '{}_2'.format(ogds_user.id),
+                'form.widgets.sender_phonenumber': '{}_3'.format(ogds_user.id),
+                'form.widgets.sender_url': '{}_1'.format(ogds_user.id),
+            }).save()
+
+        document = self.dossier.listFolderContents()[0]
+        self.assertEqual(u'Test Docx.docx', document.file.filename)
+
+        expected_org_role_properties = {
+            'ogg.sender.contact.title': u'M\xfcller Peter',
+            'ogg.sender.contact.description': u'nix',
+            'ogg.sender.person.salutation': 'Prof. Dr.',
+            'ogg.sender.person.firstname': 'Peter',
+            'ogg.sender.person.lastname': u'M\xfcller',
+            'ogg.sender.address.street': u'Kappelenweg 13, Postfach 1234',
+            'ogg.sender.address.zip_code': '1234',
+            'ogg.sender.address.city': u'Vorkappelen',
+            'ogg.sender.address.country': u'Schweiz',
+            'ogg.sender.email.address': u'bar@example.com',
+            'ogg.sender.phone.number': u'012 34 56 76',
+            'ogg.sender.url.url': u'http://www.example.com',
+        }
+        expected_org_role_properties.update(self.expected_doc_properties)
+
+        with TemporaryDocFile(document.file) as tmpfile:
+            properties = CustomProperties(Document(tmpfile.path)).items()
+            self.assertItemsEqual(expected_org_role_properties.items(), properties)
+        self.assert_doc_properties_updated_journal_entry_generated(document)
+
+    @browsing
+    def test_recipient_and_sender_properties_are_added(self, browser):
+        ogds_user = create(
+            Builder('ogds_user')
+            .id('ogds-peter')
+            .having(**OGDS_USER_ATTRIBUTES)
+            .as_contact_adapter(),
+        )
+
+        address1 = create(
+            Builder('address')
+            .for_contact(self.peter)
+            .labeled(u'Home')
+            .having(
+                street=u'Musterstrasse 283',
+                zip_code=u'1234',
+                city=u'Hinterkappelen',
+                country=u'Schweiz',
+            ),
+        )
+
+        mailaddress = create(
+            Builder('mailaddress')
+            .for_contact(self.peter)
+            .having(address=u'foo@example.com'),
+        )
+
+        with freeze(self.document_date):
+            # submit first wizard step
+            browser.login().open(self.dossier, view='document_with_template')
+            browser.fill({
+                'form.widgets.template': self.template_word.UID(),
+                'Title': 'Test Docx',
+            })
+            form = browser.find_form_by_field('Recipient')
+            form.find_widget('Recipient').fill(get_contacts_token(self.peter))
+            form = browser.find_form_by_field('Sender')
+            form.find_widget('Sender').fill(get_contacts_token(ogds_user))
+            form.save()
+            # submit second wizard step
+            browser.fill({
+                'form.widgets.recipient_address': str(address1.address_id),
+                'form.widgets.recipient_mail_address': str(mailaddress.mailaddress_id),
+            }).save()
+
+            # submit third wizard step
+            browser.fill({
+                'form.widgets.sender_address': '{}_1'.format(ogds_user.id),
+                'form.widgets.sender_mail_address': '{}_2'.format(ogds_user.id),
+                'form.widgets.sender_phonenumber': '{}_3'.format(ogds_user.id),
+                'form.widgets.sender_url': '{}_1'.format(ogds_user.id),
+            }).save()
+
+        document = self.dossier.listFolderContents()[0]
+        self.assertEqual(u'Test Docx.docx', document.file.filename)
+
+        expected_org_role_properties = {
+            'ogg.recipient.contact.title': u'M\xfcller Peter',
+            'ogg.recipient.person.firstname': 'Peter',
+            'ogg.recipient.person.lastname': u'M\xfcller',
+            'ogg.recipient.address.street': u'Musterstrasse 283',
+            'ogg.recipient.address.zip_code': '1234',
+            'ogg.recipient.address.city': 'Hinterkappelen',
+            'ogg.recipient.address.country': 'Schweiz',
+            'ogg.recipient.email.address': u'foo@example.com',
+            'ogg.sender.contact.title': u'M\xfcller Peter',
+            'ogg.sender.contact.description': u'nix',
+            'ogg.sender.person.salutation': 'Prof. Dr.',
+            'ogg.sender.person.firstname': 'Peter',
+            'ogg.sender.person.lastname': u'M\xfcller',
+            'ogg.sender.address.street': u'Kappelenweg 13, Postfach 1234',
+            'ogg.sender.address.zip_code': '1234',
+            'ogg.sender.address.city': u'Vorkappelen',
+            'ogg.sender.address.country': u'Schweiz',
+            'ogg.sender.email.address': u'bar@example.com',
+            'ogg.sender.phone.number': u'012 34 56 76',
+            'ogg.sender.url.url': u'http://www.example.com',
+        }
+        expected_org_role_properties.update(self.expected_doc_properties)
+
+        with TemporaryDocFile(document.file) as tmpfile:
+            properties = CustomProperties(Document(tmpfile.path)).items()
+            self.assertItemsEqual(expected_org_role_properties.items(), properties)
+        self.assert_doc_properties_updated_journal_entry_generated(document)
+
 
 class TestDocumentWithTemplateFormWithKuBContacts(KuBIntegrationTestCase):
 
@@ -663,7 +970,7 @@ class TestDocumentWithTemplateFormWithKuBContacts(KuBIntegrationTestCase):
             browser.fill({
                 'form.widgets.template': self.normal_template.UID(),
                 'Title': 'Test Docx',
-                }).save()
+            }).save()
 
         self.assertEqual(1, len(children['added']))
         doc = children['added'].pop()
@@ -673,7 +980,7 @@ class TestDocumentWithTemplateFormWithKuBContacts(KuBIntegrationTestCase):
 class TestDocumentWithTemplateFormWithOfficeConnector(IntegrationTestCase):
     features = (
         'officeconnector-checkout',
-        )
+    )
 
     @browsing
     def test_opens_doc_with_officeconnector_when_feature_flaged(self, browser):
@@ -682,13 +989,13 @@ class TestDocumentWithTemplateFormWithOfficeConnector(IntegrationTestCase):
         browser.fill({
             'form.widgets.template': self.normal_template.UID(),
             'Title': 'Test OfficeConnector',
-            }).save()
+        }).save()
 
         self.assertIn(
             "'oc:",
             browser.css('script.redirector').first.text,
             'OfficeConnector redirection script not found',
-            )
+        )
 
 
 class TestTemplateFolder(FunctionalTestCase):
@@ -715,14 +1022,14 @@ class TestTemplateFolder(FunctionalTestCase):
         self.assertNotIn(
             'Template Folder',
             factoriesmenu.addable_types()
-            )
+        )
 
         self.grant('Manager')
         browser.reload()
         self.assertIn(
             'Template Folder',
             factoriesmenu.addable_types()
-            )
+        )
 
     @browsing
     def test_manager_addable_types(self, browser):
@@ -839,7 +1146,7 @@ class TestTemplateFolderMeetingEnabled(IntegrationTestCase):
 
     features = (
         'meeting',
-        )
+    )
 
     @browsing
     def test_addable_types_with_meeting_feature(self, browser):
@@ -853,7 +1160,7 @@ class TestTemplateFolderMeetingEnabled(IntegrationTestCase):
             'Sablon Template',
             'Task Template Folder',
             'Template Folder',
-            ]
+        ]
 
         addable_types = factoriesmenu.addable_types()
 
@@ -904,7 +1211,7 @@ class TestTemplateFolderListings(SolrIntegrationTestCase):
             'Reference number',
             'File extension',
             'Keywords',
-            ]
+        ]
 
         self.assertEqual(expected_table_header, browser.css('table.listing').first.lists()[0])
 
@@ -926,7 +1233,7 @@ class TestTemplateFolderListings(SolrIntegrationTestCase):
             'Reference number',
             'File extension',
             'Keywords',
-            ]
+        ]
 
         self.assertEqual(expected_table_header, browser.css('table.listing').first.lists()[0])
 
@@ -948,7 +1255,7 @@ class TestTemplateFolderListings(SolrIntegrationTestCase):
             'Reference number',
             'File extension',
             'Keywords',
-            ]
+        ]
 
         self.assertEqual(expected_table_header, browser.css('table.listing').first.lists()[0])
 
@@ -962,7 +1269,7 @@ class TestTemplateFolderListings(SolrIntegrationTestCase):
             'Copy items',
             'Export selection',
             'Move items',
-            ]
+        ]
 
         self.assertItemsEqual(expected_action_menu_content, browser.css('.actionMenuContent li').text)
 
@@ -977,7 +1284,7 @@ class TestTemplateFolderListings(SolrIntegrationTestCase):
             'Export selection',
             'Delete',
             'Move items',
-            ]
+        ]
 
         self.assertItemsEqual(expected_action_menu_content, browser.css('.actionMenuContent li').text)
 
@@ -999,12 +1306,12 @@ class TestTemplateFolderListings(SolrIntegrationTestCase):
             self.asset_template.absolute_url(),
             self.normal_template.absolute_url(),
             self.empty_template.absolute_url(),
-            ]
+        ]
 
         document_urls = [
             element.get('Title').css('a').first.get('href')
             for element in templates
-            ]
+        ]
 
         self.assertEqual(expected_document_urls, document_urls)
         self.assertNotIn(self.subtemplate.absolute_url(), document_urls)
@@ -1018,7 +1325,7 @@ class TestTemplateFolderListings(SolrIntegrationTestCase):
             'Export as Zip',
             'Copy items',
             'Export selection',
-            ]
+        ]
 
         self.assertItemsEqual(expected_actions, browser.css('.actionMenuContent li').text)
 
@@ -1032,7 +1339,7 @@ class TestTemplateFolderListings(SolrIntegrationTestCase):
             'Check in without comment',
             'Export selection',
             'Delete',
-            ]
+        ]
 
         self.assertItemsEqual(expected_actions, browser.css('.actionMenuContent li').text)
 
@@ -1050,7 +1357,7 @@ class TestTemplateFolderListings(SolrIntegrationTestCase):
             'Export as Zip',
             'Copy items',
             'Export selection',
-            ]
+        ]
 
         self.assertItemsEqual(expected_actions, browser.css('.actionMenuContent li').text)
 
@@ -1064,7 +1371,7 @@ class TestTemplateFolderListings(SolrIntegrationTestCase):
             'Check in without comment',
             'Export selection',
             'Delete',
-            ]
+        ]
 
         self.assertItemsEqual(expected_actions, browser.css('.actionMenuContent li').text)
 
@@ -1165,7 +1472,7 @@ class TestTemplateDocumentTabsWithOneoffixx(IntegrationTestCase):
 class TestDossierTemplateFeature(IntegrationTestCase):
     features = (
         'dossiertemplate',
-        )
+    )
 
     @browsing
     def test_visible_tabs(self, browser):


### PR DESCRIPTION
With this PR we add support for defining a sender when creating a document from a template. This will add the corresponding docproperties to the created document. We of course also add support for defining a sender in the API.

For [CA-4429]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
- New translations
  - [x] All msg-strings are unicode

[CA-4429]: https://4teamwork.atlassian.net/browse/CA-4429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ