### PR TITLE
Policytemplate: Always configure ALL shared service URLs in SaaS buildouts

### DIFF
--- a/changes/CA-485.other
+++ b/changes/CA-485.other
@@ -1,0 +1,1 @@
+Policytemplate: Always configure ALL shared service URLs. [lgraf]

--- a/opengever/policytemplates/policy_template/.mrbob.ini
+++ b/opengever/policytemplates/policy_template/.mrbob.ini
@@ -26,11 +26,6 @@ base.domain.post_ask_question = opengever.policytemplates.hooks:post_base_domain
 base.ogds_db_name.question = OGDS DB Name
 base.ogds_db_name.required = True
 
-base.setup_with_services.question = Sablon, Msg_convert and pdflatex as services?
-base.setup_with_services.required = True
-base.setup_with_services.default = true
-base.setup_with_services.post_ask_question = mrbob.hooks:to_boolean
-
 base.apps_endpoint_url.question = Apps endpoint url
 base.apps_endpoint_url.required = True
 

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/deployment-+base.server_name+-+base.deployment_number+-+base.domain+.cfg.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/deployment-+base.server_name+-+base.deployment_number+-+base.domain+.cfg.bob
@@ -25,8 +25,6 @@ supervisor-client-stopwaitsecs = 5
 supervisor-memmon-instance-size = 1200MB
 supervisor-memmon-options = -p instance1=${buildout:supervisor-memmon-instance-size} -p instance2=${buildout:supervisor-memmon-instance-size} -p instance3=${buildout:supervisor-memmon-instance-size} -p instance4=${buildout:supervisor-memmon-instance-size} -m ${buildout:supervisor-email}
 
-parts -= gems
-
 [instance0]
 environment-vars +=
     BUMBLEBEE_APP_ID {{{base.bumblebee_app_id}}}

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/deployment-+base.server_name+-+base.deployment_number+-+base.domain+.cfg.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/deployment-+base.server_name+-+base.deployment_number+-+base.domain+.cfg.bob
@@ -26,9 +26,6 @@ supervisor-memmon-instance-size = 1200MB
 supervisor-memmon-options = -p instance1=${buildout:supervisor-memmon-instance-size} -p instance2=${buildout:supervisor-memmon-instance-size} -p instance3=${buildout:supervisor-memmon-instance-size} -p instance4=${buildout:supervisor-memmon-instance-size} -m ${buildout:supervisor-email}
 
 parts -= gems
-{{% if not base.setup_with_services %}}
-sablon-executable = /opt/sablon/bin/sablon
-{{% endif %}}
 
 [instance0]
 environment-vars +=
@@ -37,14 +34,10 @@ environment-vars +=
     BUMBLEBEE_PUBLIC_URL https://{{{base.domain}}}/
     BUMBLEBEE_SECRET {{{base.bumblebee_secret}}}
     APPS_ENDPOINT_URL {{{base.apps_endpoint_url}}}
-{{% if base.setup_with_services %}}
     MSGCONVERT_URL http://localhost:8090/
     SABLON_URL http://localhost:8091/
     PDFLATEX_URL http://localhost:8092/
-{{% endif %}}
-{{% if is_teamraum %}}
-{{% if setup.enable_workspace_meeting_feature %}}
     WEASYPRINT_URL http://localhost:8093/
-{{% endif %}}
+{{% if is_teamraum %}}
     WORKSPACE_SECRET {{{base.workspace_secret}}}
 {{% endif %}}


### PR DESCRIPTION
Policytemplate: Always configure ALL shared service URLs:

For SaaS-Servers, we've decided that all GEVER shared services (Sablon, PDFLatex, MSGConvert and WeasyPrint) will *always* be deployed on all servers (teamraum-servers as well as GEVER-servers).

Therefore we simplify the buildouts by always configuring all service URLs, irrespective of whether they're actually needed or not.

In addition, we remove the `parts -= gems` hack from the policytemplate, since it's not necessary anymore.

For [CA-485](https://4teamwork.atlassian.net/browse/CA-485)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
