### PR TITLE
No longer cache kub label mapping for an hour, use If-Modified-Since header instead

### DIFF
--- a/changes/CA-4802.other
+++ b/changes/CA-4802.other
@@ -1,0 +1,1 @@
+No longer cache kub label mapping for an hour, use If-Modified-Since header instead. [tinagerber]

--- a/opengever/kub/tests/test_kub_client.py
+++ b/opengever/kub/tests/test_kub_client.py
@@ -1,6 +1,9 @@
+from datetime import datetime
+from ftw.testing import freeze
 from opengever.kub.testing import KUB_RESPONSES
 from opengever.kub.testing import KuBIntegrationTestCase
 import json
+import pytz
 import requests_mock
 
 
@@ -53,3 +56,39 @@ class TestKubClient(KuBIntegrationTestCase):
         resp = self.client.get_by_id(self.memb_jean_ftw)
         self.assertEqual("membership", resp["type"])
         self.assertEqual(KUB_RESPONSES[url], resp)
+
+    def test_get_kub_id_label_mapping_uses_if_modified_since_header(self, mocker):
+        labels = {'label_1': ' Maria Meier', 'label2': 'Donald Duck'}
+        self.client._storage[self.client.STORAGE_MODIFIED_KEY] = 'Tue, 12 Oct 2021 13:37:00 GMT'
+        self.client._storage[self.client.STORAGE_LABEL_MAPPING_KEY] = labels
+
+        url = u'{}labels'.format(self.client.kub_api_url)
+        mocker.get(url, status_code=304)
+        self.assertEqual(labels, self.client.get_kub_id_label_mapping())
+        self.assertEqual('Tue, 12 Oct 2021 13:37:00 GMT',
+                         self.client._storage[self.client.STORAGE_MODIFIED_KEY])
+
+        self.mock_labels(mocker)
+
+        expected_labels = {
+            u'person:9af7d7cc-b948-423f-979f-587158c6bc65': u'Dupont Jean',
+            u'person:0e623708-2d0d-436a-82c6-c1a9c27b65dc': u'Dupont Julie',
+            u'person:5db3e407-7fc3-4093-a6cf-96030044285a': u'Schaudi Julia',
+            u'membership:8345fcfe-2d67-4b75-af46-c25b2f387448': u'Dupont Jean - 4Teamwork (CEO)',
+            u'person:1193d423-ce13-4dd9-aa8d-1f224f6a2b96': u'Peter Hans',
+            u'organization:30bab83d-300a-4886-97d4-ff592e88a56a': u'4Teamwork'}
+
+        with freeze(datetime(2021, 10, 16, 12, 0, tzinfo=pytz.timezone('Europe/Zurich'))):
+            self.assertEqual(expected_labels, self.client.get_kub_id_label_mapping())
+            self.assertEqual('Tue, 12 Oct 2021 13:37:00 GMT',
+                             mocker.last_request._request.headers['If-Modified-Since'])
+            self.assertEqual('Sat, 16 Oct 2021 10:00:00 GMT',
+                             self.client._storage[self.client.STORAGE_MODIFIED_KEY])
+
+        with freeze(datetime(2021, 10, 19, 11, 35, tzinfo=pytz.timezone('Europe/Zurich'))):
+            mocker.get(url, status_code=304)
+            self.assertEqual(expected_labels, self.client.get_kub_id_label_mapping())
+            self.assertEqual('Sat, 16 Oct 2021 10:00:00 GMT',
+                             mocker.last_request._request.headers['If-Modified-Since'])
+            self.assertEqual('Sat, 16 Oct 2021 10:00:00 GMT',
+                             self.client._storage[self.client.STORAGE_MODIFIED_KEY])


### PR DESCRIPTION
With the `If-Modified-Since` header the labels are only returned if something has changed since the given date, otherwise a response with status code 304 is returned.
Since, if there have been no changes, the request is very fast, we therefore no longer have to cache the labels for an hour. Since with some requests (`@actors`endpoint) the label mapping is queried several times, I still cache the mapping for 5 seconds so that KuB is requested only once.

For [CA-4802]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-4802]: https://4teamwork.atlassian.net/browse/CA-4802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ