### PR TITLE
Handle empty recently touched log in @recently-touched endpoint.

### DIFF
--- a/opengever/api/recently_touched.py
+++ b/opengever/api/recently_touched.py
@@ -113,14 +113,17 @@ class RecentlyTouchedGet(Service):
         touched_only_uids = [m['uid'] for m in recently_touched_log
                              if m['uid'] not in checked_out_uids]
 
-        touched_solr_docs = self.solr.search(
-            filters=make_filters(
-                UID=touched_only_uids,
-                object_provides=[
-                    i.__identifier__ for i in
-                    RECENTLY_TOUCHED_INTERFACES_TO_TRACK],
-            ),
-        )
+        if touched_only_uids:
+            touched_solr_docs = self.solr.search(
+                filters=make_filters(
+                    UID=touched_only_uids,
+                    object_provides=[
+                        i.__identifier__ for i in
+                        RECENTLY_TOUCHED_INTERFACES_TO_TRACK],
+                ),
+            )
+        else:
+            return []
 
         touched_solr_docs_by_uid = {
             d['UID']: OGSolrDocument(d)

--- a/opengever/api/tests/test_recently_touched.py
+++ b/opengever/api/tests/test_recently_touched.py
@@ -22,6 +22,20 @@ class TestRecentlyModifiedGet(SolrIntegrationTestCase, ResolveTestHelper):
         del IAnnotations(self.portal)[RECENTLY_TOUCHED_KEY][user_id][:]
 
     @browsing
+    def test_handles_empty_recently_touched_log(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        self._clear_recently_touched_log(self.regular_user.getId())
+
+        url = '%s/@recently-touched/%s' % (
+            self.portal.absolute_url(), self.regular_user.getId())
+        browser.open(url, method='GET', headers={'Accept': 'application/json'})
+
+        self.assertEqual(200, browser.status_code)
+        self.assertEqual({'checked_out': [], 'recently_touched': []},
+                         browser.json)
+
+    @browsing
     def test_lists_recently_modified_objs_for_given_user(self, browser):
         self.login(self.regular_user, browser=browser)
 


### PR DESCRIPTION
The switch of `@recently-touched` to solr has led to errors being thrown in solr when the the user does not have any recently touched item. While the endpoint correctly returns an empty list, as `ftw.solr` swallows all solr errors, it leads to a lot of junk in the output of e2e tests (e.g. search for "Solr response error. " in https://ci.4teamwork.ch/builds/518375/tasks/989597).

Note that the tests also pass without the current change to the endpoint (as I said, solr errors are swallowed in `ftw.solr`), but I think it's still a good idea to test the endpoint for empty recently touched list.

For [CA-3644]

## Checklist
- [ ] Changelog entry -> no changelog entry if we merge it in the current release?
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-3644]: https://4teamwork.atlassian.net/browse/CA-3644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ