### PR TITLE
Add backend support to copy subdossiers to teamraum

### DIFF
--- a/bin/mtest
+++ b/bin/mtest
@@ -33,8 +33,8 @@ import sys
 
 
 EXCLUDED_LAYERS = [
-    'opengever.core.testing.opengever.core:integration:solr',
-    'opengever.core.testing.opengever.core:functional:solr',
+    'opengever.core.testing.opengever.core:solr-integration',
+    'opengever.core.testing.opengever.core:solr-functional',
 ]
 
 

--- a/bin/mtest
+++ b/bin/mtest
@@ -35,6 +35,7 @@ import sys
 EXCLUDED_LAYERS = [
     'opengever.core.testing.opengever.core:solr-integration',
     'opengever.core.testing.opengever.core:solr-functional',
+    'opengever.core.testing.opengever.core:solr-zserver',
 ]
 
 

--- a/changes/CA-4726-1.other
+++ b/changes/CA-4726-1.other
@@ -1,0 +1,1 @@
+@copy-document-to-workspace: Also allow copying documents to workspace folders.

--- a/changes/CA-4726.other
+++ b/changes/CA-4726.other
@@ -1,0 +1,1 @@
+Add `@prepare-copy-dossier-to-workspace` endpoint to prepare copying a subdossier to a workspace.

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -13,6 +13,8 @@ Other Changes
 ^^^^^^^^^^^^^
 - ``@solrsearch``: The results can now be filtered by ``-@id_parent`` or ``-url_parent``.
 - ``@config``: Add ``template_folder_url`` key to expose the path to the template_folder.
+- ``@upload-document-copy``: Is now available on workspace folders as well.
+- ``@copy-document-to-workspace``: Also allow copying documents to workspace folders
 - ``@prepare-copy-dossier-to-workspace``: New endpoint to prepare copying a subdossier to a workspace.
 
 2022.19.0 (2022-09-28)

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -13,6 +13,7 @@ Other Changes
 ^^^^^^^^^^^^^
 - ``@solrsearch``: The results can now be filtered by ``-@id_parent`` or ``-url_parent``.
 - ``@config``: Add ``template_folder_url`` key to expose the path to the template_folder.
+- ``@prepare-copy-dossier-to-workspace``: New endpoint to prepare copying a subdossier to a workspace.
 
 2022.19.0 (2022-09-28)
 ----------------------

--- a/docs/public/dev-manual/api/linked_workspaces.rst
+++ b/docs/public/dev-manual/api/linked_workspaces.rst
@@ -220,6 +220,8 @@ Ein GEVER-Dokument in einen verknüpften Teamraum kopieren
 
 Über den Endpoint `@copy-document-to-workspace` kann eine Kopie eines GEVER-Dokuments in einen bestehenden Teamraum hochgeladen werden. Dabei ist zu beachten, dass der Teamraum mit dem Haupt-Dossier verknüpft sein muss und dass sich das Dokument innerhalb des aktuellen Hauptdossier oder in einem seiner Subdossiers befindet.
 
+Wird eine `folder_uid` angegeben, wird das Dokument in den enstprechenden Folder im Teamraum kopiert, ansonsten in das root des angegebenen Teamraums.
+
 Die Kopie wird mit dem originalen Dokument verknüpft. Diese Verknüpfung wird auf beiden Objekten eingetragen (dem ursprünglichen GEVER-Dokument, und der Kopie im Teamraum), und ist in einem GET Request auf das entsprechende Dokument im Property ``teamraum_connnect_links`` sichtbar.
 
 Ein automatisches Zurückführen oder Synchronisieren mit dem Originaldokument ist zur Zeit allerdings noch nicht möglich.
@@ -237,6 +239,7 @@ Das GEVER-Dokument kann beim Kopieren gesperrt werden, wenn der optionale ``lock
     {
       "workspace_uid": "c11627f492b6447fb61617bb06b9a21a"
       "document_uid": "c2ae40cf41c84493ac4b7618d75ee7f7"
+      "folder_uid": "dd0d865477204f11b8aa2108cd3940bd"
       "lock": "True"
     }
 
@@ -254,6 +257,62 @@ Das GEVER-Dokument kann beim Kopieren gesperrt werden, wenn der optionale ``lock
       "title": "Ein Dokument",
        "...": "..."
     }
+
+
+Ein GEVER-Dossier in einen verknüpften Teamraum kopieren
+--------------------------------------------------------
+
+Ein Dossier, inkl. Subdossiers, kann in mehreren Schritten in den mit dem Hauptdossier verküpften Teamraum kopiert werden:
+
+Zuerst kann über den ``@prepare-copy-dossier-to-workspace`` Endpoint die Ordnerstruktur des Dossiers in den Teamraum gespiegelt werden. Der Endpoint erstellt im Teamraum die entsprechende Ordnerstruktur, und liefert eine Liste von zu kopierenden Dokumenten zurück, und welchem Ordner diese zugeordnet werden. Danach können diese Dokumente über den ``@copy-document-to-workspace`` Endpoint in die jeweiligen Ordner kopiert werden.
+
+
+Der ``@prepare-copy-dossier-to-workspace`` wird auf dem zu kopierenden Dossier aufgerufen, und hat zwei Modi: Validierung, und Erstellung der Struktur.
+
+In beiden Fällen muss die ``workspace_uid`` des Teamraums angegeben werden, in welchen das Dossier kopiert werden soll.
+
+Wenn der Parameter ``validate_only`` auf true gesetzt ist, prüft der Endpoint nur die entsprechenden Vorbedingungen (Hautpdossier mit Teamraum verküpft, keine ausgecheckten Dokumente), und liefert ggf. die Fehler zurück.
+
+Wenn ``validate_only`` auf false gesetzt ist, erstellt der Endpoint im angegebenen Workspace eine leere Ordnerstruktur, welche der Dossierstruktur entspricht. In der Response gibt der Endpoint dann eine Liste von Dokumenten zurück, und die Angabe, in welchen Ordner sie kopiert werden sollen:
+
+
+
+**Beispiel-Request**:
+
+  .. sourcecode:: http
+
+    POST /ordnungssystem/dossier-23/@prepare-copy-dossier-to-workspace HTTP/1.1
+    Accept: application/json
+    Content-Type: application/json
+
+    {
+      "workspace_uid": "c11627f492b6447fb61617bb06b9a21a",
+      "validate_only": false
+    }
+
+
+**Beispiel-Response**:
+
+  .. sourcecode:: http
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    {
+        "docs_to_upload": [
+            {
+                "source_document_uid": "24c8742581a046f9b645f24c9a9cd874",
+                "target_folder_uid": "d95b653a1fc642c18851616d79b6e5d5",
+                "title": "Some document"
+            },
+            {
+                "source_document_uid": "189f2688fb334c1ea7c7ba60411baf78",
+                "target_folder_uid": "b529713f1f28421da968550f3aef7cdb",
+                "title": "Document in Subdossier"
+            }
+        ]
+    }
+
 
 Dokumente in einem verknüpften Teamraum auflisten
 -------------------------------------------------
@@ -303,6 +362,8 @@ Dokumente in einem verknüpften Teamraum auflisten
         ],
       "items_total": 2
     }
+
+
 
 
 Ein GEVER-Dokument von einem verknüpften Teamraum zurückführen

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -970,6 +970,14 @@
 
   <plone:service
       method="POST"
+      name="@upload-document-copy"
+      for="opengever.workspace.interfaces.IWorkspaceFolder"
+      factory=".workspace.UploadDocumentCopy"
+      permission="cmf.AddPortalContent"
+      />
+
+  <plone:service
+      method="POST"
       name="@move"
       for="opengever.workspace.interfaces.IToDoList"
       factory=".todo.ToDoMove"

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -1105,6 +1105,14 @@
 
   <plone:service
       method="POST"
+      name="@prepare-copy-dossier-to-workspace"
+      for="opengever.dossier.behaviors.dossier.IDossierMarker"
+      factory=".linked_workspaces.PrepareCopyDossierToWorkspacePost"
+      permission="opengever.workspaceclient.UseWorkspaceClient"
+      />
+
+  <plone:service
+      method="POST"
       name="@document-from-template"
       for="opengever.dossier.behaviors.dossier.IDossierMarker"
       factory=".templatefolder.DocumentFromTemplatePost"

--- a/opengever/api/linked_workspaces.py
+++ b/opengever/api/linked_workspaces.py
@@ -291,12 +291,14 @@ class PrepareCopyDossierToWorkspacePost(Service):
             uid = dossier.UID()
             msg = _(u'main_dossier_not_linked_to_workspace')
             return {
-                'msg': translate(msg, context=self.request),
-                'msgid': unicode(msg),
-                'obj_uid': uid,
-                'obj_title': dossier.title,
-                'obj_url': dossier.absolute_url(),
-                'obj_type': dossier.portal_type,
+                'translated_message': translate(msg, context=self.request),
+                'message': unicode(msg),
+                'additional_metadata': {
+                    'obj_uid': uid,
+                    'obj_title': dossier.title,
+                    'obj_url': dossier.absolute_url(),
+                    'obj_type': dossier.portal_type,
+                },
             }
 
     def validate_document(self, doc):
@@ -304,12 +306,14 @@ class PrepareCopyDossierToWorkspacePost(Service):
         if doc.is_checked_out():
             msg = _(u'document_is_checked_out')
             return {
-                'msg': translate(msg, context=self.request),
-                'msgid': unicode(msg),
-                'obj_uid': doc.UID(),
-                'obj_title': doc.title,
-                'obj_url': doc.absolute_url(),
-                'obj_type': doc.portal_type,
+                'translated_message': translate(msg, context=self.request),
+                'message': unicode(msg),
+                'additional_metadata': {
+                    'obj_uid': doc.UID(),
+                    'obj_title': doc.title,
+                    'obj_url': doc.absolute_url(),
+                    'obj_type': doc.portal_type,
+                },
             }
 
     def collect_documents(self, dossier_to_copy):

--- a/opengever/api/linked_workspaces.py
+++ b/opengever/api/linked_workspaces.py
@@ -162,16 +162,18 @@ class CopyDocumentToWorkspacePost(LinkedWorkspacesService):
         # Disable CSRF protection
         alsoProvides(self.request, IDisableCSRFProtection)
 
-        workspace_uid, document, lock = self.validate_data(json_body(self.request))
+        workspace_uid, folder_uid, document, lock = self.validate_data(json_body(self.request))
 
         return ILinkedWorkspaces(self.context).copy_document_to_workspace(
-            document, workspace_uid, lock)
+            document, workspace_uid, lock, folder_uid)
 
     def validate_data(self, data):
         workspace_uid = data.get('workspace_uid')
         if not workspace_uid:
             raise BadRequest(_(u"workspace_uid_required",
                                default=u"Property 'workspace_uid' is required"))
+
+        folder_uid = data.get('folder_uid')
 
         document_uid = data.get('document_uid')
         if not document_uid:
@@ -191,7 +193,7 @@ class CopyDocumentToWorkspacePost(LinkedWorkspacesService):
                 "Only documents within the current main dossier are allowed")
 
         lock = data.get('lock', False)
-        return workspace_uid, document, lock
+        return workspace_uid, folder_uid, document, lock
 
     def obj_contained_in(self, obj, container):
         catalog = api.portal.get_tool('portal_catalog')

--- a/opengever/api/linked_workspaces.py
+++ b/opengever/api/linked_workspaces.py
@@ -1,6 +1,11 @@
+from ftw.solr.interfaces import ISolrSearch
+from ftw.solr.query import make_filters
 from opengever.api import _
 from opengever.api.utils import create_proxy_request_error_handler
+from opengever.base.solr import OGSolrDocument
 from opengever.document.behaviors import IBaseDocument
+from opengever.dossier.behaviors.dossier import IDossierMarker
+from opengever.dossier.utils import find_parent_dossier
 from opengever.workspaceclient import is_workspace_client_feature_available
 from opengever.workspaceclient.exceptions import CopyFromWorkspaceForbidden
 from opengever.workspaceclient.interfaces import ILinkedWorkspaces
@@ -14,7 +19,9 @@ from plone.restapi.services import Service
 from zExceptions import BadRequest
 from zExceptions import NotFound
 from zExceptions import Unauthorized
+from zope.component import getUtility
 from zope.component import queryMultiAdapter
+from zope.i18n import translate
 from zope.interface import alsoProvides
 from zope.interface import implements
 from zope.publisher.interfaces import IPublishTraverse
@@ -193,6 +200,199 @@ class CopyDocumentToWorkspacePost(LinkedWorkspacesService):
             UID=obj.UID())
 
         return len(results)
+
+
+class PrepareCopyDossierToWorkspacePost(Service):
+    """API Endpoint to prepare copying a dossier to a linked workspace.
+
+    This endpoints operates in two modes: Validation, or preparing an empty
+    folder structure on the teamraum side to upload documents to.
+
+    In validation mode, it checks that the given structure (subdossier(s) and
+    documents) satisfies all the constraints to be copied to a workspace. If
+    not, a detailed list of errors by object is returned.
+
+    In "prepare structure" mode, it will mirror the structure of the given
+    subdossier to teamraum by creating empty folders in the workspace, and
+    returning a list of documents, including their target folders that the
+    client should then upload them to.
+
+    The second stage ("prepare structure") does not perform validation again.
+    It assumes that the client validated the structure beforehand, and either
+    everything is ok, or the user selected "copy anyway", in which case some
+    individual document uploads will fail.
+    """
+    @teamraum_request_error_handler
+    def reply(self):
+        alsoProvides(self.request, IDisableCSRFProtection)
+
+        if not is_workspace_client_feature_available():
+            raise NotFound
+
+        workspace_uid, validate_only, lock = self.validate_data(
+            json_body(self.request))
+
+        dossier = self.context
+        self.client = ILinkedWorkspaces(dossier).client
+
+        if validate_only:
+            return self.validate_objects(workspace_uid, dossier)
+        else:
+            created_structure = self.create_structure(dossier, workspace_uid)
+            response = {'docs_to_upload': []}
+            for dossier_path, dossier_info in sorted(created_structure.items()):
+                for doc in dossier_info['docs']:
+                    response['docs_to_upload'].append({
+                        'title': doc.title,
+                        'target_folder_uid': dossier_info['uid'],
+                        'source_document_uid': doc.UID(),
+                    })
+            return response
+
+    def validate_data(self, data):
+        workspace_uid = data.get('workspace_uid')
+        if not workspace_uid:
+            raise BadRequest(_(u"workspace_uid_required",
+                               default=u"Property 'workspace_uid' is required"))
+
+        validate_only = data.get('validate_only', False)
+
+        lock = data.get('lock', False)
+        return workspace_uid, validate_only, lock
+
+    def validate_objects(self, workspace_uid, dossier):
+        errors = []
+
+        dossier_error = self.validate_dossier(workspace_uid, dossier)
+        if dossier_error:
+            errors.append(dossier_error)
+
+        for doc in self.collect_documents(dossier):
+            doc_error = self.validate_document(doc)
+            if doc_error:
+                errors.append(doc_error)
+
+        if not errors:
+            validation_result = {'ok': True}
+        else:
+            self.request.RESPONSE.setStatus(400)
+            validation_result = {
+                'ok': False,
+                'errors': errors,
+            }
+        return validation_result
+
+    def validate_dossier(self, workspace_uid, dossier):
+        # Main dossier must be linked to given workspace
+        main_dossier = dossier.get_main_dossier()
+        if workspace_uid not in ILinkedWorkspaces(main_dossier).storage:
+            uid = dossier.UID()
+            msg = _(u'main_dossier_not_linked_to_workspace')
+            return {
+                'msg': translate(msg, context=self.request),
+                'msgid': unicode(msg),
+                'obj_uid': uid,
+                'obj_title': dossier.title,
+                'obj_url': dossier.absolute_url(),
+                'obj_type': dossier.portal_type,
+            }
+
+    def validate_document(self, doc):
+        # Document must not be checked out
+        if doc.is_checked_out():
+            msg = _(u'document_is_checked_out')
+            return {
+                'msg': translate(msg, context=self.request),
+                'msgid': unicode(msg),
+                'obj_uid': doc.UID(),
+                'obj_title': doc.title,
+                'obj_url': doc.absolute_url(),
+                'obj_type': doc.portal_type,
+            }
+
+    def collect_documents(self, dossier_to_copy):
+        return self._collect_objects(dossier_to_copy, IBaseDocument, trashed=False)
+
+    def collect_dossiers(self, dossier_to_copy):
+        return self._collect_objects(dossier_to_copy, IDossierMarker)
+
+    def _collect_objects(self, dossier_to_copy, iface, trashed=None):
+        solr = getUtility(ISolrSearch)
+        query = {
+            'path': {
+                'query': '/'.join(dossier_to_copy.getPhysicalPath()),
+                'depth': -1,
+            },
+            'object_provides': iface.__identifier__,
+        }
+
+        if trashed is not None:
+            query['trashed'] = trashed
+
+        response = solr.search(
+            filters=make_filters(**query),
+            sort='path asc',
+        )
+        objs = [OGSolrDocument(item).getObject() for item in response.docs]
+        return objs
+
+    def create_folder(self, parent_url, title):
+        response = self.client.post(parent_url, json={
+            '@type': 'opengever.workspace.folder',
+            'title': title,
+        })
+        folder_url, folder_uid = response['@id'], response['UID']
+        return folder_url, folder_uid
+
+    def create_structure(self, dossier_to_copy, workspace_uid):
+        workspace = self.client.get_by_uid(uid=workspace_uid)
+        workspace_url = workspace['@id']
+
+        def get_path(obj):
+            return '/'.join(obj.getPhysicalPath())
+
+        # Gather all subdossiers to mirror (including empty ones)
+        dossiers_to_mirror = {}
+        for subdossier in self.collect_dossiers(dossier_to_copy):
+            dossier_path = get_path(subdossier)
+            dossiers_to_mirror[dossier_path] = {'title': subdossier.title}
+
+        # Gather all documents to mirror, and attach them to the correct
+        # dossier-to-mirror node (we track them so we can tell what teamraum
+        # folder a document goes into in the final response).
+        for doc in self.collect_documents(dossier_to_copy):
+            # If a doc is contained in a non-dossier container (task, proposal,
+            # ...), we mirror it into the closest containing subdossier.
+            parent_dossier = find_parent_dossier(doc)
+            parent_path = get_path(parent_dossier)
+
+            dossier_info = dossiers_to_mirror[parent_path]
+            docs_in_dossier = dossier_info.setdefault('docs', [])
+            docs_in_dossier.append(doc)
+
+        # Now mirror the dossier structure to teamraum by creating empty
+        # folders, and track the folder's URLs, uids and docs that should be
+        # uploaded to them.
+        created_dossiers = {}
+
+        # Iterating over sorted paths ensures we create parents before children
+        for dossier_path, dossier_info in sorted(dossiers_to_mirror.items()):
+            # The parent_url for the folder we're about to create is either
+            # one we just created before, and tracked, or the URL of the
+            # workspace (which is linked to the main dossier).
+            parent_path = dossier_path.rsplit('/', 1)[0]
+            parent_url = created_dossiers.get(parent_path, {}).get('url')
+            if not parent_url:
+                parent_url = workspace_url
+
+            title = dossier_info['title']
+            folder_url, folder_uid = self.create_folder(parent_url, title)
+            created_dossiers[dossier_path] = {
+                'url': folder_url,
+                'uid': folder_uid,
+                'docs': dossier_info.pop('docs', []),
+            }
+        return created_dossiers
 
 
 class ListDocumentsInLinkedWorkspaceGet(ProxyHypermediaBatch):

--- a/opengever/api/locales/de/LC_MESSAGES/opengever.api.po
+++ b/opengever/api/locales/de/LC_MESSAGES/opengever.api.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-08-25 13:12+0000\n"
+"POT-Creation-Date: 2022-10-10 14:33+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -37,6 +37,10 @@ msgstr "Sie sind nicht berechtigt, dieses Objekt zu kopieren."
 msgid "disallowed_participant"
 msgstr "Der Teilnehmer ${actorid} ist nicht erlaubt"
 
+#: ./opengever/api/linked_workspaces.py
+msgid "document_is_checked_out"
+msgstr "Dokument ist ausgecheckt"
+
 #. Default: "The participant ${actorid} already exists"
 #: ./opengever/api/participations.py
 msgid "duplicate_participant"
@@ -56,6 +60,10 @@ msgstr "Status ${state} existiert nicht."
 #: ./opengever/api/participations.py
 msgid "invalid_role"
 msgstr "Die Rolle ${role} ist ungültig. Gültige Rollen sind: ${allowed_roles}"
+
+#: ./opengever/api/linked_workspaces.py
+msgid "main_dossier_not_linked_to_workspace"
+msgstr "Hauptdossier ist nicht mit Teamraum verknüpft"
 
 #. Default: "Missing parameter 'participant'"
 #: ./opengever/api/participations.py

--- a/opengever/api/locales/en/LC_MESSAGES/opengever.api.po
+++ b/opengever/api/locales/en/LC_MESSAGES/opengever.api.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-08-25 13:12+0000\n"
+"POT-Creation-Date: 2022-10-10 14:33+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -37,6 +37,10 @@ msgstr "You are not allowed to copy this object."
 msgid "disallowed_participant"
 msgstr "The participant ${actorid} is not allowed"
 
+#: ./opengever/api/linked_workspaces.py
+msgid "document_is_checked_out"
+msgstr "Document is checked out"
+
 #. Default: "The participant ${actorid} already exists"
 #: ./opengever/api/participations.py
 msgid "duplicate_participant"
@@ -56,6 +60,10 @@ msgstr "State ${state} does not exist."
 #: ./opengever/api/participations.py
 msgid "invalid_role"
 msgstr "Role ${role} is not available. Available roles are: ${allowed_roles}"
+
+#: ./opengever/api/linked_workspaces.py
+msgid "main_dossier_not_linked_to_workspace"
+msgstr "Main dossier not linked to workspace"
 
 #. Default: "Missing parameter 'participant'"
 #: ./opengever/api/participations.py

--- a/opengever/api/locales/fr/LC_MESSAGES/opengever.api.po
+++ b/opengever/api/locales/fr/LC_MESSAGES/opengever.api.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-08-25 13:12+0000\n"
+"POT-Creation-Date: 2022-10-10 14:33+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -37,6 +37,10 @@ msgstr "Vous n'êtes pas autorisé à copier cet objet."
 msgid "disallowed_participant"
 msgstr "Le participant ${actorid} n'est pas autorisé"
 
+#: ./opengever/api/linked_workspaces.py
+msgid "document_is_checked_out"
+msgstr ""
+
 #. Default: "The participant ${actorid} already exists"
 #: ./opengever/api/participations.py
 msgid "duplicate_participant"
@@ -56,6 +60,10 @@ msgstr "Le statut ${state} n'existe pas."
 #: ./opengever/api/participations.py
 msgid "invalid_role"
 msgstr "Le rôle ${role} n'est pas valable. Les rôles valides sont: ${allowed_roles}"
+
+#: ./opengever/api/linked_workspaces.py
+msgid "main_dossier_not_linked_to_workspace"
+msgstr ""
 
 #. Default: "Missing parameter 'participant'"
 #: ./opengever/api/participations.py

--- a/opengever/api/locales/opengever.api.pot
+++ b/opengever/api/locales/opengever.api.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-08-25 13:12+0000\n"
+"POT-Creation-Date: 2022-10-10 14:33+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -40,6 +40,10 @@ msgstr ""
 msgid "disallowed_participant"
 msgstr ""
 
+#: ./opengever/api/linked_workspaces.py
+msgid "document_is_checked_out"
+msgstr ""
+
 #. Default: "The participant ${actorid} already exists"
 #: ./opengever/api/participations.py
 msgid "duplicate_participant"
@@ -58,6 +62,10 @@ msgstr ""
 #. Default: "Role ${role} is not available. Available roles are: ${allowed_roles}"
 #: ./opengever/api/participations.py
 msgid "invalid_role"
+msgstr ""
+
+#: ./opengever/api/linked_workspaces.py
+msgid "main_dossier_not_linked_to_workspace"
 msgstr ""
 
 #. Default: "Missing parameter 'participant'"

--- a/opengever/api/tests/test_linked_workspaces.py
+++ b/opengever/api/tests/test_linked_workspaces.py
@@ -1038,12 +1038,14 @@ class TestPrepareCopyDossierToWorkspaceValidation(FunctionalWorkspaceClientTestC
                 )
         expected = {
             'errors': [{
-                'msg': 'Main dossier not linked to workspace',
-                'msgid': 'main_dossier_not_linked_to_workspace',
-                'obj_title': 'My dossier',
-                'obj_type': 'opengever.dossier.businesscasedossier',
-                'obj_uid': self.dossier.UID(),
-                'obj_url': self.dossier.absolute_url(),
+                'translated_message': 'Main dossier not linked to workspace',
+                'message': 'main_dossier_not_linked_to_workspace',
+                'additional_metadata': {
+                    'obj_title': 'My dossier',
+                    'obj_type': 'opengever.dossier.businesscasedossier',
+                    'obj_uid': self.dossier.UID(),
+                    'obj_url': self.dossier.absolute_url(),
+                },
             }],
             'ok': False,
         }
@@ -1077,12 +1079,14 @@ class TestPrepareCopyDossierToWorkspaceValidation(FunctionalWorkspaceClientTestC
                 )
         expected = {
             'errors': [{
-                'msg': 'Document is checked out',
-                'msgid': 'document_is_checked_out',
-                'obj_title': u'Testdokum\xe4nt',
-                'obj_type': 'opengever.document.document',
-                'obj_uid': document.UID(),
-                'obj_url': document.absolute_url(),
+                'translated_message': 'Document is checked out',
+                'message': 'document_is_checked_out',
+                'additional_metadata': {
+                    'obj_title': u'Testdokum\xe4nt',
+                    'obj_type': 'opengever.document.document',
+                    'obj_uid': document.UID(),
+                    'obj_url': document.absolute_url(),
+                },
             }],
             'ok': False,
         }

--- a/opengever/api/workspace.py
+++ b/opengever/api/workspace.py
@@ -28,7 +28,8 @@ class SerializeWorkspaceToJson(GeverSerializeFolderToJson):
 
 
 class UploadDocumentCopy(GeverFolderPost):
-    """Endpoint to upload a complete copy of a GEVER document to a workspace.
+    """Endpoint to upload a complete copy of a GEVER document to a workspace
+    or workspace folder.
 
     Expects a multipart request that includes the document blob as well as
     the document metadata.

--- a/opengever/base/listing_actions.py
+++ b/opengever/base/listing_actions.py
@@ -26,6 +26,7 @@ class BaseListingActions(object):
         self.maybe_add_pdf_taskslisting()
         self.maybe_add_create_disposition()
         self.maybe_add_copy_documents_to_workspace()
+        self.maybe_add_copy_dossier_to_workspace()
         self.maybe_add_trash_content()
         self.maybe_add_untrash_content()
         self.maybe_add_remove()
@@ -40,6 +41,9 @@ class BaseListingActions(object):
         return False
 
     def is_copy_documents_to_workspace_available(self):
+        return False
+
+    def is_copy_dossier_to_workspace_available(self):
         return False
 
     def is_copy_items_available(self):
@@ -106,6 +110,10 @@ class BaseListingActions(object):
     def maybe_add_copy_documents_to_workspace(self):
         if self.is_copy_documents_to_workspace_available():
             self.add_action(u'copy_documents_to_workspace')
+
+    def maybe_add_copy_dossier_to_workspace(self):
+        if self.is_copy_dossier_to_workspace_available():
+            self.add_action(u'copy_dossier_to_workspace')
 
     def maybe_add_copy_items(self):
         if self.is_copy_items_available():

--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -734,3 +734,10 @@ OPENGEVER_SOLR_FUNCTIONAL_TESTING = FunctionalTesting(
     bases=(OPENGEVER_FIXTURE_SQLITE_WITH_SOLR,
            set_builder_session_factory(functional_session_factory)),
     name="opengever.core:solr-functional")
+
+
+OPENGEVER_FUNCTIONAL_SOLR_ZSERVER_TESTING = FunctionalTesting(
+    bases=(z2.ZSERVER_FIXTURE,
+           OPENGEVER_SOLR_FUNCTIONAL_TESTING,
+           set_builder_session_factory(functional_session_factory)),
+    name="opengever.core:solr-zserver")

--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -680,7 +680,7 @@ OPENGEVER_SOLR_INTEGRATION_TESTING = GEVERIntegrationTesting(
     # Warning: do not try to base other layers on ContentFixtureWithSolrLayer.
     # See docstring of ContentFixtureLayer.
     bases=(ContentFixtureWithSolrLayer(), TRAVERSAL_BROWSER_FIXTURE),
-    name="opengever.core:integration:solr")
+    name="opengever.core:solr-integration")
 
 PDFLATEX_SERVICE_INTEGRATION_TESTING = GEVERIntegrationTesting(
     bases=(PDFLATEX_SERVICE_FIXTURE, OPENGEVER_FIXTURE),
@@ -733,4 +733,4 @@ OPENGEVER_FIXTURE_SQLITE_WITH_SOLR = OpengeverFixtureWithSolr(
 OPENGEVER_SOLR_FUNCTIONAL_TESTING = FunctionalTesting(
     bases=(OPENGEVER_FIXTURE_SQLITE_WITH_SOLR,
            set_builder_session_factory(functional_session_factory)),
-    name="opengever.core:functional:solr")
+    name="opengever.core:solr-functional")

--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -718,6 +718,13 @@ class OpengeverFixtureWithSolr(SolrTestingBase, OpengeverFixture):
         self.maybe_stop_solr()
         super(OpengeverFixtureWithSolr, self).tearDownZope(app)
 
+    def testTearDown(self):
+        client = SolrReplicationAPIClient.get_instance()
+        if client._configured:
+            client.restore_backup('fixture')
+            client.await_restored()
+        super(OpengeverFixtureWithSolr, self).testTearDown()
+
 
 OPENGEVER_FIXTURE_SQLITE_WITH_SOLR = OpengeverFixtureWithSolr(
     sql_layer=sqlite_testing.SQLITE_MEMORY_FIXTURE)

--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -697,7 +697,7 @@ WEASYPRINT_SERVICE_INTEGRATION_TESTING = GEVERIntegrationTesting(
 
 class OpengeverFixtureWithSolr(SolrTestingBase, OpengeverFixture):
 
-    solr_port = os.environ.get('PORT5', '19905')
+    solr_port = os.environ.get('PORT2', '19905')
     solr_core = 'functionaltesting'
 
     def setUpPloneSite(self, portal):

--- a/opengever/dossier/actions.py
+++ b/opengever/dossier/actions.py
@@ -59,6 +59,23 @@ class DossierTemplateListingActions(BaseListingActions):
 
 
 @adapter(IDossierMarker, IOpengeverBaseLayer)
+class SubDossierListingActions(DossierListingActions):
+
+    def is_copy_dossier_to_workspace_available(self):
+        if not self.context.is_open():
+            return False
+        if not is_workspace_client_feature_available():
+            return False
+        if not api.user.has_permission('Modify portal content', obj=self.context):
+            return False
+        if not api.user.has_permission('opengever.workspaceclient: Use Workspace Client'):
+            return False
+
+        linked_workspaces_manager = ILinkedWorkspaces(self.context.get_main_dossier())
+        return linked_workspaces_manager.has_linked_workspaces()
+
+
+@adapter(IDossierMarker, IOpengeverBaseLayer)
 class DossierContextActions(BaseContextActions):
 
     def __init__(self, context, request):

--- a/opengever/dossier/configure.zcml
+++ b/opengever/dossier/configure.zcml
@@ -92,6 +92,11 @@
            opengever.base.interfaces.IOpengeverBaseLayer"
       />
 
+  <adapter
+      factory=".actions.SubDossierListingActions"
+      name="dossiers"
+      />
+
   <adapter factory=".actions.DossierContextActions" />
   <adapter factory=".actions.TemplateFolderContextActions" />
   <adapter factory=".actions.DossierTemplateContextActions" />

--- a/opengever/dossier/tests/test_actions.py
+++ b/opengever/dossier/tests/test_actions.py
@@ -57,6 +57,28 @@ class TestDossierListingActions(IntegrationTestCase):
         self.assertEqual(expected_actions, self.get_actions(self.private_folder))
 
 
+class TestWorkspaceClientDossierListingActions(FunctionalWorkspaceClientTestCase):
+
+    def get_actions(self, context):
+        adapter = queryMultiAdapter((context, self.request),
+                                    interface=IListingActions,
+                                    name='dossiers')
+        return adapter.get_actions() if adapter else []
+
+    def test_copy_dossier_to_workspace_action_available_in_open_dossier_with_linked_workspaces(self):
+        with self.workspace_client_env():
+            self.assertNotIn(u'copy_dossier_to_workspace', self.get_actions(self.dossier))
+            manager = ILinkedWorkspaces(self.dossier)
+            manager.storage.add(self.workspace.UID())
+            transaction.commit()
+            self.assertIn(u'copy_dossier_to_workspace', self.get_actions(self.dossier))
+
+            api.content.transition(obj=self.dossier,
+                                   transition='dossier-transition-deactivate')
+
+            self.assertNotIn(u'copy_dossier_to_workspace', self.get_actions(self.dossier))
+
+
 class TestDossierTemplateListingActions(IntegrationTestCase):
 
     def get_actions(self, context):

--- a/opengever/testing/test_case.py
+++ b/opengever/testing/test_case.py
@@ -124,6 +124,11 @@ class FunctionalTestCase(TestCase):
     layer = OPENGEVER_FUNCTIONAL_TESTING
     use_default_fixture = True
 
+    api_headers = {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+    }
+
     def setUp(self):
         super(FunctionalTestCase, self).setUp()
         self.portal = self.layer['portal']

--- a/opengever/workspaceclient/client.py
+++ b/opengever/workspaceclient/client.py
@@ -146,7 +146,7 @@ class WorkspaceClient(object):
 
     def upload_document_copy(self, url_or_path, file_, content_type,
                              filename, document_metadata, gever_document_uid):
-        """Creates a copy of a GEVER document in a workspace.
+        """Creates a copy of a GEVER document in a workspace or folder.
 
         :param url_or_path: Location where to create the new document
         :param file_: Readable IO which holds the content of the file

--- a/opengever/workspaceclient/exceptions.py
+++ b/opengever/workspaceclient/exceptions.py
@@ -39,6 +39,13 @@ class WorkspaceNotFound(Exception):
             'No workspace found.')
 
 
+class FolderNotFound(Exception):
+
+    def __init__(self):
+        super(FolderNotFound, self).__init__(
+            'No folder found.')
+
+
 class CopyToWorkspaceForbidden(Exception):
     """Raised if copying a document to a workspace is not permitted for
     business logic reasons.

--- a/opengever/workspaceclient/tests/__init__.py
+++ b/opengever/workspaceclient/tests/__init__.py
@@ -2,8 +2,8 @@ from contextlib import contextmanager
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.tokenauth.testing.builders import KeyPairBuilder  # noqa
-from opengever.core.testing import OPENGEVER_FUNCTIONAL_ZSERVER_TESTING
-from opengever.testing import FunctionalTestCase
+from opengever.core.testing import OPENGEVER_FUNCTIONAL_SOLR_ZSERVER_TESTING
+from opengever.testing import SolrFunctionalTestCase
 from opengever.workspaceclient.client import WorkspaceClient
 from opengever.workspaceclient.interfaces import IWorkspaceClientSettings
 from opengever.workspaceclient.session import SESSION_STORAGE
@@ -17,9 +17,9 @@ import transaction
 DEFAULT_MARKER = object()
 
 
-class FunctionalWorkspaceClientTestCase(FunctionalTestCase):
+class FunctionalWorkspaceClientTestCase(SolrFunctionalTestCase):
 
-    layer = OPENGEVER_FUNCTIONAL_ZSERVER_TESTING
+    layer = OPENGEVER_FUNCTIONAL_SOLR_ZSERVER_TESTING
 
     def setUp(self):
         super(FunctionalWorkspaceClientTestCase, self).setUp()

--- a/opengever/workspaceclient/tests/__init__.py
+++ b/opengever/workspaceclient/tests/__init__.py
@@ -34,7 +34,9 @@ class FunctionalWorkspaceClientTestCase(SolrFunctionalTestCase):
         # Minimal GEVER setup
         self.repository_root = create(Builder('repository_root'))
         self.leaf_repofolder = create(Builder('repository').within(self.repository_root))
-        self.dossier = create(Builder('dossier').within(self.leaf_repofolder))
+        self.dossier = create(Builder('dossier')
+                              .titled(u'My dossier')
+                              .within(self.leaf_repofolder))
         self.expired_dossier = create(Builder('dossier').within(
             self.leaf_repofolder).in_state('dossier-state-resolved'))
 

--- a/test-functional-solr.cfg
+++ b/test-functional-solr.cfg
@@ -11,7 +11,7 @@ jenkins_python = $PYTHON27
 git-clone-depth = 1
 
 [test-jenkins]
-test-command-no-coverage = bin/test --layer "opengever.core.testing.opengever.core:functional:solr" $@
+test-command-no-coverage = bin/test --layer "opengever.core.testing.opengever.core:solr-functional" $@
 input = inline:
     #!/bin/sh
     ${test-jenkins:pre-test}

--- a/test-functional-zserver-solr.cfg
+++ b/test-functional-zserver-solr.cfg
@@ -1,0 +1,21 @@
+[buildout]
+extends =
+    base-plone-4.3.x.cfg
+
+parts =
+    test
+    test-jenkins
+
+jenkins_python = $PYTHON27
+
+git-clone-depth = 1
+
+[test-jenkins]
+test-command-no-coverage = bin/test --layer "opengever.core:solr-zserver" $@
+input = inline:
+    #!/bin/sh
+    ${test-jenkins:pre-test}
+    ${test-jenkins:test-command}
+    result=$?
+    ${test-jenkins:post-test}
+    exit $result

--- a/test-solr.cfg
+++ b/test-solr.cfg
@@ -11,7 +11,7 @@ jenkins_python = $PYTHON27
 git-clone-depth = 1
 
 [test-jenkins]
-test-command-no-coverage = bin/test --layer "opengever.core.testing.opengever.core:integration:solr" $@
+test-command-no-coverage = bin/test --layer "opengever.core.testing.opengever.core:solr-integration" $@
 input = inline:
     #!/bin/sh
     ${test-jenkins:pre-test}


### PR DESCRIPTION
This adds backend support for copying (sub)dossiers to teamraum by:
- adding a new `@prepare-copy-dossier-to-workspace` endpoint that will create the respective folder structure on the teamraum side
- allowing the `@copy-document-to-workspace` endpoint to also take teamraum folders as targets

The frontend will then call the `@prepare-copy-dossier-to-workspace` first (with `validate_only=True`) to validate preconditions (main dossier linked to workspace, no checked out documents), and display any errors to the user. It will then call it a second time to have it create an empty folder structure on the teamraum that mirrors the subdossier structure. The endpoint will then return a list of all documents that need to be copied by the frontend, and the teamraum folders they should be copied to.

The frontend will then copy these documents to their respective folders using the existing `@copy-document-to-workspace` endpoint.

For [CA-4726](https://4teamwork.atlassian.net/browse/CA-4726)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry