### PR TITLE
Use disposition creator's fullname in eCH0160 'ablieferndeStelle' field

### DIFF
--- a/changes/CA-3864-1.bugfix
+++ b/changes/CA-3864-1.bugfix
@@ -1,0 +1,1 @@
+Fix unicode error when disposing a disposition on admin unit with umlaut in title. [lgraf]

--- a/changes/CA-3864-2.bugfix
+++ b/changes/CA-3864-2.bugfix
@@ -1,0 +1,1 @@
+Use disposition creator's fullname in eCH0160 'ablieferndeStelle' field. [lgraf]

--- a/opengever/disposition/ech0160/sippackage.py
+++ b/opengever/disposition/ech0160/sippackage.py
@@ -6,6 +6,7 @@ from opengever.base.utils import file_checksum
 from opengever.disposition.ech0160 import model as ech0160
 from opengever.disposition.ech0160.bindings import arelda
 from opengever.ogds.base.utils import get_current_admin_unit
+from opengever.ogds.models.service import ogds_service
 from opengever.repository.repositoryroot import IRepositoryRoot
 from pkg_resources import resource_filename
 from plone import api
@@ -87,15 +88,14 @@ class SIPPackage(object):
 
         return content_folder
 
-    # XXX
     def get_transferring_office(self):
         """Returns the current adminunits label, followed by the
-        current users fullname.
+        disposition creator's fullname.
         """
-        # TODO: should use the fullname of the dispositiion creator rather
-        # than current users fullname
-        return '{}, {}'.format(get_current_admin_unit().label(),
-                               api.user.get_current().title_or_id())
+        creator = self.disposition.Creator()
+        user = ogds_service().fetch_user(creator)
+        fullname = user.fullname() if user else creator
+        return u'{}, {}'.format(get_current_admin_unit().label(), fullname)
 
     def get_repository_title(self):
         # TODO: use disposition itself instead of the first dossier

--- a/opengever/disposition/tests/test_sippackage.py
+++ b/opengever/disposition/tests/test_sippackage.py
@@ -3,6 +3,8 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testing import freeze
 from opengever.disposition.ech0160.sippackage import SIPPackage
+from opengever.ogds.base.utils import get_current_admin_unit
+from opengever.ogds.models.service import ogds_service
 from opengever.testing import FunctionalTestCase
 from opengever.testing import IntegrationTestCase
 from tempfile import TemporaryFile
@@ -29,16 +31,20 @@ class TestSIPPackageIntegration(IntegrationTestCase):
                 u'SIP_20161106_PLONE_10\xe434', package.get_folder_name())
 
     def test_ablieferungs_metadata(self):
+        rm_user = ogds_service().fetch_user(self.records_manager.getId())
+        rm_user.firstname = u'R\xe4mon'
+        get_current_admin_unit().title = u'Hauptmand\xe4nt'
+
         self.login(self.records_manager)
         package = SIPPackage(self.disposition)
 
         self.assertEquals(
             u'GEVER', package.ablieferung.ablieferungstyp)
         self.assertEquals(
-            'Hauptmandant, ramon.flucht',
+            u'Hauptmand\xe4nt, Flucht R\xe4mon',
             package.ablieferung.ablieferndeStelle)
         self.assertEquals(
-            u'Hauptmandant', package.ablieferung.provenienz.aktenbildnerName)
+            u'Hauptmand\xe4nt', package.ablieferung.provenienz.aktenbildnerName)
         self.assertEquals(
             u'Ordnungssystem', package.ablieferung.provenienz.registratur)
 


### PR DESCRIPTION
According to comments in the code, this is what's supposed to be used in this field, instead of the current user's name.

This also fixes a unicode error when disposing a disposition on a deployment where the admin unit title contains non-ASCII characters.

For [CA-4889](https://4teamwork.atlassian.net/browse/CA-4889)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

