### PR TITLE
Set placeful workflow for workspace root in policytemplates.

### DIFF
--- a/changes/CA-4627.other
+++ b/changes/CA-4627.other
@@ -1,0 +1,1 @@
+Set placeful workflow for workspace root in policytemplates. [njohner]

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/profiles/workspaces_content/opengever_content/01-initial-structure.json
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/profiles/workspaces_content/opengever_content/01-initial-structure.json
@@ -4,6 +4,8 @@
         "_type": "opengever.workspace.root",
         "title_de": "Teamräume",
         "title_fr": "Espaces partagés",
-        "title_en": "Workspaces"
+        "title_en": "Workspaces",
+        "_placefulworkflow": ["opengever_workspace_policy",
+                              "opengever_workspace_policy"]
     }
 ]


### PR DESCRIPTION
It seems that in https://github.com/4teamwork/opengever.core/pull/6786 we forgot to also set the placeful workflow for the workspace root in the policytemplates. So I guess all new teamraums do not have the placeful workflow set correctly.

For [CA-4627]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-4627]: https://4teamwork.atlassian.net/browse/CA-4627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ