### PR TITLE
Fix debug patch checking for out of sync modification date.

### DIFF
--- a/opengever/debug/patches/modified_out_of_sync.py
+++ b/opengever/debug/patches/modified_out_of_sync.py
@@ -28,6 +28,7 @@ def check_modified_in_sync(succeeded, obj, instruction):
         log.warn(u'Error when querying for: {} {}'.format(
             repr(obj), query)
         )
+        return
 
     brain = brains[0]
     if brain.modified == obj.modified():


### PR DESCRIPTION
When deleting the `ContactFolder` this patch gave rise to an error on `01-dev.onegovgever.ch-fd`

For [CA-2605]

## Checklist
- [ ] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-2605]: https://4teamwork.atlassian.net/browse/CA-2605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ