### PR TITLE
Re-enable forbidding tus-replace when document is locked by another user.

### DIFF
--- a/changes/CA-4982.other
+++ b/changes/CA-4982.other
@@ -1,0 +1,1 @@
+Re-enable forbidding tus-replace when document is locked by another user. [njohner]

--- a/opengever/api/tests/test_tus.py
+++ b/opengever/api/tests/test_tus.py
@@ -168,11 +168,6 @@ class TestTUSUpload(IntegrationTestCase):
         self.login(self.regular_user, browser)
         self.assert_tus_replace_fails(self.document, browser)
 
-    @skipIf(
-        datetime.now() < datetime(2022, 11, 18),
-        "Lock verification temporary disabled, because it's not yet supported "
-        "by Office Connector",
-    )
     @browsing
     def test_cannot_replace_document_if_lock_token_not_provided(self, browser):
         self.login(self.regular_user, browser)

--- a/opengever/api/tus.py
+++ b/opengever/api/tus.py
@@ -84,11 +84,8 @@ class UploadPatch(GeverUploadPatch):
         if self.context.has_file() and not manager.is_checked_out_by_current_user():
             raise Forbidden("Document not checked out.")
 
-        # XXX: Currently not supported by the latest Office Connector 1.10.0
-        # Enable this after a grace period when OC > 1.10.0 has been rolled out
-        # to customers.
-        # if manager.is_locked_by_other():
-        #     raise Forbidden("Document is locked.")
+        if manager.is_locked_by_other():
+            raise Forbidden("Document is locked.")
 
         if self.is_proposal_document_upload() or self.is_proposal_template_upload():
             tus_upload = self.tus_upload()


### PR DESCRIPTION

For [CA-4982]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-4982]: https://4teamwork.atlassian.net/browse/CA-4982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ