### PR TITLE
Make max dossier depth restriction less strict

### DIFF
--- a/changes/CA-4662.other
+++ b/changes/CA-4662.other
@@ -1,0 +1,1 @@
+Make max dossier depth restriction less strict. [lgraf]

--- a/opengever/api/tests/test_move.py
+++ b/opengever/api/tests/test_move.py
@@ -217,13 +217,13 @@ class TestMove(IntegrationTestCase):
         message = u'msg_would_exceed_max_dossier_level'
         translated = u'This would exceed the maximally allowed dossier depth.'
         self.assert_cannot_move(
-            browser, self.empty_dossier, self.subdossier, message, translated)
+            browser, self.empty_dossier, self.subsubdossier, message, translated)
 
         api.portal.set_registry_record(name='maximum_dossier_depth',
-                                       value=2,
+                                       value=3,
                                        interface=IDossierContainerTypes)
 
-        self.assert_can_move(browser, self.empty_dossier, self.subdossier)
+        self.assert_can_move(browser, self.empty_dossier, self.subsubdossier)
 
     @browsing
     def test_moving_dossier_with_subdossier_respects_maximum_dossier_depth(self, browser):

--- a/opengever/dossier/tests/test_base.py
+++ b/opengever/dossier/tests/test_base.py
@@ -79,20 +79,20 @@ class TestDossierContainer(IntegrationTestCase):
     def test_max_subdossier_depth_is_1_by_default(self):
         self.login(self.dossier_responsible)
         self.assertIn('opengever.dossier.businesscasedossier',
-                      [fti.id for fti in self.dossier.allowedContentTypes()])
+                      [fti.id for fti in self.meeting_dossier.allowedContentTypes()])
 
         self.assertNotIn('opengever.dossier.businesscasedossier',
-                         [fti.id for fti in self.subdossier.allowedContentTypes()])
+                         [fti.id for fti in self.subdossier2.allowedContentTypes()])
 
     def test_max_subdossier_depth_is_configurable(self):
         self.login(self.dossier_responsible)
         self.assertNotIn('opengever.dossier.businesscasedossier',
-                         [fti.id for fti in self.subdossier.allowedContentTypes()])
+                         [fti.id for fti in self.subsubdossier.allowedContentTypes()])
 
         proxy = getUtility(IRegistry).forInterface(IDossierContainerTypes)
-        proxy.maximum_dossier_depth = 2
+        proxy.maximum_dossier_depth = 3
         self.assertIn('opengever.dossier.businesscasedossier',
-                      [fti.id for fti in self.subdossier.allowedContentTypes()])
+                      [fti.id for fti in self.subsubdossier.allowedContentTypes()])
 
     def test_get_subdossiers_is_recursive_by_default(self):
         self.login(self.dossier_responsible)

--- a/opengever/dossier/tests/test_move_items.py
+++ b/opengever/dossier/tests/test_move_items.py
@@ -1574,14 +1574,16 @@ class TestDossierMovabilityChecker(IntegrationTestCase):
             interface=IDossierContainerTypes
             ))
 
-        # empty_dossier can only be moved to main dossier
+        # empty_dossier can only be moved to main dossier, or a dossier that
+        # already contains a subdossier on the same level
         with self.assertRaises(Forbidden):
             DossierMovabiliyChecker(self.empty_dossier).validate_movement(
                 self.subsubdossier)
 
-        with self.assertRaises(Forbidden):
-            DossierMovabiliyChecker(self.empty_dossier).validate_movement(
-                self.subdossier)
+        # Allowed even though this will exceed the max nesting depth, because
+        # self.subsubdossier already exists on the same level
+        DossierMovabiliyChecker(self.empty_dossier).validate_movement(
+            self.subdossier)
 
         DossierMovabiliyChecker(self.empty_dossier).validate_movement(
             self.dossier)
@@ -1594,6 +1596,13 @@ class TestDossierMovabilityChecker(IntegrationTestCase):
 
         DossierMovabiliyChecker(self.subsubdossier).validate_movement(
             self.empty_dossier)
+
+        # a dossier containing a subdossier can even be moved to a place
+        # where it would exceed the max nesting depth by 2, if another
+        # subdossier with a subsubdossier already exists on that level and
+        # already violates the max nesting depth by 2.
+        DossierMovabiliyChecker(self.resolvable_dossier).validate_movement(
+            self.dossier)
 
         # two subdossier levels allowed.
         api.portal.set_registry_record(


### PR DESCRIPTION
Don't enforce max dossier depth if a structure of same nesting level as the new one already exists.

For example: If a dossier already contains a subdossier with a sub-sub-dossier that already exceeds the max depth by 2, then it will be allowed to create more content on that level that exceeds the depth by up to 2 levels (but not more).

**Note:**
I tried to switch `Dossier.get_subdossiers()` to Solr instead of ZCatalog queries, because it is now (often) used when viewing a dossier, and having to determine whether to show subdossiers as addable or not.

However, I had to abort that attempt because `get_subdossiers()` is used in so many places, that ~80 tests failed, and among those 13 `Functional` test cases, which would not easily be converted to `SolrIntegrationTestCases` in the scope of this story.

For [CA-4662](https://4teamwork.atlassian.net/browse/CA-4662)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

