### PR TITLE
Only save custom properties defaults of active and default slots.

### DIFF
--- a/changes/CA-4530.other
+++ b/changes/CA-4530.other
@@ -1,0 +1,1 @@
+Only save custom properties defaults of active and default slots. [njohner]

--- a/opengever/api/deserializer.py
+++ b/opengever/api/deserializer.py
@@ -36,9 +36,14 @@ class GeverDeserializeFromJson(DeserializeFromJson):
         if create:
             container = aq_parent(aq_inner(self.context))
             set_default_values(self.context, container, data)
-            initialize_customproperties_defaults(self.context)
 
         schema_data, errors = self.get_schema_data(data, validate_all)
+
+        # set custom properties defaults, we do this after deserializing the
+        # other fields as the active slot is needed and defaults are only
+        # set if field was not set otherwise
+        if create:
+            initialize_customproperties_defaults(self.context)
 
         # Validate schemata
         for schema, field_data in schema_data.items():

--- a/opengever/propertysheets/creation_defaults.py
+++ b/opengever/propertysheets/creation_defaults.py
@@ -1,21 +1,7 @@
 from copy import copy
-from opengever.document.behaviors import IBaseDocument
 from opengever.propertysheets.storage import PropertySheetSchemaStorage
+from opengever.propertysheets.utils import get_customproperties_behavior
 from zope.component import queryAdapter
-
-
-def get_customproperties_behavior(obj):
-    # Avoid import problems when importing a bundle
-    from opengever.document.behaviors.customproperties import IDocumentCustomProperties
-    from opengever.dossier.behaviors.customproperties import IDossierCustomProperties
-    from opengever.dossier.behaviors.dossier import IDossierMarker
-
-    if IDossierMarker.providedBy(obj):
-        return IDossierCustomProperties
-    elif IBaseDocument.providedBy(obj):
-        return IDocumentCustomProperties
-
-    return
 
 
 def initialize_customproperties_defaults(obj, reindex=True):

--- a/opengever/propertysheets/utils.py
+++ b/opengever/propertysheets/utils.py
@@ -1,19 +1,25 @@
 from opengever.document.behaviors import IBaseDocument
-from opengever.document.behaviors.customproperties import IDocumentCustomProperties
-from opengever.dossier.behaviors.customproperties import IDossierCustomProperties
-from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.propertysheets.storage import PropertySheetSchemaStorage
 from zope.schema import getFields
+
+
+def get_customproperties_behavior(obj):
+    from opengever.document.behaviors.customproperties import IDocumentCustomProperties
+    from opengever.dossier.behaviors.customproperties import IDossierCustomProperties
+    from opengever.dossier.behaviors.dossier import IDossierMarker
+    if IDossierMarker.providedBy(obj):
+        return IDossierCustomProperties
+    elif IBaseDocument.providedBy(obj):
+        return IDocumentCustomProperties
+
+    return
 
 
 def get_custom_properties(obj):
     data = {}
 
-    if IDossierMarker.providedBy(obj):
-        customprops_behavior = IDossierCustomProperties
-    elif IBaseDocument.providedBy(obj):
-        customprops_behavior = IDocumentCustomProperties
-    else:
+    customprops_behavior = get_customproperties_behavior(obj)
+    if customprops_behavior is None:
         return data
 
     adapted = customprops_behavior(obj, None)


### PR DESCRIPTION
With this PR we fix an issue where custom properties defaults were saved on objects even if that object did not have the corresponding slot as active (i.e. is not of the corresponding document or dossier type). As these properties are not displayed, it is "unimportant", but it's unnecessary and makes things unnecessarily difficult when we want to modify a given propertysheet, as its default values are stored everywhere...

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-4530]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-4530]: https://4teamwork.atlassian.net/browse/CA-4530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ