### PR TITLE
Add template_folder_url to the @config endpoint

### DIFF
--- a/changes/CA-3220.other
+++ b/changes/CA-3220.other
@@ -1,0 +1,1 @@
+Add template_folder_url to the @config endpoint. [elioschmutz]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,7 +11,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
-
+- ``@config``: Add ``template_folder_url`` key to expose the path to the template_folder.
 
 2022.19.0 (2022-09-28)
 ----------------------

--- a/docs/public/dev-manual/api/config.rst
+++ b/docs/public/dev-manual/api/config.rst
@@ -125,6 +125,7 @@ GEVER-Mandanten abgefragt werden.
               "black_list_prefix": "^$",
               "white_list_prefix": "^.+"
           },
+          "template_folder_url": "http://localhost:8080/fd/vorlagen",
           "user_settings": {
               "notify_inbox_actions": true,
               "notify_own_actions": false,

--- a/opengever/api/config.py
+++ b/opengever/api/config.py
@@ -2,6 +2,7 @@ from ftw.bumblebee.config import bumblebee_config
 from opengever.base import utils
 from opengever.base.colorization import get_color
 from opengever.base.interfaces import IGeverSettings
+from opengever.dossier.templatefolder import get_template_folder
 from opengever.inbox.utils import get_current_inbox
 from opengever.officeconnector.helpers import is_client_ip_in_office_connector_disallowed_ip_ranges
 from opengever.ogds.base.utils import get_current_admin_unit
@@ -47,6 +48,9 @@ class ConfigGet(Service):
 
         plone_inbox = get_current_inbox(self.context)
         config['inbox_folder_url'] = plone_inbox.absolute_url() if plone_inbox else ''
+
+        template_folder = get_template_folder()
+        config['template_folder_url'] = template_folder.absolute_url() if template_folder else ''
 
         ogds_inbox = get_current_org_unit().inbox()
         current_user = ogds_service().fetch_current_user()

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -301,6 +301,16 @@ class TestConfig(IntegrationTestCase):
         )
 
     @browsing
+    def test_config_contains_url_to_template_folder(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.config_url, headers=self.api_headers)
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual(
+            u'http://nohost/plone/vorlagen',
+            browser.json.get(u'template_folder_url')
+        )
+
+    @browsing
     def test_config_contains_current_inbox_url_if_available(self, browser):
         self.login(self.secretariat_user, browser)
 


### PR DESCRIPTION
This PR extends the `@config` endpoint with the `template_folder_url` property.

We need this property to exclude template folder contents from the search.

For [CA-3220]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-3220]: https://4teamwork.atlassian.net/browse/CA-3220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ