### PR TITLE
Fix upgrade steps that add new indexes

### DIFF
--- a/changes/CA-5038-1.other
+++ b/changes/CA-5038-1.other
@@ -1,0 +1,1 @@
+Use create_index_if_not_exists() for recent upgrade steps that create indexes. [lgraf]

--- a/changes/CA-5038.other
+++ b/changes/CA-5038.other
@@ -1,0 +1,1 @@
+SchemaMigration: Add create_index_if_not_exists() helper method. [lgraf]

--- a/opengever/core/tests/test_upgrade.py
+++ b/opengever/core/tests/test_upgrade.py
@@ -1,10 +1,8 @@
-from alembic.migration import MigrationContext
 from opengever.base.behaviors.classification import IClassification
 from opengever.base.behaviors.classification import public_trial_default
 from opengever.base.default_values import get_persisted_value_for_field
 from opengever.base.default_values import object_has_value_for_field
 from opengever.core.upgrade import DefaultValuePersister
-from opengever.core.upgrade import IdempotentOperations
 from opengever.core.upgrade import IntIdMaintenanceJobContextManagerMixin
 from opengever.core.upgrade import NightlyIndexer
 from opengever.core.upgrade import NightlyWorkflowSecurityUpdater
@@ -17,81 +15,8 @@ from opengever.testing import obj2brain
 from opengever.testing import solr_data_for
 from opengever.testing import SolrIntegrationTestCase
 from plone.uuid.interfaces import IUUID
-from sqlalchemy import Column
-from sqlalchemy import create_engine
-from sqlalchemy import Integer
-from sqlalchemy import MetaData
-from sqlalchemy import String
-from sqlalchemy import Table
-from sqlalchemy.engine.reflection import Inspector
-from unittest import TestCase
 from zope.component import getUtility
 from zope.intid.interfaces import IIntIds
-
-
-class TestIdempotentOperations(TestCase):
-    """Test database migration utilities.
-
-    Unfortunately not all operations can be tested with an SQLite database
-    since not all ALTER TABLE operations are supported, see
-    http://www.sqlite.org/lang_altertable.html.
-
-    Currenlty these untested operations are:
-    - IdempotentOperations. drop_column
-    - DeactivatedFKConstraint
-
-    """
-    def setUp(self):
-        self.connection = create_engine('sqlite:///:memory:').connect()
-        self.metadata = MetaData(self.connection)
-        self.table = Table('thingy', self.metadata,
-                           Column('thingy_id', Integer, primary_key=True))
-        self.metadata.create_all()
-
-        self.migration_context = MigrationContext.configure(self.connection)
-        self.op = IdempotentOperations(self.migration_context, self.metadata)
-        self.inspector = Inspector(self.connection)
-
-    def tearDown(self):
-        self.metadata.drop_all()
-        self.connection.close()
-
-    def refresh_metadata(self):
-        self.metadata.clear()
-        self.metadata.reflect()
-
-    def test_add_column_works_with_valid_preconditions(self):
-        self.assertEqual(['thingy_id'],
-                         self.metadata.tables['thingy'].columns.keys())
-
-        self.op.add_column('thingy', Column('foo', String))
-        self.refresh_metadata()
-
-        self.assertEqual(['thingy_id', 'foo'],
-                         self.metadata.tables['thingy'].columns.keys())
-
-    def test_add_column_skips_add_when_column_name_already_exists(self):
-        self.assertEqual(['thingy_id'],
-                         self.metadata.tables['thingy'].columns.keys())
-
-        self.op.add_column('thingy', Column('thingy_id', String))
-        self.refresh_metadata()
-
-        self.assertEqual(['thingy_id'],
-                         self.metadata.tables['thingy'].columns.keys())
-
-    def test_create_tables_skips_create_when_table_already_exists(self):
-        self.assertEqual(['thingy'], self.metadata.tables.keys())
-
-        self.op.create_table('thingy')
-        self.refresh_metadata()
-        self.assertEqual(['thingy'], self.metadata.tables.keys())
-
-    def test_create_table_works_with_valid_preconditions(self):
-        self.assertEqual(['thingy'], self.metadata.tables.keys())
-        self.op.create_table('xuq', Column('foo', Integer, primary_key=True))
-        self.refresh_metadata()
-        self.assertEqual(['thingy', 'xuq'], self.metadata.tables.keys())
 
 
 class DummyIntIdMaintenanceJobManager(IntIdMaintenanceJobContextManagerMixin):

--- a/opengever/core/upgrades/20220914101403_add_case_insensitive_sql_indexes_for_user_and_group_i_ds/upgrade.py
+++ b/opengever/core/upgrades/20220914101403_add_case_insensitive_sql_indexes_for_user_and_group_i_ds/upgrade.py
@@ -13,4 +13,4 @@ class AddCaseInsensitiveSQLIndexesForUserAndGroupIDs(SchemaMigration):
         )
 
         for idx_name, table_name, idx_columns in INDEXES:
-            self.op.create_index(idx_name, table_name, idx_columns)
+            self.create_index_if_not_exists(idx_name, table_name, idx_columns)

--- a/opengever/core/upgrades/20220914151051_add_case_insensitive_sql_index_for_groups_users_userid/upgrade.py
+++ b/opengever/core/upgrades/20220914151051_add_case_insensitive_sql_index_for_groups_users_userid/upgrade.py
@@ -12,4 +12,4 @@ class AddCaseInsensitiveSQLIndexForGroupsUsersUserid(SchemaMigration):
         )
 
         for idx_name, table_name, idx_columns in INDEXES:
-            self.op.create_index(idx_name, table_name, idx_columns)
+            self.create_index_if_not_exists(idx_name, table_name, idx_columns)

--- a/opengever/core/upgrades/20221013095934_add_index_for_predecessor_id/upgrade.py
+++ b/opengever/core/upgrades/20221013095934_add_index_for_predecessor_id/upgrade.py
@@ -10,4 +10,4 @@ class AddIndexForPredecessorId(SchemaMigration):
         if is_oracle():
             # The index already exists for Zug.
             return
-        self.op.create_index('ix_tasks_predecessor_id', 'tasks', ['predecessor_id'])
+        self.create_index_if_not_exists('ix_tasks_predecessor_id', 'tasks', ['predecessor_id'])

--- a/opengever/ogds/base/upgrades/to4004.py
+++ b/opengever/ogds/base/upgrades/to4004.py
@@ -1,6 +1,10 @@
-from opengever.core.upgrade import DeactivatedFKConstraint
 from opengever.core.upgrade import SchemaMigration
 from sqlalchemy import String
+
+
+# Dropped since we don't support MySQL anymore and this UpgradeStep is so
+# ancient that we might remove it anyway.
+DeactivatedFKConstraint = None
 
 
 class MigrateAdminUnitOrgUnitSchema(SchemaMigration):

--- a/opengever/ogds/base/upgrades/to4006.py
+++ b/opengever/ogds/base/upgrades/to4006.py
@@ -1,6 +1,10 @@
-from opengever.core.upgrade import DeactivatedFKConstraint
 from opengever.core.upgrade import SchemaMigration
 from sqlalchemy import String
+
+
+# Dropped since we don't support MySQL anymore and this UpgradeStep is so
+# ancient that we might remove it anyway.
+DeactivatedFKConstraint = None
 
 
 class IncreaseColumnLength(SchemaMigration):


### PR DESCRIPTION
This introduces a new helper method `.create_index_if_not_exists()` on the `SchemaMigration` class that will only emit a `CREATE INDEX` statement if the index by that name doesn't exist yet, and makes the (recent) upgrade steps that add new indexes use it.

This makes those upgrade steps idempotent, so that they won't fail if executed a second time.

In addition, I removed the `IdempotentOperations` class and some other special handling for MySQL, which we dropped support for years ago.

For [CA-5038](https://4teamwork.atlassian.net/browse/CA-5038)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)