### PR TITLE
Fix workspace invitations portal redirects.

### DIFF
--- a/changes/CA-4846.bugfix
+++ b/changes/CA-4846.bugfix
@@ -1,0 +1,1 @@
+Fix workspace invitations portal redirects. [phgross]

--- a/opengever/workspace/participation/browser/my_invitations.py
+++ b/opengever/workspace/participation/browser/my_invitations.py
@@ -174,7 +174,7 @@ class MyWorkspaceInvitations(BrowserView):
                 accept_url = "{}?invitation={}".format(
                     accept_url, serialize_and_sign_payload(accept_params))
                 params = {'next': accept_url}
-                redirect_url = "{}/login?{}".format(
+                redirect_url = "{}?{}".format(
                     get_gever_portal_url(), urlencode(params))
 
             return self.request.RESPONSE.redirect(redirect_url)

--- a/opengever/workspace/tests/test_my_invitations.py
+++ b/opengever/workspace/tests/test_my_invitations.py
@@ -86,7 +86,7 @@ class TestMyInvitationsView(IntegrationTestCase):
 
             # check that we get redirected to login
             parsed_url = urlparse.urlparse(browser.url)
-            self.assertEqual('/portal/login', parsed_url.path)
+            self.assertEqual('/portal', parsed_url.path)
 
             # with redirect_url to accept the invitation and no_redirect in payload
             payload = serialize_and_sign_payload({'iid': self.invitation_id,


### PR DESCRIPTION
No longer redirect to the login page and redirect to the portal page instead. Because only the portal page, redirects to external authentication service, like secure-connect.

For [CA-4846]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

Needs backporting to the SG Prod Release 

[CA-4846]: https://4teamwork.atlassian.net/browse/CA-4846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ