### PR TITLE
Addressblock formatting: Filter any None values before joining lines.

### DIFF
--- a/opengever/base/addressblock/addressblock.py
+++ b/opengever/base/addressblock/addressblock.py
@@ -107,6 +107,9 @@ class AddressBlockData(object):
             if not any(name in self.country.lower() for name in names):
                 lines.append(self.country)
 
+        # Filter any None values or empty strings
+        lines = [line for line in lines if line]
+
         return u'\n'.join(lines)
 
     def join_tokens(self, *tokens):

--- a/opengever/base/addressblock/tests/test_address_formatting.py
+++ b/opengever/base/addressblock/tests/test_address_formatting.py
@@ -227,3 +227,14 @@ class TestAddressFormatting(TestCase):
         United States of America
         """)
         self.assertEqual(expected, block.format())
+
+    def test_filters_none_values_and_empty_strings(self):
+        block = AddressBlockData(
+            first_name=u'Bill',
+            last_name=u'Gates',
+        )
+
+        expected = addr(u"""
+        Bill Gates
+        """)
+        self.assertEqual(expected, block.format())


### PR DESCRIPTION
Addressblock formatting: Filter any `None` values or empty strings before joining lines.

This may be needed when certain attributes required for a complete address are missing. This will result in incomplete addresses being produced, but that's still preferable to having the "Create document from template" action fail (or any other context, where that DocProperty is generated).

For [CA-5079](https://4teamwork.atlassian.net/browse/CA-5079)

## Checklist

- [ ] Changelog entry (_bug fixed in same release as it was introduced_) 
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

