### PR TITLE
No longer escape custom_invitation_mail_content in teamraum invitation mail

### DIFF
--- a/changes/CA-4897.other
+++ b/changes/CA-4897.other
@@ -1,0 +1,1 @@
+No longer escape custom_invitation_mail_content in teamraum invitation mail. [tinagerber]

--- a/opengever/workspace/participation/templates/invitation_mail.pt
+++ b/opengever/workspace/participation/templates/invitation_mail.pt
@@ -22,7 +22,7 @@
         <p>
           <tal:summary tal:repeat="line options/custom_mail_content">
             <tal:last tal:define="is_last repeat/line/end">
-              <tal:line tal:replace="line" /><br tal:condition="not: is_last" />
+              <p tal:replace="structure line" /><br tal:condition="not: is_last" />
             </tal:last>
           </tal:summary>
         </p>


### PR DESCRIPTION
In some email clients, e.g. office365 online, the links are not displayed as links if the a tag is not used. Therefore, it must be possible to use the a tag in custom_invitation_mail_content.

For [CA-4897]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-4897]: https://4teamwork.atlassian.net/browse/CA-4897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ