### PR TITLE
Add `organization` column to OGDS user model:

### DIFF
--- a/changes/CA-4734-6.other
+++ b/changes/CA-4734-6.other
@@ -1,0 +1,1 @@
+Add `organization` column to OGDS user model. [lgraf]

--- a/docs/schema-dumps/_opengever.ogds.models.user.User.schema.json
+++ b/docs/schema-dumps/_opengever.ogds.models.user.User.schema.json
@@ -81,6 +81,13 @@
             "description": "",
             "_zope_schema_type": "Text"
         },
+        "organization": {
+            "type": "string",
+            "title": "organization",
+            "maxLength": 255,
+            "description": "",
+            "_zope_schema_type": "Text"
+        },
         "email": {
             "type": "string",
             "title": "email",
@@ -231,6 +238,7 @@
         "directorate_abbr",
         "department",
         "department_abbr",
+        "organization",
         "email",
         "email2",
         "url",

--- a/opengever/api/tests/test_ogdsuser.py
+++ b/opengever/api/tests/test_ogdsuser.py
@@ -106,6 +106,7 @@ class TestOGDSUserGet(IntegrationTestCase):
              u'phone_mobile': u'012 34 56 76',
              u'phone_office': u'012 34 56 78',
              u'object_sid': None,
+             u'organization': None,
              u'salutation': u'Prof. Dr.',
              u'teams': [{u'@id': u'http://nohost/plone/@teams/4',
                          u'@type': u'virtual.ogds.team',

--- a/opengever/bundle/schemas/ogds_users.schema.json
+++ b/opengever/bundle/schemas/ogds_users.schema.json
@@ -111,6 +111,16 @@
                     "description": "",
                     "_zope_schema_type": "Text"
                 },
+                "organization": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "title": "organization",
+                    "maxLength": 255,
+                    "description": "",
+                    "_zope_schema_type": "Text"
+                },
                 "email": {
                     "type": [
                         "null",
@@ -328,6 +338,7 @@
                 "directorate_abbr",
                 "department",
                 "department_abbr",
+                "organization",
                 "email",
                 "email2",
                 "url",

--- a/opengever/core/upgrades/20220928114307_add_users_organization_sql_column/upgrade.py
+++ b/opengever/core/upgrades/20220928114307_add_users_organization_sql_column/upgrade.py
@@ -1,0 +1,15 @@
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy import Column
+from sqlalchemy import String
+
+
+class AddUsersOrganizationSQLColumn(SchemaMigration):
+    """Add users.organization SQL column.
+    """
+
+    def migrate(self):
+        # No need to pre-populate the column during the upgrade, since this
+        # will be done during the next OGDS sync.
+        self.op.add_column(
+            'users', Column('organization', String(255), nullable=True)
+        )

--- a/opengever/ogds/models/user.py
+++ b/opengever/ogds/models/user.py
@@ -43,6 +43,7 @@ class User(Base):
     directorate_abbr = Column(String(50))
     department = Column(String(255))
     department_abbr = Column(String(50))
+    organization = Column(String(255))
 
     email = Column(String(EMAIL_LENGTH))
     email2 = Column(String(EMAIL_LENGTH))
@@ -85,6 +86,7 @@ class User(Base):
         'external_id',
         'firstname',
         'lastname',
+        'organization',
         'phone_fax',
         'phone_mobile',
         'phone_office',


### PR DESCRIPTION
This column is intended to track a user's organization in a simpler way than the existing directorate and department columns.

In order to be populated, it will need to be mapped in the LDAP schema to an AD/LDAP attribute first, with a public_name of 'organization'. Then it will be synced to OGDS.

For [CA-4734](https://4teamwork.atlassian.net/browse/CA-4734)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- Upgrade-Steps:
  - [x] SQL Operations do not use imported model 
  - DB-Schema migration
    - [x] All changes on a model (columns, etc) are included in a DB-schema migration.
