### PR TITLE
Use solr to parse documente uids for office connector url

### DIFF
--- a/changes/CA-4701.bugfix
+++ b/changes/CA-4701.bugfix
@@ -1,0 +1,1 @@
+Fix attaching documents for external users. [tinagerber]

--- a/opengever/locking/tests/test_force_unlock.py
+++ b/opengever/locking/tests/test_force_unlock.py
@@ -3,12 +3,12 @@ from ftw.testbrowser.pages.statusmessages import info_messages
 from ftw.testing import freeze
 from opengever.officeconnector.testing import FREEZE_DATE
 from opengever.officeconnector.testing import JWT_SIGNING_SECRET_PLONE
-from opengever.officeconnector.testing import OCIntegrationTestCase
+from opengever.officeconnector.testing import OCSolrIntegrationTestCase
 from plone.locking.interfaces import ILockable
 import jwt
 
 
-class TestDocumentForceUnlock(OCIntegrationTestCase):
+class TestDocumentForceUnlock(OCSolrIntegrationTestCase):
 
     features = ('officeconnector-checkout',)
 

--- a/opengever/officeconnector/testing.py
+++ b/opengever/officeconnector/testing.py
@@ -5,7 +5,7 @@ from opengever.journal.handlers import DOCUMENT_ATTACHED
 from opengever.journal.handlers import DOCUMENT_CHECKED_IN
 from opengever.journal.handlers import DOCUMENT_CHECKED_OUT
 from opengever.journal.tests.utils import get_journal_entry
-from opengever.testing import IntegrationTestCase
+from opengever.testing import SolrIntegrationTestCase
 from opengever.testing.fixtures import JWT_SECRET
 from os import fstat
 from os.path import basename
@@ -21,8 +21,8 @@ JWT_SIGNING_SECRET_PLONE = '/'.join((JWT_SECRET, 'plone', 'acl_users', 'jwt_auth
 JWT_SIGNING_SECRET_ZOPE = '/'.join((JWT_SECRET, 'acl_users', 'jwt_auth'))
 
 
-class OCIntegrationTestCase(IntegrationTestCase):
-    """Extend IntegrationTestCase with Office Connector specific helpers."""
+class OCIntegrationTestCase(SolrIntegrationTestCase):
+    """Extend SolrIntegrationTestCase with Office Connector specific helpers."""
 
     @contextmanager
     def as_officeconnector(self, browser):

--- a/opengever/officeconnector/testing.py
+++ b/opengever/officeconnector/testing.py
@@ -21,7 +21,7 @@ JWT_SIGNING_SECRET_PLONE = '/'.join((JWT_SECRET, 'plone', 'acl_users', 'jwt_auth
 JWT_SIGNING_SECRET_ZOPE = '/'.join((JWT_SECRET, 'acl_users', 'jwt_auth'))
 
 
-class OCIntegrationTestCase(SolrIntegrationTestCase):
+class OCSolrIntegrationTestCase(SolrIntegrationTestCase):
     """Extend SolrIntegrationTestCase with Office Connector specific helpers."""
 
     @contextmanager

--- a/opengever/officeconnector/tests/test_api_dossier_attach.py
+++ b/opengever/officeconnector/tests/test_api_dossier_attach.py
@@ -4,13 +4,13 @@ from ftw.testbrowser import browsing
 from ftw.testing import freeze
 from opengever.officeconnector.testing import FREEZE_DATE
 from opengever.officeconnector.testing import JWT_SIGNING_SECRET_PLONE
-from opengever.officeconnector.testing import OCIntegrationTestCase
+from opengever.officeconnector.testing import OCSolrIntegrationTestCase
 from plone.uuid.interfaces import IUUID
 import json
 import jwt
 
 
-class TestOfficeconnectorDossierAPIWithAttach(OCIntegrationTestCase):
+class TestOfficeconnectorDossierAPIWithAttach(OCSolrIntegrationTestCase):
 
     features = (
         '!officeconnector-checkout',

--- a/opengever/officeconnector/tests/test_api_dossier_attach.py
+++ b/opengever/officeconnector/tests/test_api_dossier_attach.py
@@ -1,8 +1,11 @@
+from ftw.builder import Builder
+from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testing import freeze
 from opengever.officeconnector.testing import FREEZE_DATE
 from opengever.officeconnector.testing import JWT_SIGNING_SECRET_PLONE
 from opengever.officeconnector.testing import OCIntegrationTestCase
+from plone.uuid.interfaces import IUUID
 import json
 import jwt
 
@@ -564,6 +567,34 @@ class TestOfficeconnectorDossierAPIWithAttach(OCIntegrationTestCase):
         raw_token = url.split(':')[-1]
         token = jwt.decode(raw_token, JWT_SIGNING_SECRET_PLONE, algorithms=('HS256',))
         self.assertEqual(u'-links', token['flags'])
+
+    @browsing
+    def test_attach_multiple_documents_works_for_external_user(self, browser):
+        external_user = create(Builder('user').with_userid('external.user').with_roles([]))
+        with self.login(self.administrator):
+            self.meeting_dossier.__ac_local_roles_block__ = True
+            self.set_roles(self.leaf_repofolder, 'external.user', ['Reader'])
+            docs =['/'.join(doc.getPhysicalPath()) for doc
+                   in [self.document, self.empty_document, self.mail_eml, self.meeting_document]]
+            segments = list(self.subdocument.getPhysicalPath())
+            segments.remove('plone')
+            docs.append('/'.join(segments))
+            data =  json.dumps({'documents': docs})
+
+        self.login(external_user, browser)
+        browser.open(
+            self.portal,
+            method='POST',
+            headers=self.api_headers,
+            view='officeconnector_attach_url',
+            data=data
+        )
+        url = browser.json['url']
+        raw_token = url.split(':')[-1]
+        token = jwt.decode(raw_token, JWT_SIGNING_SECRET_PLONE, algorithms=('HS256',))
+        with self.login(self.regular_user):
+            self.assertEqual([IUUID(self.document), IUUID(self.subdocument), IUUID(self.mail_eml)],
+                             token['documents'])
 
     @browsing
     def test_attach_multiple_documents_does_not_set_links_flag(self, browser):

--- a/opengever/officeconnector/tests/test_api_dossier_checkout.py
+++ b/opengever/officeconnector/tests/test_api_dossier_checkout.py
@@ -6,13 +6,13 @@ from hashlib import sha256
 from opengever.document.document import Document
 from opengever.officeconnector.testing import FREEZE_DATE
 from opengever.officeconnector.testing import JWT_SIGNING_SECRET_PLONE
-from opengever.officeconnector.testing import OCIntegrationTestCase
+from opengever.officeconnector.testing import OCSolrIntegrationTestCase
 from opengever.testing.assets import path_to_asset
 from zope.annotation.interfaces import IAnnotations
 import jwt
 
 
-class TestOfficeconnectorDossierAPIWithCheckout(OCIntegrationTestCase):
+class TestOfficeconnectorDossierAPIWithCheckout(OCSolrIntegrationTestCase):
 
     features = (
         '!officeconnector-attach',

--- a/opengever/officeconnector/tests/test_api_dossier_disabled.py
+++ b/opengever/officeconnector/tests/test_api_dossier_disabled.py
@@ -1,9 +1,9 @@
 from ftw.testbrowser import browsing
 from opengever.document.document import Document
-from opengever.officeconnector.testing import OCIntegrationTestCase
+from opengever.officeconnector.testing import OCSolrIntegrationTestCase
 
 
-class TestOfficeconnectorDossierAPIDisabled(OCIntegrationTestCase):
+class TestOfficeconnectorDossierAPIDisabled(OCSolrIntegrationTestCase):
 
     features = (
         '!officeconnector-attach',

--- a/opengever/officeconnector/tests/test_api_dossier_oneoffixx.py
+++ b/opengever/officeconnector/tests/test_api_dossier_oneoffixx.py
@@ -3,7 +3,7 @@ from ftw.testbrowser import browsing
 from ftw.testing import freeze
 from opengever.officeconnector.testing import FREEZE_DATE
 from opengever.officeconnector.testing import JWT_SIGNING_SECRET_PLONE
-from opengever.officeconnector.testing import OCIntegrationTestCase
+from opengever.officeconnector.testing import OCSolrIntegrationTestCase
 from opengever.testing.assets import path_to_asset
 from pkg_resources import resource_string
 import jwt
@@ -11,7 +11,7 @@ import re
 import xml.etree.ElementTree as ET
 
 
-class TestOfficeconnectorDossierAPIWithOneOffixx(OCIntegrationTestCase):
+class TestOfficeconnectorDossierAPIWithOneOffixx(OCSolrIntegrationTestCase):
     features = (
         'officeconnector-checkout',
         'oneoffixx'

--- a/opengever/officeconnector/tests/test_api_forwarding_attach.py
+++ b/opengever/officeconnector/tests/test_api_forwarding_attach.py
@@ -2,11 +2,11 @@ from ftw.testbrowser import browsing
 from ftw.testing import freeze
 from opengever.officeconnector.testing import FREEZE_DATE
 from opengever.officeconnector.testing import JWT_SIGNING_SECRET_PLONE
-from opengever.officeconnector.testing import OCIntegrationTestCase
+from opengever.officeconnector.testing import OCSolrIntegrationTestCase
 import jwt
 
 
-class TestOfficeconnectorForwardingAPIWithAttach(OCIntegrationTestCase):
+class TestOfficeconnectorForwardingAPIWithAttach(OCSolrIntegrationTestCase):
     features = (
         'officeconnector-attach',
     )

--- a/opengever/officeconnector/tests/test_api_forwarding_checkout.py
+++ b/opengever/officeconnector/tests/test_api_forwarding_checkout.py
@@ -1,8 +1,8 @@
 from ftw.testbrowser import browsing
-from opengever.officeconnector.testing import OCIntegrationTestCase
+from opengever.officeconnector.testing import OCSolrIntegrationTestCase
 
 
-class TestOfficeconnectorForwardingAPIWithCheckout(OCIntegrationTestCase):
+class TestOfficeconnectorForwardingAPIWithCheckout(OCSolrIntegrationTestCase):
 
     features = (
         '!officeconnector-attach',

--- a/opengever/officeconnector/tests/test_api_forwarding_disabled.py
+++ b/opengever/officeconnector/tests/test_api_forwarding_disabled.py
@@ -1,8 +1,8 @@
 from ftw.testbrowser import browsing
-from opengever.officeconnector.testing import OCIntegrationTestCase
+from opengever.officeconnector.testing import OCSolrIntegrationTestCase
 
 
-class TestOfficeconnectorForwardingAPIDisabled(OCIntegrationTestCase):
+class TestOfficeconnectorForwardingAPIDisabled(OCSolrIntegrationTestCase):
 
     features = (
         '!officeconnector-attach',

--- a/opengever/officeconnector/tests/test_api_mail_attach.py
+++ b/opengever/officeconnector/tests/test_api_mail_attach.py
@@ -2,11 +2,11 @@ from ftw.testbrowser import browsing
 from ftw.testing import freeze
 from opengever.officeconnector.testing import FREEZE_DATE
 from opengever.officeconnector.testing import JWT_SIGNING_SECRET_PLONE
-from opengever.officeconnector.testing import OCIntegrationTestCase
+from opengever.officeconnector.testing import OCSolrIntegrationTestCase
 import jwt
 
 
-class TestOfficeconnectorMailAPIWithAttach(OCIntegrationTestCase):
+class TestOfficeconnectorMailAPIWithAttach(OCSolrIntegrationTestCase):
 
     features = ("!officeconnector-checkout", "officeconnector-attach")
 
@@ -157,7 +157,7 @@ class TestOfficeconnectorMailAPIWithAttach(OCIntegrationTestCase):
             self.assertIsNone(oc_url)
 
 
-class TestOfficeconnectorMailAPIWithAttachInTeamraum(OCIntegrationTestCase):
+class TestOfficeconnectorMailAPIWithAttachInTeamraum(OCSolrIntegrationTestCase):
 
     features = ('!officeconnector-checkout', 'officeconnector-attach', 'workspace')
 

--- a/opengever/officeconnector/tests/test_api_task_checkout.py
+++ b/opengever/officeconnector/tests/test_api_task_checkout.py
@@ -5,12 +5,12 @@ from ftw.testing import freeze
 from hashlib import sha256
 from opengever.officeconnector.testing import FREEZE_DATE
 from opengever.officeconnector.testing import JWT_SIGNING_SECRET_PLONE
-from opengever.officeconnector.testing import OCIntegrationTestCase
+from opengever.officeconnector.testing import OCSolrIntegrationTestCase
 from opengever.testing.assets import path_to_asset
 import jwt
 
 
-class TestOfficeconnectorTaskAPIWithCheckoutWithRESTAPI(OCIntegrationTestCase):
+class TestOfficeconnectorTaskAPIWithCheckoutWithRESTAPI(OCSolrIntegrationTestCase):
 
     features = (
         '!officeconnector-attach',

--- a/opengever/officeconnector/tests/test_zopemaster.py
+++ b/opengever/officeconnector/tests/test_zopemaster.py
@@ -4,12 +4,12 @@ from ftw.testing import freeze
 from hashlib import sha256
 from opengever.officeconnector.testing import FREEZE_DATE
 from opengever.officeconnector.testing import JWT_SIGNING_SECRET_ZOPE
-from opengever.officeconnector.testing import OCIntegrationTestCase
+from opengever.officeconnector.testing import OCSolrIntegrationTestCase
 from opengever.testing.assets import path_to_asset
 import jwt
 
 
-class TestOfficeconnectorAsZopemasterDossierAPIWithAttach(OCIntegrationTestCase):
+class TestOfficeconnectorAsZopemasterDossierAPIWithAttach(OCSolrIntegrationTestCase):
     features = (
         'officeconnector-attach',
     )
@@ -54,7 +54,7 @@ class TestOfficeconnectorAsZopemasterDossierAPIWithAttach(OCIntegrationTestCase)
         self.assertEquals(file_contents, self.document.file.data)
 
 
-class TestOfficeconnectorAsZopemasterDossierAPIWithCheckout(OCIntegrationTestCase):
+class TestOfficeconnectorAsZopemasterDossierAPIWithCheckout(OCSolrIntegrationTestCase):
     features = (
         'officeconnector-checkout',
     )


### PR DESCRIPTION
For external users the previous implementation did not work, because the documents were fetched with `api.content.get`. `api.content.get` does a `restrictedTraverse` in the background, this did not work for external users, because they sometimes had access only to one repo folder.
Since only the document UIDs are needed anyway, I switched the query to Solr.

For [CA-4701]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-4701]: https://4teamwork.atlassian.net/browse/CA-4701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ