### PR TITLE
Sequential tasks: Only allow subtasks to be started when parent is in progress

### DIFF
--- a/changes/CA-4945.bugfix
+++ b/changes/CA-4945.bugfix
@@ -1,0 +1,1 @@
+Sequential tasks: Only allow subtasks to be started when parent is in progress. [lgraf]

--- a/opengever/task/__init__.py
+++ b/opengever/task/__init__.py
@@ -31,6 +31,8 @@ TASK_STATE_PLANNED = 'task-state-planned'
 
 TASK_STATE_SKIPPED = 'task-state-skipped'
 
+TASK_STATE_IN_PROGRESS = 'task-state-in-progress'
+
 FINAL_TASK_STATES = [
     'task-state-tested-and-closed',
     'task-state-cancelled',

--- a/opengever/task/browser/transitioncontroller.py
+++ b/opengever/task/browser/transitioncontroller.py
@@ -170,9 +170,8 @@ class TaskTransitionController(BrowserView):
     def open_guard(self, transition, c):
         if IInternalWorkflowTransition.providedBy(getRequest()):
             return True
-        if not self.context.is_part_of_sequential_process:
-            return False
-        return self.context.all_predecessors_are_skipped()
+
+        return self.context.may_be_started()
 
     @guard('task-transition-cancelled-open')
     def cancelled_to_open_guard(self, c, include_agency):

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -751,6 +751,15 @@ class Task(Container, TaskReminderSupport):
 
         return None
 
+    def may_be_started(self):
+        """Whether a sequential task may be started.
+        (Transitioned from 'planned' to 'open')
+        """
+        if not self.is_part_of_sequential_process:
+            return False
+
+        return self.all_predecessors_are_skipped()
+
     def all_predecessors_are_skipped(self):
         return self.get_sql_object().all_predecessors_are_skipped()
 

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -30,6 +30,7 @@ from opengever.task import _
 from opengever.task import FINAL_TASK_STATES
 from opengever.task import is_optional_task_permissions_revoking_enabled
 from opengever.task import is_private_task_feature_enabled
+from opengever.task import TASK_STATE_IN_PROGRESS
 from opengever.task import TASK_STATE_PLANNED
 from opengever.task import TASK_STATE_SKIPPED
 from opengever.task import util
@@ -756,6 +757,10 @@ class Task(Container, TaskReminderSupport):
         (Transitioned from 'planned' to 'open')
         """
         if not self.is_part_of_sequential_process:
+            return False
+
+        parent_state = api.content.get_state(aq_parent(aq_inner(self)))
+        if parent_state != TASK_STATE_IN_PROGRESS:
             return False
 
         return self.all_predecessors_are_skipped()


### PR DESCRIPTION
In a nested task structure that contains a sequential subprocess, it was possible to manually start a subtask inside such a subprocess even though the containing parent task was still in the planned state.

This lead to an invalid task structure, causing the logic that is supposed start the next task when a task is closed to trip up, because it doesn't expect the next task to be already in progress.

Sentry: https://sentry.4teamwork.ch/organizations/sentry/issues/98191/

For [CA-4945](https://4teamwork.atlassian.net/browse/CA-4945)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

Bug fixed:
 - [x] Resolved any Sentry issues caused by this bug
