### PR TITLE
Handle deleted dossiers in NightlyDossierJournalPDF.

### DIFF
--- a/changes/CA-3276.bugfix
+++ b/changes/CA-3276.bugfix
@@ -1,0 +1,1 @@
+Handle deleted dossiers in NightlyDossierJournalPDF. [njohner]

--- a/opengever/disposition/nightly_jobs.py
+++ b/opengever/disposition/nightly_jobs.py
@@ -94,10 +94,10 @@ class NightlyDossierJournalPDF(NightlyJobProviderBase):
     def run_job(self, job, interrupt_if_necessary):
         """Run the job for the dossier identified by the IntId `job`.
         """
-        dossier = self.intids.getObject(job)
-
-        self.logger.info("Creating journal PDF for %r" % dossier)
-        dossier.create_or_update_journal_pdf()
+        dossier = self.intids.queryObject(job)
+        if dossier is not None:
+            self.logger.info("Creating journal PDF for %r" % dossier)
+            dossier.create_or_update_journal_pdf()
 
         queue = self.get_queue()
         queue.remove(job)


### PR DESCRIPTION
Nightly jobs have not run on dev.onegovgever.ch/fd (see https://dev.onegovgever.ch/fd/@@health-check?extended=1) in the last month because of nightly jobs referencing deleted objects. We fix it here for the dossier journal PDF nightly jobs.

Sentry: 

- https://sentry.4teamwork.ch/organizations/sentry/issues/88595
- https://sentry.4teamwork.ch/organizations/sentry/issues/88464
- https://sentry.4teamwork.ch/organizations/sentry/issues/88465 (maybe)

For [CA-3276]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug

[CA-3276]: https://4teamwork.atlassian.net/browse/CA-3276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ