### PR TITLE
Use a-tags for the workspace invitation email template to properly render links in mail-clients

### DIFF
--- a/changes/CA-4675.feature
+++ b/changes/CA-4675.feature
@@ -1,0 +1,1 @@
+Improve links of workspace invitation email template. [elioschmutz]

--- a/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-06-17 09:57+0000\n"
+"POT-Creation-Date: 2022-09-09 12:33+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -128,6 +128,16 @@ msgstr "Verwendete URL um eine Videokonferenz für diesen Teamraum zu starten."
 msgid "invitation"
 msgstr "Einladung"
 
+#. Default: "Please click the following link if you want to accept the invitation: ${accept_url}"
+#: ./opengever/workspace/participation/templates/invitation_mail.pt
+msgid "invitation_accept"
+msgstr "Wenn Sie die Einladung annehmen möchten, klicken Sie auf folgenden Link: ${accept_url}"
+
+#. Default: "accept invitation"
+#: ./opengever/workspace/participation/templates/invitation_mail.pt
+msgid "invitation_accept_link"
+msgstr "Einladung annehmen"
+
 #. Default: "You were invited by ${user} to the workspace \"${title}\"."
 #: ./opengever/workspace/participation/invitation_mailer.py
 msgid "invitation_mail_description"
@@ -143,16 +153,15 @@ msgstr "Nachricht von ${user}:"
 msgid "invitation_mail_subject"
 msgstr "Einladung zum Teamraum \"${title}\""
 
-#. Default: "Hello,\n\nYou were invited by ${user} to the workspace \"${title}\" at ${platform}.\n\nPlease click the following link if you want to accept the invitation:\n${accept_url}"
-#: ./opengever/workspace/participation/invitation_mailer.py
-msgid "invitation_mail_summary"
-msgstr ""
-"Guten Tag,\n"
-"\n"
-"${user} hat Sie eingeladen, an \"${title}\" auf der Plattform ${platform} teilzunehmen.\n"
-"\n"
-"Wenn Sie die Einladung annehmen möchten, klicken Sie auf folgenden Link:\n"
-"${accept_url}"
+#. Default: "Hello"
+#: ./opengever/workspace/participation/templates/invitation_mail.pt
+msgid "invitation_salutation"
+msgstr "Guten Tag"
+
+#. Default: "You were invited by ${user} to the workspace \"${workspace_title}\" at ${platform}."
+#: ./opengever/workspace/participation/templates/invitation_mail.pt
+msgid "invitation_text"
+msgstr "${user} hat Sie eingeladen, an \"${workspace_title}\" auf der Plattform ${platform} teilzunehmen."
 
 #. Default: "Attendees"
 #: ./opengever/workspace/browser/templates/meeting_minutes.pt
@@ -234,6 +243,7 @@ msgid "label_owner"
 msgstr "Besitzer"
 
 #. Default: "Related items"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
 #: ./opengever/workspace/todo.py
 #: ./opengever/workspace/workspace_meeting_agenda_item.py
 msgid "label_related_items"

--- a/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-06-17 09:57+0000\n"
+"POT-Creation-Date: 2022-09-09 12:33+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -150,6 +150,16 @@ msgstr "URL to launch a video conference for this workspace"
 msgid "invitation"
 msgstr "Invitation"
 
+#. Default: "Please click the following link if you want to accept the invitation: ${accept_url}"
+#: ./opengever/workspace/participation/templates/invitation_mail.pt
+msgid "invitation_accept"
+msgstr ""
+
+#. Default: "accept invitation"
+#: ./opengever/workspace/participation/templates/invitation_mail.pt
+msgid "invitation_accept_link"
+msgstr ""
+
 #. German translation: Sie wurden von ${user} in den Teamraum \"${title}\" eingeladen.
 #. Default: "You were invited by ${user} to the workspace \"${title}\"."
 #: ./opengever/workspace/participation/invitation_mailer.py
@@ -168,17 +178,15 @@ msgstr "Message from ${user}:"
 msgid "invitation_mail_subject"
 msgstr "Invitation to workspace \"${title}\""
 
-#. German translation: "Guten Tag,\n\n${user} hat Sie eingeladen, an \"${title}\" auf der Plattform ${platform} teilzunehmen.\n\nWenn Sie die Einladung annehmen möchten, klicken Sie auf folgenden Link:\n${accept_url}""
-#. Default: "Hello,\n\nYou were invited by ${user} to the workspace \"${title}\" at ${platform}.\n\nPlease click the following link if you want to accept the invitation:\n${accept_url}"
-#: ./opengever/workspace/participation/invitation_mailer.py
-msgid "invitation_mail_summary"
+#. Default: "Hello"
+#: ./opengever/workspace/participation/templates/invitation_mail.pt
+msgid "invitation_salutation"
 msgstr ""
-"Hello,\n"
-"\n"
-"You were invited by ${user} to the workspace \"${title}\" at ${platform}.\n"
-"\n"
-"Please click the following link to accept the invitation:\n"
-"${accept_url}"
+
+#. Default: "You were invited by ${user} to the workspace \"${workspace_title}\" at ${platform}."
+#: ./opengever/workspace/participation/templates/invitation_mail.pt
+msgid "invitation_text"
+msgstr ""
 
 #. Default: "Attendees"
 #: ./opengever/workspace/browser/templates/meeting_minutes.pt
@@ -269,6 +277,7 @@ msgid "label_owner"
 msgstr "Owner"
 
 #. Default: "Related items"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
 #: ./opengever/workspace/todo.py
 #: ./opengever/workspace/workspace_meeting_agenda_item.py
 msgid "label_related_items"

--- a/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-06-17 09:57+0000\n"
+"POT-Creation-Date: 2022-09-09 12:33+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -128,6 +128,16 @@ msgstr "URL utilisée pour lancer une vidéoconférence pour cet espace partagé
 msgid "invitation"
 msgstr "Invitation"
 
+#. Default: "Please click the following link if you want to accept the invitation: ${accept_url}"
+#: ./opengever/workspace/participation/templates/invitation_mail.pt
+msgid "invitation_accept"
+msgstr "Pour accepter cette invitation, veuillez cliquer sur le lien suivant: ${accept_url}"
+
+#. Default: "accept invitation"
+#: ./opengever/workspace/participation/templates/invitation_mail.pt
+msgid "invitation_accept_link"
+msgstr "Accepter"
+
 #. Default: "You were invited by ${user} to the workspace \"${title}\"."
 #: ./opengever/workspace/participation/invitation_mailer.py
 msgid "invitation_mail_description"
@@ -143,16 +153,15 @@ msgstr "Message de ${user}:"
 msgid "invitation_mail_subject"
 msgstr "Invitation pour le teamraum \"${title}\""
 
-#. Default: "Hello,\n\nYou were invited by ${user} to the workspace \"${title}\" at ${platform}.\n\nPlease click the following link if you want to accept the invitation:\n${accept_url}"
-#: ./opengever/workspace/participation/invitation_mailer.py
-msgid "invitation_mail_summary"
-msgstr ""
-"Bonjour,\n"
-"\n"
-"${user} vous a invité, à participer à \"${title}\", sur la plateforme ${platform}.\n"
-"\n"
-"Pour accepter cette invitation, veuillez cliquer sur le lien suivant:\n"
-"${accept_url}"
+#. Default: "Hello"
+#: ./opengever/workspace/participation/templates/invitation_mail.pt
+msgid "invitation_salutation"
+msgstr "Bonjour"
+
+#. Default: "You were invited by ${user} to the workspace \"${workspace_title}\" at ${platform}."
+#: ./opengever/workspace/participation/templates/invitation_mail.pt
+msgid "invitation_text"
+msgstr "${user} vous a invité, à participer à \"${workspace_title}\", sur la plateforme ${platform}."
 
 #. Default: "Attendees"
 #: ./opengever/workspace/browser/templates/meeting_minutes.pt
@@ -234,6 +243,7 @@ msgid "label_owner"
 msgstr "Propriétaire"
 
 #. Default: "Related items"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
 #: ./opengever/workspace/todo.py
 #: ./opengever/workspace/workspace_meeting_agenda_item.py
 msgid "label_related_items"

--- a/opengever/workspace/locales/opengever.workspace.pot
+++ b/opengever/workspace/locales/opengever.workspace.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-06-17 09:57+0000\n"
+"POT-Creation-Date: 2022-09-09 12:33+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -131,6 +131,16 @@ msgstr ""
 msgid "invitation"
 msgstr ""
 
+#. Default: "Please click the following link if you want to accept the invitation: ${accept_url}"
+#: ./opengever/workspace/participation/templates/invitation_mail.pt
+msgid "invitation_accept"
+msgstr ""
+
+#. Default: "accept invitation"
+#: ./opengever/workspace/participation/templates/invitation_mail.pt
+msgid "invitation_accept_link"
+msgstr ""
+
 #. Default: "You were invited by ${user} to the workspace \"${title}\"."
 #: ./opengever/workspace/participation/invitation_mailer.py
 msgid "invitation_mail_description"
@@ -146,9 +156,14 @@ msgstr ""
 msgid "invitation_mail_subject"
 msgstr ""
 
-#. Default: "Hello,\n\nYou were invited by ${user} to the workspace \"${title}\" at ${platform}.\n\nPlease click the following link if you want to accept the invitation:\n${accept_url}"
-#: ./opengever/workspace/participation/invitation_mailer.py
-msgid "invitation_mail_summary"
+#. Default: "Hello"
+#: ./opengever/workspace/participation/templates/invitation_mail.pt
+msgid "invitation_salutation"
+msgstr ""
+
+#. Default: "You were invited by ${user} to the workspace \"${workspace_title}\" at ${platform}."
+#: ./opengever/workspace/participation/templates/invitation_mail.pt
+msgid "invitation_text"
 msgstr ""
 
 #. Default: "Attendees"
@@ -231,6 +246,7 @@ msgid "label_owner"
 msgstr ""
 
 #. Default: "Related items"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
 #: ./opengever/workspace/todo.py
 #: ./opengever/workspace/workspace_meeting_agenda_item.py
 msgid "label_related_items"

--- a/opengever/workspace/participation/invitation_mailer.py
+++ b/opengever/workspace/participation/invitation_mailer.py
@@ -55,22 +55,8 @@ class InvitationMailer(Mailer):
             name='custom_invitation_mail_content',
             interface=IWorkspaceSettings)
         if custom_mail_content:
-            content = safe_unicode(custom_mail_content).format(
+            custom_mail_content = safe_unicode(custom_mail_content).format(
                 **content_variables)
-        else:
-            content = translate(
-                _(
-                    u'invitation_mail_summary',
-                    default=u'Hello,\n'
-                    u'\n'
-                    u'You were invited by ${user} to the workspace "${title}" at ${platform}.\n'
-                    u'\n'
-                    u'Please click the following link if you want to accept the invitation:\n'
-                    u'${accept_url}',
-                    mapping=content_variables
-                ),
-                context=self.request
-            )
 
         comment_title = translate(
             _(
@@ -83,10 +69,14 @@ class InvitationMailer(Mailer):
 
         data = {
             'title': title,
-            'content': content.splitlines(),
             'comment_title': comment_title,
             'comment': invitation['comment'].splitlines(),
             'public_url': get_current_admin_unit().public_url,
+            'admin_unit_title': get_current_admin_unit().title,
+            'user': content_variables.get('user'),
+            'workspace_title': content_variables.get('title'),
+            'accept_url': content_variables.get('accept_url'),
+            'custom_mail_content': custom_mail_content and custom_mail_content.splitlines(),
         }
         msg, mail_to, mail_from = self.prepare_mail(
             subject=subject, to_email=invitation['recipient_email'],

--- a/opengever/workspace/participation/templates/invitation_mail.pt
+++ b/opengever/workspace/participation/templates/invitation_mail.pt
@@ -18,13 +18,26 @@
     </metal:title>
 
     <metal:content metal:fill-slot="content">
-      <p>
-        <tal:summary tal:repeat="line options/content">
-          <tal:last tal:define="is_last repeat/line/end">
-            <tal:line tal:replace="line" /><br tal:condition="not: is_last" />
-          </tal:last>
-        </tal:summary>
-      </p>
+      <tal:custom-content tal:condition="options/custom_mail_content">
+        <p>
+          <tal:summary tal:repeat="line options/custom_mail_content">
+            <tal:last tal:define="is_last repeat/line/end">
+              <tal:line tal:replace="line" /><br tal:condition="not: is_last" />
+            </tal:last>
+          </tal:summary>
+        </p>
+      </tal:custom-content>
+
+      <tal:default-content tal:condition="not: options/custom_mail_content">
+        <p i18n:translate="invitation_salutation">Hello</p>
+        <p i18n:translate="invitation_text">
+          You were invited by <span i18n:name="user" tal:content="options/user">User</span> to the workspace "<span i18n:name="workspace_title" tal:content="options/workspace_title"></span>" at <a i18n:name="platform" tal:attributes="href options/public_url" tal:content="options/admin_unit_title">platform</a>.
+        </p>
+        <p i18n:translate="invitation_accept">
+          Please click the following link if you want to accept the invitation: <a i18n:name="accept_url" tal:attributes="href options/accept_url" i18n:translate="invitation_accept_link">accept invitation</a>
+        </p>
+      </tal:default-content>
+
       <tal:comment tal:condition="options/comment">
           <p><strong tal:content="options/comment_title"/></p>
         <tal:block tal:repeat="line options/comment">


### PR DESCRIPTION
This PR updates the workspace invitation email template by adding anchor-tags for links.

This will fix an issue in some mail clients where the urls are not automatically recognized as links. In addition, we're able to add a label to the links which makes it much more user friendly.

## Before
<img width="1221" alt="Bildschirmfoto 2022-09-09 um 15 18 26" src="https://user-images.githubusercontent.com/557005/189358970-19e3863e-e865-4517-b0d8-2e1cad39d2fb.png">

⚠️ in some mail clients, i.e. office365 online, the links are not even rendered as links. This is a functionality of the mail clients that they'll be clickable.

## After
<img width="1227" alt="Bildschirmfoto 2022-09-09 um 15 08 54" src="https://user-images.githubusercontent.com/557005/189359271-ae96687b-1d5b-4252-afbe-2bc94be90cf9.png">

For [CA-4675]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-4675]: https://4teamwork.atlassian.net/browse/CA-4675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ