### PR TITLE
Explicitly add some parts in dev buildout:

### DIFF
--- a/development.cfg
+++ b/development.cfg
@@ -35,9 +35,11 @@ code-audit-parts =
 # with our complicated inheritance hierarchy
 parts +=
     ${buildout:early-parts}
+    ${buildout:development-parts}
     ${buildout:tool-parts}
     ${buildout:test-parts}
     ${buildout:code-audit-parts}
+    ${buildout:format-xml-parts}
     ${buildout:i18n-parts}
 
 parts -=


### PR DESCRIPTION
With the recent changes to buildout for the removal of the ruby-gems it appears that the buildout bug that drops parts (beyond a certain level of extends) has struck again and drops the 'development-parts' and others.

We therefore explicitly add them to `parts` in the dev buildout.

⚠️ There might still be some more parts that are dropped, I might add those in a later PR. These are the most important ones for now, in order to fix the local development buildout.

For [CA-485](https://4teamwork.atlassian.net/browse/CA-485)

## Checklist

- [ ] Changelog entry _(deemed unneccesary)_
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

