### PR TITLE
Fix user lookup by email for workspace invitation mail

### DIFF
--- a/changes/CA-4925.bugfix
+++ b/changes/CA-4925.bugfix
@@ -1,0 +1,1 @@
+Fix user lookup by email for workspace invitation mail. [tinagerber]

--- a/opengever/api/tests/test_tus.py
+++ b/opengever/api/tests/test_tus.py
@@ -169,7 +169,7 @@ class TestTUSUpload(IntegrationTestCase):
         self.assert_tus_replace_fails(self.document, browser)
 
     @skipIf(
-        datetime.now() < datetime(2022, 11, 11),
+        datetime.now() < datetime(2022, 11, 18),
         "Lock verification temporary disabled, because it's not yet supported "
         "by Office Connector",
     )


### PR DESCRIPTION
The same problem as in #7552 , but unfortunately it was solved only for incoming mails. See also: https://github.com/4teamwork/opengever.core/pull/7552#issue-1349663726

For the lock check I created an issue: https://4teamwork.atlassian.net/browse/CA-4982

For [CA-4925]

⚠️ Needs backport to 2022.15.x ⚠️

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-4925]: https://4teamwork.atlassian.net/browse/CA-4925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ