### PR TITLE
Avoid creating journal entries during contact migration.

### DIFF
--- a/changes/CA-2605.other
+++ b/changes/CA-2605.other
@@ -1,0 +1,1 @@
+Avoid creating journal entries during contact migration. [njohner]

--- a/opengever/contact/interfaces.py
+++ b/opengever/contact/interfaces.py
@@ -27,3 +27,9 @@ class IContactSettings(Interface):
         description=u'Temporary feature flag for the improvements on the'
         'contact module (Persons and Organizations)',
         default=False)
+
+
+class IDuringContactMigration(Interface):
+    """Request layer to indicate that contacts are being migrated to KuB.
+    It is used to skip creation of journal entries during the migration.
+    """

--- a/opengever/journal/handlers.py
+++ b/opengever/journal/handlers.py
@@ -4,6 +4,7 @@ from OFS.interfaces import IObjectWillBeAddedEvent
 from OFS.interfaces import IObjectWillBeRemovedEvent
 from opengever.base.behaviors import classification
 from opengever.base.browser.paste import ICopyPasteRequestLayer
+from opengever.contact.interfaces import IDuringContactMigration
 from opengever.document.document import Document
 from opengever.document.document import IDocumentSchema
 from opengever.dossier.browser.participants import role_list_helper
@@ -618,6 +619,8 @@ PARTICIPANT_ADDED = 'Participant added'
 
 
 def participation_created(context, event):
+    if IDuringContactMigration.providedBy(getRequest()):
+        return
     author = readable_ogds_author(event.participant,
                                   event.participant.contact)
     roles = role_list_helper(event.participant,


### PR DESCRIPTION
Contact migration will also migrate the dossier participations, i.e. add new participations and delete the old ones, which generates journal entries. To avoid this we add a marker interface that will be provided during contact migration and skip creation of journal entries during migration.

For [CA-2605]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-2605]: https://4teamwork.atlassian.net/browse/CA-2605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ