### PR TITLE
Allow moving proposals outside main dossier during meeting migration.

### DIFF
--- a/changes/CA-3912.other
+++ b/changes/CA-3912.other
@@ -1,1 +1,1 @@
-Support disabled meetings feature. [njohner]
+Add support for meetings migration. [njohner]

--- a/opengever/meeting/handlers.py
+++ b/opengever/meeting/handlers.py
@@ -11,6 +11,7 @@ from opengever.base.security import elevated_privileges
 from opengever.meeting.activity.watchers import add_watcher_on_proposal_created
 from opengever.meeting.command import UpdateExcerptInDossierCommand
 from opengever.meeting.exceptions import ProposalMovedOutsideOfMainDossierError
+from opengever.meeting.interfaces import IDuringMeetingMigration
 from opengever.meeting.model import GeneratedExcerpt
 from opengever.meeting.model import Proposal
 from opengever.meeting.model import SubmittedDocument
@@ -124,6 +125,11 @@ def proposal_will_be_moved(obj, event):
         # In this case, the obj is the proposal, but the event object is the
         # dossier. In this case we don't want to validate the new parent of
         # the proposal because it will be the same.
+        return
+
+    if IDuringMeetingMigration.providedBy(getRequest()):
+        # Meeting dossiers are replaced by normal dossiers, so if a proposal
+        # is inside a meeting dossier it will effectively get moved.
         return
 
     old_main_dossier = event.oldParent.get_main_dossier()

--- a/opengever/meeting/interfaces.py
+++ b/opengever/meeting/interfaces.py
@@ -41,3 +41,10 @@ class IMembershipWrapper(ISQLObjectWrapper):
 
 class IMeetingDossier(model.Schema):
     """Marker interface for MeetingDossier"""
+
+
+class IDuringMeetingMigration(Interface):
+    """Request layer to indicate that meetings are being migrated
+    to prepare deletion of the meeting feature. It is used to skip certain
+    checks that would prevent the migration.
+    """


### PR DESCRIPTION
Handle meeting dossiers containing proposals during meeting migration. For this we need to allow moving the proposals, as we replace the meeting dossier with a normal dossier, effectively moving the proposal.

I did not add a test, as this is not used in Gever, only in the migration of the meetings.

For [CA-3912]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-3912]: https://4teamwork.atlassian.net/browse/CA-3912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ