### PR TITLE
Fix permission check for revive_bumblebee_preview action

### DIFF
--- a/changes/CA-5090.bugfix
+++ b/changes/CA-5090.bugfix
@@ -1,0 +1,1 @@
+Fix permission check for revive_bumblebee_preview action. [tinagerber]

--- a/opengever/core/profiles/default/rolemap.xml
+++ b/opengever/core/profiles/default/rolemap.xml
@@ -74,9 +74,16 @@
       <role name="LimitedAdmin" />
       <role name="Manager" />
       <role name="Reader" />
+      <role name="Contributor" />
+      <role name="TaskResponsible" />
+      <role name="Editor" />
+      <role name="Reviewer" />
       <role name="WorkspaceAdmin" />
       <role name="WorkspaceMember" />
       <role name="WorkspaceGuest" />
+      <role name="CommitteeAdministrator" />
+      <role name="CommitteeMember" />
+      <role name="CommitteeResponsible" />
     </permission>
 
     <permission name="opengever.api: View AllowedRolesAndPrincipals" acquire="False">

--- a/opengever/core/upgrades/20221208084514_allow_users_with_document_view_permission_to_revive_bumblebee_preview/rolemap.xml
+++ b/opengever/core/upgrades/20221208084514_allow_users_with_document_view_permission_to_revive_bumblebee_preview/rolemap.xml
@@ -1,0 +1,20 @@
+<rolemap>
+  <permissions>
+    <permission name="opengever.bumblebee: Revive Preview" acquire="True">
+      <role name="Administrator" />
+      <role name="LimitedAdmin" />
+      <role name="Manager" />
+      <role name="Reader" />
+      <role name="Contributor" />
+      <role name="TaskResponsible" />
+      <role name="Editor" />
+      <role name="Reviewer" />
+      <role name="WorkspaceAdmin" />
+      <role name="WorkspaceMember" />
+      <role name="WorkspaceGuest" />
+      <role name="CommitteeAdministrator" />
+      <role name="CommitteeMember" />
+      <role name="CommitteeResponsible" />
+    </permission>
+  </permissions>
+</rolemap>

--- a/opengever/core/upgrades/20221208084514_allow_users_with_document_view_permission_to_revive_bumblebee_preview/upgrade.py
+++ b/opengever/core/upgrades/20221208084514_allow_users_with_document_view_permission_to_revive_bumblebee_preview/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AllowUsersWithDocumentViewPermissionToReviveBumblebeePreview(UpgradeStep):
+    """Allow users with document view permission to revive bumblebee preview.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/document/actions.py
+++ b/opengever/document/actions.py
@@ -199,7 +199,7 @@ class BaseDocumentContextActions(BaseContextActions):
     def is_revive_bumblebee_preview_available(self):
         if not is_bumblebee_feature_enabled():
             return False
-        if not api.user.has_permission('opengever.bumblebee: Revive Preview'):
+        if not api.user.has_permission('opengever.bumblebee: Revive Preview', obj=self.context):
             return False
         return IBumblebeeable.providedBy(self.context)
 

--- a/opengever/document/tests/test_actions.py
+++ b/opengever/document/tests/test_actions.py
@@ -117,27 +117,27 @@ class TestDocumentContextActions(IntegrationTestCase):
         self.login(self.regular_user)
         expected_actions = [u'attach_to_email', u'checkout_document', u'copy_item',
                             u'download_copy', u'edit', u'move_item', u'new_task_from_document',
-                            u'oc_direct_checkout', u'open_as_pdf', u'save_document_as_pdf',
-                            u'trash_context']
+                            u'oc_direct_checkout', u'open_as_pdf', u'revive_bumblebee_preview',
+                            u'save_document_as_pdf', u'trash_context']
         self.assertEqual(expected_actions, self.get_actions(self.document))
 
     def test_context_actions_for_mail_in_dossier(self):
         self.login(self.regular_user)
         expected_actions = [u'attach_to_email', u'copy_item', u'download_copy', u'edit',
                             u'move_item', u'new_task_from_document', u'open_as_pdf',
-                            u'trash_context']
+                            u'revive_bumblebee_preview', u'trash_context']
         self.assertEqual(expected_actions, self.get_actions(self.mail_eml))
 
     def test_context_actions_for_trashed_document_in_dossier(self):
         self.login(self.regular_user)
         ITrasher(self.document).trash()
-        expected_actions = [u'untrash_context']
+        expected_actions = [u'revive_bumblebee_preview', u'untrash_context']
         self.assertEqual(expected_actions, self.get_actions(self.document))
 
     def test_context_actions_for_trashed_mail_in_dossier(self):
         self.login(self.regular_user)
         ITrasher(self.mail_eml).trash()
-        expected_actions = [u'untrash_context']
+        expected_actions = [u'revive_bumblebee_preview', u'untrash_context']
         self.assertEqual(expected_actions, self.get_actions(self.mail_eml))
 
     def test_context_actions_for_checked_out_document(self):
@@ -146,29 +146,31 @@ class TestDocumentContextActions(IntegrationTestCase):
         queryMultiAdapter((self.document, self.request), ICheckinCheckoutManager).checkout()
         expected_actions = [u'attach_to_email', u'cancel_checkout', u'checkin_with_comment',
                             u'checkin_without_comment', u'download_copy', u'edit',
-                            u'new_task_from_document', u'oc_direct_edit', u'open_as_pdf']
+                            u'new_task_from_document', u'oc_direct_edit', u'open_as_pdf',
+                            u'revive_bumblebee_preview']
         self.assertEqual(expected_actions, self.get_actions(self.document))
 
     def test_context_actions_for_document_in_inbox(self):
         self.login(self.secretariat_user)
         expected_actions = [u'attach_to_email', u'checkout_document', u'copy_item',
                             u'create_forwarding', u'download_copy', u'edit', u'move_item',
-                            u'oc_direct_checkout', u'open_as_pdf', u'save_document_as_pdf',
-                            u'trash_context']
+                            u'oc_direct_checkout', u'open_as_pdf', u'revive_bumblebee_preview',
+                            u'save_document_as_pdf', u'trash_context']
         self.assertEqual(expected_actions, self.get_actions(self.inbox_document))
 
     def test_context_actions_for_proposal_document(self):
         self.login(self.regular_user)
         expected_actions = [u'attach_to_email', u'copy_item', u'download_copy',
-                            u'new_task_from_document', u'open_as_pdf', u'save_document_as_pdf']
+                            u'new_task_from_document', u'open_as_pdf',
+                            u'revive_bumblebee_preview', u'save_document_as_pdf']
         self.assertEqual(expected_actions, self.get_actions(self.proposaldocument))
 
     def test_context_actions_for_task_document(self):
         self.login(self.regular_user)
         expected_actions = [u'attach_to_email', u'checkout_document', u'copy_item',
                             u'download_copy', u'edit', u'new_task_from_document',
-                            u'oc_direct_checkout', u'open_as_pdf', u'save_document_as_pdf',
-                            u'trash_context']
+                            u'oc_direct_checkout', u'open_as_pdf', u'revive_bumblebee_preview',
+                            u'save_document_as_pdf', u'trash_context']
         self.assertEqual(expected_actions, self.get_actions(self.taskdocument))
 
     def test_context_actions_for_template_document(self):


### PR DESCRIPTION
Since the permission check was wrong, it was only possible for users with global roles (i.e. administrators) to revive the preview. 

Furthermore, the permission should be available to all roles that have View Permission. A TaskResponsible does not necessarily have to be a Reader.

Only the first commit needs to be backported.

For [CA-5090]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-5090]: https://4teamwork.atlassian.net/browse/CA-5090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ