### PR TITLE
Return an active-flag for available roles in in the `@participations endpoint.

### DIFF
--- a/changes/CA-4943.bugfix
+++ b/changes/CA-4943.bugfix
@@ -1,0 +1,1 @@
+Return an 'active'-flag for available roles in in the ``@participations`` endpoint. [elioschmutz]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,6 +11,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- ``@participations``: Returns an active-flag for each available role.
 - ``@solrsearch``: The results can now be filtered by ``-@id_parent`` or ``-url_parent``.
 - ``@config``: Add ``template_folder_url`` key to expose the path to the template_folder.
 

--- a/docs/public/dev-manual/api/dossier_participations.rst
+++ b/docs/public/dev-manual/api/dossier_participations.rst
@@ -33,15 +33,18 @@ Ein Beteiligter kann in verschiedenen Rollen an einem Dossier beteiligt sein. Mi
         "available_roles": [
           {
             "title": "Kenntnisnahme",
-            "token": "regard"
+            "token": "regard",
+            "active": true,
           },
           {
             "title": "Mitwirkung",
-            "token": "participation"
+            "token": "participation",
+            "active": true,
           },
           {
             "title": "Schlusszeichnung",
-            "token": "final-drawing"
+            "token": "final-drawing",
+            "active": true,
           }
         ],
         "items": [

--- a/opengever/api/dossier_participations.py
+++ b/opengever/api/dossier_participations.py
@@ -28,8 +28,13 @@ from zope.schema.vocabulary import getVocabularyRegistry
 
 
 def available_roles(context):
+    active_roles = api.portal.get_registry_record('roles', IDossierParticipants) or []
     vocabulary = getVocabularyRegistry().get(context, "opengever.dossier.participation_roles")
-    return [{"token": term.token, "title": term.title} for term in vocabulary]
+    return [{
+        "token": term.token,
+        "title": term.title,
+        "active": term.token in active_roles if active_roles else True
+    } for term in vocabulary]
 
 
 def primary_participation_roles(context):

--- a/opengever/api/tests/test_dossier_participations.py
+++ b/opengever/api/tests/test_dossier_participations.py
@@ -30,11 +30,14 @@ class TestParticipationsGet(IntegrationTestCase):
             u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen'
                     u'/dossier-1/@participations',
             u'available_roles': [{u'title': u'Final signature',
-                                  u'token': u'final-drawing'},
+                                  u'token': u'final-drawing',
+                                  u'active': True},
                                  {u'title': u'For your information',
-                                  u'token': u'regard'},
+                                  u'token': u'regard',
+                                  u'active': True},
                                  {u'title': u'Participation',
-                                  u'token': u'participation'},
+                                  u'token': u'participation',
+                                  u'active': True},
                                  ],
             u'items': [{u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/'
                         u'vertrage-und-vereinbarungen/dossier-1/@participations/kathi.barfuss',
@@ -93,6 +96,35 @@ class TestParticipationsGet(IntegrationTestCase):
         self.assertEqual(3, len(browser.json['available_roles']))
         self.assertIn('batching', browser.json)
 
+    @browsing
+    def test_available_roles_can_be_deactivated_through_the_registry(self, browser):
+        self.login(self.regular_user, browser=browser)
+        api.portal.set_registry_record(
+            name='roles', interface=IDossierParticipants,
+            value=['regard', 'final-drawing'])
+        browser.open(self.dossier, view='@participations', method='GET', headers=self.api_headers)
+
+        self.assertEqual(
+            [
+                {
+                    u'title': u'Final signature',
+                    u'token': u'final-drawing',
+                    u'active': True
+                },
+                {
+                    u'title': u'For your information',
+                    u'token': u'regard',
+                    u'active': True
+                },
+                {
+                    u'title': u'Participation',
+                    u'token': u'participation',
+                    u'active': False
+                },
+            ],
+            browser.json['available_roles']
+        )
+
 
 @requests_mock.Mocker()
 class TestParticipationsGetWithKubFeatureEnabled(KuBIntegrationTestCase):
@@ -113,11 +145,14 @@ class TestParticipationsGetWithKubFeatureEnabled(KuBIntegrationTestCase):
         expected_json = {
             u'@id': participations_url,
             u'available_roles': [{u'title': u'Final signature',
-                                  u'token': u'final-drawing'},
+                                  u'token': u'final-drawing',
+                                  u'active': True},
                                  {u'title': u'For your information',
-                                  u'token': u'regard'},
+                                  u'token': u'regard',
+                                  u'active': True},
                                  {u'title': u'Participation',
-                                  u'token': u'participation'}],
+                                  u'token': u'participation',
+                                  u'active': True}],
             u'items': [
                 {u'@id': "{}/{}".format(participations_url, self.org_ftw),
                  u'participant_actor': {
@@ -210,11 +245,14 @@ class TestParticipationsGetWithContactFeatureEnabled(IntegrationTestCase):
             u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/'
                     u'vertrage-und-vereinbarungen/dossier-1/@participations',
             u'available_roles': [{u'title': u'Final signature',
-                                  u'token': u'final-drawing'},
+                                  u'token': u'final-drawing',
+                                  u'active': True},
                                  {u'title': u'For your information',
-                                  u'token': u'regard'},
+                                  u'token': u'regard',
+                                  u'active': True},
                                  {u'title': u'Participation',
-                                  u'token': u'participation'},
+                                  u'token': u'participation',
+                                  u'active': True},
                                  ],
             u'items': [{u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-'
                                 u'vereinbarungen/dossier-1/@participations/person:1',
@@ -883,11 +921,14 @@ class TestParticipationsExpansion(IntegrationTestCase):
         expected = {
             u'@id': url,
             u'available_roles': [{u'title': u'Final signature',
-                                  u'token': u'final-drawing'},
+                                  u'token': u'final-drawing',
+                                  u'active': True},
                                  {u'title': u'For your information',
-                                  u'token': u'regard'},
+                                  u'token': u'regard',
+                                  u'active': True},
                                  {u'title': u'Participation',
-                                  u'token': u'participation'},
+                                  u'token': u'participation',
+                                  u'active': True},
                                  ],
             u'items': [{u'@id': '{}/{}'.format(url, data.participant_id),
                         u'participant_id': data.participant_id,


### PR DESCRIPTION
This PR extends the `available_roles` items of the `@participations` endpoint with an `active` flag for each available role.

The flag will be set to `false` if the registry entry: `opengever.dossier.interfaces.IDossierParticipants.roles` is used and the given role is not listed in the list of roles.

This flag is required for the ui to know if a specific role is selectable or not. Just remove these roles is not possible because we need the inactive items for the `title` lookup for already existing entries.

For [CA-4943]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-4943]: https://4teamwork.atlassian.net/browse/CA-4943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ