### PR TITLE
Include title in private folder serialization

### DIFF
--- a/changes/CA-4684.other
+++ b/changes/CA-4684.other
@@ -1,0 +1,1 @@
+Include title in private folder serialization. [tinagerber]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -12,6 +12,7 @@ Breaking Changes
 Other Changes
 ^^^^^^^^^^^^^
 - ``@participation``: Sort dossier participations by ``participant_title``.
+- Include title in private folder serialization.
 
 2022.18.0 (2022-09-13)
 ----------------------

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -27,6 +27,7 @@
   <adapter factory=".serializer.GeverSerializeToJson" />
   <adapter factory=".serializer.GeverSerializeToJsonSummary" />
   <adapter factory=".serializer.GeverSerializeFolderToJson" />
+  <adapter factory=".serializer.GeverSerializePrivateFolderToJson" />
   <adapter factory=".serializer.SerializeTeamModelToJson" />
   <adapter factory=".serializer.SerializeUserModelToJson" />
   <adapter factory=".serializer.SerializeGroupModelToJson" />

--- a/opengever/api/serializer.py
+++ b/opengever/api/serializer.py
@@ -28,6 +28,7 @@ from opengever.ogds.models.group import groups_users
 from opengever.ogds.models.org_unit import OrgUnit
 from opengever.ogds.models.team import Team
 from opengever.ogds.models.user import User
+from opengever.private.folder import IPrivateFolder
 from opengever.repository.interfaces import IRepositoryFolder
 from plone import api
 from plone.dexterity.interfaces import IDexterityContainer
@@ -180,6 +181,15 @@ class GeverSerializeFolderToJson(SerializeFolderToJson):
         extend_with_sequence_number(result, self.context, self.request)
 
         drop_inactive_language_fields(result)
+        return result
+
+
+@adapter(IPrivateFolder, IOpengeverBaseLayer)
+class GeverSerializePrivateFolderToJson(GeverSerializeFolderToJson):
+
+    def __call__(self, *args, **kwargs):
+        result = super(GeverSerializePrivateFolderToJson, self).__call__(*args, **kwargs)
+        result['title'] = self.context.title
         return result
 
 

--- a/opengever/api/tests/test_serializer.py
+++ b/opengever/api/tests/test_serializer.py
@@ -1,7 +1,9 @@
+# -*- coding: utf-8 -*-
 from ftw.bumblebee.interfaces import IBumblebeeDocument
 from ftw.bumblebee.tests.helpers import DOCX_CHECKSUM
 from ftw.testbrowser import browsing
 from opengever.base.oguid import Oguid
+from opengever.private import get_private_folder
 from opengever.repository.behaviors.responsibleorg import IResponsibleOrgUnit
 from opengever.testing import IntegrationTestCase
 from plone import api
@@ -97,6 +99,20 @@ class TestRepositoryFolderSerializer(IntegrationTestCase):
         self.assertEqual(
             u'plone:%s' % int_id,
             browser.json.get(u'oguid'))
+
+
+class TestPrivateFolderSerializer(IntegrationTestCase):
+    features = ('private', )
+
+    @browsing
+    def test_private_folder_serialization_contains_title(self, browser):
+        membership_tool = api.portal.get_tool('portal_membership')
+        self.login(self.regular_user, browser)
+        membership_tool.createMemberarea()
+        private_folder = get_private_folder()
+        browser.open(private_folder, headers=self.api_headers)
+        self.assertEqual(200, browser.status_code)
+        self.assertEqual(u'Bärfuss Käthi', browser.json.get(u'title'))
 
 
 class TestDossierSerializer(IntegrationTestCase):


### PR DESCRIPTION
Currently, in the new frontend, the folder id is displayed as the heading in the private folder. This is a little bit unpleasant, because the id was normalized. It would be better to display the label of the user.

For [CA-4684]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))

[CA-4684]: https://4teamwork.atlassian.net/browse/CA-4684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ