### PR TITLE
Fix excel export if multiple custom fields with same name exits.

### DIFF
--- a/changes/CA-4537.bugfix
+++ b/changes/CA-4537.bugfix
@@ -1,0 +1,1 @@
+Fix excel export if multiple customfields with same name are configured. [phgross]

--- a/opengever/base/solr/fields.py
+++ b/opengever/base/solr/fields.py
@@ -820,7 +820,14 @@ class SolrFieldMapper(object):
         dynamic_solr_fields = self.get_custom_property_solr_fields()
         matches = [f for f in dynamic_solr_fields if f['name'] == field_name]
         if matches:
-            assert len(matches) == 1
+            if len(matches) > 1:
+                # Check if all field definitions are equal
+                if len(set([tuple(match.items()) for match in matches])) > 1:
+                    raise Exception(
+                        u'PropertySheet incorrectly configured. Multiple fields '
+                        u'defined with name `{}`, but with a different '
+                        u'configuration.'.format(field_name))
+
             return matches[0]
 
     def get_custom_property_solr_fields(self, all_slots=False):


### PR DESCRIPTION
Currently it is not possible to assign multiple propertysheets to one slot, therefore we need to duplicate the field configuration in some cases. This has led to errors in the Excel report.

The current assertion can be ignored, if multiple fields are defined with the same name but are equal.

For [CA-4537]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira) 

[CA-4537]: https://4teamwork.atlassian.net/browse/CA-4537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ