### PR TITLE
Implement new endopint @linked-workspace-invitations to invite users from gever to a workspace

### DIFF
--- a/changes/CA-4595.feature
+++ b/changes/CA-4595.feature
@@ -1,0 +1,1 @@
+Allow to invite users to a workspace through the workspace-client from GEVER. [elioschmutz]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,6 +11,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- ``@linked-workspace-invitations``: New endpoint to invite users from GEVER into a workspace.
 
 2022.17.0 (2022-08-30)
 ----------------------

--- a/docs/public/dev-manual/api/linked_workspaces.rst
+++ b/docs/public/dev-manual/api/linked_workspaces.rst
@@ -189,6 +189,32 @@ Mit dem ``@linked-workspace-participations`` Endpoint können Teilnehmer auf ein
     }
 
 
+Teilnehmer in einen verknüpften Teamraum einladen
+-------------------------------------------------
+
+Mit dem ``@linked-workspace-invitations`` Endpoint können Teilnehmer auf einem verknüpften Teamraum eingeladen werden.
+
+**Beispiel-Request**:
+
+  .. sourcecode:: http
+
+    POST /ordnungssystem/dossier-23/@linked-workspace-invitations HTTP/1.1
+    Accept: application/json
+    Content-Type: application/json
+
+    {
+      "workspace_uid": "c11627f492b6447fb61617bb06b9a21a"
+      "recipient_email": "max.muster@example.com",
+      "role": {"token": "WorkspaceGuest"},
+    }
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 204 No Content
+
+
 Ein GEVER-Dokument in einen verknüpften Teamraum kopieren
 ---------------------------------------------------------
 

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -1199,6 +1199,14 @@
       />
 
   <plone:service
+      method="POST"
+      name="@linked-workspace-invitations"
+      for="opengever.dossier.behaviors.dossier.IDossierMarker"
+      factory=".linked_workspaces.AddInvitationOnWorkspacePost"
+      permission="opengever.workspaceclient.UseWorkspaceClient"
+      />
+
+  <plone:service
       method="GET"
       name="@allowed-roles-and-principals"
       for="Products.CMFCore.interfaces.IContentish"

--- a/opengever/api/linked_workspaces.py
+++ b/opengever/api/linked_workspaces.py
@@ -309,3 +309,32 @@ class AddParticipationsOnWorkspacePost(LinkedWorkspacesService):
             "@id": "{}/@linked-workspace-participations".format(self.context.absolute_url()),
             "items": items
         }
+
+
+class AddInvitationOnWorkspacePost(LinkedWorkspacesService):
+    """API Endpoint to add invitations on a linked workspace.
+    """
+
+    @teamraum_request_error_handler
+    def reply(self):
+        alsoProvides(self.request, IDisableCSRFProtection)
+        data = json_body(self.request)
+        workspace_uid = data.get('workspace_uid')
+        if not workspace_uid:
+            raise BadRequest(_(u"workspace_uid_required",
+                               default=u"Property 'workspace_uid' is required"))
+
+        recipient_email = data.get('recipient_email')
+        if not recipient_email:
+            raise BadRequest(_(u"recipient_email_required",
+                               default=u"Property 'recipient_email' is required"))
+
+        role = data.get('role')
+        if not role:
+            raise BadRequest(_(u"role_required",
+                               default=u"Property 'role' is required"))
+
+        ILinkedWorkspaces(self.context).add_invitation(workspace_uid, data)
+
+        self.request.response.setStatus(204)
+        return super(AddInvitationOnWorkspacePost, self).reply()

--- a/opengever/api/locales/de/LC_MESSAGES/opengever.api.po
+++ b/opengever/api/locales/de/LC_MESSAGES/opengever.api.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-06-28 14:05+0000\n"
+"POT-Creation-Date: 2022-08-25 13:12+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -196,6 +196,16 @@ msgstr "Nur Antworten vom Typ \"Kommentar\" können gelöscht werden."
 #: ./opengever/api/linked_workspaces.py
 msgid "participant_required"
 msgstr "Parameter 'participants' ist erforderlich"
+
+#. Default: "Property 'recipient_email' is required"
+#: ./opengever/api/linked_workspaces.py
+msgid "recipient_email_required"
+msgstr "Parameter 'recipient_email' ist erforderlich"
+
+#. Default: "Property 'role' is required"
+#: ./opengever/api/linked_workspaces.py
+msgid "role_required"
+msgstr "Parameter 'role' ist erforderlich"
 
 #. Default: "Property 'transfer_number' is required."
 #: ./opengever/api/disposition.py

--- a/opengever/api/locales/en/LC_MESSAGES/opengever.api.po
+++ b/opengever/api/locales/en/LC_MESSAGES/opengever.api.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-06-28 14:05+0000\n"
+"POT-Creation-Date: 2022-08-25 13:12+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -196,6 +196,16 @@ msgstr "Only responses of type \"Comment\" can be edited."
 #: ./opengever/api/linked_workspaces.py
 msgid "participant_required"
 msgstr "Property 'participants' is required"
+
+#. Default: "Property 'recipient_email' is required"
+#: ./opengever/api/linked_workspaces.py
+msgid "recipient_email_required"
+msgstr "Property 'recipient_email' is required"
+
+#. Default: "Property 'role' is required"
+#: ./opengever/api/linked_workspaces.py
+msgid "role_required"
+msgstr "Property 'role' is required"
 
 #. Default: "Property 'transfer_number' is required."
 #: ./opengever/api/disposition.py

--- a/opengever/api/locales/fr/LC_MESSAGES/opengever.api.po
+++ b/opengever/api/locales/fr/LC_MESSAGES/opengever.api.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-06-28 14:05+0000\n"
+"POT-Creation-Date: 2022-08-25 13:12+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -196,6 +196,16 @@ msgstr "Seules les réponses de type \"Commentaire\" peuvent être éditées."
 #: ./opengever/api/linked_workspaces.py
 msgid "participant_required"
 msgstr "Le paramètre 'participants' est requis"
+
+#. Default: "Property 'recipient_email' is required"
+#: ./opengever/api/linked_workspaces.py
+msgid "recipient_email_required"
+msgstr "Le paramètre 'recipient_email' est requis"
+
+#. Default: "Property 'role' is required"
+#: ./opengever/api/linked_workspaces.py
+msgid "role_required"
+msgstr "Le paramètre 'role' est requis"
 
 #. Default: "Property 'transfer_number' is required."
 #: ./opengever/api/disposition.py

--- a/opengever/api/locales/opengever.api.pot
+++ b/opengever/api/locales/opengever.api.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-06-28 14:05+0000\n"
+"POT-Creation-Date: 2022-08-25 13:12+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -198,6 +198,16 @@ msgstr ""
 #. Default: "Property 'participants' is required"
 #: ./opengever/api/linked_workspaces.py
 msgid "participant_required"
+msgstr ""
+
+#. Default: "Property 'recipient_email' is required"
+#: ./opengever/api/linked_workspaces.py
+msgid "recipient_email_required"
+msgstr ""
+
+#. Default: "Property 'role' is required"
+#: ./opengever/api/linked_workspaces.py
+msgid "role_required"
 msgstr ""
 
 #. Default: "Property 'transfer_number' is required."

--- a/opengever/workspaceclient/linked_workspaces.py
+++ b/opengever/workspaceclient/linked_workspaces.py
@@ -34,6 +34,7 @@ from zope.i18n import translate
 from zope.interface import alsoProvides
 from zope.interface import implementer
 from zope.interface import noLongerProvides
+import json
 import sys
 import transaction
 
@@ -551,3 +552,11 @@ class LinkedWorkspaces(object):
         return self.client.post(
             '{}/@participations'.format(workspace_url),
             json={'participants': participations})
+
+    def add_invitation(self, workspace_uid, invitation_data):
+        """ Adds an invitation on the workspace
+        """
+        workspace_url = self._get_linked_workspace_url(workspace_uid)
+        return self.client.post(
+            '{}/@invitations'.format(workspace_url),
+            json=invitation_data)


### PR DESCRIPTION
This PR adds a new endpoint `@linked-workspace-invitations` which allows to invite users to a linked workspace from GEVER.

This allows us to directly invite users on workspace creation within GEVER.

For [CA-4595]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide]
- New translations
  - [x] All msg-strings are unicode

[CA-4595]: https://4teamwork.atlassian.net/browse/CA-4595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ