### PR TITLE
Only prevent reopening a document if the referencing task is for approval.

### DIFF
--- a/changes/CA-5045.feature
+++ b/changes/CA-5045.feature
@@ -1,0 +1,1 @@
+Only prevent reopening a document if the referencing task is for approval. [njohner]

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -374,16 +374,16 @@ class Document(Item, BaseDocumentMixin):
     def is_finalize_allowed(self):
         return not self.is_checked_out()
 
-    def is_referenced_by_pending_task(self):
+    def is_referenced_by_pending_approval_task(self):
         tasks = self.related_items(include_forwardrefs=False, include_backrefs=True, tasks_only=True)
-        return any((task.is_pending() for task in tasks))
+        return any((task.is_pending() and task.is_approval_task() for task in tasks))
 
     def is_reopen_allowed(self):
         # reopen is not allowed if a pending task is referencing the document
         user = api.user.get_current()
         return ((is_administrator(user)
                  or user.getId() == self.finalizer)
-                and not self.is_referenced_by_pending_task())
+                and not self.is_referenced_by_pending_approval_task())
 
     @property
     def finalizer(self):

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -79,6 +79,8 @@ TASKTEMPLATE_PREDECESSOR_KEY = 'tasktemplate_predecessor'
 TASK_PROCESS_ORDER_KEY = 'task_process_order'
 TASK_FORMER_RESPONSIBLES_KEY = 'task_former_responsibles'
 
+TASK_TYPE_APPROVAL = 'approval'
+
 
 def deadline_default():
     offset = api.portal.get_registry_record(
@@ -438,6 +440,9 @@ class Task(Container, TaskReminderSupport):
         """If the task is the main task of a sequential process.
         """
         return IContainSequentialProcess.providedBy(self)
+
+    def is_approval_task(self):
+        return self.task_type == TASK_TYPE_APPROVAL
 
     @property
     def is_in_final_state(self):

--- a/opengever/task/transition.py
+++ b/opengever/task/transition.py
@@ -309,7 +309,7 @@ class ResolveTransitionExtender(DefaultTransitionExtender):
         approved_documents = map(unrestrictedUuidToObject, approved_documents)
 
         if approved_documents:
-            if self.context.task_type != 'approval':
+            if not self.context.is_approval_task():
                 raise BadRequest(
                     "Param 'approved_documents' is only supported for tasks "
                     "of task_type 'approval'.")


### PR DESCRIPTION
Preventing reopening only makes sense if the task is in an approval process. Otherwise any document referenced by a pending task which gets closed by accident cannot be reopened.

For [CA-5045]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-5045]: https://4teamwork.atlassian.net/browse/CA-5045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ