### PR TITLE
Allow admins and workspace admins to modify and delete their own workspace participations

### DIFF
--- a/changes/CA-4529.other
+++ b/changes/CA-4529.other
@@ -1,0 +1,1 @@
+Allow admins and workspace admins to modify and delete their own workspace participations. [tinagerber]

--- a/opengever/workspace/participation/__init__.py
+++ b/opengever/workspace/participation/__init__.py
@@ -66,12 +66,9 @@ def get_full_user_info(userid=None, member=None):
 
 
 def can_manage_member(context, actor=None, roles=None):
-    if actor and actor.identifier == api.user.get_current().getId():
-        return False
-    else:
-        return api.user.has_permission(
-            'Sharing page: Delegate WorkspaceAdmin role',
-            obj=context)
+    return api.user.has_permission(
+        'Sharing page: Delegate WorkspaceAdmin role',
+        obj=context)
 
 
 def invitation_to_item(invitation, context):

--- a/opengever/workspace/participation/browser/manage_participants.py
+++ b/opengever/workspace/participation/browser/manage_participants.py
@@ -146,8 +146,8 @@ class ManageParticipants(BrowserView):
         if role not in MANAGED_ROLES:
             raise Unauthorized('Inavlid role provided.')
 
-        if token == api.user.get_current().id:
-            raise Unauthorized('Not allowed to modify the current user.')
+        if not can_manage_member(self.context, Actor.lookup(token)):
+            raise Unauthorized()
 
         if type_ in ['user', 'group']:
             assignment_manager = RoleAssignmentManager(self.context)


### PR DESCRIPTION
Since it checks if the user has the permission "Sharing page: Delegate WorkspaceAdmin role", it is only possible for administrators to modify/delete their own participations.

For [CA-4529]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-4529]: https://4teamwork.atlassian.net/browse/CA-4529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ