### PR TITLE
OfficeConnector cancel checkout

### DIFF
--- a/changes/CA-3864.other
+++ b/changes/CA-3864.other
@@ -1,0 +1,1 @@
+Add support for canceling checkout with Office Connector. [buchi]

--- a/opengever/document/configure.zcml
+++ b/opengever/document/configure.zcml
@@ -241,6 +241,12 @@
 
   <subscriber
       for="opengever.document.document.IDocumentSchema
+           zope.lifecycleevent.interfaces.IObjectModifiedEvent"
+      handler=".handlers.mark_pending_changes"
+      />
+
+  <subscriber
+      for="opengever.document.document.IDocumentSchema
            opengever.document.interfaces.IObjectRevertedToVersion"
       handler=".handlers.document_reverted_to_version"
       />
@@ -249,6 +255,18 @@
       for="opengever.document.document.IDocumentSchema
            opengever.document.interfaces.IObjectCheckedInEvent"
       handler=".handlers.document_version_created"
+      />
+
+  <subscriber
+      for="opengever.document.document.IDocumentSchema
+           opengever.document.interfaces.IObjectCheckedInEvent"
+      handler=".handlers.unmark_pending_changes"
+      />
+
+  <subscriber
+      for="opengever.document.document.IDocumentSchema
+           opengever.document.interfaces.IObjectCheckoutCanceledEvent"
+      handler=".handlers.unmark_pending_changes"
       />
 
   <adapter

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -59,8 +59,8 @@ import os.path
 
 
 DOCUMENT_FINALIZER_KEY = 'opengever.document.finalizer'
-
 DOCUMENT_STATE_FINAL = 'document-state-final'
+DOCUMENT_HAS_PENDING_CHANGES = '_document_has_pending_changes'
 
 LOG = logging.getLogger('opengever.document')
 MAIL_EXTENSIONS = ['.eml', '.msg', '.p7m']
@@ -520,6 +520,16 @@ class Document(Item, BaseDocumentMixin):
         if self.has_file():
             return self.file._p_mtime
         return None
+
+    @property
+    def has_pending_changes(self):
+        """True if the document has changes that haven't been checked-in yet.
+        """
+        return IAnnotations(self).get(DOCUMENT_HAS_PENDING_CHANGES, False)
+
+    @has_pending_changes.setter
+    def has_pending_changes(self, value):
+        IAnnotations(self)[DOCUMENT_HAS_PENDING_CHANGES] = value
 
     def get_download_view_name(self):
         return 'download'

--- a/opengever/document/handlers.py
+++ b/opengever/document/handlers.py
@@ -160,3 +160,17 @@ def author_or_title_changed(context, event):
         DocumentTitleChangedActivity(context, getRequest()).record()
     if author_changed:
         DocumentAuthorChangedActivity(context, getRequest()).record()
+
+
+def mark_pending_changes(context, event):
+    if context.REQUEST.method == 'PUT':
+        context.has_pending_changes = True
+    else:
+        for desc in event.descriptions:
+            if 'IDocumentSchema.file' in desc.attributes or 'file' in desc.attributes:
+                context.has_pending_changes = True
+                return
+
+
+def unmark_pending_changes(context, event):
+    context.has_pending_changes = False

--- a/opengever/officeconnector/service.py
+++ b/opengever/officeconnector/service.py
@@ -263,6 +263,8 @@ class OfficeConnectorCheckoutPayload(OfficeConnectorPayload):
                 payload['upload'] = '@tus-replace'
                 payload['checkin'] = '@checkin'
                 payload['unlock'] = '@unlock'
+                payload['cancelcheckout'] = '@cancelcheckout'
+                payload['has_pending_changes'] = document.has_pending_changes
 
             else:
                 # Fail per default

--- a/opengever/officeconnector/tests/test_api_dossier_checkout.py
+++ b/opengever/officeconnector/tests/test_api_dossier_checkout.py
@@ -183,12 +183,14 @@ class TestOfficeconnectorDossierAPIWithCheckout(OCSolrIntegrationTestCase):
 
         expected_payloads = [{
             u'status': u'status',
+            u'cancelcheckout': u'@cancelcheckout',
             u'checkin': u'@checkin',
             u'checkout': u'@checkout',
             u'content-type': u'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
             u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-14',
             u'download': u'download',
             u'filename': u'Vertraegsentwurf.docx',
+            u'has_pending_changes': False,
             u'lock': u'@lock',
             u'unlock': u'@unlock',
             u'upload': u'@tus-replace',
@@ -249,12 +251,14 @@ class TestOfficeconnectorDossierAPIWithCheckout(OCSolrIntegrationTestCase):
 
         expected_payloads = [{
             u'status': u'status',
+            u'cancelcheckout': u'@cancelcheckout',
             u'checkin': u'@checkin',
             u'checkout': u'@checkout',
             u'content-type': u'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
             u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-14',
             u'download': u'download',
             u'filename': u'Vertraegsentwurf.docx',
+            u'has_pending_changes': False,
             u'lock': u'@lock',
             u'unlock': u'@unlock',
             u'upload': u'@tus-replace',

--- a/opengever/officeconnector/tests/test_api_dossier_oneoffixx.py
+++ b/opengever/officeconnector/tests/test_api_dossier_oneoffixx.py
@@ -86,12 +86,14 @@ class TestOfficeconnectorDossierAPIWithOneOffixx(OCSolrIntegrationTestCase):
 
         expected_payloads = [{
             u'status': u'status',
+            u'cancelcheckout': u'@cancelcheckout',
             u'checkin': u'@checkin',
             u'checkout': u'@checkout',
             u'content-type': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
             u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-41',
             u'download': u'download',
             u'filename': None,
+            u'has_pending_changes': False,
             u'lock': u'@lock',
             u'unlock': u'@unlock',
             u'upload': u'@tus-replace',

--- a/opengever/officeconnector/tests/test_api_task_checkout.py
+++ b/opengever/officeconnector/tests/test_api_task_checkout.py
@@ -56,12 +56,14 @@ class TestOfficeconnectorTaskAPIWithCheckoutWithRESTAPI(OCSolrIntegrationTestCas
 
         expected_payloads = [{
             u'status': u'status',
+            u'cancelcheckout': u'@cancelcheckout',
             u'checkin': u'@checkin',
             u'checkout': u'@checkout',
             u'content-type': u'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
             u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-14',
             u'download': u'download',
             u'filename': u'Vertraegsentwurf.docx',
+            u'has_pending_changes': False,
             u'lock': u'@lock',
             u'unlock': u'@unlock',
             u'upload': u'@tus-replace',

--- a/opengever/officeconnector/tests/test_zopemaster.py
+++ b/opengever/officeconnector/tests/test_zopemaster.py
@@ -82,12 +82,14 @@ class TestOfficeconnectorAsZopemasterDossierAPIWithCheckout(OCSolrIntegrationTes
 
         expected_payloads = [{
             u'status': u'status',
+            u'cancelcheckout': u'@cancelcheckout',
             u'checkin': u'@checkin',
             u'checkout': u'@checkout',
             u'content-type': u'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
             u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-14',
             u'download': u'download',
             u'filename': u'Vertraegsentwurf.docx',
+            u'has_pending_changes': False,
             u'lock': u'@lock',
             u'unlock': u'@unlock',
             u'upload': u'@tus-replace',


### PR DESCRIPTION
Track if a document has pending changes and include this info in the checkout metadata for Office Connector.

We want to know if a document was modified since the last checkout and if there are changes that haven't been checked in yet. Unfortunately we can not determine this directly as Word documents are always modified on checkout and checkin because of DocProperties updates. Even if this is not the case, it's hard to determine if a document was really modified. We would have to diff the file contents of the current working copy with the last version. Therefore we add a marker when a new document version gets uploaded.

Requires a new Office Connector version (>1.16.0) to get the feature working, but older versions still work as before.
See: https://github.com/4teamwork/OfficeConnector/pull/392

For [CA-3864](https://4teamwork.atlassian.net/browse/CA-3864)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


