### PR TITLE
Allow to exclude paths by url in solrsearch

### DIFF
--- a/changes/CA-3220-2.other
+++ b/changes/CA-3220-2.other
@@ -1,0 +1,1 @@
+@solrsearch provieds filters for -@id_parent and -url_parent to exclude path parents. [elioschmutz]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,6 +11,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- ``@solrsearch``: The results can now be filtered by ``-@id_parent`` or ``-url_parent``.
 - ``@config``: Add ``template_folder_url`` key to expose the path to the template_folder.
 
 2022.19.0 (2022-09-28)

--- a/docs/public/dev-manual/api/searching.rst
+++ b/docs/public/dev-manual/api/searching.rst
@@ -161,6 +161,12 @@ Gibt alle Inhalte zurück die unterhalb des angegebenen Parents liegen und das p
   GET /plone/@solrsearch?fq:list=url_parent:http://example.com/dossier-1&fq:list=@id_parent:http://example.com/dossier-2 HTTP/1.1
 
 
+Gibt alle Inhalte zurück die **nicht** unterhalb des angegebenen Parents liegen:
+
+.. sourcecode:: http
+
+  GET /plone/@solrsearch?fq:list=-url_parent:http://example.com/dossier-1&fq:list=-@id_parent:http://example.com/dossier-2 HTTP/1.1
+
 
 Fields
 ~~~~~~

--- a/opengever/api/solrsearch.py
+++ b/opengever/api/solrsearch.py
@@ -123,6 +123,7 @@ class SolrSearchGet(SolrQueryBaseService):
 
     def add_url_path_parent_filters(self, filters):
         self.add_url_filters(filters, ['@id_parent:', 'url_parent:'], 'path_parent')
+        self.add_url_filters(filters, ['-@id_parent:', '-url_parent:'], '-path_parent')
 
     def add_url_filters(self, filters, query_prefix, filter_name,):
         """Beside the 'path' filter, we provide an 'url' (alias '@id')

--- a/opengever/api/tests/test_solrsearch.py
+++ b/opengever/api/tests/test_solrsearch.py
@@ -1030,6 +1030,40 @@ class TestSolrSearchGet(SolrIntegrationTestCase):
             ],
             [item['@id'] for item in browser.json['items']])
 
+    @browsing
+    def test_fq_with_excluded_url_parents(self, browser):
+        self.login(self.administrator, browser=browser)
+        ids_filter = 'fq=id:(dossiertemplate-1 OR document-12 OR document-24)'
+
+        url = u'{}/@solrsearch?{}'.format(
+            self.portal.absolute_url(),
+            '&'.join([ids_filter]))
+
+        browser.open(url, method='GET', headers=self.api_headers)
+
+        self.assertItemsEqual(
+            [
+                u'http://nohost/plone/vorlagen/dossiertemplate-1',
+                u'http://nohost/plone/eingangskorb/eingangskorb_fa/document-12',
+                u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/dossier-2/document-24',
+            ],
+            [item['@id'] for item in browser.json['items']])
+
+        url = u'{}/@solrsearch?{}'.format(
+            self.portal.absolute_url(),
+            '&'.join([
+                ids_filter,
+                'fq:list=-@id_parent:{}'.format(self.templates.absolute_url()),
+                'fq:list=-url_parent:{}'.format(self.inbox.absolute_url())
+            ]))
+
+        browser.open(url, method='GET', headers=self.api_headers)
+        self.assertItemsEqual(
+            [
+                u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/dossier-2/document-24',
+            ],
+            [item['@id'] for item in browser.json['items']])
+
 
 class TestSolrSearchPost(SolrIntegrationTestCase):
     """The POST endpoint should behave exactly the same as the GET endpoint. We do not


### PR DESCRIPTION
This PR extends the `@solrsearch` endpoint with the possiblity to exclude path-parents by url.

We need this to exclude the template folder area from search queries in the frontend.

For [CA-3220]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-3220]: https://4teamwork.atlassian.net/browse/CA-3220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ