### PR TITLE
Proposal handles proposal document moved to dossier.

### DIFF
--- a/changes/CA-3912.other
+++ b/changes/CA-3912.other
@@ -1,0 +1,1 @@
+Support disabled meetings feature. [njohner]

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -19,6 +19,7 @@ from opengever.document.widgets.document_link import DocumentLinkWidget
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.utils import get_containing_dossier
 from opengever.meeting import _
+from opengever.meeting import is_meeting_feature_enabled
 from opengever.meeting import SUBMITTED_PROPOSAL_STATES
 from opengever.meeting.activity.activities import ProposalCommentedActivity
 from opengever.meeting.activity.activities import ProposalRejectedActivity
@@ -255,7 +256,10 @@ class ProposalBase(object):
         if document is None:
             raise ValueError('Proposal document seems to have vanished.')
 
-        if aq_parent(aq_inner(document)) != self:
+        # if meeting feature is disabled, we might have moved the meeting
+        # documents into the meeting dossier as preparation for removal of
+        # the meeting feature from Gever.
+        if aq_parent(aq_inner(document)) != self and is_meeting_feature_enabled():
             raise ValueError('Proposal document is in wrong location.')
 
         return document


### PR DESCRIPTION
For the migration of Meetings to RIS, we copy or move all documents from the meetings into the meeting dossier (see https://github.com/4teamwork/opengever.maintenance/pull/336). This leads to failure to display proposals, and is fixed here. We simply check for deactivated meetings feature as this is a clear sign of having migrated the meetings to RIS.

For [CA-3912]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-3912]: https://4teamwork.atlassian.net/browse/CA-3912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ