### PR TITLE
Setup test environment for workspace client e2e tests

### DIFF
--- a/base-testserver.cfg
+++ b/base-testserver.cfg
@@ -25,6 +25,7 @@ initialization =
     os.environ.setdefault('ZSERVER_PORT', '55001')
     os.environ.setdefault('LISTENER_PORT', os.environ.get('TESTSERVER_CTL_PORT', '55002'))
     os.environ.setdefault('FTW_STRUCTLOG_MUTE_SETUP_ERRORS', 'true')
+    os.environ.setdefault('TEAMRAUM_URL', 'http://localhost')
     import sys
     sys.argv.insert(1, 'opengever.core.testserver.OPENGEVER_TESTSERVER')
     # Enable c.indexing during tests, but patch it to not defer operations

--- a/changes/CA-4595.other
+++ b/changes/CA-4595.other
@@ -1,0 +1,1 @@
+Setup test environment for workspace client e2e tests [elioschmutz]

--- a/opengever/base/tests/test_configuration_adapter.py
+++ b/opengever/base/tests/test_configuration_adapter.py
@@ -23,10 +23,11 @@ class TestConfigurationAdapter(IntegrationTestCase):
             ('current_user', OrderedDict([
                 ('username', 'kathi.barfuss'),
                 ('description', None),
-                ('roles', ['Member']),
+                ('roles', ['Member', 'WorkspaceClientUser']),
                 ('home_page', None),
                 ('roles_and_principals', ['principal:kathi.barfuss',
                                           'Member',
+                                          'WorkspaceClientUser',
                                           'Authenticated',
                                           'principal:AuthenticatedUsers',
                                           'principal:fa_users',

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -274,6 +274,7 @@ class OpengeverContentFixture(object):
             'regular_user',
             u'K\xe4thi',
             u'B\xe4rfuss',
+            ['WorkspaceClientUser'],
             address1='Kappelenweg 13',
             address2='Postfach 1234',
             city='Vorkappelen',


### PR DESCRIPTION
This PR is properly configuring the test environment to make it possible to write workspace client related e2e tests.

We do not really setup a teamraum-env. We just add the necessary roles and configuration to simulate the existence of a teamraum deployment. This allows us to use forms and actions in the ui which are related to the workspace-client feature.

We'll not do real requests to the `TEAMRAUM_URL` but we need to configure it that the backend "thinks" we've configured a teamraum. In e2e-tests, we'll mock the requests to the teamraum-backend.

For [CA-4595]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-4595]: https://4teamwork.atlassian.net/browse/CA-4595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ