### PR TITLE
Introduce a new option hide_members_for_guests on workspaces

### DIFF
--- a/changes/CA-4950.feature
+++ b/changes/CA-4950.feature
@@ -1,0 +1,1 @@
+Introduce a new option hide_members_for_guests on workspaces. [phgross]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,6 +11,8 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- Workspace and workspace folders serialization contains a new attribute ``can_access_members``.
+- ``@participations`` and ``@@workspace-content-members`` is no longer available for guests in workspaces with enabled ``hide_member_details`` option.
 
 2022.23.0 (2022-11-24)
 ----------------------

--- a/docs/schema-dumps/opengever.workspace.workspace.schema.json
+++ b/docs/schema-dumps/opengever.workspace.workspace.schema.json
@@ -30,6 +30,12 @@
             "description": "",
             "_zope_schema_type": "TextLine"
         },
+        "hide_members_for_guests": {
+            "type": "boolean",
+            "title": "Teamraum Mitglieder f\u00fcr G\u00e4ste ausblenden",
+            "description": "",
+            "_zope_schema_type": "Bool"
+        },
         "changed": {
             "type": "string",
             "title": "Zuletzt ver\u00e4ndert",
@@ -58,6 +64,7 @@
         "videoconferencing_url",
         "external_reference",
         "gever_url",
+        "hide_members_for_guests",
         "changed",
         "title",
         "description"

--- a/opengever/api/participations.py
+++ b/opengever/api/participations.py
@@ -116,6 +116,9 @@ class ParticipationsGet(ParticipationTraverseService):
     GET workspace/@participations HTTP/1.1
     """
     def reply(self):
+        if not self.context.access_members_allowed():
+            raise Forbidden
+
         token = self.read_params()
         if token:
             return self.prepare_response_item(self.find_participant(

--- a/opengever/api/tests/test_participation.py
+++ b/opengever/api/tests/test_participation.py
@@ -8,6 +8,7 @@ from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.testing import IntegrationTestCase
 from opengever.workspace.participation.storage import IInvitationStorage
 from plone.restapi.serializer.converters import json_compatible
+from zExceptions import Forbidden
 from zExceptions import Unauthorized
 from zope.component import getUtility
 import json
@@ -141,6 +142,18 @@ class TestParticipationGet(IntegrationTestCase):
                                u'title': u'Projekt A'},
               u'role': {u'title': u'Member', u'token': u'WorkspaceMember'}}],
             response.get('items'))
+
+    @browsing
+    def test_raises_forbidden_for_guests_if_members_are_hidden(self, browser):
+        browser.exception_bubbling = True
+
+        self.login(self.workspace_admin)
+        self.workspace.hide_members_for_guests = True
+
+        self.login(self.workspace_guest, browser)
+        with self.assertRaises(Forbidden):
+            browser.open(self.workspace, view='@participations',
+                         method='GET', headers=self.api_headers)
 
     @browsing
     def test_list_all_current_participants_in_folder_lists_participants_of_the_workspace(self, browser):

--- a/opengever/api/tests/test_workspace.py
+++ b/opengever/api/tests/test_workspace.py
@@ -46,3 +46,15 @@ class TestWorkspaceSerializer(IntegrationTestCase):
         browser.open(self.workspace, headers=self.api_headers)
         self.assertEqual(200, browser.status_code)
         self.assertEqual(u'1018013300@example.org', browser.json[u'email'])
+
+    @browsing
+    def test_workspace_serialization_contains_can_access_members(self, browser):
+        self.login(self.workspace_guest, browser)
+        browser.open(self.workspace, headers=self.api_headers)
+        self.assertTrue(browser.json['can_access_members'])
+
+        with self.login(self.workspace_admin, browser):
+            self.workspace.hide_members_for_guests = True
+
+        browser.open(self.workspace, headers=self.api_headers)
+        self.assertFalse(browser.json['can_access_members'])

--- a/opengever/api/tests/test_workspace_content_members.py
+++ b/opengever/api/tests/test_workspace_content_members.py
@@ -3,6 +3,7 @@ from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.base.role_assignments import SharingRoleAssignment
 from opengever.testing import IntegrationTestCase
 from plone import api
+from zExceptions import Forbidden
 import json
 
 
@@ -26,6 +27,18 @@ class TestWorkspaceContentMembersGetGet(IntegrationTestCase):
                         u'token': u'beatrice.schrodinger'}],
             u'items_total': 4}
         self.assertEqual(expected_json, browser.json)
+
+    @browsing
+    def test_raises_forbidden_for_guests_if_members_are_hidden(self, browser):
+        browser.exception_bubbling = True
+
+        self.login(self.workspace_admin)
+        self.workspace.hide_members_for_guests = True
+
+        self.login(self.workspace_guest, browser=browser)
+        url = self.workspace.absolute_url() + '/@workspace-content-members'
+        with self.assertRaises(Forbidden):
+            browser.open(url, method='GET', headers=self.api_headers)
 
     @browsing
     def test_get_workspace_content_members_with_query(self, browser):

--- a/opengever/api/tests/test_workspace_folder.py
+++ b/opengever/api/tests/test_workspace_folder.py
@@ -26,3 +26,15 @@ class TestWorkspaceFolderSerializer(IntegrationTestCase):
         browser.open(self.workspace_folder, headers=self.api_headers)
         self.assertEqual(200, browser.status_code)
         self.assertEqual(u'1018033300@example.org', browser.json['email'])
+
+    @browsing
+    def test_workspace_folder_serialization_contains_can_access_members(self, browser):
+        self.login(self.workspace_guest, browser)
+        browser.open(self.workspace_folder, headers=self.api_headers)
+        self.assertTrue(browser.json['can_access_members'])
+
+        with self.login(self.workspace_admin, browser):
+            self.workspace.hide_members_for_guests = True
+
+        browser.open(self.workspace_folder, headers=self.api_headers)
+        self.assertFalse(browser.json['can_access_members'])

--- a/opengever/api/workspace.py
+++ b/opengever/api/workspace.py
@@ -22,6 +22,7 @@ class SerializeWorkspaceToJson(GeverSerializeFolderToJson):
         result = super(SerializeWorkspaceToJson, self).__call__(*args, **kwargs)
 
         result[u"can_manage_participants"] = can_manage_member(self.context)
+        result[u"can_access_members"] = self.context.access_members_allowed()
         result[u'email'] = IEmailAddress(self.request).get_email_for_object(self.context)
 
         return result

--- a/opengever/api/workspace_content_members.py
+++ b/opengever/api/workspace_content_members.py
@@ -6,6 +6,7 @@ from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.services import Service
 from Products.CMFPlone.utils import safe_unicode
 from zExceptions import BadRequest
+from zExceptions import Forbidden
 from zope.component import getMultiAdapter
 
 
@@ -13,6 +14,10 @@ class WorkspaceContentMembersGet(Service):
     def reply(self):
         if not is_within_workspace(self.context):
             raise BadRequest("'{}' is not within a workspace".format(self.context.getId()))
+
+        if not self.context.access_members_allowed():
+            raise Forbidden
+
         source = WorkspaceContentMemberUsersSource(self.context)
         query = safe_unicode(self.request.form.get('query', ''))
         results = source.search(query)

--- a/opengever/api/workspace_folder.py
+++ b/opengever/api/workspace_folder.py
@@ -2,6 +2,7 @@ from ftw.mail.interfaces import IEmailAddress
 from opengever.api.serializer import GeverSerializeFolderToJson
 from opengever.trash.trash import ITrasher
 from opengever.workspace.interfaces import IWorkspaceFolder
+from opengever.workspace.utils import get_containing_workspace
 from zope.component import adapter
 from zope.interface import Interface
 
@@ -13,4 +14,6 @@ class SerializeWorkspaceFolderToJson(GeverSerializeFolderToJson):
         result = super(SerializeWorkspaceFolderToJson, self).__call__(*args, **kwargs)
         result[u'email'] = IEmailAddress(self.request).get_email_for_object(self.context)
         result["trashed"] = ITrasher(self.context).is_trashed()
+        result[u"can_access_members"] = get_containing_workspace(
+            self.context).access_members_allowed()
         return result

--- a/opengever/base/tests/test_solr.py
+++ b/opengever/base/tests/test_solr.py
@@ -90,6 +90,7 @@ class TestSolr(IntegrationTestCase):
             'date_of_completion',
             'getId',
             'predecessor',
+            'hide_member_details',
         ]
 
         for index in catalog.indexes():

--- a/opengever/base/visible_users_and_groups_filter.py
+++ b/opengever/base/visible_users_and_groups_filter.py
@@ -62,7 +62,8 @@ class VisibleUsersAndGroupsFilter:
         catalog = api.portal.get_tool('portal_catalog')
         zcatalog = catalog._catalog
 
-        workspace_brains = catalog(portal_type="opengever.workspace.workspace")
+        workspace_brains = catalog(portal_type="opengever.workspace.workspace",
+                                   hide_member_details=False)
         allowedRolesAndUsers_index = zcatalog.getIndex('allowedRolesAndUsers')
         rids = [zcatalog.uids[brain.getPath()] for brain in workspace_brains]
 

--- a/opengever/bundle/schemas/workspaces.schema.json
+++ b/opengever/bundle/schemas/workspaces.schema.json
@@ -48,6 +48,15 @@
                     "description": "",
                     "_zope_schema_type": "TextLine"
                 },
+                "hide_members_for_guests": {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "title": "Teamraum Mitglieder f\u00fcr G\u00e4ste ausblenden",
+                    "description": "",
+                    "_zope_schema_type": "Bool"
+                },
                 "changed": {
                     "type": [
                         "null",
@@ -127,6 +136,7 @@
                 "videoconferencing_url",
                 "external_reference",
                 "gever_url",
+                "hide_members_for_guests",
                 "changed",
                 "title",
                 "description"

--- a/opengever/core/hooks.py
+++ b/opengever/core/hooks.py
@@ -15,6 +15,7 @@ import opengever.repository.hooks
 import opengever.tabbedview.hooks
 import opengever.task.hooks
 import opengever.trash.hooks
+import opengever.workspace.hooks
 import opengever.workspaceclient.hooks
 import re
 
@@ -103,6 +104,7 @@ def trigger_subpackage_hooks(site):
     opengever.quota.hooks.policy_installed(site)
     # Added after the profile merge
     opengever.repository.hooks.installed(site)
+    opengever.workspace.hooks.installed(site)
     opengever.workspaceclient.hooks.installed(site)
 
 

--- a/opengever/core/lawgiver.zcml
+++ b/opengever/core/lawgiver.zcml
@@ -246,6 +246,7 @@
                    opengever.workspace: Update Content Order,
                    opengever.workspaceclient: Unlink Workspace,
                    opengever.workspace: Access all users and groups,
+                   opengever.workspace: Access hidden members,
                    opengever.workspaceclient: Use Workspace Client,
                    plone.app.collection: Add Collection,
                    plone.restapi: Access Plone user information,

--- a/opengever/core/profiles/default/rolemap.xml
+++ b/opengever/core/profiles/default/rolemap.xml
@@ -421,6 +421,13 @@
       <role name="WorkspacesCreator" />
     </permission>
 
+    <permission name="opengever.workspace: Access hidden members" acquire="True">
+      <role name="Manager" />
+      <role name="Administrator" />
+      <role name="WorkspaceAdmin" />
+      <role name="WorkspaceMember" />
+    </permission>
+
     <permission name="opengever.ogds.base: Sync the OGDS" acquire="True">
       <role name="Manager" />
       <role name="Administrator" />

--- a/opengever/core/upgrades/20221124083002_add_workspace_members_hidden_index/upgrade.py
+++ b/opengever/core/upgrades/20221124083002_add_workspace_members_hidden_index/upgrade.py
@@ -1,0 +1,23 @@
+from ftw.upgrade import UpgradeStep
+from opengever.workspace.interfaces import IWorkspace
+
+
+class AddWorkspaceMembersHiddenIndex(UpgradeStep):
+    """Add workspace_members_hidden index.
+    """
+
+    index_name = 'workspace_members_hidden'
+
+    deferrable = True
+
+    def __call__(self):
+        self.install_upgrade_profile()
+
+        if not self.catalog_has_index(self.index_name):
+            self.catalog_add_index(self.index_name, 'BooleanIndex')
+
+        query = {'object_provides': IWorkspace.__identifier__}
+        for obj in self.objects(
+                query, u'Reindex workspace_members_hidden for workspaces'):
+
+            obj.reindexObject(idxs=[self.index_name])

--- a/opengever/core/upgrades/20221124100757_add_new_access_hidden_members_permission/rolemap.xml
+++ b/opengever/core/upgrades/20221124100757_add_new_access_hidden_members_permission/rolemap.xml
@@ -1,0 +1,14 @@
+<rolemap>
+
+  <permissions>
+
+    <permission name="opengever.workspace: Access hidden members" acquire="True">
+      <role name="Manager" />
+      <role name="Administrator" />
+      <role name="WorkspaceAdmin" />
+      <role name="WorkspaceMember" />
+    </permission>
+
+  </permissions>
+
+</rolemap>

--- a/opengever/core/upgrades/20221124100757_add_new_access_hidden_members_permission/upgrade.py
+++ b/opengever/core/upgrades/20221124100757_add_new_access_hidden_members_permission/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddNewAccessHiddenMembersPermission(UpgradeStep):
+    """Add new AccessHiddenMembers permission.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/document/tests/test_copy_document.py
+++ b/opengever/document/tests/test_copy_document.py
@@ -229,6 +229,7 @@ class TestCopyDocuments(IntegrationTestCase):
                                'filesize',
                                'firstname',
                                'getObjPositionInParent',
+                               'hide_member_details',
                                'is_folderish',
                                'is_subtask',
                                'lastname',

--- a/opengever/dossier/tests/test_move_items.py
+++ b/opengever/dossier/tests/test_move_items.py
@@ -260,6 +260,7 @@ class TestMoveItemsUpdatesIndexAndMetadata(SolrIntegrationTestCase, MoveItemsHel
         'firstname',
         'getId',
         'getObjPositionInParent',
+        'hide_member_details',
         'id',
         'is_folderish',
         'is_subtask',

--- a/opengever/readonly/tests/test_all_roles_and_permissions_mapped.py
+++ b/opengever/readonly/tests/test_all_roles_and_permissions_mapped.py
@@ -185,6 +185,7 @@ NON_WRITE_PERMISSIONS = [
     'opengever.workspace: Access all users and groups',
     'opengever.workspace: Manage Workspaces',
     'opengever.workspaceclient: Use Workspace Client',
+    'opengever.workspace: Access hidden members',
     'Plone Site Setup: Calendar',
     'Plone Site Setup: Editing',
     'Plone Site Setup: Filtering',

--- a/opengever/workspace/actions.py
+++ b/opengever/workspace/actions.py
@@ -7,6 +7,7 @@ from opengever.workspace.interfaces import IToDo
 from opengever.workspace.interfaces import IWorkspace
 from opengever.workspace.interfaces import IWorkspaceFolder
 from opengever.workspace.interfaces import IWorkspaceMeeting
+from opengever.workspace.utils import get_containing_workspace
 from plone import api
 from plone.dexterity.interfaces import IDexterityContainer
 from zExceptions import Forbidden
@@ -30,7 +31,7 @@ class WorkspaceFolderListingActions(BaseListingActions):
 class TodoContextActions(BaseContextActions):
 
     def is_share_content_available(self):
-        return True
+        return get_containing_workspace(self.context).access_members_allowed()
 
     def is_edit_available(self):
         return api.user.has_permission('Modify portal content', obj=self.context)
@@ -46,7 +47,7 @@ class WorkspaceMeetingContextActions(BaseContextActions):
         return True
 
     def is_share_content_available(self):
-        return True
+        return get_containing_workspace(self.context).access_members_allowed()
 
 
 @adapter(IWorkspace, IOpengeverBaseLayer)
@@ -60,7 +61,7 @@ class WorkspaceContextActions(BaseContextActions):
         return self.context.is_deletion_allowed()
 
     def is_share_content_available(self):
-        return True
+        return get_containing_workspace(self.context).access_members_allowed()
 
     def is_zipexport_available(self):
         return True
@@ -82,7 +83,7 @@ class WorkspaceFolderContextActions(BaseContextActions):
         return super(WorkspaceFolderContextActions, self).is_edit_available()
 
     def is_share_content_available(self):
-        return True
+        return get_containing_workspace(self.context).access_members_allowed()
 
     def is_trash_context_available(self):
         return ITrasher(self.context).verify_may_trash(raise_on_violations=False)

--- a/opengever/workspace/config.py
+++ b/opengever/workspace/config.py
@@ -1,6 +1,11 @@
 import os
 
 
+INDEXES = (
+    ('hide_member_details', 'BooleanIndex'),
+)
+
+
 class WorkspaceConfig(object):
 
     @property

--- a/opengever/workspace/configure.zcml
+++ b/opengever/workspace/configure.zcml
@@ -103,6 +103,11 @@
       />
 
   <adapter
+      factory=".indexers.hide_member_details"
+      name="hide_member_details"
+      />
+
+  <adapter
       factory=".indexers.attendees"
       name="attendees"
       />

--- a/opengever/workspace/hooks.py
+++ b/opengever/workspace/hooks.py
@@ -1,0 +1,7 @@
+from opengever.core.catalog import add_catalog_indexes
+from opengever.workspace.config import INDEXES
+import logging
+
+
+def installed(site):
+    add_catalog_indexes(INDEXES, logging.getLogger('opengever.workspace'))

--- a/opengever/workspace/indexers.py
+++ b/opengever/workspace/indexers.py
@@ -65,3 +65,8 @@ class WorkspaceMeetingSearchableTextExtender(object):
 @indexer(IWorkspaceMeeting)
 def attendees(obj):
     return obj.attendees
+
+
+@indexer(IWorkspaceSchema)
+def hide_member_details(obj):
+    return bool(obj.hide_members_for_guests)

--- a/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-11-03 15:09+0000\n"
+"POT-Creation-Date: 2022-11-24 14:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -215,6 +215,11 @@ msgstr "Ordner"
 #: ./opengever/workspace/workspace.py
 msgid "label_gever_url"
 msgstr "GEVER URL"
+
+#. Default: "Hide workspace members for workspace guests"
+#: ./opengever/workspace/workspace.py
+msgid "label_hide_members_for_guests"
+msgstr "Teamraum Mitglieder für Gäste ausblenden"
 
 #. Default: "Journal"
 #: ./opengever/workspace/browser/tabbed.py

--- a/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-11-03 15:09+0000\n"
+"POT-Creation-Date: 2022-11-24 14:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -245,6 +245,11 @@ msgstr "Folders"
 #: ./opengever/workspace/workspace.py
 msgid "label_gever_url"
 msgstr "GEVER URL"
+
+#. Default: "Hide workspace members for workspace guests"
+#: ./opengever/workspace/workspace.py
+msgid "label_hide_members_for_guests"
+msgstr "Hide workspace members for workspace guests"
 
 #. German translation: Journal
 #. Default: "Journal"

--- a/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-11-03 15:09+0000\n"
+"POT-Creation-Date: 2022-11-24 14:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -215,6 +215,11 @@ msgstr "Répertoires"
 #: ./opengever/workspace/workspace.py
 msgid "label_gever_url"
 msgstr "GEVER URL"
+
+#. Default: "Hide workspace members for workspace guests"
+#: ./opengever/workspace/workspace.py
+msgid "label_hide_members_for_guests"
+msgstr ""
 
 #. Default: "Journal"
 #: ./opengever/workspace/browser/tabbed.py

--- a/opengever/workspace/locales/opengever.workspace.pot
+++ b/opengever/workspace/locales/opengever.workspace.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-11-03 15:09+0000\n"
+"POT-Creation-Date: 2022-11-24 14:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -217,6 +217,11 @@ msgstr ""
 #. Default: "GEVER URL"
 #: ./opengever/workspace/workspace.py
 msgid "label_gever_url"
+msgstr ""
+
+#. Default: "Hide workspace members for workspace guests"
+#: ./opengever/workspace/workspace.py
+msgid "label_hide_members_for_guests"
 msgstr ""
 
 #. Default: "Journal"

--- a/opengever/workspace/permissions.zcml
+++ b/opengever/workspace/permissions.zcml
@@ -28,4 +28,6 @@
 
   <permission id="opengever.workspace.AccessAllUsersAndGroups" title="opengever.workspace: Access all users and groups" />
 
+  <permission id="opengever.workspace.AccessHiddenMembers" title="opengever.workspace: Access hidden members" />
+
 </configure>

--- a/opengever/workspace/tests/test_actions.py
+++ b/opengever/workspace/tests/test_actions.py
@@ -28,8 +28,15 @@ class TestTodoContextActions(IntegrationTestCase):
 
     def test_todo_context_actions(self):
         self.login(self.workspace_member)
-        expected_actions = [u'edit', u'share_content']
-        self.assertEqual(expected_actions, self.get_actions(self.todo))
+        self.assertEqual([u'edit', u'share_content'], self.get_actions(self.todo))
+
+        self.login(self.workspace_guest)
+        self.assertEqual([u'share_content'], self.get_actions(self.todo))
+
+        with self.login(self.workspace_admin):
+            self.workspace.hide_members_for_guests = True
+
+        self.assertEqual([], self.get_actions(self.todo))
 
 
 class TestWorkspaceMeetingContextActions(IntegrationTestCase):
@@ -44,6 +51,18 @@ class TestWorkspaceMeetingContextActions(IntegrationTestCase):
                             u'share_content']
         self.assertEqual(expected_actions, self.get_actions(self.workspace_meeting))
 
+        self.login(self.workspace_guest)
+        self.assertEqual(
+            [u'meeting_ical_download', u'meeting_minutes_pdf', u'share_content'],
+            self.get_actions(self.workspace_meeting))
+
+        with self.login(self.workspace_admin):
+            self.workspace.hide_members_for_guests = True
+
+        self.assertEqual(
+            [u'meeting_ical_download', u'meeting_minutes_pdf'],
+            self.get_actions(self.workspace_meeting))
+
 
 class TestWorkspaceContextActions(IntegrationTestCase):
 
@@ -55,6 +74,16 @@ class TestWorkspaceContextActions(IntegrationTestCase):
         self.login(self.workspace_member)
         expected_actions = [u'edit', u'share_content', 'zipexport']
         self.assertEqual(expected_actions, self.get_actions(self.workspace))
+
+    def test_workspace_context_actions_for_guests(self):
+        self.login(self.workspace_guest)
+        self.assertEqual([u'share_content', 'zipexport'],
+                         self.get_actions(self.workspace))
+
+        with self.login(self.workspace_admin):
+            self.workspace.hide_members_for_guests = True
+
+        self.assertEqual([u'zipexport'], self.get_actions(self.workspace))
 
     def test_workspace_context_actions_for_workspace_admins(self):
         self.login(self.workspace_admin)
@@ -84,6 +113,16 @@ class TestWorkspaceFolderContextActions(IntegrationTestCase):
         self.login(self.workspace_member)
         expected_actions = [u'edit', u'share_content', u'trash_context', 'zipexport']
         self.assertEqual(expected_actions, self.get_actions(self.workspace_folder))
+
+    def test_workspace_context_actions_for_guests(self):
+        self.login(self.workspace_guest)
+        self.assertEqual([u'share_content', 'zipexport'],
+                         self.get_actions(self.workspace_folder))
+
+        with self.login(self.workspace_admin):
+            self.workspace.hide_members_for_guests = True
+
+        self.assertEqual([u'zipexport'], self.get_actions(self.workspace_folder))
 
     def test_workspace_folder_context_actions_for_workspace_admins(self):
         self.login(self.workspace_admin)

--- a/opengever/workspace/tests/test_workspace_workspace.py
+++ b/opengever/workspace/tests/test_workspace_workspace.py
@@ -278,6 +278,29 @@ class TestWorkspaceWorkspace(IntegrationTestCase):
         self.maxDiff = None
         self.assertEquals(expected, got)
 
+    def test_access_members_allowed_for_guests_if_flag_disabled(self):
+        self.login(self.workspace_admin)
+        self.workspace.hide_members_for_guests = False
+
+        self.login(self.workspace_guest)
+        self.assertTrue(self.workspace.access_members_allowed())
+
+    def test_access_members_disallowed_for_guests_if_flag_enabled(self):
+        self.login(self.workspace_admin)
+        self.workspace.hide_members_for_guests = True
+
+        self.login(self.workspace_guest)
+        self.assertFalse(self.workspace.access_members_allowed())
+
+    def test_access_members_allowed_for_members_and_admins(self):
+        self.login(self.workspace_admin)
+        self.workspace.hide_members_for_guests = True
+
+        self.assertTrue(self.workspace.access_members_allowed())
+
+        self.login(self.workspace_member)
+        self.assertTrue(self.workspace.access_members_allowed())
+
 
 class TestWorkspaceWorkspaceAPI(IntegrationTestCase):
 

--- a/opengever/workspace/workspace.py
+++ b/opengever/workspace/workspace.py
@@ -65,6 +65,11 @@ class IWorkspaceSchema(model.Schema):
         default=u'',
         missing_value=u''
     )
+    hide_members_for_guests = schema.Bool(
+        title=_(u'label_hide_members_for_guests',
+                default=u'Hide workspace members for workspace guests'),
+        required=False,
+    )
 
 
 class Workspace(WorkspaceBase):
@@ -91,6 +96,13 @@ class Workspace(WorkspaceBase):
             return True
         except Forbidden:
             return False
+
+    def access_members_allowed(self):
+        if self.hide_members_for_guests:
+            return api.user.has_permission(
+                'opengever.workspace: Access hidden members', obj=self)
+
+        return True
 
 
 class WorkspaceContentPatch(ContentPatch):


### PR DESCRIPTION
This PR adds a new option `hide members for guests`, which allows a workspace admin to hide the member data for guests.
Enabling the flag, which is disabled by default, means:
 - The share_content action is not available for guests of a workspace
 - The participant listing stays empty, and displays a corresponding message instead
 - All members of such a workspace are excluded of general user listings in other workspaces (for example in the `Add User` Select-field)

**Technical thoughts**
- `@participations` and `@workspace-content-members` endpoint raises unauthorized for Guests if the flag is enabled
- The VisibleUsersAndGroupsFilter skip workspaces with enabled flag, so that the hidden workspace members are not available in other workspaces.  To accomplish this, I introduced a new BooleanIndex `hide_member_details`.

For [CA-4950]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- Upgrade-Steps:
  - [x] Execute as much as possible conditionally
- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
- New translations
  - [x] All msg-strings are unicode

[CA-4950]: https://4teamwork.atlassian.net/browse/CA-4950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ