### PR TITLE
Update changed field and mark document as recently touched when copying documents as new version from workspace

### DIFF
--- a/changes/CA-4772.bugfix
+++ b/changes/CA-4772.bugfix
@@ -1,0 +1,1 @@
+Update changed field and ark document as recently touched when copying documents as new version from workspace. [tinagerber]

--- a/opengever/document/events.py
+++ b/opengever/document/events.py
@@ -30,9 +30,10 @@ class ObjectCheckedInEvent(ObjectEvent):
     was checked in.
     """
 
-    def __init__(self, obj, comment):
+    def __init__(self, obj, comment, suppress_journal_entry_creation=False):
         self.object = obj
         self.comment = comment
+        self.suppress_journal_entry_creation = suppress_journal_entry_creation
 
 
 @implementer(interfaces.IObjectCheckoutCanceledEvent)

--- a/opengever/journal/handlers.py
+++ b/opengever/journal/handlers.py
@@ -378,6 +378,8 @@ DOCUMENT_CHECKED_IN = 'Document checked in'
 
 
 def document_checked_in(context, event):
+    if event.suppress_journal_entry_creation:
+        return
     user_comment = event.comment
     title = _(u'label_document_checkin',
               default=u'Document checked in', )

--- a/opengever/workspaceclient/linked_workspaces.py
+++ b/opengever/workspaceclient/linked_workspaces.py
@@ -3,6 +3,7 @@ from opengever.api.add import GeverFolderPost
 from opengever.api.not_reported_exceptions import BadRequest as NotReportedBadRequest
 from opengever.base.oguid import Oguid
 from opengever.base.sentry import maybe_report_exception
+from opengever.document.events import ObjectCheckedInEvent
 from opengever.document.versioner import Versioner
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.utils import get_main_dossier
@@ -28,6 +29,7 @@ from time import time
 from zExceptions import BadRequest
 from zope.component import adapter
 from zope.component import getMultiAdapter
+from zope.event import notify
 from zope.globalrequest import getRequest
 from zope.i18n import translate
 from zope.interface import alsoProvides
@@ -407,6 +409,7 @@ class LinkedWorkspaces(object):
                         u'document from teamraum.')
         )
 
+        notify(ObjectCheckedInEvent(gever_doc, '', suppress_journal_entry_creation=True))
         ILockable(gever_doc).unlock(COPIED_TO_WORKSPACE_LOCK)
         return gever_doc
 

--- a/opengever/workspaceclient/linked_workspaces.py
+++ b/opengever/workspaceclient/linked_workspaces.py
@@ -1,6 +1,7 @@
 from AccessControl.unauthorized import Unauthorized
 from opengever.api.add import GeverFolderPost
 from opengever.api.not_reported_exceptions import BadRequest as NotReportedBadRequest
+from opengever.base.handlers import ObjectTouchedEvent
 from opengever.base.oguid import Oguid
 from opengever.base.sentry import maybe_report_exception
 from opengever.document.events import ObjectCheckedInEvent
@@ -410,6 +411,7 @@ class LinkedWorkspaces(object):
         )
 
         notify(ObjectCheckedInEvent(gever_doc, '', suppress_journal_entry_creation=True))
+        notify(ObjectTouchedEvent(gever_doc))
         ILockable(gever_doc).unlock(COPIED_TO_WORKSPACE_LOCK)
         return gever_doc
 

--- a/opengever/workspaceclient/tests/test_linked_workspaces.py
+++ b/opengever/workspaceclient/tests/test_linked_workspaces.py
@@ -1,7 +1,10 @@
 from contextlib import contextmanager
+from datetime import datetime
 from ftw.builder import Builder
 from ftw.builder import create
+from ftw.testing import freeze
 from mock import patch
+from opengever.base.behaviors.changed import IChanged
 from opengever.base.command import CreateEmailCommand
 from opengever.base.oguid import Oguid
 from opengever.document.behaviors.related_docs import IRelatedDocuments
@@ -20,9 +23,11 @@ from opengever.workspaceclient.tests import FunctionalWorkspaceClientTestCase
 from plone import api
 from plone.locking.interfaces import ILockable
 from plone.uuid.interfaces import IUUID
+from tzlocal import get_localzone
 from zExceptions import BadRequest
 from zope.component import getMultiAdapter
 from zope.interface import alsoProvides
+import pytz
 import transaction
 
 
@@ -562,12 +567,13 @@ class TestLinkedWorkspaces(FunctionalWorkspaceClientTestCase):
         with self.workspace_client_env():
             manager = ILinkedWorkspaces(self.dossier)
             manager.storage.add(self.workspace.UID())
-
+            freeze_time = datetime(2018, 4, 30, 7, 30, tzinfo=pytz.UTC)
             with self.observe_children(self.dossier) as children:
                 with auto_commit_after_request(manager.client):
-                    dst_doc, retrieval_mode = manager.copy_document_from_workspace(
-                        self.workspace.UID(), workspace_doc.UID(),
-                        as_new_version=True)
+                    with freeze(freeze_time):
+                        dst_doc, retrieval_mode = manager.copy_document_from_workspace(
+                            self.workspace.UID(), workspace_doc.UID(),
+                            as_new_version=True)
 
             self.assertEqual(0, len(children['added']))
             self.assertEqual(gever_doc, dst_doc)
@@ -605,6 +611,7 @@ class TestLinkedWorkspaces(FunctionalWorkspaceClientTestCase):
                 action_type='Document retrieved from teamraum',
                 title=u'Document Testdokum\xe4nt copied back from workspace.',
             )
+            self.assertEqual(freeze_time, IChanged(gever_doc).changed)
 
     def test_copy_document_from_a_workspace_and_trash_tr_document(self):
         document = create(Builder('document')

--- a/opengever/workspaceclient/tests/test_linked_workspaces.py
+++ b/opengever/workspaceclient/tests/test_linked_workspaces.py
@@ -7,6 +7,7 @@ from mock import patch
 from opengever.base.behaviors.changed import IChanged
 from opengever.base.command import CreateEmailCommand
 from opengever.base.oguid import Oguid
+from opengever.base.touched import RECENTLY_TOUCHED_KEY
 from opengever.document.behaviors.related_docs import IRelatedDocuments
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.document.versioner import Versioner
@@ -25,6 +26,7 @@ from plone.locking.interfaces import ILockable
 from plone.uuid.interfaces import IUUID
 from tzlocal import get_localzone
 from zExceptions import BadRequest
+from zope.annotation import IAnnotations
 from zope.component import getMultiAdapter
 from zope.interface import alsoProvides
 import pytz
@@ -612,6 +614,11 @@ class TestLinkedWorkspaces(FunctionalWorkspaceClientTestCase):
                 title=u'Document Testdokum\xe4nt copied back from workspace.',
             )
             self.assertEqual(freeze_time, IChanged(gever_doc).changed)
+            local_freeze_time = freeze_time.astimezone(get_localzone())
+            last_entry = IAnnotations(self.portal)[RECENTLY_TOUCHED_KEY]['test_user_1_'][-1]
+            self.assertEqual(
+                {'last_touched': local_freeze_time, 'uid': IUUID(gever_doc)},
+                last_entry)
 
     def test_copy_document_from_a_workspace_and_trash_tr_document(self):
         document = create(Builder('document')


### PR DESCRIPTION
When copying documents as a new version from the workspace, no events were fired. Therefore, among other things, the "changed" field was not updated

For [CA-4772]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-4772]: https://4teamwork.atlassian.net/browse/CA-4772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ