### PR TITLE
 Include KuB organization phone number in membership docproperties.

### DIFF
--- a/changes/CA-4703.feature
+++ b/changes/CA-4703.feature
@@ -1,0 +1,1 @@
+Include KuB organization phone number in membership docproperties. [lgraf]

--- a/opengever/base/docprops.py
+++ b/opengever/base/docprops.py
@@ -23,10 +23,15 @@ class BaseDocPropertyProvider(object):
 
         return tuple(name_or_iterable)
 
-    def _prefix_properties_with_namespace(self, properties, prefix=None):
+    def _prefix_properties_with_namespace(
+            self, properties, prefix=None, with_app_prefix=True):
         """Prefix all keys in properties with the correct namespace."""
 
-        namespace = self._as_ns_part(self.NS_APP)
+        if with_app_prefix:
+            namespace = self._as_ns_part(self.NS_APP)
+        else:
+            namespace = ()
+
         if prefix:
             namespace += self._as_ns_part(prefix)
         namespace += self._as_ns_part(self.DEFAULT_PREFIX)
@@ -48,7 +53,7 @@ class BaseDocPropertyProvider(object):
         merged.update(d2)
         return merged
 
-    def get_properties(self, prefix=None):
+    def get_properties(self, prefix=None, with_app_prefix=True):
         properties = self._collect_properties()
         return self._prefix_properties_with_namespace(
-            properties, prefix=prefix)
+            properties, prefix=prefix, with_app_prefix=with_app_prefix)

--- a/opengever/base/tests/test_base_docprops_provider.py
+++ b/opengever/base/tests/test_base_docprops_provider.py
@@ -1,0 +1,51 @@
+from opengever.base.docprops import BaseDocPropertyProvider
+import unittest
+
+
+class SampleProvider(BaseDocPropertyProvider):
+
+    def _collect_properties(self):
+        return {
+            'foo': 42,
+            'bar': 'Hello',
+        }
+
+
+class TestBaseDocPropertyProvider(unittest.TestCase):
+
+    def setUp(self):
+        self.provider = SampleProvider(context=None)
+
+    def test_get_properties_prefixes_with_app_by_default(self):
+        actual = self.provider.get_properties()
+        expected = {
+            'ogg.foo': 42,
+            'ogg.bar': 'Hello',
+        }
+        self.assertEqual(expected, actual)
+
+    def test_get_properties_supports_custom_prefix(self):
+        actual = self.provider.get_properties(prefix='my_scope')
+        expected = {
+            'ogg.my_scope.foo': 42,
+            'ogg.my_scope.bar': 'Hello',
+        }
+        self.assertEqual(expected, actual)
+
+    def test_get_properties_supports_default_prefix(self):
+        provider = SampleProvider(context=None)
+        provider.DEFAULT_PREFIX = ('default_prefix', )
+
+        actual = provider.get_properties()
+        expected = {
+            'ogg.default_prefix.foo': 42,
+            'ogg.default_prefix.bar': 'Hello',
+        }
+        self.assertEqual(expected, actual)
+
+        actual = provider.get_properties(prefix='my_scope')
+        expected = {
+            'ogg.my_scope.default_prefix.foo': 42,
+            'ogg.my_scope.default_prefix.bar': 'Hello',
+        }
+        self.assertEqual(expected, actual)

--- a/opengever/base/tests/test_base_docprops_provider.py
+++ b/opengever/base/tests/test_base_docprops_provider.py
@@ -49,3 +49,28 @@ class TestBaseDocPropertyProvider(unittest.TestCase):
             'ogg.my_scope.default_prefix.bar': 'Hello',
         }
         self.assertEqual(expected, actual)
+
+    def test_get_properties_supports_omitting_app_prefix(self):
+        actual = self.provider.get_properties(with_app_prefix=False)
+        expected = {
+            'foo': 42,
+            'bar': 'Hello',
+        }
+        self.assertEqual(expected, actual)
+
+        provider = SampleProvider(context=None)
+        provider.DEFAULT_PREFIX = ('default_prefix', )
+
+        actual = provider.get_properties(with_app_prefix=False)
+        expected = {
+            'default_prefix.foo': 42,
+            'default_prefix.bar': 'Hello',
+        }
+        self.assertEqual(expected, actual)
+
+        actual = provider.get_properties(prefix='my_scope', with_app_prefix=False)
+        expected = {
+            'my_scope.default_prefix.foo': 42,
+            'my_scope.default_prefix.bar': 'Hello',
+        }
+        self.assertEqual(expected, actual)

--- a/opengever/kub/docprops.py
+++ b/opengever/kub/docprops.py
@@ -109,7 +109,12 @@ class KuBOrganizationDocPropertyProvider(BaseDocPropertyProvider):
     DEFAULT_PREFIX = ('organization',)
 
     def _collect_properties(self):
-        return {'name': self.context.get("name")}
+        properties = {
+            'name': self.context.get("name"),
+        }
+        phone_provider = KuBPhoneNumberDocPropertyProvider(self.context)
+        properties.update(phone_provider.get_properties(with_app_prefix=False))
+        return properties
 
 
 class KuBMembershipDocPropertyProvider(BaseDocPropertyProvider):

--- a/opengever/kub/testing.py
+++ b/opengever/kub/testing.py
@@ -361,7 +361,20 @@ KUB_RESPONSES = {
             }
         ],
         "emailAddresses": [],
-        "phoneNumbers": [],
+        "phoneNumbers": [
+            {
+                "id": "4b92f284-4924-4608-8f6f-068c668ebdc8",
+                "label": "Arbeit",
+                "phoneNumber": "+41 31 511 04 00",
+                "phoneCategory": 5,
+                "otherPhoneCategory": None,
+                "phoneCategoryText": u'Gesch\xe4ftliche Nummer (Zentrale)',
+                "isDefault": True,
+                "thirdPartyId": None,
+                "modified": "2022-09-29T14:06:26.994768+02:00",
+                "created": "2022-09-29T14:04:50.142282+02:00"
+            }
+        ],
         "urls": [],
         "memberships": [
             {
@@ -387,7 +400,18 @@ KUB_RESPONSES = {
             }
         ],
         "primaryEmail": None,
-        "primaryPhoneNumber": None,
+        "primaryPhoneNumber": {
+            "id": "4b92f284-4924-4608-8f6f-068c668ebdc8",
+            "label": "Arbeit",
+            "phoneNumber": "+41 31 511 04 00",
+            "phoneCategory": 5,
+            "otherPhoneCategory": None,
+            "phoneCategoryText": u'Gesch\xe4ftliche Nummer (Zentrale)',
+            "isDefault": True,
+            "thirdPartyId": None,
+            "modified": "2022-09-29T14:06:26.994768+02:00",
+            "created": "2022-09-29T14:04:50.142282+02:00"
+        },
         "tags": [
             "Bude"
         ],

--- a/opengever/kub/tests/test_docprops.py
+++ b/opengever/kub/tests/test_docprops.py
@@ -55,7 +55,8 @@ class TestKuBEntityDocPropertyProvider(KuBIntegrationTestCase):
              'ogg.contact.title': u'4Teamwork',
              'ogg.email.address': None,
              'ogg.organization.name': u'4Teamwork',
-             'ogg.phone.number': None,
+             'ogg.organization.phone.number': u'+41 31 511 04 00',
+             'ogg.phone.number': u'+41 31 511 04 00',
              'ogg.url.url': None},
             properties)
 
@@ -74,6 +75,7 @@ class TestKuBEntityDocPropertyProvider(KuBIntegrationTestCase):
              'ogg.contact.title': u'Dupont Jean - 4Teamwork (CEO)',
              'ogg.email.address': u'Jean.dupon@example.com',
              'ogg.organization.name': u'4Teamwork',
+             'ogg.organization.phone.number': u'+41 31 511 04 00',
              'ogg.orgrole.department': u'',
              'ogg.orgrole.description': u'',
              'ogg.orgrole.function': u'CEO',


### PR DESCRIPTION
Include KuB organization phone number in membership docproperties:

When serializing a KuB membership to DocProperties, this will also include the organization's phone number in `ogg.[scope].organization.phone.number` (where [scope] may currently be `sender` or `recipient`).

A side effect of this is that when serializing an `organization` entity, its phone number is now exposed twice in DocProperties: Once in `ogg.[scope].organization.phone.number` and once in `ogg.[scope.]phone.number`.

This is because the phone number is once included by the `KuBPhoneNumberDocPropertyProvider` at the upper, generic level (that exposes common properties in an entity type agnostic way), and once more by the `KuBOrganizationDocPropertyProvider` under `ogg.[scope].organization.phone.number`, to be able to distinguish the org's phone number from the person's.

For [CA-4703](https://4teamwork.atlassian.net/browse/CA-4703)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
