### PR TITLE
Remove group memberships in ogds sync when ldap group is deactivated

### DIFF
--- a/changes/CA-4721.bugfix
+++ b/changes/CA-4721.bugfix
@@ -1,0 +1,1 @@
+Remove group memberships in ogds sync when ldap group is deactivated. [tinagerber]

--- a/opengever/core/upgrades/20220917130346_remove_inactive_group_memberships/upgrade.py
+++ b/opengever/core/upgrades/20220917130346_remove_inactive_group_memberships/upgrade.py
@@ -1,0 +1,40 @@
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy.sql.expression import column
+from sqlalchemy.sql.expression import select
+from sqlalchemy.sql.expression import table
+
+
+groups_table = table(
+    'groups',
+    column('active'),
+    column('external_id'),
+    column('groupid'),
+    column('groupname'),
+    column('is_local'),
+    column('title'),
+)
+
+groups_users_table = table(
+    'groups_users',
+    column('groupid'),
+    column('userid'),
+)
+
+
+class RemoveInactiveGroupMemberships(SchemaMigration):
+    """Remove inactive group memberships.
+    """
+
+    def migrate(self):
+
+        rows = self.execute(
+            select([groups_table.c.groupid])
+            .where(groups_table.c.active.is_(False))
+            .where(groups_table.c.is_local.is_(False))
+        ).fetchall()
+
+        groupids = [row[0] for row in rows]
+
+        self.execute(
+            groups_users_table.delete()
+            .where(groups_users_table.c.groupid.in_(groupids)))

--- a/opengever/ogds/base/sync/ogds_updater.py
+++ b/opengever/ogds/base/sync/ogds_updater.py
@@ -286,6 +286,12 @@ class OGDSUpdater(object):
                     logger.info('Added user %s into group %s.', userid, groupid)
                 modified_count += 1
 
+        for deleted in deleted_mappings:
+            group = ogds_groups[deleted['groupid']]
+            group.users = []
+            logger.info('Removed all users from group %s.', deleted['groupid'])
+            modified_count += 1
+
         logger.info('Groups added: %s', len(added_mappings))
         logger.info('Groups deactivated: %s', len(deleted_mappings))
         logger.info('Groups modified: %s', len(modified_mappings))


### PR DESCRIPTION
So far, the group memberships have not been removed. This resulted in groups being displayed for users that no longer existed.

For [CA-4721]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [x] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))

[CA-4721]: https://4teamwork.atlassian.net/browse/CA-4721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ