### PR TITLE
Sort dossier participations by label in @participations endpoint

### DIFF
--- a/changes/CA-4678.bugfix
+++ b/changes/CA-4678.bugfix
@@ -1,0 +1,1 @@
+Sort dossier participants by participant_title in @participations endpoint. [tinagerber]

--- a/changes/CA-4678.other
+++ b/changes/CA-4678.other
@@ -1,0 +1,1 @@
+Optimize KuBContactActor. [tinagerber]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,6 +11,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- ``@participation``: Sort dossier participations by ``participant_title``.
 
 2022.18.0 (2022-09-13)
 ----------------------

--- a/docs/public/dev-manual/api/dossier_participations.rst
+++ b/docs/public/dev-manual/api/dossier_participations.rst
@@ -46,6 +46,18 @@ Ein Beteiligter kann in verschiedenen Rollen an einem Dossier beteiligt sein. Mi
         ],
         "items": [
           {
+            "@id": "https://example.org/ordnungssystem/fuehrung/dossier-1/@participations/contact:james-bond",
+            "participant_id": "contact:james-bond",
+            "participant_title": "Bond James (james@example.com)",
+            "participant_actor": {
+              "@id": "https://example.org/@actors/contact:james-bond",
+              "identifier": "contact:james-bond"
+            },
+            "roles": [
+              "final-drawing"
+            ]
+          },
+          {
             "@id": "https://example.org/ordnungssystem/fuehrung/dossier-1/@participations/rolf.ziegler",
             "participant_id": "rolf.ziegler",
             "participant_title": "Ziegler Rolf (rolf.ziegler)",
@@ -56,18 +68,6 @@ Ein Beteiligter kann in verschiedenen Rollen an einem Dossier beteiligt sein. Mi
             "roles": [
               "regard",
               "participation"
-            ]
-          },
-          {
-            "@id": "https://example.org/ordnungssystem/fuehrung/dossier-1/@participations/contact:james-bond",
-            "participant_id": "contact:james-bond",
-            "participant_title": "Bond James (james@example.com)",
-            "participant_actor": {
-              "@id": "https://example.org/@actors/contact:james-bond",
-              "identifier": "contact:james-bond"
-            },
-            "roles": [
-              "final-drawing"
             ]
           }
         ],

--- a/opengever/api/tests/test_dossier_participations.py
+++ b/opengever/api/tests/test_dossier_participations.py
@@ -102,15 +102,10 @@ class TestParticipationsGetWithKubFeatureEnabled(KuBIntegrationTestCase):
         self.login(self.regular_user, browser=browser)
         handler = IParticipationAware(self.dossier)
 
-        self.mock_get_by_id(mocker, self.person_jean)
         self.mock_labels(mocker)
         handler.add_participation(
             self.person_jean, ['regard', 'participation', 'final-drawing'])
-
-        self.mock_get_by_id(mocker, self.org_ftw)
         handler.add_participation(self.org_ftw, ['regard'])
-
-        self.mock_get_by_id(mocker, self.memb_jean_ftw)
         handler.add_participation(self.memb_jean_ftw, ['participation'])
 
         participations_url = "{}/@participations".format(self.dossier.absolute_url())
@@ -167,11 +162,9 @@ class TestParticipationsGetWithKubFeatureEnabled(KuBIntegrationTestCase):
         handler = IParticipationAware(self.dossier)
 
         self.mock_labels(mocker)
-        self.mock_get_by_id(mocker, self.person_jean)
         handler.add_participation(
             self.person_jean, ['regard', 'participation', 'final-drawing'])
 
-        self.mock_get_by_id(mocker, self.org_ftw)
         handler.add_participation(self.org_ftw, ['regard'])
 
         browser.open(self.dossier.absolute_url() + '/@participations?b_size=1',

--- a/opengever/api/tests/test_dossier_participations.py
+++ b/opengever/api/tests/test_dossier_participations.py
@@ -119,6 +119,13 @@ class TestParticipationsGetWithKubFeatureEnabled(KuBIntegrationTestCase):
                                  {u'title': u'Participation',
                                   u'token': u'participation'}],
             u'items': [
+                {u'@id': "{}/{}".format(participations_url, self.org_ftw),
+                 u'participant_actor': {
+                    u'@id': u'http://nohost/plone/@actors/' + self.org_ftw,
+                    u'identifier': self.org_ftw},
+                 u'participant_id': self.org_ftw,
+                 u'participant_title': u'4Teamwork',
+                 u'roles': [u'regard']},
                 {u'@id': "{}/{}".format(participations_url, self.person_jean),
                  u'participant_actor': {
                     u'@id': u'http://nohost/plone/@actors/' + self.person_jean,
@@ -133,19 +140,13 @@ class TestParticipationsGetWithKubFeatureEnabled(KuBIntegrationTestCase):
                  u'participant_id': self.memb_jean_ftw,
                  u'participant_title': u'Dupont Jean - 4Teamwork (CEO)',
                  u'roles': [u'participation']},
-                {u'@id': "{}/{}".format(participations_url, self.org_ftw),
-                 u'participant_actor': {
-                    u'@id': u'http://nohost/plone/@actors/' + self.org_ftw,
-                    u'identifier': self.org_ftw},
-                 u'participant_id': self.org_ftw,
-                 u'participant_title': u'4Teamwork',
-                 u'roles': [u'regard']},
             ],
             u'items_total': 3,
             u'primary_participation_roles': []}
 
         browser.open(self.dossier.absolute_url() + '/@participations',
                      method='GET', headers=self.api_headers)
+
         self.assertEqual(expected_json, browser.json)
 
         browser.open(self.dossier, method='GET', headers=self.api_headers)
@@ -175,6 +176,23 @@ class TestParticipationsGetWithKubFeatureEnabled(KuBIntegrationTestCase):
         self.assertEqual(3, len(browser.json['available_roles']))
         self.assertIn('batching', browser.json)
 
+    @browsing
+    def test_participants_are_sorted_by_title(self, mocker, browser):
+        self.login(self.regular_user, browser=browser)
+        handler = IParticipationAware(self.dossier)
+
+        self.mock_labels(mocker)
+        handler.add_participation(self.person_jean, ['regard'])
+        handler.add_participation(self.person_julie, ['participation'])
+        handler.add_participation(self.regular_user.getId(), ['participation'])
+        handler.add_participation(self.dossier_responsible.getId(), ['regard'])
+
+        browser.open(self.dossier, view='@participations',
+                     method='GET', headers=self.api_headers)
+        self.assertEqual([u'B\xe4rfuss K\xe4thi (kathi.barfuss)', u'Dupont Jean', u'Dupont Julie',
+                          u'Ziegler Robert (robert.ziegler)'], [item['participant_title']
+                         for item in browser.json['items']])
+
 
 class TestParticipationsGetWithContactFeatureEnabled(IntegrationTestCase):
 
@@ -199,21 +217,21 @@ class TestParticipationsGetWithContactFeatureEnabled(IntegrationTestCase):
                                   u'token': u'participation'},
                                  ],
             u'items': [{u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-'
-                                u'vereinbarungen/dossier-1/@participations/organization:2',
-                        u'participant_id': u'organization:2',
-                        u'participant_title': u'Meier AG',
-                        u'participant_actor': {
-                            u'@id': u'http://nohost/plone/@actors/organization:2',
-                            u'identifier': u'organization:2'},
-                        u'roles': [u'final-drawing']},
-                       {u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-'
                                 u'vereinbarungen/dossier-1/@participations/person:1',
                         u'participant_id': u'person:1',
                         u'participant_title': u'B\xfchler Josef',
                         u'participant_actor': {
                             u'@id': u'http://nohost/plone/@actors/person:1',
                             u'identifier': u'person:1'},
-                        u'roles': [u'final-drawing', u'participation']}],
+                        u'roles': [u'final-drawing', u'participation']},
+                       {u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-'
+                                u'vereinbarungen/dossier-1/@participations/organization:2',
+                        u'participant_id': u'organization:2',
+                        u'participant_title': u'Meier AG',
+                        u'participant_actor': {
+                            u'@id': u'http://nohost/plone/@actors/organization:2',
+                            u'identifier': u'organization:2'},
+                        u'roles': [u'final-drawing']}],
             u'items_total': 2,
             u'primary_participation_roles': []}
         self.assertEqual(expected_json, browser.json)

--- a/opengever/ogds/base/actor.py
+++ b/opengever/ogds/base/actor.py
@@ -499,16 +499,7 @@ class KuBContactActor(Actor):
 
     def get_label(self, with_principal=True):
         mapping = KuBClient().get_kub_id_label_mapping()
-        name = mapping.get(self.identifier, self.identifier)
-
-        if with_principal:
-            # XXX Primary_email is currently not returned by the KuB search
-            # endpoint. This should change once we have an endpoint to actually
-            # resolve the contact ids.
-            email = self.contact.get("primary_email", "")
-            if email:
-                return u'{} ({})'.format(name, email)
-        return name
+        return mapping.get(self.identifier, self.identifier)
 
     def get_profile_url(self):
         # XXX This should be an URL pointing to KUB, e.g.

--- a/opengever/ogds/base/actor.py
+++ b/opengever/ogds/base/actor.py
@@ -38,6 +38,7 @@ from opengever.contact.models import Person
 from opengever.contact.utils import get_contactfolder_url
 from opengever.inbox.utils import get_inbox_for_org_unit
 from opengever.kub import is_kub_feature_enabled
+from opengever.kub.client import KuBClient
 from opengever.kub.entity import KuBEntity
 from opengever.ogds.base import _
 from opengever.ogds.base.browser.userdetails import UserDetails
@@ -48,6 +49,7 @@ from opengever.ogds.models.service import ogds_service
 from opengever.ogds.models.team import Team
 from plone import api
 from plone.dexterity.utils import safe_unicode
+from plone.memoize import instance
 from Products.CMFCore.interfaces._tools import IMemberData
 from Products.CMFCore.utils import getToolByName
 from Products.PluggableAuthService.interfaces.authservice import IPropertiedUser
@@ -484,24 +486,29 @@ class KuBContactActor(Actor):
     css_class = 'actor-contact'
     actor_type = 'kubcontact'
 
-    def __init__(self, identifier, contact=None):
-        super(KuBContactActor, self).__init__(identifier)
-        self.contact = contact
-
     def corresponds_to(self, user):
         return False
 
-    def get_label(self, with_principal=True):
-        name = self.contact.get("text", "")
+    @instance.memoize
+    def get_contact(self, identifier):
+        return KuBEntity(identifier)
 
-        # XXX Primary_email is currently not returned by the KuB search
-        # endpoint. This should change once we have an endpoint to actually
-        # resolve the contact ids.
-        email = self.contact.get("primary_email", "")
-        if with_principal and email:
-            return u'{} ({})'.format(name, email)
-        else:
-            return name
+    @property
+    def contact(self):
+        return self.get_contact(self.identifier)
+
+    def get_label(self, with_principal=True):
+        mapping = KuBClient().get_kub_id_label_mapping()
+        name = mapping.get(self.identifier, self.identifier)
+
+        if with_principal:
+            # XXX Primary_email is currently not returned by the KuB search
+            # endpoint. This should change once we have an endpoint to actually
+            # resolve the contact ids.
+            email = self.contact.get("primary_email", "")
+            if email:
+                return u'{} ({})'.format(name, email)
+        return name
 
     def get_profile_url(self):
         # XXX This should be an URL pointing to KUB, e.g.
@@ -759,14 +766,11 @@ class ActorLookup(object):
 
         return ContactActor(self.identifier, contact=contact)
 
-    def create_kub_contact_actor(self, contact=None):
-        if not contact:
-            try:
-                contact = KuBEntity(self.identifier)
-            except LookupError:
-                return self.create_null_actor()
-
-        return KuBContactActor(self.identifier, contact=contact)
+    def create_kub_contact_actor(self):
+        mapping = KuBClient().get_kub_id_label_mapping()
+        if not mapping.get(self.identifier):
+            return self.create_null_actor()
+        return KuBContactActor(self.identifier)
 
     def create_sql_contact_actor(self, contact=None):
         if not contact:

--- a/opengever/ogds/base/tests/test_actor.py
+++ b/opengever/ogds/base/tests/test_actor.py
@@ -200,6 +200,7 @@ class TestActorLookup(IntegrationTestCase):
 class TestKuBContactActor(KuBIntegrationTestCase):
 
     def test_person_actor_lookup(self, mocker):
+        self.mock_labels(mocker)
         url = self.mock_get_by_id(mocker, self.person_jean)
         self.login(self.regular_user)
         actor = Actor.lookup(self.person_jean)
@@ -211,6 +212,7 @@ class TestKuBContactActor(KuBIntegrationTestCase):
                          actor.represents().data)
 
     def test_organization_actor_lookup(self, mocker):
+        self.mock_labels(mocker)
         url = self.mock_get_by_id(mocker, self.org_ftw)
         self.login(self.regular_user)
         actor = Actor.lookup(self.org_ftw)
@@ -221,6 +223,7 @@ class TestKuBContactActor(KuBIntegrationTestCase):
         self.assertEqual(KUB_RESPONSES[url], actor.represents().data)
 
     def test_membership_actor_lookup(self, mocker):
+        self.mock_labels(mocker)
         url = self.mock_get_by_id(mocker, self.memb_jean_ftw)
         self.login(self.regular_user)
         actor = Actor.lookup(self.memb_jean_ftw)
@@ -240,7 +243,7 @@ class TestKuBContactActor(KuBIntegrationTestCase):
 
     @browsing
     def test_actors_response_for_kubcontact(self, mocker, browser):
-        self.mock_get_by_id(mocker, self.person_jean)
+        self.mock_labels(mocker)
         self.login(self.regular_user, browser=browser)
         url = "{}/@actors/{}".format(self.portal.absolute_url(), self.person_jean)
         browser.open(url, headers=self.api_headers)
@@ -266,6 +269,7 @@ class TestKuBContactActor(KuBIntegrationTestCase):
     @browsing
     def test_full_representation_for_kubcontact(self, mocker, browser):
         self.mock_get_by_id(mocker, self.person_jean)
+        self.mock_labels(mocker)
         self.login(self.regular_user, browser=browser)
         url = "{}/@actors/{}?full_representation=true".format(
             self.portal.absolute_url(), self.person_jean)


### PR DESCRIPTION
Participants are now sorted by `participant_title` in the `@participations` endpoint.

During the implementation I noticed that the endpoint with KuB participations is extremely slow. Therefore I optimized the KuBActor so that KuB is only requested when necessary.

A request of the endpoint with 5 KuB participations took more than 1.5 seconds. Now the request is about a factor of 45 faster.

For [CA-4678]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))

[CA-4678]: https://4teamwork.atlassian.net/browse/CA-4678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ