### PR TITLE
Revoke roles when objects are removed from a task's related items.

### DIFF
--- a/changes/CA-5006.bugfix
+++ b/changes/CA-5006.bugfix
@@ -1,0 +1,1 @@
+Revoke roles when objects are removed from a task's related items.

--- a/opengever/core/upgrades/20221125151226_store_task_related_items_in_annotations/upgrade.py
+++ b/opengever/core/upgrades/20221125151226_store_task_related_items_in_annotations/upgrade.py
@@ -1,0 +1,23 @@
+from Acquisition import aq_base
+from ftw.upgrade import UpgradeStep
+from opengever.task.localroles import RELATED_ITEMS_KEY
+from opengever.task.task import ITask
+from persistent.list import PersistentList
+from zope.annotation.interfaces import IAnnotations
+
+
+class StoreTaskRelatedItemsInAnnotations(UpgradeStep):
+    """Store task related items in annotations.
+    """
+
+    deferrable = True
+
+    def __call__(self):
+        query = {'object_provides': ITask.__identifier__}
+        msg = 'Store task related items in annotations.'
+
+        for task in self.objects(query, msg):
+            annotations = IAnnotations(task)
+            to_ids = [item.to_id for item in getattr(aq_base(task), 'relatedItems', [])]
+            if RELATED_ITEMS_KEY not in annotations:
+                annotations[RELATED_ITEMS_KEY] = PersistentList(to_ids)

--- a/opengever/task/localroles.py
+++ b/opengever/task/localroles.py
@@ -13,7 +13,14 @@ from opengever.globalindex.handlers.task import sync_task
 from opengever.meeting.proposal import IBaseProposal
 from opengever.ogds.base.actor import Actor
 from opengever.ogds.base.utils import get_current_org_unit
+from persistent.list import PersistentList
 from plone import api
+from zope.annotation.interfaces import IAnnotations
+from zope.component import getUtility
+from zope.intid import IIntIds
+
+
+RELATED_ITEMS_KEY = 'opengever.task.related_items'
 
 
 class LocalRolesSetter(object):
@@ -144,6 +151,25 @@ class LocalRolesSetter(object):
 
     def set_roles_on_related_items(self):
         """Set local roles on related items (usually documents)."""
+
+        # Some related items might have been deleted, we need to revoke the roles
+        # on those first.
+        annotations = IAnnotations(self.task)
+        to_ids = [item.to_id for item in getattr(aq_base(self.task), 'relatedItems', [])]
+        if RELATED_ITEMS_KEY not in annotations:
+            annotations[RELATED_ITEMS_KEY] = PersistentList(to_ids)
+        deleted_intids = set(annotations[RELATED_ITEMS_KEY]) - set(to_ids)
+        if deleted_intids:
+            intids = getUtility(IIntIds)
+            for deleted_intid in deleted_intids:
+                try:
+                    obj = intids.getObject(deleted_intid)
+                except KeyError:
+                    # obj has been deleted
+                    continue
+                self._revoke_roles(obj)
+            annotations[RELATED_ITEMS_KEY] = PersistentList(to_ids)
+
         roles = ['Reader']
         if self.task.task_type_category in [
                 'bidirectional_by_reference', 'unidirectional_by_value']:

--- a/opengever/task/localroles.py
+++ b/opengever/task/localroles.py
@@ -158,7 +158,9 @@ class LocalRolesSetter(object):
         to_ids = [item.to_id for item in getattr(aq_base(self.task), 'relatedItems', [])]
         if RELATED_ITEMS_KEY not in annotations:
             annotations[RELATED_ITEMS_KEY] = PersistentList(to_ids)
-        deleted_intids = set(annotations[RELATED_ITEMS_KEY]) - set(to_ids)
+        to_ids_set = set(to_ids)
+        annotations_related_items_set = set(annotations[RELATED_ITEMS_KEY])
+        deleted_intids = annotations_related_items_set - to_ids_set
         if deleted_intids:
             intids = getUtility(IIntIds)
             for deleted_intid in deleted_intids:
@@ -168,6 +170,8 @@ class LocalRolesSetter(object):
                     # obj has been deleted
                     continue
                 self._revoke_roles(obj)
+
+        if annotations_related_items_set != to_ids_set:
             annotations[RELATED_ITEMS_KEY] = PersistentList(to_ids)
 
         roles = ['Reader']


### PR DESCRIPTION
Local roles are added on documents that are related to a task. When closing that task, the local roles are revoked on the current list of related items, but if some objects were removed from the list of related items at some point, the local roles on these documents would never get revoked.
For newly added related items, the local roles were correctly updated in an event handler. To revoke the local roles on related items that get removed, we need to find out which objects were removed from the list of related items. This information is not accessible in the event handler, so we had to store the list of related items in the annotations on each task, allowing us to compare it with the `relatedItems` field on the task and revoking the local roles accordingly.

For [CA-5006]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [x] Make it deferrable if possible
  - [x] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)

[CA-5006]: https://4teamwork.atlassian.net/browse/CA-5006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ