### PR TITLE
Add missing French translations.

### DIFF
--- a/docs/schema-dumps/opengever.workspace.workspace.schema.json
+++ b/docs/schema-dumps/opengever.workspace.workspace.schema.json
@@ -32,7 +32,7 @@
         },
         "hide_members_for_guests": {
             "type": "boolean",
-            "title": "Teamraum Mitglieder f\u00fcr G\u00e4ste ausblenden",
+            "title": "Teamraum-Teilnehmer f\u00fcr G\u00e4ste ausblenden",
             "description": "",
             "_zope_schema_type": "Bool"
         },

--- a/opengever/bundle/schemas/workspaces.schema.json
+++ b/opengever/bundle/schemas/workspaces.schema.json
@@ -53,7 +53,7 @@
                         "null",
                         "boolean"
                     ],
-                    "title": "Teamraum Mitglieder f\u00fcr G\u00e4ste ausblenden",
+                    "title": "Teamraum-Teilnehmer f\u00fcr G\u00e4ste ausblenden",
                     "description": "",
                     "_zope_schema_type": "Bool"
                 },

--- a/opengever/propertysheets/locales/fr/LC_MESSAGES/opengever.propertysheets.po
+++ b/opengever/propertysheets/locales/fr/LC_MESSAGES/opengever.propertysheets.po
@@ -68,7 +68,7 @@ msgstr "Type de contenu pour lequel cette Property Sheet sera disponible"
 #. Default: "Whether the field should be available as docproperty or not"
 #: ./opengever/propertysheets/metaschema.py
 msgid "help_available_as_docproperty"
-msgstr ""
+msgstr "Rendre le champ accessible en tant que docproperty"
 
 #. Default: "Default value for this field"
 #: ./opengever/propertysheets/metaschema.py
@@ -123,7 +123,7 @@ msgstr "Assignations"
 #. Default: "Available as docproperty"
 #: ./opengever/propertysheets/metaschema.py
 msgid "label_available_as_docproperty"
-msgstr ""
+msgstr "Accessible en tant que docproperty"
 
 #. Default: "Default"
 #: ./opengever/propertysheets/metaschema.py

--- a/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
@@ -219,7 +219,7 @@ msgstr "GEVER URL"
 #. Default: "Hide workspace members for workspace guests"
 #: ./opengever/workspace/workspace.py
 msgid "label_hide_members_for_guests"
-msgstr "Teamraum Mitglieder für Gäste ausblenden"
+msgstr "Teamraum-Teilnehmer für Gäste ausblenden"
 
 #. Default: "Journal"
 #: ./opengever/workspace/browser/tabbed.py

--- a/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
@@ -249,7 +249,7 @@ msgstr "GEVER URL"
 #. Default: "Hide workspace members for workspace guests"
 #: ./opengever/workspace/workspace.py
 msgid "label_hide_members_for_guests"
-msgstr "Hide workspace members for workspace guests"
+msgstr "Hide workspace participants for workspace guests"
 
 #. German translation: Journal
 #. Default: "Journal"

--- a/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
@@ -219,7 +219,7 @@ msgstr "GEVER URL"
 #. Default: "Hide workspace members for workspace guests"
 #: ./opengever/workspace/workspace.py
 msgid "label_hide_members_for_guests"
-msgstr ""
+msgstr "Masquer les membres de l'espace de travail pour les invités"
 
 #. Default: "Journal"
 #: ./opengever/workspace/browser/tabbed.py

--- a/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
@@ -219,7 +219,7 @@ msgstr "GEVER URL"
 #. Default: "Hide workspace members for workspace guests"
 #: ./opengever/workspace/workspace.py
 msgid "label_hide_members_for_guests"
-msgstr "Masquer les membres de l'espace de travail pour les invités"
+msgstr "Masquer les participants à l'espace de travail pour les invités"
 
 #. Default: "Journal"
 #: ./opengever/workspace/browser/tabbed.py


### PR DESCRIPTION
@phgross I think you used "Member" instead of "Participant" for the feature hiding the workspace participants. Member is a role on the workspace, so this is confusing IMO. I corrected it here and in the frontend (see https://github.com/4teamwork/gever-ui/pull/2447)

For [CA-4958]

## Checklist
- [ ] Changelog entry -> no CL
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-4958]: https://4teamwork.atlassian.net/browse/CA-4958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ