### PR TITLE
Clean-up activity translations.

### DIFF
--- a/changes/CA-4663.other
+++ b/changes/CA-4663.other
@@ -1,0 +1,1 @@
+Clean-up activity translations. [njohner]

--- a/opengever/activity/__init__.py
+++ b/opengever/activity/__init__.py
@@ -69,66 +69,8 @@ def send_digest_zopectl_handler(app, args):
 
 
 ACTIVITY_TRANSLATIONS = {
-    'task-added': _('task-added', default=u'Task added'),
-    'task-transition-cancelled-open': _(
-        'task-transition-cancelled-open', default=u'Task reopened'),
-    'task-transition-delegate': _(
-        'task-transition-delegate', default=u'Task delegated'),
-    'task-transition-in-progress-resolved': _(
-        'task-transition-in-progress-resolved', default=u'Task resolved'),
-    'task-transition-in-progress-tested-and-closed': _(
-        'task-transition-in-progress-tested-and-closed',
-        default=u'Task closed'),
-    'task-transition-modify-deadline': _(
-        'task-transition-modify-deadline', default=u'Task deadline modified'),
-    'task-transition-open-cancelled': _(
-        'task-transition-open-cancelled', default=u'Task cancelled'),
-    'task-transition-open-in-progress': _(
-        'task-transition-open-in-progress', default=u'Task accepted'),
-    'task-transition-open-rejected': _(
-        'task-transition-open-rejected', default=u'Task rejected'),
-    'task-transition-open-resolved': _(
-        'task-transition-open-resolved', default=u'Task resolved'),
-    'task-transition-open-tested-and-closed': _(
-        'task-transition-open-tested-and-closed', default=u'Task closed'),
-    'task-commented': _('task-commented', default=u'Task commented'),
-    'task-transition-reassign': _(
-        'task-transition-reassign', default=u'Task reassign'),
-    'task-transition-rejected-open': _(
-        'task-transition-rejected-open', default=u'Task reopened'),
-    'task-transition-resolved-in-progress': _(
-        'task-transition-resolved-in-progress', default=u'Task revision wanted'),  # noqa
-    'task-transition-resolved-tested-and-closed': _(
-        'task-transition-resolved-tested-and-closed', default=u'Task closed'),
-    'task-transition-skipped-open': _(
-        'task-transition-skipped-open', default=u'Task reopened'),
-    'task-transition-rejected-skipped': _(
-        'task-transition-rejected-skipped', default=u'Task skipped'),
-    'task-transition-planned-skipped': _(
-        'task-transition-planned-skipped', default=u'Task skipped'),
     'task-reminder': _(
         'task-reminder', default=u'Task reminder'),
-    'task-watcher-added': _(
-        'task-watcher-added', default=u'Added as watcher to task'),
-    'transition-add-subtask': _('transition-add-subtask', 'Subtask added'),
-    'transition-add-document': _('transition-add-document', 'Document added'),
-    'forwarding-added': _(
-        'forwarding-added', default=u'Forwarding added'),
-    'forwarding-transition-accept': _(
-        'forwarding-transition-accept', default=u'Forwarding accepted'),
-    'forwarding-transition-assign-to-dossier': _(
-        'forwarding-transition-assign-to-dossier',
-        default=u'Forwarding assigned to dossier'),
-    'forwarding-transition-close': _('forwarding-transition-close', default=u'Forwarding closed'),  # noqa
-    'forwarding-transition-reassign': _(
-        'forwarding-transition-reassign', default=u'Forwarding reassigned'),
-    'forwarding-transition-reassign-refused': _(
-        'forwarding-transition-reassign-refused',
-        default=u'Forwarding reassigned and refused'),
-    'forwarding-transition-refuse': _(
-        'forwarding-transition-refuse', default=u'Forwarding refused'),
-    'forwarding-watcher-added': _(
-        'forwarding-watcher-added', default=u'Added as watcher to forwarding'),
     'proposal-transition-reject': _(
         'proposal-transition-reject', default=u'Proposal rejected'),
     'proposal-transition-schedule': _(
@@ -148,33 +90,6 @@ ACTIVITY_TRANSLATIONS = {
     'submitted-proposal-commented': _(
         'submitted-proposal-commented',
         default=u'Submitted proposal commented'),
-    'disposition-added': _(
-        'disposition-added',
-        default=u'Disposition added'),
-    'disposition-transition-appraise': _(
-        'disposition-transition-appraise',
-        default=u'Disposition appraised'),
-    'disposition-transition-archive': _(
-        'disposition-transition-archive',
-        default=u'Disposition archived'),
-    'disposition-transition-dispose': _(
-        'disposition-transition-dispose',
-        default=u'Disposition disposed'),
-    'disposition-transition-refuse': _(
-        'disposition-transition-refuse',
-        default=u'Disposition refused'),
-    'disposition-transition-close': _(
-        'disposition-transition-close',
-        default=u'Disposition closed'),
-    'dossier-overdue': _(
-        'dossier-overdue',
-        default=u'Overdue dossier'),
-    'todo-assigned': _(
-        'todo-assigned',
-        default=u'ToDo assigned'),
-    'todo-modified': _(
-        'todo-modified',
-        default=u'ToDo modified'),
     'document-author-changed': _(
         'document-author-changed',
         default=u'Document author changed'),
@@ -184,7 +99,4 @@ ACTIVITY_TRANSLATIONS = {
     'document-version-created': _(
         'document-version-created',
         default=u'New document version created'),
-    'document-watcher-added': _(
-        'document-watcher-added',
-        default=u'Added as watcher to document'),
 }

--- a/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-12-08 16:03+0000\n"
+"POT-Creation-Date: 2022-10-07 09:20+0000\n"
 "PO-Revision-Date: 2015-02-24 08:40+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -73,37 +73,31 @@ msgid "created"
 msgstr "Erstellt"
 
 #. Default: "Disposition added"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "disposition-added"
 msgstr "Angebot hinzugefügt"
 
 #. Default: "Disposition appraised"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "disposition-transition-appraise"
 msgstr "Bewertung finalisiert"
 
 #. Default: "Disposition archived"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "disposition-transition-archive"
 msgstr "Archivierung bestätigt"
 
 #. Default: "Disposition closed"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "disposition-transition-close"
 msgstr "Angebot abgeschlossen"
 
 #. Default: "Disposition disposed"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "disposition-transition-dispose"
 msgstr "Zur Archivierung angeboten"
 
 #. Default: "Disposition refused"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "disposition-transition-refuse"
 msgstr "Angebot abgelehnt"
@@ -128,13 +122,7 @@ msgstr "Titel des Dokuments geändert"
 msgid "document-version-created"
 msgstr "Neue Dokumentversion erstellt"
 
-#. Default: "Added as watcher to document"
-#: ./opengever/activity/__init__.py
-msgid "document-watcher-added"
-msgstr "Als Beobachter hinzugefügt zu Dokument"
-
 #. Default: "Overdue dossier"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "dossier-overdue"
 msgstr "Überfälliges Dossier"
@@ -148,46 +136,6 @@ msgstr "Federführend"
 #: ./opengever/activity/notification_settings.py
 msgid "external-activity"
 msgstr "Externe Aktivitäten"
-
-#. Default: "Forwarding added"
-#: ./opengever/activity/__init__.py
-msgid "forwarding-added"
-msgstr "Weiterleitung hinzugefügt"
-
-#. Default: "Forwarding accepted"
-#: ./opengever/activity/__init__.py
-msgid "forwarding-transition-accept"
-msgstr "Weiterleitung akzeptiert"
-
-#. Default: "Forwarding assigned to dossier"
-#: ./opengever/activity/__init__.py
-msgid "forwarding-transition-assign-to-dossier"
-msgstr "Weiterleitung einem Dossier zugewiesen"
-
-#. Default: "Forwarding closed"
-#: ./opengever/activity/__init__.py
-msgid "forwarding-transition-close"
-msgstr "Weiterleitung abgeschlossen"
-
-#. Default: "Forwarding reassigned"
-#: ./opengever/activity/__init__.py
-msgid "forwarding-transition-reassign"
-msgstr "Weiterleitung neu zugewiesen"
-
-#. Default: "Forwarding reassigned and refused"
-#: ./opengever/activity/__init__.py
-msgid "forwarding-transition-reassign-refused"
-msgstr "Weiterleitung neu zugewiesen und abgelehnt"
-
-#. Default: "Forwarding refused"
-#: ./opengever/activity/__init__.py
-msgid "forwarding-transition-refuse"
-msgstr "Weiterleitung abgelehnt"
-
-#. Default: "Added as watcher to forwarding"
-#: ./opengever/activity/__init__.py
-msgid "forwarding-watcher-added"
-msgstr "Als Beobachter hinzugefügt zu Weiterleitung"
 
 #. Default: "Notifications"
 #: ./opengever/activity/viewlets/notification.pt
@@ -378,18 +326,12 @@ msgstr "GEVER Aktivität"
 msgid "submitted-proposal-commented"
 msgstr "Eingereichter Antrag kommentiert"
 
-#. Default: "Task added"
-#: ./opengever/activity/__init__.py
-msgid "task-added"
-msgstr "Aufgabe hinzugefügt"
-
 #. Default: "Task added / reassigned"
 #: ./opengever/activity/notification_settings.py
 msgid "task-added-or-reassigned"
 msgstr "Aufgabe erstellt / neu zugewiesen"
 
 #. Default: "Task commented"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "task-commented"
 msgstr "Aufgabe kommentiert"
@@ -400,96 +342,10 @@ msgstr "Aufgabe kommentiert"
 msgid "task-reminder"
 msgstr "Aufgaben-Erinnerung"
 
-#. Default: "Task reopened"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-cancelled-open"
-msgstr "Aufgabe wieder eröffnet"
-
-#. Default: "Task delegated"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-delegate"
-msgstr "Aufgabe delegiert"
-
-#. Default: "Task resolved"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-in-progress-resolved"
-msgstr "Aufgabe erledigt"
-
-#. Default: "Task closed"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-in-progress-tested-and-closed"
-msgstr "Aufgabe abgeschlossen"
-
 #. Default: "Task deadline modified"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "task-transition-modify-deadline"
 msgstr "Aufgaben-Frist verändert"
-
-#. Default: "Task cancelled"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-open-cancelled"
-msgstr "Aufgaben abgebrochen"
-
-#. Default: "Task accepted"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-open-in-progress"
-msgstr "Aufgabe akzeptiert"
-
-#. Default: "Task rejected"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-open-rejected"
-msgstr "Aufgabe abgelehnt"
-
-#. Default: "Task resolved"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-open-resolved"
-msgstr "Aufgabe erledigt"
-
-#. Default: "Task closed"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-open-tested-and-closed"
-msgstr "Aufgabe abgeschlossen"
-
-#. Default: "Task skipped"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-planned-skipped"
-msgstr "Aufgabe übersprungen"
-
-#. Default: "Task reassign"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-reassign"
-msgstr "Aufgabe neu zugewiesen"
-
-#. Default: "Task reopened"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-rejected-open"
-msgstr "Aufgabe wieder eröffnet"
-
-#. Default: "Task skipped"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-rejected-skipped"
-msgstr "Aufgabe übersprungen"
-
-#. Default: "Task revision wanted"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-resolved-in-progress"
-msgstr "Aufgaben-Überarbeitung gefordert"
-
-#. Default: "Task closed"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-resolved-tested-and-closed"
-msgstr "Aufgabe abgeschlossen"
-
-#. Default: "Task reopened"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-skipped-open"
-msgstr "Aufgabe wieder eröffnet"
-
-#. Default: "Added as watcher to task"
-#: ./opengever/activity/__init__.py
-msgid "task-watcher-added"
-msgstr "Als Beobachter hinzugefügt zu Aufgabe"
 
 #. Default: "Task issuer"
 #: ./opengever/activity/roles.py
@@ -517,13 +373,11 @@ msgid "title_daily_digest"
 msgstr "Tageszusammenfassung für ${username}"
 
 #. Default: "ToDo assigned"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "todo-assigned"
 msgstr "ToDo zugewiesen"
 
 #. Default: "ToDo modified"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "todo-modified"
 msgstr "ToDo modifiziert"
@@ -532,16 +386,6 @@ msgstr "ToDo modifiziert"
 #: ./opengever/activity/roles.py
 msgid "todo_responsible_role"
 msgstr "ToDo Verantwortlicher"
-
-#. Default: "Document added"
-#: ./opengever/activity/__init__.py
-msgid "transition-add-document"
-msgstr "Dokument hinzugefügt"
-
-#. Default: "Subtask added"
-#: ./opengever/activity/__init__.py
-msgid "transition-add-subtask"
-msgstr "Unteraufgabe erstellt"
 
 #. Default: "Workspace member"
 #: ./opengever/activity/roles.py

--- a/opengever/activity/locales/en/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/en/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-12-08 16:03+0000\n"
+"POT-Creation-Date: 2022-10-07 09:20+0000\n"
 "PO-Revision-Date: 2015-02-24 08:40+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -84,42 +84,36 @@ msgstr "Created"
 
 #. German translation: Angebot hinzugefügt
 #. Default: "Disposition added"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "disposition-added"
 msgstr "Offer added"
 
 #. German translation: Bewertung finalisiert
 #. Default: "Disposition appraised"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "disposition-transition-appraise"
 msgstr "Appraisal finalised"
 
 #. German translation: Archivierung bestätigt
 #. Default: "Disposition archived"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "disposition-transition-archive"
 msgstr "Archival confirmed"
 
 #. German translation: Angebot abgeschlossen
 #. Default: "Disposition closed"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "disposition-transition-close"
 msgstr "Offer closed"
 
 #. German translation: Zur Archivierung angeboten
 #. Default: "Disposition disposed"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "disposition-transition-dispose"
 msgstr "Offered for archival"
 
 #. German translation: Angebot abgelehnt
 #. Default: "Disposition refused"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "disposition-transition-refuse"
 msgstr "Offer refused"
@@ -144,14 +138,8 @@ msgstr "Document title changed"
 msgid "document-version-created"
 msgstr "New document version created"
 
-#. Default: "Added as watcher to document"
-#: ./opengever/activity/__init__.py
-msgid "document-watcher-added"
-msgstr "Added as watcher to document"
-
 #. German translation: Überfälliges Dossier
 #. Default: "Overdue dossier"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "dossier-overdue"
 msgstr "Overdue dossier"
@@ -166,54 +154,6 @@ msgstr "Dossier responsible"
 #: ./opengever/activity/notification_settings.py
 msgid "external-activity"
 msgstr "External activities"
-
-#. German translation: Weiterleitung hinzugefügt
-#. Default: "Forwarding added"
-#: ./opengever/activity/__init__.py
-msgid "forwarding-added"
-msgstr "Forwarding added"
-
-#. German translation: Weiterleitung akzeptiert
-#. Default: "Forwarding accepted"
-#: ./opengever/activity/__init__.py
-msgid "forwarding-transition-accept"
-msgstr "Forwarding accepted"
-
-#. German translation: Weiterleitung einem Dossier zugewiesen
-#. Default: "Forwarding assigned to dossier"
-#: ./opengever/activity/__init__.py
-msgid "forwarding-transition-assign-to-dossier"
-msgstr "Forwarding assigned to dossier"
-
-#. German translation: Weiterleitung abgeschlossen
-#. Default: "Forwarding closed"
-#: ./opengever/activity/__init__.py
-msgid "forwarding-transition-close"
-msgstr "Forwarding closed"
-
-#. German translation: Weiterleitung neu zugewiesen
-#. Default: "Forwarding reassigned"
-#: ./opengever/activity/__init__.py
-msgid "forwarding-transition-reassign"
-msgstr "Forwarding reassigned"
-
-#. German translation: Weiterleitung neu zugewiesen und abgelehnt
-#. Default: "Forwarding reassigned and refused"
-#: ./opengever/activity/__init__.py
-msgid "forwarding-transition-reassign-refused"
-msgstr "Forwarding reassigned and refused"
-
-#. German translation: Weiterleitung abgelehnt
-#. Default: "Forwarding refused"
-#: ./opengever/activity/__init__.py
-msgid "forwarding-transition-refuse"
-msgstr "Forwarding refused"
-
-#. German translation: Als Beobachter hinzugefügt zu Weiterleitung
-#. Default: "Added as watcher to forwarding"
-#: ./opengever/activity/__init__.py
-msgid "forwarding-watcher-added"
-msgstr "Added as watcher to forwarding"
 
 #. German translation: Benachrichtigungen
 #. Default: "Notifications"
@@ -441,12 +381,6 @@ msgstr "GEVER Activity"
 msgid "submitted-proposal-commented"
 msgstr "Submitted proposal commented"
 
-#. German translation: Aufgabe hinzugefügt
-#. Default: "Task added"
-#: ./opengever/activity/__init__.py
-msgid "task-added"
-msgstr "Task added"
-
 #. German translation: Aufgabe erstellt / neu zugewiesen
 #. Default: "Task added / reassigned"
 #: ./opengever/activity/notification_settings.py
@@ -455,7 +389,6 @@ msgstr "Task added / reassigned"
 
 #. German translation: Aufgabe kommentiert
 #. Default: "Task commented"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "task-commented"
 msgstr "Task commented"
@@ -467,114 +400,11 @@ msgstr "Task commented"
 msgid "task-reminder"
 msgstr "Task reminder"
 
-#. German translation: Aufgabe wieder eröffnet
-#. Default: "Task reopened"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-cancelled-open"
-msgstr "Task reopened"
-
-#. German translation: Aufgabe delegiert
-#. Default: "Task delegated"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-delegate"
-msgstr "Task delegated"
-
-#. German translation: Aufgabe erledigt
-#. Default: "Task resolved"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-in-progress-resolved"
-msgstr "Task resolved"
-
-#. German translation: Aufgabe abgeschlossen
-#. Default: "Task closed"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-in-progress-tested-and-closed"
-msgstr "Task closed"
-
 #. German translation: Aufgaben-Frist verändert
 #. Default: "Task deadline modified"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "task-transition-modify-deadline"
 msgstr "Task deadline modified"
-
-#. German translation: Aufgaben abgebrochen
-#. Default: "Task cancelled"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-open-cancelled"
-msgstr "Task cancelled"
-
-#. German translation: Aufgabe akzeptiert
-#. Default: "Task accepted"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-open-in-progress"
-msgstr "Task accepted"
-
-#. German translation: Aufgabe abgelehnt
-#. Default: "Task rejected"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-open-rejected"
-msgstr "Task rejected"
-
-#. German translation: Aufgabe erledigt
-#. Default: "Task resolved"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-open-resolved"
-msgstr "Task resolved"
-
-#. German translation: Aufgabe abgeschlossen
-#. Default: "Task closed"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-open-tested-and-closed"
-msgstr "Task closed"
-
-#. German translation: Aufgabe übersprungen
-#. Default: "Task skipped"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-planned-skipped"
-msgstr "Task skipped"
-
-#. German translation: Aufgabe neu zugewiesen
-#. Default: "Task reassign"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-reassign"
-msgstr "Task reassigned"
-
-#. German translation: Aufgabe wieder eröffnet
-#. Default: "Task reopened"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-rejected-open"
-msgstr "Task reopened"
-
-#. German translation: Aufgabe übersprungen
-#. Default: "Task skipped"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-rejected-skipped"
-msgstr "Task skipped"
-
-#. German translation: Aufgaben-Überarbeitung gefordert
-#. Default: "Task revision wanted"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-resolved-in-progress"
-msgstr "Task revision requested"
-
-#. German translation: Aufgabe abgeschlossen
-#. Default: "Task closed"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-resolved-tested-and-closed"
-msgstr "Task closed"
-
-#. German translation: Aufgabe wieder eröffnet
-#. Default: "Task reopened"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-skipped-open"
-msgstr "Task reopened"
-
-#. German translation: Als Beobachter hinzugefügt zu Aufgabe
-#. Default: "Added as watcher to task"
-#: ./opengever/activity/__init__.py
-msgid "task-watcher-added"
-msgstr "Added as watcher to task"
 
 #. German translation: Auftraggeber
 #. Default: "Task issuer"
@@ -608,14 +438,12 @@ msgstr "Daily Digest for ${username}"
 
 #. German translation: ToDo zugewiesen
 #. Default: "ToDo assigned"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "todo-assigned"
 msgstr "ToDo assigned"
 
 #. German translation: ToDo modifiziert
 #. Default: "ToDo modified"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "todo-modified"
 msgstr "ToDo modified"
@@ -625,18 +453,6 @@ msgstr "ToDo modified"
 #: ./opengever/activity/roles.py
 msgid "todo_responsible_role"
 msgstr "ToDo responsible"
-
-#. German translation: Dokument hinzugefügt
-#. Default: "Document added"
-#: ./opengever/activity/__init__.py
-msgid "transition-add-document"
-msgstr "Document added"
-
-#. German translation: Unteraufgabe erstellt
-#. Default: "Subtask added"
-#: ./opengever/activity/__init__.py
-msgid "transition-add-subtask"
-msgstr "Subtask added"
 
 #. German translation: Teamraum Mitglied
 #. Default: "Workspace member"

--- a/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-12-08 16:03+0000\n"
+"POT-Creation-Date: 2022-10-07 09:20+0000\n"
 "PO-Revision-Date: 2017-12-03 16:14+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-activity/fr/>\n"
@@ -75,37 +75,31 @@ msgid "created"
 msgstr "Créé"
 
 #. Default: "Disposition added"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "disposition-added"
 msgstr "Offre ajoutée"
 
 #. Default: "Disposition appraised"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "disposition-transition-appraise"
 msgstr "Evaluation finalisée"
 
 #. Default: "Disposition archived"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "disposition-transition-archive"
 msgstr "Archivage confirmé"
 
 #. Default: "Disposition closed"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "disposition-transition-close"
 msgstr "Offre clôturée"
 
 #. Default: "Disposition disposed"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "disposition-transition-dispose"
 msgstr "Proposé pour archivage"
 
 #. Default: "Disposition refused"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "disposition-transition-refuse"
 msgstr "Offre refusée"
@@ -130,13 +124,7 @@ msgstr "Titre du document modifié"
 msgid "document-version-created"
 msgstr "Nouvelle version du document créée"
 
-#. Default: "Added as watcher to document"
-#: ./opengever/activity/__init__.py
-msgid "document-watcher-added"
-msgstr "Ajouté comme observateur à un document"
-
 #. Default: "Overdue dossier"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "dossier-overdue"
 msgstr "Dossier en souffrance"
@@ -150,46 +138,6 @@ msgstr "Responsable"
 #: ./opengever/activity/notification_settings.py
 msgid "external-activity"
 msgstr "Activités externes"
-
-#. Default: "Forwarding added"
-#: ./opengever/activity/__init__.py
-msgid "forwarding-added"
-msgstr "une transmission à été ajoutée"
-
-#. Default: "Forwarding accepted"
-#: ./opengever/activity/__init__.py
-msgid "forwarding-transition-accept"
-msgstr "transmission acceptée"
-
-#. Default: "Forwarding assigned to dossier"
-#: ./opengever/activity/__init__.py
-msgid "forwarding-transition-assign-to-dossier"
-msgstr "transmission assignée à un dossier"
-
-#. Default: "Forwarding closed"
-#: ./opengever/activity/__init__.py
-msgid "forwarding-transition-close"
-msgstr "transmission terminée"
-
-#. Default: "Forwarding reassigned"
-#: ./opengever/activity/__init__.py
-msgid "forwarding-transition-reassign"
-msgstr "transmission réassignée"
-
-#. Default: "Forwarding reassigned and refused"
-#: ./opengever/activity/__init__.py
-msgid "forwarding-transition-reassign-refused"
-msgstr "transmission réassignée et refusée"
-
-#. Default: "Forwarding refused"
-#: ./opengever/activity/__init__.py
-msgid "forwarding-transition-refuse"
-msgstr "transmission refusée"
-
-#. Default: "Added as watcher to forwarding"
-#: ./opengever/activity/__init__.py
-msgid "forwarding-watcher-added"
-msgstr "Ajouté comme observateur à une transmission"
 
 #. Default: "Notifications"
 #: ./opengever/activity/viewlets/notification.pt
@@ -380,18 +328,12 @@ msgstr "Activité GEVER"
 msgid "submitted-proposal-commented"
 msgstr "Requête soumise commentée"
 
-#. Default: "Task added"
-#: ./opengever/activity/__init__.py
-msgid "task-added"
-msgstr "tâche ajoutée"
-
 #. Default: "Task added / reassigned"
 #: ./opengever/activity/notification_settings.py
 msgid "task-added-or-reassigned"
 msgstr "Tâche créée / réassignée"
 
 #. Default: "Task commented"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "task-commented"
 msgstr "tâche commentée"
@@ -402,96 +344,10 @@ msgstr "tâche commentée"
 msgid "task-reminder"
 msgstr "Rappel tâche"
 
-#. Default: "Task reopened"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-cancelled-open"
-msgstr "tâche rouverte"
-
-#. Default: "Task delegated"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-delegate"
-msgstr "tâche déléguée"
-
-#. Default: "Task resolved"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-in-progress-resolved"
-msgstr "tâche accomplie"
-
-#. Default: "Task closed"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-in-progress-tested-and-closed"
-msgstr "tâche clôturée"
-
 #. Default: "Task deadline modified"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "task-transition-modify-deadline"
 msgstr "le délai attribué à la tâche a été modifié"
-
-#. Default: "Task cancelled"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-open-cancelled"
-msgstr "tâches annulées"
-
-#. Default: "Task accepted"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-open-in-progress"
-msgstr "tâche acceptée"
-
-#. Default: "Task rejected"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-open-rejected"
-msgstr "tâche refusée"
-
-#. Default: "Task resolved"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-open-resolved"
-msgstr "tâche accomplie"
-
-#. Default: "Task closed"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-open-tested-and-closed"
-msgstr "tâche clôturée"
-
-#. Default: "Task skipped"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-planned-skipped"
-msgstr "tâche omise"
-
-#. Default: "Task reassign"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-reassign"
-msgstr "tâche réassignée"
-
-#. Default: "Task reopened"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-rejected-open"
-msgstr "tâche rouverte"
-
-#. Default: "Task skipped"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-rejected-skipped"
-msgstr "tâche omise"
-
-#. Default: "Task revision wanted"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-resolved-in-progress"
-msgstr "révision de la tâche requise"
-
-#. Default: "Task closed"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-resolved-tested-and-closed"
-msgstr "tâche clôturée"
-
-#. Default: "Task reopened"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-skipped-open"
-msgstr "tâche rouverte"
-
-#. Default: "Added as watcher to task"
-#: ./opengever/activity/__init__.py
-msgid "task-watcher-added"
-msgstr "Ajouté comme observateur à une tâche"
 
 #. Default: "Task issuer"
 #: ./opengever/activity/roles.py
@@ -519,13 +375,11 @@ msgid "title_daily_digest"
 msgstr "Résumé quotidien pour ${username}"
 
 #. Default: "ToDo assigned"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "todo-assigned"
 msgstr "ToDo assigné"
 
 #. Default: "ToDo modified"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "todo-modified"
 msgstr "ToDo Modifié"
@@ -534,16 +388,6 @@ msgstr "ToDo Modifié"
 #: ./opengever/activity/roles.py
 msgid "todo_responsible_role"
 msgstr "Responsable d'un ToDo"
-
-#. Default: "Document added"
-#: ./opengever/activity/__init__.py
-msgid "transition-add-document"
-msgstr "Document ajouté"
-
-#. Default: "Subtask added"
-#: ./opengever/activity/__init__.py
-msgid "transition-add-subtask"
-msgstr "Sous-tâche ajoutée"
 
 #. Default: "Workspace member"
 #: ./opengever/activity/roles.py

--- a/opengever/activity/locales/opengever.activity.pot
+++ b/opengever/activity/locales/opengever.activity.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-12-08 16:03+0000\n"
+"POT-Creation-Date: 2022-10-07 09:20+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -73,37 +73,31 @@ msgid "created"
 msgstr ""
 
 #. Default: "Disposition added"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "disposition-added"
 msgstr ""
 
 #. Default: "Disposition appraised"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "disposition-transition-appraise"
 msgstr ""
 
 #. Default: "Disposition archived"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "disposition-transition-archive"
 msgstr ""
 
 #. Default: "Disposition closed"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "disposition-transition-close"
 msgstr ""
 
 #. Default: "Disposition disposed"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "disposition-transition-dispose"
 msgstr ""
 
 #. Default: "Disposition refused"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "disposition-transition-refuse"
 msgstr ""
@@ -128,13 +122,7 @@ msgstr ""
 msgid "document-version-created"
 msgstr ""
 
-#. Default: "Added as watcher to document"
-#: ./opengever/activity/__init__.py
-msgid "document-watcher-added"
-msgstr ""
-
 #. Default: "Overdue dossier"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "dossier-overdue"
 msgstr ""
@@ -144,49 +132,9 @@ msgstr ""
 msgid "dossier_responsible_role"
 msgstr ""
 
-#. Default: "External activity"
+#. Default: "External activities"
 #: ./opengever/activity/notification_settings.py
 msgid "external-activity"
-msgstr ""
-
-#. Default: "Forwarding added"
-#: ./opengever/activity/__init__.py
-msgid "forwarding-added"
-msgstr ""
-
-#. Default: "Forwarding accepted"
-#: ./opengever/activity/__init__.py
-msgid "forwarding-transition-accept"
-msgstr ""
-
-#. Default: "Forwarding assigned to dossier"
-#: ./opengever/activity/__init__.py
-msgid "forwarding-transition-assign-to-dossier"
-msgstr ""
-
-#. Default: "Forwarding closed"
-#: ./opengever/activity/__init__.py
-msgid "forwarding-transition-close"
-msgstr ""
-
-#. Default: "Forwarding reassigned"
-#: ./opengever/activity/__init__.py
-msgid "forwarding-transition-reassign"
-msgstr ""
-
-#. Default: "Forwarding reassigned and refused"
-#: ./opengever/activity/__init__.py
-msgid "forwarding-transition-reassign-refused"
-msgstr ""
-
-#. Default: "Forwarding refused"
-#: ./opengever/activity/__init__.py
-msgid "forwarding-transition-refuse"
-msgstr ""
-
-#. Default: "Added as watcher to forwarding"
-#: ./opengever/activity/__init__.py
-msgid "forwarding-watcher-added"
 msgstr ""
 
 #. Default: "Notifications"
@@ -378,18 +326,12 @@ msgstr ""
 msgid "submitted-proposal-commented"
 msgstr ""
 
-#. Default: "Task added"
-#: ./opengever/activity/__init__.py
-msgid "task-added"
-msgstr ""
-
 #. Default: "Task added / reassigned"
 #: ./opengever/activity/notification_settings.py
 msgid "task-added-or-reassigned"
 msgstr ""
 
 #. Default: "Task commented"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "task-commented"
 msgstr ""
@@ -400,95 +342,9 @@ msgstr ""
 msgid "task-reminder"
 msgstr ""
 
-#. Default: "Task reopened"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-cancelled-open"
-msgstr ""
-
-#. Default: "Task delegated"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-delegate"
-msgstr ""
-
-#. Default: "Task resolved"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-in-progress-resolved"
-msgstr ""
-
-#. Default: "Task closed"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-in-progress-tested-and-closed"
-msgstr ""
-
 #. Default: "Task deadline modified"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "task-transition-modify-deadline"
-msgstr ""
-
-#. Default: "Task cancelled"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-open-cancelled"
-msgstr ""
-
-#. Default: "Task accepted"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-open-in-progress"
-msgstr ""
-
-#. Default: "Task rejected"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-open-rejected"
-msgstr ""
-
-#. Default: "Task resolved"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-open-resolved"
-msgstr ""
-
-#. Default: "Task closed"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-open-tested-and-closed"
-msgstr ""
-
-#. Default: "Task skipped"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-planned-skipped"
-msgstr ""
-
-#. Default: "Task reassign"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-reassign"
-msgstr ""
-
-#. Default: "Task reopened"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-rejected-open"
-msgstr ""
-
-#. Default: "Task skipped"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-rejected-skipped"
-msgstr ""
-
-#. Default: "Task revision wanted"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-resolved-in-progress"
-msgstr ""
-
-#. Default: "Task closed"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-resolved-tested-and-closed"
-msgstr ""
-
-#. Default: "Task reopened"
-#: ./opengever/activity/__init__.py
-msgid "task-transition-skipped-open"
-msgstr ""
-
-#. Default: "Added as watcher to task"
-#: ./opengever/activity/__init__.py
-msgid "task-watcher-added"
 msgstr ""
 
 #. Default: "Task issuer"
@@ -517,13 +373,11 @@ msgid "title_daily_digest"
 msgstr ""
 
 #. Default: "ToDo assigned"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "todo-assigned"
 msgstr ""
 
 #. Default: "ToDo modified"
-#: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "todo-modified"
 msgstr ""
@@ -531,16 +385,6 @@ msgstr ""
 #. Default: "ToDo responsible"
 #: ./opengever/activity/roles.py
 msgid "todo_responsible_role"
-msgstr ""
-
-#. Default: "Document added"
-#: ./opengever/activity/__init__.py
-msgid "transition-add-document"
-msgstr ""
-
-#. Default: "Subtask added"
-#: ./opengever/activity/__init__.py
-msgid "transition-add-subtask"
 msgstr ""
 
 #. Default: "Workspace member"


### PR DESCRIPTION
It seems that when we modified the activity settings we stopped using the `ACTIVITY_TRANSLATIONS` in the `NotificationSettingsView` (see https://github.com/4teamwork/opengever.core/pull/6397), but did not remove the translations that were not used anymore.

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-4663]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-4663]: https://4teamwork.atlassian.net/browse/CA-4663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ