### PR TITLE
Switch `@recently-touched` endpoint to Solr.

### DIFF
--- a/changes/CA-3644.other
+++ b/changes/CA-3644.other
@@ -1,0 +1,1 @@
+Switch `@recently-touched` endpoint to Solr. [lgraf]

--- a/opengever/api/recently_touched.py
+++ b/opengever/api/recently_touched.py
@@ -1,17 +1,23 @@
+from ftw.solr.interfaces import ISolrSearch
+from ftw.solr.query import make_filters
 from opengever.base.browser.helper import get_css_class
 from opengever.base.interfaces import IRecentlyTouchedSettings
+from opengever.base.solr import OGSolrDocument
 from opengever.base.touched import RECENTLY_TOUCHED_INTERFACES_TO_TRACK
 from opengever.base.touched import RECENTLY_TOUCHED_KEY
 from plone import api
 from plone.api.portal import get_registry_record
 from plone.restapi.serializer.summary import ISerializeToJsonSummary
 from plone.restapi.services import Service
+from pytz import timezone
 from zExceptions import BadRequest
 from zExceptions import Unauthorized
 from zope.annotation import IAnnotations
 from zope.component import getMultiAdapter
+from zope.component import getUtility
 from zope.interface import implements
 from zope.publisher.interfaces import IPublishTraverse
+import dateutil
 
 
 class RecentlyTouchedGet(Service):
@@ -28,7 +34,8 @@ class RecentlyTouchedGet(Service):
     def __init__(self, context, request):
         super(RecentlyTouchedGet, self).__init__(context, request)
         self.params = []
-        self._checked_out_brains = None
+        self._checked_out_solr_docs = None
+        self.solr = getUtility(ISolrSearch)
 
     def publishTraverse(self, request, name):
         # Consume any path segments after /@recently-touched as parameters
@@ -46,34 +53,36 @@ class RecentlyTouchedGet(Service):
         }
         return results
 
-    def _get_checked_out_brains(self, user_id):
-        """Returns brains of objects currently checked out by `user_id`.
+    def _get_checked_out_solr_docs(self, user_id):
+        """Returns Solr docs of objects currently checked out by `user_id`.
 
         This is memoized, because its used for building both the
         'checked_out' and 'recently_touched' lists.
         """
-        if self._checked_out_brains is None:
-            catalog = api.portal.get_tool('portal_catalog')
-            self._checked_out_brains = catalog(
-                object_provides=[
-                    i.__identifier__
-                    for i in RECENTLY_TOUCHED_INTERFACES_TO_TRACK],
-                checked_out=user_id,
-                sort_on='modified',
-                sort_order='reverse')
-        return self._checked_out_brains
+        if self._checked_out_solr_docs is None:
+            response = self.solr.search(
+                filters=make_filters(
+                    object_provides=[
+                        i.__identifier__ for i in
+                        RECENTLY_TOUCHED_INTERFACES_TO_TRACK],
+                    checked_out=user_id,
+                ),
+                sort='modified desc',
+            )
+            self._checked_out_solr_docs = [OGSolrDocument(d) for d in response.docs]
+
+        return self._checked_out_solr_docs
 
     def _get_checked_out(self, user_id):
         """Get the list of documents currently checked out by `user_id`.
 
-        This is entirely based on information from the catalog.
+        This is entirely based on information from Solr.
         """
-        # We're using the catalog's modified timestamp for these, since we
+        # We're using the modified timestamp from Solr for these, since we
         # take care to update it on checkin/checkout
         entries = []
-        for brain in self._get_checked_out_brains(user_id):
-            entries.append(
-                self.serialize_brain(brain, brain.modified.ISO8601()))
+        for solr_doc in self._get_checked_out_solr_docs(user_id):
+            entries.append(self.serialize(solr_doc, solr_doc['modified']))
         return entries
 
     def _get_recently_touched(self, user_id):
@@ -82,10 +91,10 @@ class RecentlyTouchedGet(Service):
         This list is compiled by reading recently touched log for the given
         user_id, subtracting any checked out documents (because those are
         already displayed in the other list), and combining them with
-        catalog brains (by UID) for any information other than the timestamp.
+        Solr documents (by UID) for any information other than the timestamp.
 
         Timestamps used for display and ordering are fully based on the
-        recently touched log, the catalog's 'modified' timestamp isn't being
+        recently touched log, the 'modified' timestamp from Solr isn't being
         used here.
 
         This is because 'modified' is a very technical timestamp,
@@ -94,35 +103,40 @@ class RecentlyTouchedGet(Service):
         as "touched" so we control the semantics.
         """
         portal = api.portal.get()
-        catalog = api.portal.get_tool('portal_catalog')
 
         recently_touched_log = IAnnotations(portal).get(
             RECENTLY_TOUCHED_KEY, {}).get(user_id, [])
 
         # Subtract checked out docs from recently touched list
-        checked_out_brains = self._get_checked_out_brains(user_id)
-        checked_out_uids = [b.UID for b in checked_out_brains]
+        checked_out_solr_docs = self._get_checked_out_solr_docs(user_id)
+        checked_out_uids = [b['UID'] for b in checked_out_solr_docs]
         touched_only_uids = [m['uid'] for m in recently_touched_log
                              if m['uid'] not in checked_out_uids]
 
-        touched_brains = catalog(
-            UID=touched_only_uids,
-            object_provides=[i.__identifier__
-                             for i in RECENTLY_TOUCHED_INTERFACES_TO_TRACK],
+        touched_solr_docs = self.solr.search(
+            filters=make_filters(
+                UID=touched_only_uids,
+                object_provides=[
+                    i.__identifier__ for i in
+                    RECENTLY_TOUCHED_INTERFACES_TO_TRACK],
+            ),
         )
 
-        touched_brains_by_uid = {b.UID: b for b in touched_brains}
+        touched_solr_docs_by_uid = {
+            d['UID']: OGSolrDocument(d)
+            for d in touched_solr_docs.docs
+        }
 
         entries = []
         for entry in recently_touched_log:
-            brain = touched_brains_by_uid.get(entry['uid'])
-            if brain is None:
+            solr_doc = touched_solr_docs_by_uid.get(entry['uid'])
+            if solr_doc is None:
                 # Might have checked out docs in storage, or items that don't
                 # match the currently tracked types
                 continue
 
             entries.append(
-                self.serialize_brain(brain, entry['last_touched'].isoformat()))
+                self.serialize(solr_doc, entry['last_touched'].isoformat()))
 
         # Truncate list to currently configured limit (storage might still
         # contain more entries until they get rotated out).
@@ -131,18 +145,31 @@ class RecentlyTouchedGet(Service):
 
         return entries
 
-    def serialize_brain(self, brain, last_touched):
-        """Serialize the brain with the summary serialization from plone restapi
-        and extend the result with the two additional data `icon_class` and
-        `last_touched`.
+    def serialize(self, solr_doc, last_touched):
+        """Serialize the OGSolrDocument with the summary serialization from
+        plone restapi and extend the result with the two additional data
+        `icon_class` and `last_touched`.
         """
 
         result = getMultiAdapter(
-            (brain, self.request), ISerializeToJsonSummary)()
-        result.update({"icon_class": get_css_class(brain),
-                       "last_touched": last_touched})
+            (solr_doc, self.request),
+            ISerializeToJsonSummary)()
 
+        result.update({
+            "icon_class": get_css_class(solr_doc),
+            "last_touched": self.localize(last_touched),
+            "file_extension": solr_doc.data['file_extension'],
+            "checked_out": solr_doc.data['checked_out']
+        })
         return result
+
+    def localize(self, datetimestr):
+        """Turn an ISO datetime string into one that is always in our
+        local time, so we can provide consistency in API responses.
+        """
+        tz = timezone('Europe/Zurich')
+        dt = dateutil.parser.parse(datetimestr)
+        return dt.astimezone(tz).isoformat()
 
     def read_params(self):
         if len(self.params) != 1:

--- a/opengever/api/tests/test_recently_touched.py
+++ b/opengever/api/tests/test_recently_touched.py
@@ -9,14 +9,14 @@ from opengever.base.touched import ObjectTouchedEvent
 from opengever.base.touched import RECENTLY_TOUCHED_KEY
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.dossier.tests.test_resolve import ResolveTestHelper
-from opengever.testing import IntegrationTestCase
+from opengever.testing import SolrIntegrationTestCase
 from plone import api
 from zope.annotation import IAnnotations
 from zope.component import queryMultiAdapter
 from zope.event import notify
 
 
-class TestRecentlyModifiedGet(IntegrationTestCase, ResolveTestHelper):
+class TestRecentlyModifiedGet(SolrIntegrationTestCase, ResolveTestHelper):
 
     def _clear_recently_touched_log(self, user_id):
         del IAnnotations(self.portal)[RECENTLY_TOUCHED_KEY][user_id][:]
@@ -63,6 +63,8 @@ class TestRecentlyModifiedGet(IntegrationTestCase, ResolveTestHelper):
                 (self.document, self.request), ICheckinCheckoutManager)
             manager.checkout()
 
+        self.commit_solr()
+
         url = '%s/@recently-touched/%s' % (
             self.portal.absolute_url(), self.regular_user.getId())
         browser.open(url, method='GET', headers={'Accept': 'application/json'})
@@ -93,6 +95,8 @@ class TestRecentlyModifiedGet(IntegrationTestCase, ResolveTestHelper):
             manager = queryMultiAdapter(
                 (self.document, self.request), ICheckinCheckoutManager)
             manager.checkout()
+
+        self.commit_solr()
 
         url = '%s/@recently-touched/%s?metadata_fields:list=checked_out&metadata_fields:list=filename' % (
             self.portal.absolute_url(), self.regular_user.getId())
@@ -134,6 +138,8 @@ class TestRecentlyModifiedGet(IntegrationTestCase, ResolveTestHelper):
                 (self.document, self.request), ICheckinCheckoutManager)
             manager.checkout()
 
+        self.commit_solr()
+
         url = '%s/@recently-touched/%s' % (
             self.portal.absolute_url(), self.regular_user.getId())
         browser.open(url, method='GET', headers={'Accept': 'application/json'})
@@ -167,6 +173,8 @@ class TestRecentlyModifiedGet(IntegrationTestCase, ResolveTestHelper):
                 (self.document, self.request), ICheckinCheckoutManager)
             manager.checkout()
             notify(ObjectTouchedEvent(self.document))
+
+        self.commit_solr()
 
         url = '%s/@recently-touched/%s' % (
             self.portal.absolute_url(), self.regular_user.getId())


### PR DESCRIPTION
This switches the implementation of the `@recently-touched` endpoint to Solr instead of ZCatalog, in order to optimize performance.

The API remains unchanged.

For [CA-3644](https://4teamwork.atlassian.net/browse/CA-3644)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
