### PR TITLE
Modify order of roles in sharing tab.

### DIFF
--- a/opengever/sharing/browser/sharing.py
+++ b/opengever/sharing/browser/sharing.py
@@ -47,11 +47,11 @@ import json
 import re
 
 
-ROLES_ORDER = ['TaskResponsible', 'Reader', 'Contributor', 'Editor', 'Reviewer',
+ROLES_ORDER = ['Reader', 'Contributor', 'Editor', 'Reviewer',
                'Publisher', 'DossierManager',
                'MeetingUser', 'CommitteeAdministrator',
-               'CommitteeResponsible', 'CommitteeMember', 'WorkspaceAdmin',
-               'WorkspacesCreator',
+               'CommitteeResponsible', 'CommitteeMember', 'TaskResponsible',
+               'WorkspaceAdmin', 'WorkspacesCreator',
                'WorkspaceMember', 'WorkspaceGuest', 'WorkspacesUser']
 
 

--- a/opengever/sharing/tests/test_sharing.py
+++ b/opengever/sharing/tests/test_sharing.py
@@ -64,8 +64,8 @@ class TestOpengeverSharing(IntegrationTestCase):
                      method='GET', headers={'Accept': 'application/json'})
 
         self.assertEqual(
-            [u'TaskResponsible', u'Reader', u'Contributor', u'Editor',
-             u'Reviewer', u'Publisher', u'DossierManager'],
+            [u'Reader', u'Contributor', u'Editor', u'Reviewer',
+             u'Publisher', u'DossierManager', u'TaskResponsible'],
             [role['id'] for role in browser.json.get('available_roles')])
         self.assertEqual(
             [u'Publisher', u'TaskResponsible', u'DossierManager', u'Editor',


### PR DESCRIPTION
Place TaskResponsible role as last. It's the least important role, so it does not have to be that proeminent.

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-4395]

## Checklist
- [ ] Changelog entry -> no CL entry, it's a follow up of https://github.com/4teamwork/opengever.core/pull/7613
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-4395]: https://4teamwork.atlassian.net/browse/CA-4395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ