### PR TITLE
Use client own preserved_as_paper default when transporting documents.

### DIFF
--- a/changes/CA-4710.bugfix
+++ b/changes/CA-4710.bugfix
@@ -1,0 +1,1 @@
+Use client own preserved_as_paper default when transporting documents. [phgross]

--- a/opengever/base/transport.py
+++ b/opengever/base/transport.py
@@ -209,6 +209,10 @@ class DexterityFieldDataCollector(object):
     This adapter is used by the transporter utility.
     """
 
+    # Each client has its own preserved_as_paper default, therefore it
+    # shouldn't be copied to the other client
+    skipped_fields = ['preserved_as_paper']
+
     def __init__(self, context):
         self.context = context
 
@@ -245,6 +249,9 @@ class DexterityFieldDataCollector(object):
             for name, field in schema.getFieldsInOrder(schemata):
                 if IPropertySheetField.providedBy(field):
                     # Custom properties don't get transported
+                    continue
+
+                if name in self.skipped_fields:
                     continue
 
                 value = subdata.get(name, _marker)


### PR DESCRIPTION
Each client has its own preserved_as_paper default, therefore it shouldn't be copied to the other client

For [CA-4710]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

Maybe need backport to version currently used by opengever.zug.

[CA-4710]: https://4teamwork.atlassian.net/browse/CA-4710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ