### PR TITLE
Improve case insensitivity of OGDS sync.

### DIFF
--- a/opengever/ogds/base/sync/ogds_updater.py
+++ b/opengever/ogds/base/sync/ogds_updater.py
@@ -45,6 +45,19 @@ logger = logging.getLogger('opengever.ogds.base')
 logger.setLevel(logging.INFO)
 
 
+class CaseInsensitiveDict(dict):
+    """Dictionary that is case insensitive just for getting items.
+    """
+    def __getitem__(self, key):
+        if key in self:
+            return super(CaseInsensitiveDict, self).__getitem__(key)
+        for k, v in self.items():
+            if k.lower() == key.lower():
+                return v
+
+        raise KeyError(key)
+
+
 def sync_ogds(plone, users=True, groups=True, local_groups=False,
               update_remote_timestamps=True, disable_logfile=False):
     """Syncronize OGDS users and groups by importing users, groups and
@@ -264,9 +277,9 @@ class OGDSUpdater(object):
             logger.info('Modified group %s', modified['groupid'])
 
         # Update group members
-        ogds_users = {
+        ogds_users = CaseInsensitiveDict({
             user.userid: user for user in session.query(User)
-        }
+        })
         ogds_groups = {
             group.groupid: group
             for group in session.query(Group).filter(


### PR DESCRIPTION
When the User's userid casing is changed, the LDAP-sync failed because it is only partially case-insensitive. We fix the syncing of group memberships here.

_PR-Description: should contain all the information necessary for an outsider to understand the change without looking at the code or the issue!_

- _Why the change is necessary_
- _What the goal of the change is_
- _How change is achieved (e.g. design decisions)_
- _The author should advertise and sell the change in the PR body_

_Screenshot: whenever useful, but only as a visual aid._


Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-XXXX]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
