### PR TITLE
Optimize building labels for large `participants` facets

### DIFF
--- a/changes/CA-4752.other
+++ b/changes/CA-4752.other
@@ -1,0 +1,1 @@
+Optimize building labels for large `participants` facets. [lgraf]

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -96,16 +96,20 @@ class SolrQueryBaseService(Service):
             if not solr_facet:
                 continue
 
-            facet_counts[facet_name] = {}
-            for facet, count in solr_facet.items():
-                if field.hide_facet(facet):
-                    continue
-                facet_counts[field.field_name][facet] = {
-                    "count": count,
-                    "label": field.index_value_to_label(facet)
-                }
+            facet_counts[facet_name] = self.extract_facet(solr_facet, field)
 
         return facet_counts
+
+    def extract_facet(self, solr_facet, field):
+        counts_for_facet = {}
+        for facet, count in solr_facet.items():
+            if field.hide_facet(facet):
+                continue
+            counts_for_facet[facet] = {
+                "count": count,
+                "label": field.index_value_to_label(facet)
+            }
+        return counts_for_facet
 
     def parse_requested_fields(self, params):
         """Extracts requested fields from request


### PR DESCRIPTION
Optimize building labels for large `participants` facets:

When processing a large facet (~100k entries) of `participants`, the extraction is slow because a lot of work is repeated for each and every single entry.

This optimization adds some shortcuts that split the index value into participant_id and role only once, and then directly check in the KuB client's cached ID to label mapping if a label can be found for that participant_id.

Only if no label can be found (not cached, unknown ID, ...) it delegates to the classic implementation.

This speeds the extraction up by roughly 50% (or from ~6s to ~3s for a known pathological case).

For [CA-4752](https://4teamwork.atlassian.net/browse/CA-4752)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

