### PR TITLE
Fix updating a custom property value when the previous value contained an umlaut

### DIFF
--- a/changes/CA-4605.bugfix
+++ b/changes/CA-4605.bugfix
@@ -1,0 +1,1 @@
+Fix updating a custom property value when the previous value contained an umlaut. [elioschmutz]

--- a/opengever/propertysheets/helpers.py
+++ b/opengever/propertysheets/helpers.py
@@ -1,3 +1,4 @@
+from plone.dexterity.utils import safe_utf8
 from zope.schema import Choice
 from zope.schema import Set
 
@@ -11,7 +12,7 @@ def is_multiple_choice_field(field):
 
 
 def _add_value_to_vocabulary(vocab, value):
-    term = vocab.createTerm(value)
+    term = vocab.createTerm(safe_utf8(value))
     vocab._terms.append(term)
     vocab.by_value[term.value] = term
     vocab.by_token[term.value] = term


### PR DESCRIPTION
This PR fixes an issue where it is not possible to change a custom property value if the previous value contained an umlaut.

Example dossier: https://dev.onegovgever.ch/fd/ordnungssystem/fuehrung/gemeinderecht/uebergeordnete-erlasse/dossier-2258

https://user-images.githubusercontent.com/557005/186158574-89d8380f-9e10-439e-b81b-b815b9f9691e.mov

For [CA-4605]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- Bug fixed:
  - [x] Resolved any Sentry issues caused by this bug


[CA-4605]: https://4teamwork.atlassian.net/browse/CA-4605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ