### PR TITLE
Adjust journal entry title of manual entries

### DIFF
--- a/changes/CA-4594.other
+++ b/changes/CA-4594.other
@@ -1,0 +1,1 @@
+Adjust journal entry title of manual entries. [tinagerber]

--- a/docs/public/dev-manual/api/journal.rst
+++ b/docs/public/dev-manual/api/journal.rst
@@ -97,7 +97,7 @@ Ein GET Request gibt die Journaleinträge eines Inhalts zurück.
             }
           ],
           "time": "2019-04-15T14:00:48+00:00",
-          "title": "Manueller Eintrag: Telefongespräch"
+          "title": "Telefongespräch"
         },
         {
           "@id": "http://localhost:8080/fd/ordnungssystem/fuehrung/gemeinderecht/dossier-1/@journal/456"
@@ -109,7 +109,7 @@ Ein GET Request gibt die Journaleinträge eines Inhalts zurück.
           "category": { "token": "information", "title": "Information" }
           "related_documents": [],
           "time": "2019-04-15T13:59:21+00:00",
-          "title": "Manueller Eintrag: Telefongespräch"
+          "title": "Telefongespräch"
         }
       ],
       "items_total": 2

--- a/opengever/api/tests/test_journal.py
+++ b/opengever/api/tests/test_journal.py
@@ -230,7 +230,7 @@ class TestJournalGet(IntegrationTestCase):
                 u'review_state': u'document-state-draft',
                 u'title': self.document.title}],
             u'time': u'2017-10-16T00:00:00+00:00',
-            u'title': u'Manual entry: Information'
+            u'title': u'Information'
         }, response.get('items')[0])
 
     @browsing
@@ -306,11 +306,11 @@ class TestJournalGet(IntegrationTestCase):
         self.assertEqual(19, response.json.get('items_total'))
 
         response = browser.open(
-            self.dossier, view='@journal?search=Manual',
+            self.dossier, view='@journal?search=call',
             method='GET', headers=http_headers())
 
         self.assertEqual(
-            [u'Manual entry: Phone call', u'Manual entry: Information'],
+            [u'Phone call'],
             map(lambda item: item.get('title'), response.json.get('items')))
 
     @browsing
@@ -460,7 +460,7 @@ class TestJournalPatch(IntegrationTestCase):
         ).json.get('items')[-1]
 
         self.assertEqual(u'my new comment', entry.get('comment'))
-        self.assertEqual(u'Manual entry: Phone call', entry.get('title'))
+        self.assertEqual(u'Phone call', entry.get('title'))
         self.assertEqual(u'2017-10-16T00:00:00+00:00', entry['time'])
         self.assertEqual(
             self.document.absolute_url(),

--- a/opengever/api/tests/test_journal_manager.py
+++ b/opengever/api/tests/test_journal_manager.py
@@ -146,7 +146,7 @@ class TestJournalManager(IntegrationTestCase):
         entry = manager.list()[0]
         self.assertEqual(u'is an agent', entry.get('comments'))
         self.assertEqual(u'information', entry.get('action').get('category'))
-        self.assertEqual(u'Manual entry: Information', translate(entry.get('action').get('title')))
+        self.assertEqual(u'Information', translate(entry.get('action').get('title')))
         self.assertEqual([], entry.get('action').get('documents'))
         self.assertEqual(zope_time, entry.get('time'))
 
@@ -155,7 +155,7 @@ class TestJournalManager(IntegrationTestCase):
 
         self.assertEqual(u'my new comment', entry.get('comments'))
         self.assertEqual(u'phone-call', entry.get('action').get('category'))
-        self.assertEqual(u'Manual entry: Phone call', translate(entry.get('action').get('title')))
+        self.assertEqual(u'Phone call', translate(entry.get('action').get('title')))
         self.assertEqual([{'id': u'plone:1014073300', 'title': u'Vertr\xe4gsentwurf'}], entry.get('action').get('documents'))
         self.assertEqual(zope_time, entry.get('time'))
 

--- a/opengever/journal/locales/de/LC_MESSAGES/opengever.journal.po
+++ b/opengever/journal/locales/de/LC_MESSAGES/opengever.journal.po
@@ -199,7 +199,7 @@ msgstr "Lokale Rollen von ${repository} modifziert."
 #. Default: "Manual entry: ${category}"
 #: ./opengever/journal/manager.py
 msgid "label_manual_journal_entry"
-msgstr "Manueller Eintrag: ${category}"
+msgstr "${category}"
 
 #. Default: "Object cut: ${title}"
 #: ./opengever/journal/handlers.py

--- a/opengever/journal/locales/en/LC_MESSAGES/opengever.journal.po
+++ b/opengever/journal/locales/en/LC_MESSAGES/opengever.journal.po
@@ -237,7 +237,7 @@ msgstr "Local roles modified at ${repository}."
 #. Default: "Manual entry: ${category}"
 #: ./opengever/journal/manager.py
 msgid "label_manual_journal_entry"
-msgstr "Manual entry: ${category}"
+msgstr "${category}"
 
 #. German translation: Objekt ausgeschnitten: ${title}
 #. Default: "Object cut: ${title}"

--- a/opengever/journal/locales/fr/LC_MESSAGES/opengever.journal.po
+++ b/opengever/journal/locales/fr/LC_MESSAGES/opengever.journal.po
@@ -201,7 +201,7 @@ msgstr "Rôles à l'intérne pour ${repository} modifiés."
 #. Default: "Manual entry: ${category}"
 #: ./opengever/journal/manager.py
 msgid "label_manual_journal_entry"
-msgstr "Entrée manuelle: ${category}"
+msgstr "${category}"
 
 #. Default: "Object cut: ${title}"
 #: ./opengever/journal/handlers.py

--- a/opengever/journal/tests/test_manual_entry.py
+++ b/opengever/journal/tests/test_manual_entry.py
@@ -35,7 +35,7 @@ class TestManualJournalEntry(FunctionalTestCase):
         browser.open(self.dossier, view=u'tabbedview_view-journal')
         self.assertEquals(
             {'Changed by': 'Test User (test_user_1_)',
-             'Title': 'Manual entry: Phone call',
+             'Title': 'Phone call',
              'Comments': u'Anfrage bez\xfcglich dem Jahr 2016 von Herr Meier',
              'References': u'',
              'Time': '09.12.2016 09:40'},
@@ -141,7 +141,7 @@ class TestManualJournalEntry(FunctionalTestCase):
         browser.open(self.dossier, view=u'tabbedview_view-journal')
         row = browser.css('.listing').first.rows[1]
 
-        self.assertEquals('Manual entry: Phone call', row.dict().get('Title'))
+        self.assertEquals('Phone call', row.dict().get('Title'))
         self.assertEquals('', row.dict().get('Comments'))
 
     @browsing


### PR DESCRIPTION
"Manual entry" is removed from the title. We need to keep the translation, otherwise older journal entries would be missing the translation.

For [CA-4594]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-4594]: https://4teamwork.atlassian.net/browse/CA-4594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ