### PR TITLE
Add support for deactivating the meeting feature

### DIFF
--- a/changes/CA-3912.other
+++ b/changes/CA-3912.other
@@ -1,1 +1,1 @@
-Add support for meetings migration. [njohner]
+Add support for meetings migration and deactivation. [njohner]

--- a/opengever/base/tests/test_navigation.py
+++ b/opengever/base/tests/test_navigation.py
@@ -4,6 +4,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testing import freeze
+from opengever.meeting.utils import disable_meeting_feature
 from opengever.testing import IntegrationTestCase
 from zope.event import notify
 from zope.lifecycleevent import ObjectModifiedEvent
@@ -133,9 +134,12 @@ class TestNavigation(IntegrationTestCase):
 
 class TestCatalogNavigationTabs(IntegrationTestCase):
 
+    features = ('meeting', )
+
     @browsing
     def test_catalog_tabs(self, browser):
         self.login(self.manager, browser=browser)
+
         view = self.portal.unrestrictedTraverse('@@portal_tabs_view')
         self.assertEqual(
             [
@@ -162,6 +166,48 @@ class TestCatalogNavigationTabs(IntegrationTestCase):
                     'id': 'opengever-meeting-committeecontainer',
                     'name': 'Sitzungen',
                     'url': 'http://nohost/plone/opengever-meeting-committeecontainer',
+                },
+                {
+                    'description': '',
+                    'id': 'eingangskorb',
+                    'name': 'Eingangsk\xc3\xb6rbli',
+                    'url': 'http://nohost/plone/eingangskorb',
+                },
+                {
+                    'description': '',
+                    'id': 'workspaces',
+                    'name': 'Teamr\xc3\xa4ume',
+                    'url': 'http://nohost/plone/workspaces',
+                }
+            ],
+            view.topLevelTabs(actions=[])
+        )
+
+    @browsing
+    def test_committee_container_is_hidden_from_catalog_tabs_when_feature_disabled(self, browser):
+        self.login(self.manager, browser=browser)
+        disable_meeting_feature()
+
+        view = self.portal.unrestrictedTraverse('@@portal_tabs_view')
+        self.assertEqual(
+            [
+                {
+                    'description': '',
+                    'id': 'kontakte',
+                    'name': 'Contacts',
+                    'url': 'http://nohost/plone/kontakte',
+                },
+                {
+                    'description': '',
+                    'id': 'ordnungssystem',
+                    'name': 'Ordnungssystem',
+                    'url': 'http://nohost/plone/ordnungssystem',
+                },
+                {
+                    'description': '',
+                    'id': 'vorlagen',
+                    'name': 'Vorlagen',
+                    'url': 'http://nohost/plone/vorlagen',
                 },
                 {
                     'description': '',

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -11,6 +11,7 @@ from opengever.base.oguid import Oguid
 from opengever.base.schema import TableChoice
 from opengever.base.schema import UTCDatetime
 from opengever.meeting import _
+from opengever.meeting import is_meeting_feature_enabled
 from opengever.meeting.browser.meetings.agendaitem_list import GenerateAgendaItemList
 from opengever.meeting.browser.meetings.agendaitem_list import UpdateAgendaItemList
 from opengever.meeting.browser.meetings.transitions import MeetingTransitionController
@@ -33,6 +34,7 @@ from z3c.form.button import buttonAndHandler
 from z3c.form.field import Fields
 from z3c.form.form import Form
 from z3c.form.interfaces import HIDDEN_MODE
+from zExceptions import Forbidden
 from zope import schema
 from zope.component import getUtility
 from zope.globalrequest import getRequest
@@ -171,6 +173,12 @@ class AddMeetingWizardStep(BaseWizardStepForm, Form):
 class AddMeetingWizardStepView(FormWrapper):
 
     form = AddMeetingWizardStep
+
+    def __call__(self):
+        if not is_meeting_feature_enabled():
+            raise Forbidden('Meeting feature is disabled')
+
+        return super(AddMeetingWizardStepView, self).__call__()
 
 
 class AddMeetingDossierView(WizzardWrappedAddForm):

--- a/opengever/meeting/committeecontainer.py
+++ b/opengever/meeting/committeecontainer.py
@@ -1,4 +1,5 @@
 from opengever.base.behaviors.translated_title import TranslatedTitleMixin
+from opengever.meeting import is_meeting_feature_enabled
 from opengever.meeting.model import Member
 from opengever.meeting.wrapper import MemberWrapper
 from plone.dexterity.content import Container
@@ -37,3 +38,7 @@ class CommitteeContainer(Container, TranslatedTitleMixin):
         if default is _marker:
             raise KeyError(id_)
         return default
+
+    @property
+    def exclude_from_nav(self):
+        return not is_meeting_feature_enabled()

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -11,6 +11,7 @@ from opengever.base.oguid import Oguid
 from opengever.base.types import UnicodeCoercingText
 from opengever.base.utils import escape_html
 from opengever.meeting import _
+from opengever.meeting import is_meeting_feature_enabled
 from opengever.meeting.browser.meetings.transitions import MeetingTransitionController
 from opengever.meeting.exceptions import MissingAdHocTemplate
 from opengever.meeting.exceptions import MissingMeetingDossierPermissions
@@ -110,7 +111,8 @@ class Meeting(Base, SQLFormSupport):
              'held', 'closed',
              title=_('close_meeting', default='Close meeting')),
          Transition('closed', 'held',
-                    title=_('reopen', default='Reopen')),
+                    title=_('reopen', default='Reopen'),
+                    condition=is_meeting_feature_enabled),
          CancelTransition('pending', 'cancelled',
                           title=_('cancel', default='Cancel')),
          ],

--- a/opengever/meeting/reopen.py
+++ b/opengever/meeting/reopen.py
@@ -1,3 +1,4 @@
+from opengever.meeting import is_meeting_feature_enabled
 from opengever.meeting.model import Meeting
 from opengever.meeting.period import Period
 
@@ -31,6 +32,8 @@ class ReopenMeeting(object):
 
     def get_errors(self):
         errors = []
+        if not is_meeting_feature_enabled():
+            errors.append("Can't reopen meeting when feature is disabled.")
         if self.meeting.workflow_state not in ('held', 'closed'):
             errors.append(u"Can't reopen meeting in state '{}'.".format(
                 self.meeting.workflow_state)

--- a/opengever/meeting/tests/test_committee.py
+++ b/opengever/meeting/tests/test_committee.py
@@ -11,7 +11,28 @@ from opengever.base.oguid import Oguid
 from opengever.meeting.model import Committee
 from opengever.testing import IntegrationTestCase
 from plone.uuid.interfaces import IUUID
+from zExceptions import Unauthorized
 import pytz
+
+
+class TestCommitteeWithDisabledMeetingFeature(IntegrationTestCase):
+
+    @browsing
+    def test_committee_cannot_be_created_in_browser(self, browser):
+        self.login(self.administrator, browser)
+
+        browser.exception_bubbling = True
+        with self.assertRaises(Unauthorized):
+            browser.open(self.committee_container,
+                         view='++add++opengever.meeting.committee')
+
+    @browsing
+    def test_committee_cannot_be_edited_in_browser(self, browser):
+        self.login(self.committee_responsible, browser)
+
+        browser.exception_bubbling = True
+        with self.assertRaises(Unauthorized):
+            browser.open(self.committee, view='edit')
 
 
 class TestCommittee(IntegrationTestCase):

--- a/opengever/meeting/tests/test_meeting.py
+++ b/opengever/meeting/tests/test_meeting.py
@@ -7,6 +7,7 @@ from opengever.testing import IntegrationTestCase
 from opengever.testing.helpers import localized_datetime
 from pyquery import PyQuery
 from zExceptions import BadRequest
+from zExceptions import Forbidden
 
 
 ZIP_EXPORT_ACTION_LABEL = 'Export as ZIP file'
@@ -390,6 +391,14 @@ class TestMeeting(IntegrationTestCase):
 
 
 class TestMeetingWithDisabledMeetingFeature(IntegrationTestCase):
+
+    @browsing
+    def test_cannot_add_meeting(self, browser):
+        self.login(self.committee_responsible, browser)
+
+        browser.exception_bubbling = True
+        with self.assertRaises(Forbidden):
+            browser.open(self.committee, view='add-meeting')
 
     @browsing
     def test_cannot_reopen_closed_meeting(self, browser):

--- a/opengever/meeting/tests/test_meeting_reopen.py
+++ b/opengever/meeting/tests/test_meeting_reopen.py
@@ -16,6 +16,21 @@ class TestReopenMeeting(IntegrationTestCase):
     features = ('meeting',)
     REOPEN_MEETING_ACTION = 'Reopen meeting'
 
+    def test_cannot_reopen_meeting_if_feature_is_deactivated(self):
+        self.login(self.committee_responsible)
+
+        self.schedule_ad_hoc(self.meeting, 'Foo')
+        self.schedule_paragraph(self.meeting, u'Para')
+        agenda_item = self.schedule_proposal(
+            self.meeting, self.submitted_proposal
+        )
+        agenda_item.decide()
+
+        self.deactivate_feature('meeting')
+        self.assertEqual(
+            ["Can't reopen meeting when feature is disabled."],
+            ReopenMeeting(self.meeting.model).get_errors())
+
     def test_reopen_held_meeting(self):
         self.login(self.committee_responsible)
 

--- a/opengever/meeting/utils.py
+++ b/opengever/meeting/utils.py
@@ -44,3 +44,12 @@ def is_docx(document):
     document_mimetype = document_file.contentType
     docx_mimetype = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
     return document_mimetype == docx_mimetype
+
+
+def disable_meeting_feature():
+    api.portal.set_registry_record(
+        'is_feature_enabled', False, interface=IMeetingSettings)
+    catalog = api.portal.get_tool('portal_catalog')
+    for brain in catalog.unrestrictedSearchResults(
+            portal_type='opengever.meeting.committeecontainer'):
+        brain.getObject().reindexObject(idxs=['exclude_from_nav'])


### PR DESCRIPTION
It was never really planed that the meeting feature would get deactivated, so things are not ideal when there is a committecontainer and meetings with the feature deactivated. We make a few changes here to better handle that situation:
- Disallow reopening meetings when the meeting feature is disabled
- Hide the committeecontainer from the navigation when the feature is disabled.

For [CA-3912]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-3912]: https://4teamwork.atlassian.net/browse/CA-3912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ