### PR TITLE
Allow to revive bumblebee preview for document versions, se correct bumblebee_checksum for document versions

### DIFF
--- a/changes/CA-4316.feature
+++ b/changes/CA-4316.feature
@@ -1,0 +1,1 @@
+Allow to revive bumblebee preview for document versions. [tinagerber]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,6 +11,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- Use correct ``bumblebee_checksum`` for document versions in document serialization.
 
 2022.24.0 (2022-12-06)
 ----------------------

--- a/opengever/api/document.py
+++ b/opengever/api/document.py
@@ -1,4 +1,5 @@
 from ftw import bumblebee
+from ftw.bumblebee.interfaces import IBumblebeeDocument
 from opengever.api import _
 from opengever.api.actors import serialize_actor_id_to_json_summary
 from opengever.api.serializer import extend_with_backreferences
@@ -41,8 +42,8 @@ class SerializeDocumentToJson(GeverSerializeToJson):
 
         version = "current" if kwargs.get('version') is None else kwargs.get('version')
         obj = self.getVersion(version)
-
         bumblebee_service = bumblebee.get_service_v3()
+        result['bumblebee_checksum'] = IBumblebeeDocument(obj).get_checksum()
         result[u'thumbnail_url'] = bumblebee_service.get_representation_url(
             obj, 'thumbnail')
         result[u'preview_url'] = bumblebee_service.get_representation_url(

--- a/opengever/api/serializer.py
+++ b/opengever/api/serializer.py
@@ -1,6 +1,4 @@
 from Acquisition import aq_inner
-from ftw.bumblebee.interfaces import IBumblebeeable
-from ftw.bumblebee.interfaces import IBumblebeeDocument
 from Missing import Value as MissingValue
 from opengever.api.batch import SQLHypermediaBatch
 from opengever.base.behaviors.sequence import ISequenceNumberBehavior
@@ -71,11 +69,6 @@ def extend_with_oguid(result, context):
         oguid = None
 
     result['oguid'] = oguid
-
-
-def extend_with_bumblebee_checksum(result, context):
-    if IBumblebeeable.providedBy(context):
-        result['bumblebee_checksum'] = IBumblebeeDocument(context).get_checksum()
 
 
 def extend_with_relative_path(result, context):
@@ -159,7 +152,6 @@ class GeverSerializeToJson(SerializeToJson):
         result = super(GeverSerializeToJson, self).__call__(*args, **kwargs)
 
         extend_with_oguid(result, self.context)
-        extend_with_bumblebee_checksum(result, self.context)
         extend_with_relative_path(result, self.context)
         extend_with_responses(result, self.context, self.request)
         extend_with_sequence_number(result, self.context, self.request)

--- a/opengever/api/tests/test_history.py
+++ b/opengever/api/tests/test_history.py
@@ -288,6 +288,27 @@ class TestVersionsGetEndpointForDocuments(IntegrationTestCase):
                          [each['version'] for each in browser.json['items']])
 
     @browsing
+    def test_returns_different_bumblebee_checksums_for_different_versions(self, browser):
+        self.login(self.regular_user, browser)
+        create_document_version(self.document, 0)
+        create_document_version(self.document, 1)
+
+        browser.open(self.document,
+                     view='@versions/0',
+                     method='GET',
+                     headers=self.api_headers)
+
+        checksum_1 = browser.json['bumblebee_checksum']
+
+        browser.open(self.document,
+                     view='@versions/1',
+                     method='GET',
+                     headers=self.api_headers)
+
+        checksum_2 = browser.json['bumblebee_checksum']
+        self.assertNotEqual(checksum_1, checksum_2)
+
+    @browsing
     def test_returns_initial_version_details_for_lazy_initial_version(self, browser):
         self.login(self.regular_user, browser)
         versioner = Versioner(self.document)


### PR DESCRIPTION
I have unfortunately not managed to write a meaningful test to test that document versions can now be revived.

For [CA-4316]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))