### PR TITLE
Pin selenium in base-testserver.cfg instead of test-testserver-selftest.cfg

### DIFF
--- a/base-testserver.cfg
+++ b/base-testserver.cfg
@@ -42,3 +42,7 @@ recipe = zc.recipe.egg:scripts
 eggs = opengever.core[tests]
 entry-points = testserver-selftest=opengever.core.testserver_selftest:selftest
 scripts = testserver-selftest
+
+[versions]
+# Pin Selenium to last Py27 compatible version
+selenium = <4.0

--- a/test-testserver-selftest.cfg
+++ b/test-testserver-selftest.cfg
@@ -20,8 +20,3 @@ input = inline:
     ${buildout:bin-directory}/testserver-selftest
 output = ${buildout:bin-directory}/test-jenkins
 mode = 755
-
-[versions]
-# Pin Selenium to last Py27 compatible version
-selenium = <4.0
-


### PR DESCRIPTION
This should also fix the issue for local buildouts and gever-ui E2E tests.