### PR TITLE
Disable lock check in @tus-upload endpoint again

### DIFF
--- a/changes/CA-5093.bugfix
+++ b/changes/CA-5093.bugfix
@@ -1,0 +1,1 @@
+Disable lock check in @tus-upload endpoint again. [tinagerber]

--- a/opengever/api/tests/test_tus.py
+++ b/opengever/api/tests/test_tus.py
@@ -168,6 +168,11 @@ class TestTUSUpload(IntegrationTestCase):
         self.login(self.regular_user, browser)
         self.assert_tus_replace_fails(self.document, browser)
 
+    @skipIf(
+        datetime.now() < datetime(2023, 1, 2),
+        "Lock verification temporary disabled, because it's not yet works correctly. "
+        "Will be fixed with https://4teamwork.atlassian.net/browse/CA-5107",
+    )
     @browsing
     def test_cannot_replace_document_if_lock_token_not_provided(self, browser):
         self.login(self.regular_user, browser)

--- a/opengever/api/tus.py
+++ b/opengever/api/tus.py
@@ -84,8 +84,9 @@ class UploadPatch(GeverUploadPatch):
         if self.context.has_file() and not manager.is_checked_out_by_current_user():
             raise Forbidden("Document not checked out.")
 
-        if manager.is_locked_by_other():
-            raise Forbidden("Document is locked.")
+        # Check will be fixed with https://4teamwork.atlassian.net/browse/CA-5107
+        # if manager.is_locked_by_other():
+        #     raise Forbidden("Document is locked.")
 
         if self.is_proposal_document_upload() or self.is_proposal_template_upload():
             tus_upload = self.tus_upload()


### PR DESCRIPTION
With https://github.com/4teamwork/opengever.core/commit/51ed9dd4c66f1031525c571c2953a5c41aeba1a3 the lock check was enabled in the @tus-upload endpoint.
But the check does not work properly, so I have to disable it again. I have created a bug to address the problem:
https://4teamwork.atlassian.net/browse/CA-5107

For [CA-5093]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
- Further improvements needed:
  - [x] Create follow-up stories and link them in the PR and Jira issue

[CA-5093]: https://4teamwork.atlassian.net/browse/CA-5093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ