### PR TITLE
Filter out current participants in @possible-participations.

### DIFF
--- a/changes/CA-4679.bugfix
+++ b/changes/CA-4679.bugfix
@@ -1,0 +1,1 @@
+Current participants are now filtered out in @possible-participations endpoint. [njohner]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -13,6 +13,7 @@ Other Changes
 ^^^^^^^^^^^^^
 - ``@participation``: Sort dossier participations by ``participant_title``.
 - Include title in private folder serialization.
+- Current participants are now filtered out in ``@possible-participations`` endpoint.
 
 2022.18.0 (2022-09-13)
 ----------------------

--- a/opengever/api/dossier_participations.py
+++ b/opengever/api/dossier_participations.py
@@ -229,6 +229,12 @@ class PossibleParticipantsGet(Service):
         handler = IParticipationAware(self.context)
         results = handler.participant_source.search(query)
 
+        # filter out current participants
+        current_participants = set(
+            IParticipationData(participation).participant_id
+            for participation in handler.get_participations())
+        results = [term for term in results if term.token not in current_participants]
+
         batch = HypermediaBatch(self.request, results)
 
         serialized_terms = []


### PR DESCRIPTION
Because a participant can only have one participation on an object, participants that already have a participation on a dossier should not get returned by the `@possible-participations` endpoint.

For [CA-4679]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-4679]: https://4teamwork.atlassian.net/browse/CA-4679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ