### PR TITLE
Add object_sid column to OGDS users

### DIFF
--- a/changes/CA-4734-2.other
+++ b/changes/CA-4734-2.other
@@ -1,0 +1,1 @@
+Expose `objectSid` property via OGDS auth plugin. [lgraf]

--- a/changes/CA-4734.other
+++ b/changes/CA-4734.other
@@ -1,0 +1,1 @@
+Add users.object_sid column to OGDS. [lgraf]

--- a/docs/schema-dumps/_opengever.ogds.models.user.User.schema.json
+++ b/docs/schema-dumps/_opengever.ogds.models.user.User.schema.json
@@ -198,6 +198,13 @@
             "format": "date",
             "description": "",
             "_zope_schema_type": "Date"
+        },
+        "object_sid": {
+            "type": "string",
+            "title": "object_sid",
+            "maxLength": 255,
+            "description": "",
+            "_zope_schema_type": "Text"
         }
     },
     "required": [
@@ -233,6 +240,7 @@
         "last_login",
         "absent",
         "absent_from",
-        "absent_to"
+        "absent_to",
+        "object_sid"
     ]
 }

--- a/opengever/api/tests/test_ogdsuser.py
+++ b/opengever/api/tests/test_ogdsuser.py
@@ -104,6 +104,7 @@ class TestOGDSUserGet(IntegrationTestCase):
              u'phone_fax': u'012 34 56 77',
              u'phone_mobile': u'012 34 56 76',
              u'phone_office': u'012 34 56 78',
+             u'object_sid': None,
              u'salutation': u'Prof. Dr.',
              u'teams': [{u'@id': u'http://nohost/plone/@teams/4',
                          u'@type': u'virtual.ogds.team',

--- a/opengever/bundle/schemas/ogds_users.schema.json
+++ b/opengever/bundle/schemas/ogds_users.schema.json
@@ -280,6 +280,16 @@
                     "description": "",
                     "_zope_schema_type": "Date"
                 },
+                "object_sid": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "title": "object_sid",
+                    "maxLength": 255,
+                    "description": "",
+                    "_zope_schema_type": "Text"
+                },
                 "guid": {
                     "type": "string"
                 },
@@ -324,7 +334,8 @@
                 "last_login",
                 "absent",
                 "absent_from",
-                "absent_to"
+                "absent_to",
+                "object_sid"
             ]
         }
     }

--- a/opengever/core/upgrades/20220926163919_add_users_object_sid_sql_column/upgrade.py
+++ b/opengever/core/upgrades/20220926163919_add_users_object_sid_sql_column/upgrade.py
@@ -1,0 +1,15 @@
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy import Column
+from sqlalchemy import String
+
+
+class AddUsersObjectSidSQLColumn(SchemaMigration):
+    """Add users.object_sid SQL column.
+    """
+
+    def migrate(self):
+        # No need to pre-populate the column during the upgrade, since this
+        # will be done during the next OGDS sync.
+        self.op.add_column(
+            'users', Column('object_sid', String(255), nullable=True)
+        )

--- a/opengever/ogds/auth/plugin.py
+++ b/opengever/ogds/auth/plugin.py
@@ -108,6 +108,7 @@ class OGDSAuthenticationPlugin(BasePlugin, Cacheable):
         'firstname': User.firstname,
         'lastname': User.lastname,
         'fullname': (User.firstname + u' ' + User.lastname),
+        'objectSid': User.object_sid,
     }
     GROUP_PROPS = {
         'groupid': Group.groupid,

--- a/opengever/ogds/auth/tests/test_plugin.py
+++ b/opengever/ogds/auth/tests/test_plugin.py
@@ -427,6 +427,10 @@ class TestOGDSAuthPluginIPropertiesPlugin(TestOGDSAuthPluginBase):
     """
 
     def test_get_properties_for_user(self):
+        ogds_user = ogds_service().fetch_user('kathi.barfuss')
+        ogds_user.object_sid = u'S-1-5-21-2109130332-968164008-972369679-13586'
+        ogds_service().session.flush()
+
         member = api.user.get('kathi.barfuss')
         results = self.plugin.getPropertiesForUser(member)
         expected = {
@@ -435,6 +439,7 @@ class TestOGDSAuthPluginIPropertiesPlugin(TestOGDSAuthPluginBase):
             'firstname': 'K\xc3\xa4thi',
             'lastname': 'B\xc3\xa4rfuss',
             'fullname': 'K\xc3\xa4thi B\xc3\xa4rfuss',
+            'objectSid': 'S-1-5-21-2109130332-968164008-972369679-13586',
         }
         self.assertEqual(expected, results)
 
@@ -477,6 +482,7 @@ class TestOGDSAuthPluginIPropertiesPlugin(TestOGDSAuthPluginBase):
         ogds_user.firstname = None
         ogds_user.lastname = None
         ogds_user.email = None
+        ogds_user.object_sid = None
         ogds_service().session.flush()
         member = api.user.get('kathi.barfuss')
 
@@ -488,6 +494,7 @@ class TestOGDSAuthPluginIPropertiesPlugin(TestOGDSAuthPluginBase):
             'email': '',
             'firstname': '',
             'lastname': '',
+            'objectSid': '',
             'fullname': '',
         }
         self.assertEqual(expected, results)

--- a/opengever/ogds/base/sync/ogds_updater.py
+++ b/opengever/ogds/base/sync/ogds_updater.py
@@ -10,6 +10,7 @@ from opengever.ogds.base.interfaces import ILDAPSearch
 from opengever.ogds.base.interfaces import IOGDSSyncConfiguration
 from opengever.ogds.base.interfaces import IOGDSUpdater
 from opengever.ogds.base.sync.import_stamp import set_remote_import_stamp
+from opengever.ogds.base.sync.sid2str import sid2str
 from opengever.ogds.models.group import Group
 from opengever.ogds.models.user import User
 from plone import api
@@ -424,6 +425,11 @@ class OGDSUpdater(object):
                 user_attrs['active'] = True
                 user_attrs['external_id'] = userid
                 user_attrs['username'] = userid
+
+                object_sid = info.get('objectSid')
+                if object_sid:
+                    user_attrs['object_sid'] = sid2str(object_sid)
+
                 users[userid] = user_attrs
 
         return users

--- a/opengever/ogds/base/sync/sid2str.py
+++ b/opengever/ogds/base/sync/sid2str.py
@@ -1,0 +1,29 @@
+import struct
+
+
+def sid2str(sid):
+    """Converts a binary sid to string representation"""
+    if len(sid) < 8:
+        return ''
+    # The revision level (typically 1)
+    revision = ord(sid[0])
+    # The number of dashes minus 2
+    number_of_sub_ids = ord(sid[1])
+    # Identifier Authority Value
+    # (typically a value of 5 representing "NT Authority")
+    # ">Q" is the format string. ">" specifies that the bytes are big-endian.
+    # The "Q" specifies "unsigned long long" because 8 bytes are being decoded.
+    # Since the actual SID section being decoded is only 6 bytes, we must
+    # precede it with 2 empty bytes.
+    iav = struct.unpack('>Q', b'\x00\x00' + sid[2:8])[0]
+    # The sub-ids include the Domain SID and the RID representing the object
+    # '<I' is the format string. "<" specifies that the bytes are
+    # little-endian. "I" specifies "unsigned int".
+    # This decodes in 4 byte chunks starting from the 8th byte until the last
+    # byte.
+    if len(sid) - 8 < number_of_sub_ids * 4:
+        return ''
+    sub_ids = [struct.unpack('<I', sid[8 + 4 * i:12 + 4 * i])[0]
+               for i in range(number_of_sub_ids)]
+    return 'S-{0}-{1}-{2}'.format(
+        revision, iav, '-'.join([str(sub_id) for sub_id in sub_ids]))

--- a/opengever/ogds/base/tests/test_ogds_updater.py
+++ b/opengever/ogds/base/tests/test_ogds_updater.py
@@ -24,7 +24,13 @@ import transaction
 
 
 FAKE_LDAP_USERFOLDER = FakeLDAPUserFolder()
-BLACKLISTED_USER_COLUMNS = {'absent', 'absent_from', 'absent_to', 'last_login'}
+BLACKLISTED_USER_COLUMNS = {
+    'absent',
+    'absent_from',
+    'absent_to',
+    'last_login',
+    'object_sid',
+}
 BLACKLISTED_GROUP_COLUMNS = {'is_local'}
 
 
@@ -49,6 +55,23 @@ class TestOGDSUpdater(FunctionalTestCase):
         updater.import_users()
         self.assertIsNotNone(ogds_service().fetch_user('sk1m1'))
         self.assertIsNotNone(ogds_service().fetch_user('john'))
+
+    def test_imports_object_sid(self):
+        SAMPLE_SID = ('\x01\x05\x00\x00\x00\x00\x00\x05\x15\x00\x00\x00'
+                      '\\\xc6\xb6}\xa8\x02\xb59\x0f/\xf59\x125\x00\x00')
+        FAKE_LDAP_USERFOLDER.users = [
+            create(Builder('ldapuser')
+                   .named('user.with.sid')
+                   .having(objectSid=SAMPLE_SID))
+        ]
+
+        updater = IOGDSUpdater(self.portal)
+
+        updater.import_users()
+        user = ogds_service().fetch_user('user.with.sid')
+        self.assertEqual(
+            u'S-1-5-21-2109130332-968164008-972369679-13586',
+            user.object_sid)
 
     def test_skips_duplicates_users_with_capitalization(self):
         create(Builder('ogds_user')

--- a/opengever/ogds/base/tests/test_sid2str.py
+++ b/opengever/ogds/base/tests/test_sid2str.py
@@ -1,0 +1,17 @@
+from opengever.ogds.base.sync.sid2str import sid2str
+import unittest
+
+
+class Sid2StrTestCase(unittest.TestCase):
+
+    def test_sid2str(self):
+        sid = ('\x01\x05\x00\x00\x00\x00\x00\x05\x15\x00\x00\x00\\\xc6\xb6}'
+               '\xa8\x02\xb59\x0f/\xf59\x125\x00\x00')
+        self.assertEqual(
+            sid2str(sid), 'S-1-5-21-2109130332-968164008-972369679-13586')
+
+    def test_sid2str_with_invalid_sid(self):
+        sid = 'foo'
+        self.assertEqual(sid2str(sid), '')
+        sid = '\x01\x05\x00\x00\x00\x00\x00\x05\x15\x00\x00\x00\\\xc6\xb6'
+        self.assertEqual(sid2str(sid), '')

--- a/opengever/ogds/models/user.py
+++ b/opengever/ogds/models/user.py
@@ -66,6 +66,8 @@ class User(Base):
     absent_from = Column(Date)
     absent_to = Column(Date)
 
+    object_sid = Column(String(255))
+
     column_names_to_sync = {
         'userid', 'username', 'external_id', 'active', 'firstname', 'lastname', 'directorate',
         'directorate_abbr', 'department', 'department_abbr', 'email', 'email2',


### PR DESCRIPTION
Once the OGDS auth plugin is used and the  ActiveDirectoryMultiPlugin is removed, we need to keep the `objectSid` in OGDS for the OneOffixx integration to still work and expose it in the member properties via the OGDS auth plugin.

For [CA-4734](https://4teamwork.atlassian.net/browse/CA-4734)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- Upgrade-Steps:
  - [x] SQL Operations do not use imported model (see [docs]
  - DB-Schema migration
    - [x] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [x] Constraint names are shorter than 30 characters (`Oracle`)
