### PR TITLE
Make address block docproperties more robust

### DIFF
--- a/opengever/base/addressblock/docprops.py
+++ b/opengever/base/addressblock/docprops.py
@@ -1,0 +1,23 @@
+from logging import getLogger
+from opengever.base.addressblock.interfaces import IAddressBlockData
+from zope.component import queryAdapter
+
+
+logger = getLogger(__name__)
+
+
+def get_addressblock_docprops(context, prefix=None):
+    try:
+        properties = {}
+        address_block = queryAdapter(context, IAddressBlockData)
+
+        if address_block:
+            key = '.'.join(filter(None, ['ogg', prefix, 'address.block']))
+            properties.update({key: address_block.format()})
+
+        return properties
+
+    except Exception as exc:
+        logger.warn('Failed to render address block for %r' % context)
+        logger.exception(exc)
+        return {}

--- a/opengever/base/addressblock/extraction.py
+++ b/opengever/base/addressblock/extraction.py
@@ -78,9 +78,13 @@ class KuBAddressDataExtractor(object):
 
         # Localization data (Street or PO Box, Postal Code, City)
         if is_organization or is_membership:
-            addressed_location = provider.organization.get('primaryAddress', {})
+            addressed_entity = provider.organization
         else:
-            addressed_location = provider.person.get('primaryAddress', {})
+            addressed_entity = provider.person
+
+        addressed_location = addressed_entity.get('primaryAddress')
+        if not addressed_location:
+            addressed_location = {}
 
         street = addressed_location.get('street')
         house_no = addressed_location.get('houseNumber')

--- a/opengever/base/addressblock/tests/test_extraction.py
+++ b/opengever/base/addressblock/tests/test_extraction.py
@@ -151,3 +151,28 @@ class TestKuBEntityAddressExtraction(KuBIntegrationTestCase):
         block = IAddressBlockData(entity)
 
         self.assertEqual('7777', block.postal_code)
+
+    def test_kub_entity_extraction_handles_missing_primary_address(self, mocker):
+        self.mock_get_by_id(mocker, self.person_julie)
+        entity = KuBEntity(self.person_julie)
+
+        self.assertIsNone(entity.get('primaryAddress'))
+
+        block = IAddressBlockData(entity)
+
+        expected = {
+            'salutation': u'Frau',
+            'academic_title': u'',
+            'first_name': u'Julie',
+            'last_name': u'Dupont',
+
+            'org_name': None,
+
+            'street_and_no': u'',
+            'po_box': None,
+
+            'postal_code': None,
+            'city': None,
+            'country': None,
+        }
+        self.assertEqual(expected, block.__dict__)

--- a/opengever/kub/docprops.py
+++ b/opengever/kub/docprops.py
@@ -1,6 +1,5 @@
-from opengever.base.addressblock.interfaces import IAddressBlockData
+from opengever.base.addressblock.docprops import get_addressblock_docprops
 from opengever.base.docprops import BaseDocPropertyProvider
-from zope.component import queryAdapter
 
 
 class KuBEntityDocPropertyProvider(object):
@@ -71,12 +70,7 @@ class KuBEntityDocPropertyProvider(object):
         return provider.get_properties(prefix)
 
     def get_address_block(self, prefix):
-        address_block = queryAdapter(self.entity, IAddressBlockData)
-        if not address_block:
-            return {}
-
-        key = '.'.join(filter(None, ['ogg', prefix, 'address.block']))
-        return {key: address_block.format()}
+        return get_addressblock_docprops(self.entity, prefix)
 
     def get_email_properties(self, prefix):
         provider = KuBEmailDocPropertyProvider(self.person_or_organization)

--- a/opengever/kub/entity.py
+++ b/opengever/kub/entity.py
@@ -28,3 +28,8 @@ class KuBEntity(object):
 
     def get_doc_property_provider(self):
         return KuBEntityDocPropertyProvider(self)
+
+    def __repr__(self):
+        return '<{} {}>'.format(
+            self.__class__.__name__,
+            repr(str(self.identifier)))

--- a/opengever/ogds/base/docprops.py
+++ b/opengever/ogds/base/docprops.py
@@ -1,17 +1,11 @@
-from opengever.base.addressblock.interfaces import IAddressBlockData
+from opengever.base.addressblock.docprops import get_addressblock_docprops
 from opengever.base.docprops import BaseDocPropertyProvider
 from opengever.ogds.models.user import User
 from zope.component import adapter
-from zope.component import queryAdapter
 
 
 @adapter(User)
 class OGDSUserDocPropertyProvider(BaseDocPropertyProvider):
 
     def get_properties(self, prefix=None):
-        properties = {}
-        address_block = queryAdapter(self.context, IAddressBlockData)
-        if address_block:
-            key = '.'.join(filter(None, ['ogg', prefix, 'address.block']))
-            properties.update({key: address_block.format()})
-        return properties
+        return get_addressblock_docprops(self.context, prefix)


### PR DESCRIPTION
This fixes address block data extraction for KuB entities without a `primaryAddress`, and also makes the address block docproperties more robust in general. 

For [CA-5079](https://4teamwork.atlassian.net/browse/CA-5079)

## Checklist

- [ ] Changelog entry _(bug fixed in same release as it was introduced)_
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
