### PR TITLE
Add `display_name` column to OGDS user model

### DIFF
--- a/changes/CA-4734-3.other
+++ b/changes/CA-4734-3.other
@@ -1,0 +1,1 @@
+Add `display_name` column to OGDS user model. [lgraf]

--- a/changes/CA-4734-4.other
+++ b/changes/CA-4734-4.other
@@ -1,0 +1,1 @@
+OGDS auth plugin: Use OGDS `display_name` as the `fullname` member property. [lgraf]

--- a/changes/CA-4734-5.bugfix
+++ b/changes/CA-4734-5.bugfix
@@ -1,0 +1,1 @@
+OGDS auth plugin: Fix how we access RowProxy results from SQLAlchemy. [lgraf]

--- a/docs/schema-dumps/_opengever.ogds.models.user.User.schema.json
+++ b/docs/schema-dumps/_opengever.ogds.models.user.User.schema.json
@@ -46,6 +46,13 @@
             "description": "",
             "_zope_schema_type": "Text"
         },
+        "display_name": {
+            "type": "string",
+            "title": "display_name",
+            "maxLength": 511,
+            "description": "",
+            "_zope_schema_type": "Text"
+        },
         "directorate": {
             "type": "string",
             "title": "directorate",
@@ -219,6 +226,7 @@
         "active",
         "firstname",
         "lastname",
+        "display_name",
         "directorate",
         "directorate_abbr",
         "department",

--- a/opengever/api/tests/test_ogdsuser.py
+++ b/opengever/api/tests/test_ogdsuser.py
@@ -67,6 +67,7 @@ class TestOGDSUserGet(IntegrationTestCase):
              u'description': u'nix',
              u'directorate': u'Staatsarchiv',
              u'directorate_abbr': u'Arch',
+             u'display_name': None,
              u'email': u'foo@example.com',
              u'email2': u'bar@example.com',
              u'external_id': u'kathi.barfuss',

--- a/opengever/bundle/schemas/ogds_users.schema.json
+++ b/opengever/bundle/schemas/ogds_users.schema.json
@@ -61,6 +61,16 @@
                     "description": "",
                     "_zope_schema_type": "Text"
                 },
+                "display_name": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "title": "display_name",
+                    "maxLength": 511,
+                    "description": "",
+                    "_zope_schema_type": "Text"
+                },
                 "directorate": {
                     "type": [
                         "null",
@@ -313,6 +323,7 @@
                 "active",
                 "firstname",
                 "lastname",
+                "display_name",
                 "directorate",
                 "directorate_abbr",
                 "department",

--- a/opengever/core/upgrades/20220927162859_add_users_display_name_sql_column/upgrade.py
+++ b/opengever/core/upgrades/20220927162859_add_users_display_name_sql_column/upgrade.py
@@ -1,0 +1,15 @@
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy import Column
+from sqlalchemy import String
+
+
+class AddUsersDisplayNameSQLColumn(SchemaMigration):
+    """Add users.display_name SQL column.
+    """
+
+    def migrate(self):
+        self.op.add_column(
+            'users', Column('display_name', String(511), nullable=True)
+        )
+        # No need to pre-populate column as part of the upgrade,
+        # since it will be populated by the next OGDS sync.

--- a/opengever/ogds/auth/plugin.py
+++ b/opengever/ogds/auth/plugin.py
@@ -107,7 +107,7 @@ class OGDSAuthenticationPlugin(BasePlugin, Cacheable):
         'email': User.email,
         'firstname': User.firstname,
         'lastname': User.lastname,
-        'fullname': (User.firstname + u' ' + User.lastname),
+        'fullname': User.display_name,
         'objectSid': User.object_sid,
     }
     GROUP_PROPS = {

--- a/opengever/ogds/auth/tests/test_plugin.py
+++ b/opengever/ogds/auth/tests/test_plugin.py
@@ -144,12 +144,20 @@ class TestOGDSAuthPluginIUserEnumeration(TestOGDSAuthPluginBase):
         self.assertEqual(expected, self.ids(results))
 
     def test_enum_users_can_search_by_fullname_with_exact_match_true(self):
+        ogds_user = ogds_service().fetch_user('kathi.barfuss')
+        ogds_user.display_name = u'K\xe4thi B\xe4rfuss (FD-AFI)'
+        ogds_service().session.flush()
+
         results = self.plugin.enumerateUsers(
-            fullname='K\xc3\xa4thi B\xc3\xa4rFUSS', exact_match=True)
+            fullname='K\xc3\xa4thi B\xc3\xa4rFUSS (FD-AFI)', exact_match=True)
         expected = ('kathi.barfuss', )
         self.assertEqual(expected, self.ids(results))
 
     def test_enum_users_can_search_by_fullname_with_exact_match_false(self):
+        ogds_user = ogds_service().fetch_user('kathi.barfuss')
+        ogds_user.display_name = u'K\xe4thi B\xe4rfuss (FD-AFI)'
+        ogds_service().session.flush()
+
         results = self.plugin.enumerateUsers(fullname='THI B\xc3\xa4rFUSS')
         expected = ('kathi.barfuss', )
         self.assertEqual(expected, self.ids(results))
@@ -429,6 +437,7 @@ class TestOGDSAuthPluginIPropertiesPlugin(TestOGDSAuthPluginBase):
     def test_get_properties_for_user(self):
         ogds_user = ogds_service().fetch_user('kathi.barfuss')
         ogds_user.object_sid = u'S-1-5-21-2109130332-968164008-972369679-13586'
+        ogds_user.display_name = u'K\xe4thi B\xe4rfuss (FD-AFI)'
         ogds_service().session.flush()
 
         member = api.user.get('kathi.barfuss')
@@ -438,7 +447,7 @@ class TestOGDSAuthPluginIPropertiesPlugin(TestOGDSAuthPluginBase):
             'email': 'foo@example.com',
             'firstname': 'K\xc3\xa4thi',
             'lastname': 'B\xc3\xa4rfuss',
-            'fullname': 'K\xc3\xa4thi B\xc3\xa4rfuss',
+            'fullname': 'K\xc3\xa4thi B\xc3\xa4rfuss (FD-AFI)',
             'objectSid': 'S-1-5-21-2109130332-968164008-972369679-13586',
         }
         self.assertEqual(expected, results)

--- a/opengever/ogds/base/sync/ogds_updater.py
+++ b/opengever/ogds/base/sync/ogds_updater.py
@@ -430,6 +430,16 @@ class OGDSUpdater(object):
                 if object_sid:
                     user_attrs['object_sid'] = sid2str(object_sid)
 
+                # The LDAP/AD attributes 'displayName' or 'cn' are sometimes
+                # mapped to the 'fullname' property. If it exists, we store
+                # this in OGDS in the display_name column.
+                # This is therefore a customer-controlled display name, and
+                # different from the full name we build in the User.fullname()
+                # method by concatenating first and last name.
+                display_name = info.get('fullname')
+                if display_name:
+                    user_attrs['display_name'] = display_name.decode('utf-8')
+
                 users[userid] = user_attrs
 
         return users

--- a/opengever/ogds/base/tests/test_ogds_updater.py
+++ b/opengever/ogds/base/tests/test_ogds_updater.py
@@ -28,6 +28,7 @@ BLACKLISTED_USER_COLUMNS = {
     'absent',
     'absent_from',
     'absent_to',
+    'display_name',
     'last_login',
     'object_sid',
 }

--- a/opengever/ogds/models/user.py
+++ b/opengever/ogds/models/user.py
@@ -69,11 +69,30 @@ class User(Base):
     object_sid = Column(String(255))
 
     column_names_to_sync = {
-        'userid', 'username', 'external_id', 'active', 'firstname', 'lastname', 'directorate',
-        'directorate_abbr', 'department', 'department_abbr', 'email', 'email2',
-        'url', 'phone_office', 'phone_fax', 'phone_mobile', 'salutation',
-        'title', 'description', 'address1', 'address2', 'zip_code', 'city',
+        'active',
+        'address1',
+        'address2',
+        'city',
         'country',
+        'department',
+        'department_abbr',
+        'description',
+        'directorate',
+        'directorate_abbr',
+        'email',
+        'email2',
+        'external_id',
+        'firstname',
+        'lastname',
+        'phone_fax',
+        'phone_mobile',
+        'phone_office',
+        'salutation',
+        'title',
+        'url',
+        'userid',
+        'username',
+        'zip_code',
     }
 
     # A classmethod property needs to be defined on the metaclass

--- a/opengever/ogds/models/user.py
+++ b/opengever/ogds/models/user.py
@@ -37,6 +37,7 @@ class User(Base):
     active = Column(Boolean, default=True)
     firstname = Column(String(FIRSTNAME_LENGTH))
     lastname = Column(String(LASTNAME_LENGTH))
+    display_name = Column(String(FIRSTNAME_LENGTH + 1 + LASTNAME_LENGTH))
 
     directorate = Column(String(255))
     directorate_abbr = Column(String(50))
@@ -129,10 +130,11 @@ class User(Base):
         return u"%s (%s)" % (self.fullname(), self.userid)
 
     def fullname(self):
-        """Return a visual representation of the UserPersona as String.
-        - The default is "<lastname> <firstname>"
-        - If either one is missing it is: "<lastname>" or "<firstname>"
-        - The fallback is "<userid>"
+        """Return a visual representation of the user's full name.
+
+        Note that this is different from the 'display_name' stored on this
+        model, which is imported from LDAP/AD, and is therefore a
+        customer-controlled representation.
         """
         parts = []
         if self.lastname:


### PR DESCRIPTION
The LDAP/AD attributes `displayName` or `cn` are sometimes mapped to the `fullname` property. This is especially the case for customers that actively manage the display names of their users, e.g. to also contain the user's department or their role.

If it exists, we store it in OGDS in the `display_name` column. This is therefore a customer-controlled display name, and different from the fullname we build in the `User.fullname()` method by concatenating first and last name.

With that display ending up in the `fullname` property, Plone will use it e.g. when searching for users in the sharing tab, or to display it in the personal tools menu.

Also contains a bugfix for accessing SQLAlchemy RowProxy results.

For [CA-4734](https://4teamwork.atlassian.net/browse/CA-4734)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- Upgrade-Steps:
  - [x] SQL Operations do not use imported model (see [docs]
  - DB-Schema migration
    - [x] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [x] Constraint names are shorter than 30 characters (`Oracle`)
