### PR TITLE
Add `@@oc_checkout` view that redirects to oc: checkout URL

### DIFF
--- a/changes/CA-4900.feature
+++ b/changes/CA-4900.feature
@@ -1,0 +1,1 @@
+Add ``@@oc_checkout`` view that redirects to oc: checkout URL. [lgraf]

--- a/opengever/officeconnector/browser/configure.zcml
+++ b/opengever/officeconnector/browser/configure.zcml
@@ -11,4 +11,11 @@
       permission="zope2.View"
       />
 
+  <browser:page
+      for="opengever.document.behaviors.IBaseDocument"
+      name="oc_checkout"
+      class=".oc_checkout_redirect.RedirectToOCCheckoutURL"
+      permission="cmf.ModifyPortalContent"
+      />
+
 </configure>

--- a/opengever/officeconnector/browser/oc_checkout_redirect.py
+++ b/opengever/officeconnector/browser/oc_checkout_redirect.py
@@ -1,0 +1,17 @@
+from opengever.officeconnector.helpers import create_oc_url
+from opengever.officeconnector.helpers import is_officeconnector_checkout_feature_enabled  # noqa
+from Products.Five import BrowserView
+
+
+class RedirectToOCCheckoutURL(BrowserView):
+    """Redirects to the oc:<JWT> checkout URL for this document.
+    """
+    def __call__(self):
+        if (is_officeconnector_checkout_feature_enabled()
+                and self.context.is_checkout_and_edit_available()):
+            payload = {'action': 'checkout'}
+            url = create_oc_url(self.request, self.context, payload)
+            return self.request.RESPONSE.redirect(url)
+
+        # Redirect to document view in any failure case
+        return self.request.RESPONSE.redirect(self.context.absolute_url())

--- a/opengever/officeconnector/tests/test_oc_checkout_redirect.py
+++ b/opengever/officeconnector/tests/test_oc_checkout_redirect.py
@@ -1,0 +1,46 @@
+from datetime import datetime
+from ftw.testbrowser import browsing
+from ftw.testing import freeze
+from opengever.officeconnector.testing import JWT_SIGNING_SECRET_PLONE
+from opengever.testing import IntegrationTestCase
+import jwt
+
+
+class TestOCCheckoutRedirect(IntegrationTestCase):
+
+    @browsing
+    def test_oc_checkout_redirects_to_oc_checkout_url(self, browser):
+        self.login(self.regular_user, browser)
+
+        with freeze(datetime(2022, 11, 17)):
+            browser.allow_redirects = False
+            browser.open(self.document, view='@@oc_checkout')
+
+        self.assertEqual(302, browser.status_code)
+
+        oc_url = browser.headers['location']
+        raw_token = oc_url.split(':')[-1]
+        token = jwt.decode(raw_token, JWT_SIGNING_SECRET_PLONE, algorithms=('HS256',))
+
+        expected_token = {
+            u'action': u'checkout',
+            u'documents': [u'createtreatydossiers000000000002'],
+            u'exp': 1668686400,
+            u'sub': u'kathi.barfuss',
+            u'url': u'http://nohost/plone/oc_checkout',
+        }
+
+        self.assertEqual(expected_token, token)
+
+    @browsing
+    def test_oc_checkout_redirects_to_document_in_case_of_failure(self, browser):
+        self.login(self.dossier_responsible, browser)
+        self.checkout_document(self.document)
+
+        self.login(self.regular_user, browser)
+        browser.allow_redirects = False
+        browser.open(self.document, view='@@oc_checkout')
+
+        location = browser.headers['location']
+        self.assertEqual(302, browser.status_code)
+        self.assertEqual(self.document.absolute_url(), location)


### PR DESCRIPTION
This view allows 3rd party applications to produce links that should directly trigger a checkout using OfficeConnector on a GEVER document.

In case a necessary precondition is not satisfied (e.g., document is already checked out by someone else), the view just redirects to the regular document view, which should give the user some indication as to why the checkout didn't work.

> **Note**: This registers a browser view with the same same as the [existing `oc_checkout` REST API endpoint](https://github.com/4teamwork/opengever.core/blob/d7ee0559ca3989fba3a55ded972f623acb585adc/opengever/officeconnector/configure.zcml#L70-L77).
> This technically isn't a problem, because one is a REST service and the other a Browser View (`plone.rest` can distingiush those via content negotiation), one is on the Site Root and the other only on documents, and one is POST while the other one is GET.
> Just thought I'd point it out.

For [CA-4900](https://4teamwork.atlassian.net/browse/CA-4900)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- New functionality:
  - [ ] for `document` also works for `mail`
  _No, because mails are not supposed to be checked out_
