### PR TITLE
Allow cancellation of tasks in progress

### DIFF
--- a/changes/CA-4666.feature
+++ b/changes/CA-4666.feature
@@ -1,0 +1,1 @@
+Allow cancellation of tasks in progress. [tinagerber]

--- a/opengever/activity/notification_settings.py
+++ b/opengever/activity/notification_settings.py
@@ -65,6 +65,7 @@ NOTIFICATION_CONFIGURATION = [
                        'task-transition-skipped-open',
                        'task-transition-planned-skipped',
                        'task-transition-delegate',
+                       'task-transition-in-progress-cancelled',
                        'task-transition-in-progress-resolved',
                        'task-transition-open-resolved',
                        'task-transition-in-progress-tested-and-closed',

--- a/opengever/task/browser/transitioncontroller.py
+++ b/opengever/task/browser/transitioncontroller.py
@@ -304,10 +304,18 @@ class TaskTransitionController(BrowserView):
     @guard('task-transition-in-progress-cancelled')
     def progress_to_cancelled_guard(self, c, include_agency):
         """Checks if:
-        The task is generated from tasktemplate and its the main task.
+        - The task is generated from tasktemplate and its the main task
+        - The current user is the issuer
         """
-        return self.context.is_from_tasktemplate and not \
-            ITask.providedBy(aq_parent(self.context))
+        if self.context.is_from_tasktemplate:
+            return not ITask.providedBy(aq_parent(self.context))
+
+        if include_agency:
+            return (c.current_user.is_issuer
+                    or c.current_user.in_issuing_orgunits_inbox_group
+                    or c.current_user.is_administrator)
+
+        return c.current_user.is_issuer
 
     @action('task-transition-in-progress-cancelled')
     def progress_to_cancelled_action(self, transition, c):


### PR DESCRIPTION
The transition already existed but only for task templates. The transition is not available for cross-client tasks that are processed in  in a dossier on the responsible tenant.

For [CA-4666]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-4666]: https://4teamwork.atlassian.net/browse/CA-4666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ