### PR TITLE
Defer TUS lock test by another month.

### DIFF
--- a/opengever/api/tests/test_tus.py
+++ b/opengever/api/tests/test_tus.py
@@ -169,7 +169,7 @@ class TestTUSUpload(IntegrationTestCase):
         self.assert_tus_replace_fails(self.document, browser)
 
     @skipIf(
-        datetime.now() < datetime(2022, 10, 11),
+        datetime.now() < datetime(2022, 11, 11),
         "Lock verification temporary disabled, because it's not yet supported "
         "by Office Connector",
     )


### PR DESCRIPTION
Well tests are failing currently for all PRs and master because of this one.