### PR TITLE
Fix TaskResponsible role translation.

### DIFF
--- a/opengever/core/locales/de/LC_MESSAGES/plone.po
+++ b/opengever/core/locales/de/LC_MESSAGES/plone.po
@@ -34,9 +34,6 @@ msgstr "Erledigt"
 msgid "DossierManager"
 msgstr "Verwalten"
 
-msgid "TaskResponsible"
-msgstr "Auftragnehmer"
-
 #. Default: "Download Excel"
 #: opengever/core/profiles/default/types/opengever.repository.repositoryroot.xml
 msgid "Download Excel"
@@ -55,6 +52,9 @@ msgstr "Inaktiv"
 
 msgid "Publisher"
 msgstr "Reaktivieren"
+
+msgid "TaskResponsible"
+msgstr "Auftragnehmer"
 
 #. Default: "close"
 #: opengever/core/profiles/default/workflows/opengever_workspace_meeting/specification.txt

--- a/opengever/core/locales/en/LC_MESSAGES/plone.po
+++ b/opengever/core/locales/en/LC_MESSAGES/plone.po
@@ -36,9 +36,6 @@ msgstr "Completed"
 msgid "DossierManager"
 msgstr "Manage dossiers"
 
-msgid "TaskResponsible"
-msgstr "Task responsible"
-
 #. German translation: Als Excel exportieren
 #. Default: "Download Excel"
 #: opengever/core/profiles/default/types/opengever.repository.repositoryroot.xml
@@ -61,6 +58,9 @@ msgstr "Inactive"
 #. German translation: Reaktivieren
 msgid "Publisher"
 msgstr "Reactivate"
+
+msgid "TaskResponsible"
+msgstr "Task responsible"
 
 #. Default: "close"
 #: opengever/core/profiles/default/workflows/opengever_workspace_meeting/specification.txt

--- a/opengever/core/locales/fr/LC_MESSAGES/plone.po
+++ b/opengever/core/locales/fr/LC_MESSAGES/plone.po
@@ -34,9 +34,6 @@ msgstr "Complété"
 msgid "DossierManager"
 msgstr "Administrer"
 
-msgid "TaskResponsible"
-msgstr "Mandataire"
-
 #. Default: "Download Excel"
 #: opengever/core/profiles/default/types/opengever.repository.repositoryroot.xml
 msgid "Download Excel"
@@ -55,6 +52,9 @@ msgstr "Inactif"
 
 msgid "Publisher"
 msgstr "Reactiver"
+
+msgid "TaskResponsible"
+msgstr "Mandataire"
 
 #. Default: "close"
 #: opengever/core/profiles/default/workflows/opengever_workspace_meeting/specification.txt

--- a/opengever/core/locales/plone.pot
+++ b/opengever/core/locales/plone.pot
@@ -31,6 +31,9 @@ msgstr ""
 msgid "DossierManager"
 msgstr ""
 
+msgid "TaskResponsible"
+msgstr ""
+
 #. Default: "Download Excel"
 #: opengever/core/profiles/default/types/opengever.repository.repositoryroot.xml
 msgid "Download Excel"


### PR DESCRIPTION
Seems I forgot to add the `TaskResponsible` in the `plone.pot` file. This does not have any impact, except of course when running `i18n-build` for the next time...

For [CA-4395]

## Checklist
- [ ] Changelog entry -> Nope
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-4395]: https://4teamwork.atlassian.net/browse/CA-4395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ