### PR TITLE
Temporarily re-add rubygems to testserver buildout:

### DIFF
--- a/base-testserver.cfg
+++ b/base-testserver.cfg
@@ -1,9 +1,14 @@
 [buildout]
+extends =
+    https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/ruby-gems.cfg
+
 testserver-parts =
     testserver
     testserver-selftest
 
-parts += ${:testserver-parts}
+parts +=
+    ${:testserver-parts}
+    gems
 
 
 [testserver]


### PR DESCRIPTION
Removing rubygems from testserver will require running the GEVER shared docker services on the Jenkins nodes. For now, we therefore just re-add the rubygems to the testserver buildout in order to not break the testserver and local development buildout.

⚠️ Tests for this will fail until #7537 is merged

For [CA-485](https://4teamwork.atlassian.net/browse/CA-485)

## Checklist

- [ ] Changelog entry (deemed unnecessary)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
