### PR TITLE
Fix meeting minutes test after WeasyPrint image was updated to 56.1.

### DIFF
--- a/opengever/workspace/tests/test_meeting_minutes.py
+++ b/opengever/workspace/tests/test_meeting_minutes.py
@@ -15,7 +15,7 @@ class TestMeetingMinutes(IntegrationTestCase):
         browser.open(self.workspace_meeting, view="meeting_minutes_pdf")
         self.assertEqual(browser.status_code, 200)
         self.assertEqual(browser.headers['Content-Type'], 'application/pdf')
-        self.assertEqual(browser.contents[:8], '%PDF-1.5')
+        self.assertEqual(browser.contents[:8], '%PDF-1.7')
 
     @browsing
     def test_related_items_included_in_meeting_minutes_html(self, browser):


### PR DESCRIPTION
Fixes [this test failure](https://ci.4teamwork.ch/builds/516472/tasks/984579) that appeared after the `4teamwork/weasyprint` docker image was updated.

```
Failure in test test_meeting_minutes_pdf_view_returns_a_pdf (opengever.workspace.tests.test_meeting_minutes.TestMeetingMinutes)
Traceback (most recent call last):
  File "/usr/local/python/2.7.16/lib/python2.7/unittest/case.py", line 329, in run
    testMethod()
  File "/var/lib/jenkins/zope/eggs/ftw.testbrowser-1.30.1-py2.7.egg/ftw/testbrowser/__init__.py", line 42, in test_function
    return func(self, *args, **kwargs)
  File "/var/lib/jenkins/workspace/opengever.core-weight-6/opengever/workspace/tests/test_meeting_minutes.py", line 18, in test_meeting_minutes_pdf_view_returns_a_pdf
    self.assertEqual(browser.contents[:8], '%PDF-1.5')
  File "/usr/local/python/2.7.16/lib/python2.7/unittest/case.py", line 513, in assertEqual
    assertion_func(first, second, msg=msg)
  File "/usr/local/python/2.7.16/lib/python2.7/unittest/case.py", line 506, in _baseAssertEqual
    raise self.failureException(msg)
AssertionError: '%PDF-1.7' != '%PDF-1.5'
```
