### PR TITLE
Consider time zone when determining the end date of a dossier

### DIFF
--- a/changes/CA-4774.bugfix
+++ b/changes/CA-4774.bugfix
@@ -1,0 +1,1 @@
+Consider time zone when determining the end date of a dossier. [tinagerber]

--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -2,6 +2,7 @@ from Acquisition import aq_inner
 from Acquisition import aq_parent
 from datetime import date
 from datetime import datetime
+from dateutil import tz
 from opengever.base.behaviors.lifecycle import ILifeCycle
 from opengever.base.command import CreateDocumentCommand
 from opengever.base.interfaces import IReferenceNumber
@@ -33,6 +34,7 @@ from plone import api
 from plone.dexterity.content import Container
 from plone.dexterity.interfaces import IDexterityFTI
 from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
+from pytz import utc
 from zExceptions import Unauthorized
 from zope.component import adapter
 from zope.component import getUtility
@@ -71,7 +73,11 @@ def max_date(*dates):
 
 def as_date(datetime_obj):
     if isinstance(datetime_obj, datetime):
-        return datetime_obj.date()
+        if datetime_obj.tzinfo == utc:
+            local_zone = tz.tzlocal()
+            return datetime_obj.astimezone(local_zone).date()
+        else:
+            return datetime_obj.date()
 
     # It is already a date-object
     return datetime_obj

--- a/opengever/dossier/tests/test_dossier_helpers.py
+++ b/opengever/dossier/tests/test_dossier_helpers.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from opengever.dossier.base import as_date
 from opengever.dossier.base import max_date
 from unittest import TestCase
+import pytz
 
 
 class TestUnitDossierMaxDate(TestCase):
@@ -35,3 +36,24 @@ class TestUnitDossierAsDate(TestCase):
 
     def test_converts_datetime_to_date(self):
         self.assertEquals(date(1939, 9, 1), as_date(datetime(1939, 9, 1, 5, 45)))
+
+    def test_handles_timezone_corretly(self):
+        datetime_format = "%Y-%m-%d %H:%M"
+        date_format = "%Y-%m-%d"
+
+        utc_datetime = datetime(2017, 7, 16, 22, 15, tzinfo=pytz.utc)
+        local_datetime = utc_datetime.astimezone(pytz.timezone('Europe/Zurich'))
+        self.assertEqual('2017-07-16 22:15', utc_datetime.strftime(datetime_format))
+        self.assertEqual('2017-07-17 00:15', local_datetime.strftime(datetime_format))
+        self.assertEqual('2017-07-17', as_date(utc_datetime).strftime(date_format))
+        self.assertEqual('2017-07-17', as_date(local_datetime).strftime(date_format))
+
+        utc_datetime = datetime(2017, 11, 16, 23, 15, tzinfo=pytz.utc)
+        local_datetime = utc_datetime.astimezone(pytz.timezone('Europe/Zurich'))
+        self.assertEqual('2017-11-17 00:15', local_datetime.strftime(datetime_format))
+        self.assertEqual('2017-11-16 23:15', utc_datetime.strftime(datetime_format))
+        self.assertEqual('2017-11-17', as_date(utc_datetime).strftime(date_format))
+        self.assertEqual('2017-11-17', as_date(local_datetime).strftime(date_format))
+
+        utc_datetime = datetime(2017, 11, 16, 12, 15, tzinfo=pytz.utc)
+        self.assertEqual('2017-11-16', as_date(utc_datetime).strftime(date_format))


### PR DESCRIPTION
When determining the end date for dossiers, the time zone was not taken into account. If a document was last modified on 10.10.22 at 00:15, therefore then the date 09.10. came out, because the modified datetime is stored as utc, and from this the date was generated. Now, when converting the datetime to a date, the local time zone is respected.

For [CA-4774]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-4774]: https://4teamwork.atlassian.net/browse/CA-4774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ