### PR TITLE
Fix testserver console_script generation

### DIFF
--- a/base-testserver.cfg
+++ b/base-testserver.cfg
@@ -16,6 +16,7 @@ recipe = zc.recipe.egg
 eggs =
     ${test:eggs}
     plone.app.robotframework
+entry-points = testserver=opengever.core.testserver_zope2server:server
 initialization =
     import os
     # Enable conditional readonly patches during tests

--- a/setup.py
+++ b/setup.py
@@ -212,6 +212,5 @@ setup(name='opengever.core',
       create-policy = opengever.policytemplates.cli:main
       pyxbgen = opengever.disposition.ech0160.pyxbgen:main
       toggle-readonly = opengever.readonly.cli:main
-      testserver = opengever.core.testserver_zope2server:server
       """,
       )


### PR DESCRIPTION
This is a "fun" one.

The `bin/testserver` script was generated **twice** during buildout.

One was incomplete and broken, but until now got overwritten with the second, correct one. But the recent changes to the development buildout somehow changed the order in which these parts get built, and now the correct one gets 
overwritten by the broken one.

The correct script is produced by the [testserver] section in base-testserver.cfg. It contains the necessary additional egg `plone.app.robotframework`, as well as required initialization code.

The incorrect script was generated as part of the regular [instance] section, because it has a `testserver` console_scripts entry point. However, that entry point doesn't define either the additional dependency or the required init code. That entry point would therefore never have produced a functioning `bin/testserver`, we just didn't notice because it got overwritten.

The solution therefore is to kill the `testserver` entrypoint from `setup.py`, and specify it explicitly in `base-testserver.cfg`.


For [CA-485](https://4teamwork.atlassian.net/browse/CA-485)

## Checklist

- [ ] Changelog entry _(deemed unnecessary)_
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
