### PR TITLE
Add chamelon-cache to parts in order to fix dev-buildout.

### DIFF
--- a/development.cfg
+++ b/development.cfg
@@ -41,6 +41,7 @@ parts +=
     ${buildout:code-audit-parts}
     ${buildout:format-xml-parts}
     ${buildout:i18n-parts}
+    chameleon-cache
 
 parts -=
     gems


### PR DESCRIPTION
Add `chamelon-cache` to parts in order to fix dev-buildout. This is another part that got dropped by the buildout bug (follow up to #7539).

For [CA-485](https://4teamwork.atlassian.net/browse/CA-485)

## Checklist

- [ ] Changelog entry _(deemed unnecessary)_
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
