### PR TITLE
Config checks

### DIFF
--- a/changes/CA-5037-2.feature
+++ b/changes/CA-5037-2.feature
@@ -1,0 +1,1 @@
+Add a new endpoint: @config-checks to validate the current deployment. [elioschmutz]

--- a/changes/CA-5037.feature
+++ b/changes/CA-5037.feature
@@ -1,0 +1,1 @@
+Implement config check for the ldap authentication plugin order [elioschmutz]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,6 +11,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- Add a new endpoint: ``@config-checks`` to validate the current deployment.
 - Add the attribute ``is_manager`` tot the ``@config`` endpoint.
 - Use correct ``bumblebee_checksum`` for document versions in document serialization.
 

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,6 +11,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- Add the attribute ``is_manager`` tot the ``@config`` endpoint.
 - Use correct ``bumblebee_checksum`` for document versions in document serialization.
 
 2022.24.0 (2022-12-06)

--- a/docs/public/dev-manual/api/config.rst
+++ b/docs/public/dev-manual/api/config.rst
@@ -100,6 +100,7 @@ GEVER-Mandanten abgefragt werden.
           "gever_colorization": "#37C35A",
           "inbox_folder_url": "https://dev.onegovgever.ch/fd/eingangskorb/eingangskorb_afi",
           "is_admin": false,
+          "is_manager": false,
           "is_inbox_user": false,
           "is_propertysheets_manager": false,
           "is_emm_environment": false,

--- a/docs/public/dev-manual/api/config_checks.rst
+++ b/docs/public/dev-manual/api/config_checks.rst
@@ -1,0 +1,25 @@
+.. _config_checks:
+
+Konfigurations Checks
+=====================
+
+Über den ``/@config-checks`` Endpoint können Manager überprüfen, ob das Deployment korrekt konfiguriert ist.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       GET /@config-checks HTTP/1.1
+       Accept: application/json
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+          "@id": "http://localhost:8080/fd/@config-checks",
+          "errors": []
+      }

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -75,4 +75,5 @@ Inhalt:
    dispositions.rst
    out_of_office.rst
    substitutes.rst
+   config_checks.rst
    examples/index.rst

--- a/opengever/api/config.py
+++ b/opengever/api/config.py
@@ -42,6 +42,7 @@ class ConfigGet(Service):
         """
         config['is_emm_environment'] = is_client_ip_in_office_connector_disallowed_ip_ranges()
         config['is_admin'] = utils.is_administrator()
+        config['is_manager'] = utils.is_manager()
         config['bumblebee_app_id'] = bumblebee_config.app_id
         config['private_folder_url'] = get_private_folder_url()
         config['gever_colorization'] = get_color()

--- a/opengever/api/config_checks.py
+++ b/opengever/api/config_checks.py
@@ -1,0 +1,13 @@
+from opengever.base.config_checks.manager import ConfigCheckManager
+from plone.restapi.services import Service
+
+
+class ConfigChecks(Service):
+    """GEVER configuration checks"""
+
+    def reply(self):
+        errors = ConfigCheckManager().check_all()
+        return {
+            '@id': '{}/@config-checks'.format(self.context.absolute_url()),
+            'errors': errors,
+        }

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -1775,4 +1775,12 @@
       permission="cmf.ModifyPortalContent"
       />
 
+  <plone:service
+      method="GET"
+      name="@config-checks"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      factory=".config_checks.ConfigChecks"
+      permission="cmf.ManagePortal"
+      />
+
 </configure>

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -243,6 +243,34 @@ class TestConfig(IntegrationTestCase):
         self.assertFalse(browser.json.get(u'is_admin'))
 
     @browsing
+    def test_is_manager_is_true_for_managers(self, browser):
+        self.login(self.manager, browser)
+        browser.open(self.config_url, headers=self.api_headers)
+        self.assertEqual(browser.status_code, 200)
+        self.assertTrue(browser.json.get(u'is_manager'))
+
+    @browsing
+    def test_is_manager_is_false_for_administrators(self, browser):
+        self.login(self.administrator, browser)
+        browser.open(self.config_url, headers=self.api_headers)
+        self.assertEqual(browser.status_code, 200)
+        self.assertFalse(browser.json.get(u'is_manager'))
+
+    @browsing
+    def test_is_manager_is_false_for_limited_admins(self, browser):
+        self.login(self.limited_admin, browser)
+        browser.open(self.config_url, headers=self.api_headers)
+        self.assertEqual(browser.status_code, 200)
+        self.assertFalse(browser.json.get(u'is_manager'))
+
+    @browsing
+    def test_is_manager_is_false_for_regular_user(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.config_url, headers=self.api_headers)
+        self.assertEqual(browser.status_code, 200)
+        self.assertFalse(browser.json.get(u'is_manager'))
+
+    @browsing
     def test_is_inbox_user_is_true_for_users_assigned_to_the_inbox_group(self, browser):
         self.login(self.secretariat_user, browser)
         browser.open(self.config_url, headers=self.api_headers)

--- a/opengever/api/tests/test_config_checks.py
+++ b/opengever/api/tests/test_config_checks.py
@@ -1,0 +1,56 @@
+from ftw.testbrowser import browsing
+from opengever.base.tests.test_config_checks import DummyCheckMissconfigured1
+from opengever.base.tests.test_config_checks import DummyCheckMissconfigured2
+from opengever.testing import IntegrationTestCase
+from zope.component import getSiteManager
+
+
+class TestConfigChecks(IntegrationTestCase):
+
+    @property
+    def config_checks_url(self):
+        return self.portal.absolute_url() + '/@config-checks'
+
+    @browsing
+    def test_endpoint_is_only_available_for_managers(self, browser):
+        self.login(self.administrator, browser)
+        with browser.expect_http_error(401):
+            browser.open(self.config_checks_url, headers=self.api_headers)
+
+        self.login(self.manager, browser)
+        browser.open(self.config_checks_url, headers=self.api_headers)
+        self.assertEqual(browser.status_code, 200)
+
+    @browsing
+    def test_response_with_no_errors(self, browser):
+        self.login(self.manager, browser)
+        browser.open(self.config_checks_url, headers=self.api_headers)
+        self.assertEqual(
+            {
+                u'@id': u'http://nohost/plone/@config-checks',
+                u'errors': []
+            }, browser.json)
+
+    @browsing
+    def test_response_with_errors(self, browser):
+        self.login(self.manager, browser)
+        getSiteManager().registerAdapter(DummyCheckMissconfigured1, name="check-missconfigured-1")
+        getSiteManager().registerAdapter(DummyCheckMissconfigured2, name="check-missconfigured-2")
+
+        browser.open(self.config_checks_url, headers=self.api_headers)
+        self.assertItemsEqual(
+            {
+                u'@id': u'http://nohost/plone/@config-checks',
+                u'errors': [
+                    {
+                        u'description': u'Description 1',
+                        u'id': u'DummyCheckMissconfigured1',
+                        u'title': u'Dummy check 1'
+                    },
+                    {
+                        u'description': u'',
+                        u'id': u'DummyCheckMissconfigured2',
+                        u'title': u'Dummy check 2'
+                    }
+                ]
+            }, browser.json)

--- a/opengever/base/browser/errors.py
+++ b/opengever/base/browser/errors.py
@@ -1,8 +1,8 @@
 from Acquisition import aq_acquire
 from logging import getLogger
+from opengever.base.utils import is_manager
 from opengever.debug import write_on_read_tracing
 from opengever.debug.write_on_read_tracing import format_instruction
-from plone import api
 from Products.Five.browser import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zExceptions import NotFound
@@ -45,7 +45,7 @@ class ErrorHandlingView(BrowserView):
 
     def is_manager(self):
         if self.plone:
-            return api.user.has_permission('cmf.ManagePortal')
+            return is_manager()
 
     def is_notfound_error(self):
         return isinstance(self.context, NotFound)

--- a/opengever/base/config_checks/checks.py
+++ b/opengever/base/config_checks/checks.py
@@ -1,0 +1,14 @@
+class BaseCheck(object):
+    def __init__(self, context):
+        self.context = context
+
+    @property
+    def check_id(self):
+        return self.__class__.__name__
+
+    def config_error(self, title, description=''):
+        return {
+            'id': self.check_id,
+            'title': title,
+            'description': description,
+        }

--- a/opengever/base/config_checks/checks.py
+++ b/opengever/base/config_checks/checks.py
@@ -1,3 +1,12 @@
+from opengever.base.interfaces import IConfigCheck
+from opengever.bundle.ldap import LDAP_PLUGIN_META_TYPES
+from plone import api
+from Products.PluggableAuthService.interfaces.plugins import IAuthenticationPlugin
+from zope.component import adapter
+from zope.interface import implementer
+from zope.interface import Interface
+
+
 class BaseCheck(object):
     def __init__(self, context):
         self.context = context
@@ -12,3 +21,25 @@ class BaseCheck(object):
             'title': title,
             'description': description,
         }
+
+
+@implementer(IConfigCheck)
+@adapter(Interface)
+class LDAPPluginOrderCheck(BaseCheck):
+
+    def check(self):
+        is_first_entry = True
+        for plugin_id, plugin in self.get_plugins():
+            if plugin.meta_type in LDAP_PLUGIN_META_TYPES and not is_first_entry:
+                return self.config_error(
+                    title='LDAP authentication plugin with the ID: "{}" is not at the '
+                          'first position'.format(plugin_id),
+                    description='Move the active ldap plugin from '
+                                '/acl_users/plugins/manage_plugins > "Authentication Plugins" '
+                                'to the first position. This is required to properly lookup '
+                                'user metadata from the ldap.')
+
+            is_first_entry = False
+
+    def get_plugins(self):
+        return api.portal.get_tool('acl_users').plugins.listPlugins(IAuthenticationPlugin)

--- a/opengever/base/config_checks/configure.zcml
+++ b/opengever/base/config_checks/configure.zcml
@@ -1,0 +1,10 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:vdex="http://namespaces.zope.org/vdex"
+    i18n_domain="opengever.base">
+
+  <adapter
+      factory=".checks.LDAPPluginOrderCheck"
+      name="ldap-plugin-order"
+      />
+</configure>

--- a/opengever/base/config_checks/manager.py
+++ b/opengever/base/config_checks/manager.py
@@ -1,0 +1,21 @@
+from opengever.base.interfaces import IConfigCheck
+from opengever.base.interfaces import IConfigCheckManager
+from plone import api
+from zope.component import getAdapters
+from zope.interface import implementer
+
+
+@implementer(IConfigCheckManager)
+class ConfigCheckManager(object):
+    """Main object to handle config checks.
+
+    This object provides functions to run and manage config checks provided
+    by named IConfigCheck adapters.
+    """
+    def check_all(self):
+        errors = [config_check.check() for config_check in self._get_all_checks()]
+        return filter(lambda value: value, errors)
+
+    def _get_all_checks(self):
+        for name, adapter in getAdapters((api.portal.get(), ), IConfigCheck):
+            yield adapter

--- a/opengever/base/configure.zcml
+++ b/opengever/base/configure.zcml
@@ -23,6 +23,7 @@
   <include package=".addressblock" />
   <include package=".behaviors" />
   <include package=".browser" />
+  <include package=".config_checks" />
   <include package=".viewlets" />
   <include file="skins.zcml" />
   <include file="permissions.zcml" />

--- a/opengever/base/interfaces.py
+++ b/opengever/base/interfaces.py
@@ -608,3 +608,20 @@ class IDeleter(Interface):
     def is_delete_allowed():
         """Returns a boolean, indicating if the context could be deleted.
         """
+
+
+class IConfigCheckManager(Interface):
+    def check_all():
+        """It returns a list of all configuration errors if something is not
+        properly configured.
+
+        The list will be empty if there are no errors
+        """
+
+
+class IConfigCheck(Interface):
+    def check():
+        """Runs the specific check.
+
+        It returns a dict with error metadata for missconfigurated configs
+        """

--- a/opengever/base/tests/test_config_checks.py
+++ b/opengever/base/tests/test_config_checks.py
@@ -1,0 +1,39 @@
+from opengever.base.config_checks.checks import BaseCheck
+from opengever.base.config_checks.manager import ConfigCheckManager
+from opengever.base.interfaces import IConfigCheck
+from opengever.testing import IntegrationTestCase
+from zope.component import adapter
+from zope.component import getSiteManager
+from zope.interface import implementer
+from zope.interface import Interface
+
+
+@implementer(IConfigCheck)
+@adapter(Interface)
+class DummyCheckMissconfigured1(BaseCheck):
+    def check(self):
+        return self.config_error(title="Dummy check 1", description="Description 1")
+
+
+@implementer(IConfigCheck)
+@adapter(Interface)
+class DummyCheckMissconfigured2(BaseCheck):
+    def check(self):
+        return self.config_error(title="Dummy check 2")
+
+
+class TestConfigCheckManager(IntegrationTestCase):
+
+    def test_check_all_returns_an_empty_list_if_everything_is_ok(self):
+        self.login(self.manager)
+        self.assertEqual([], ConfigCheckManager().check_all())
+
+    def test_check_all_returns_an_error_dict_for_each_failing_check(self):
+        self.login(self.manager)
+        getSiteManager().registerAdapter(DummyCheckMissconfigured1, name="check-missconfigured-1")
+        getSiteManager().registerAdapter(DummyCheckMissconfigured2, name="check-missconfigured-2")
+
+        self.assertItemsEqual([
+            {'id': 'DummyCheckMissconfigured1', 'title': 'Dummy check 1', 'description': 'Description 1'},
+            {'id': 'DummyCheckMissconfigured2', 'title': 'Dummy check 2', 'description': ''}
+        ], ConfigCheckManager().check_all())

--- a/opengever/base/tests/test_utils.py
+++ b/opengever/base/tests/test_utils.py
@@ -6,6 +6,7 @@ from opengever.base.behaviors.utils import set_attachment_content_disposition
 from opengever.base.utils import escape_html
 from opengever.base.utils import file_checksum
 from opengever.base.utils import is_administrator
+from opengever.base.utils import is_manager
 from opengever.base.utils import safe_int
 from opengever.dossier.utils import find_parent_dossier
 from opengever.testing import IntegrationTestCase
@@ -192,3 +193,26 @@ class TestIsAdministrator(IntegrationTestCase):
         self.assertTrue(is_administrator(user=self.limited_admin))
         self.login(self.limited_admin)
         self.assertTrue(is_administrator())
+
+
+class TestIsManager(IntegrationTestCase):
+
+    def test_is_manager_with_regular_user(self):
+        self.assertFalse(is_manager(user=self.regular_user))
+        self.login(self.regular_user)
+        self.assertFalse(is_manager())
+
+    def test_is_manager_with_administrator(self):
+        self.assertFalse(is_manager(user=self.administrator))
+        self.login(self.administrator)
+        self.assertFalse(is_manager())
+
+    def test_is_manager_with_limited_admin(self):
+        self.assertFalse(is_manager(user=self.limited_admin))
+        self.login(self.limited_admin)
+        self.assertFalse(is_manager())
+
+    def test_is_manager_with_manager(self):
+        self.assertTrue(is_manager(user=self.manager))
+        self.login(self.manager)
+        self.assertTrue(is_manager())

--- a/opengever/base/utils.py
+++ b/opengever/base/utils.py
@@ -257,6 +257,10 @@ def is_administrator(user=None):
                 or user.has_role('Manager'))
 
 
+def is_manager(user=None):
+    return api.user.has_permission('cmf.ManagePortal', user=user)
+
+
 def check_group_plugin_configuration(portal):
     acl_users = getToolByName(portal, 'acl_users')
     plugins = acl_users.plugins

--- a/opengever/base/viewlets/config_check.pt
+++ b/opengever/base/viewlets/config_check.pt
@@ -1,0 +1,11 @@
+<dl class="portalMessage error"
+    tal:define="errors view/errors"
+    tal:condition="errors">
+    <tal:block tal:repeat="error errors">
+        <dt tal:content="error/id"/>
+        <dd>
+            <h3 tal:content="error/title" ></h3>
+            <p tal:content="error/description" ></p>
+        </dd>
+    </tal:block>
+</dl>

--- a/opengever/base/viewlets/config_check.py
+++ b/opengever/base/viewlets/config_check.py
@@ -1,0 +1,11 @@
+from opengever.base.config_checks.manager import ConfigCheckManager
+from plone.app.layout.viewlets.common import ViewletBase
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+
+
+class ConfigCheckViewlet(ViewletBase):
+
+    index = ViewPageTemplateFile('config_check.pt')
+
+    def errors(self):
+        return ConfigCheckManager().check_all()

--- a/opengever/base/viewlets/configure.zcml
+++ b/opengever/base/viewlets/configure.zcml
@@ -114,4 +114,11 @@
       permission="zope2.View"
       />
 
+  <browser:viewlet
+      name="opengever.base.config_check"
+      manager="plone.app.layout.viewlets.interfaces.IAboveContent"
+      class=".config_check.ConfigCheckViewlet"
+      permission="cmf.ManagePortal"
+      />
+
 </configure>

--- a/opengever/core/testserver.py
+++ b/opengever/core/testserver.py
@@ -6,6 +6,7 @@ from ftw.testing import staticuid
 from ftw.testing.layer import COMPONENT_REGISTRY_ISOLATION
 from opengever.base.interfaces import ISearchSettings
 from opengever.base.model import create_session
+from opengever.base.tests.test_config_checks import DummyCheckMissconfigured1
 from opengever.core import sqlite_testing
 from opengever.core.solr_testing import SolrReplicationAPIClient
 from opengever.core.solr_testing import SolrServer
@@ -21,6 +22,7 @@ from plone.testing import z2
 from requests.exceptions import ConnectionError
 from uuid import uuid4
 from zope.component import getGlobalSiteManager
+from zope.component import getSiteManager
 from zope.configuration import xmlconfig
 from zope.globalrequest import setRequest
 from zope.schema.interfaces import IVocabularyFactory
@@ -144,6 +146,9 @@ class TestserverLayer(OpengeverFixture):
         activate_bumblebee_feature()
 
         self.replaceDossierTypesVocabulary()
+
+        # Register a broken configuration-check
+        getSiteManager().registerAdapter(DummyCheckMissconfigured1, name="check-missconfigured-1")
 
         setRequest(portal.REQUEST)
         print 'Installing fixture. Have patience.'

--- a/opengever/meeting/browser/meetings/agendaitem.py
+++ b/opengever/meeting/browser/meetings/agendaitem.py
@@ -2,6 +2,7 @@ from ftw.zipexport.generation import ZipGenerator
 from ftw.zipexport.utils import normalize_path
 from functools import wraps
 from opengever.base.json_response import JSONResponse
+from opengever.base.utils import is_manager
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.meeting import _
 from opengever.meeting.exceptions import CannotExecuteTransition
@@ -282,7 +283,7 @@ class AgendaItemsView(BrowserView):
             if item.is_revise_possible():
                 data['revise_link'] = meeting.get_url(
                     view='agenda_items/{}/revise'.format(item.agenda_item_id))
-            if self.is_manager():
+            if is_manager():
                 data['debug_excerpt_docxcompose_link'] = meeting.get_url(
                     view='agenda_items/{}/debug_excerpt_docxcompose'.format(item.agenda_item_id))
             if item.is_paragraph:
@@ -566,11 +567,8 @@ class AgendaItemsView(BrowserView):
                 return doc
         return None
 
-    def is_manager(self):
-        return api.user.has_permission('cmf.ManagePortal')
-
     def debug_excerpt_docxcompose(self):
-        if not self.is_manager():
+        if not is_manager():
             raise Forbidden
 
         if self.agenda_item.is_paragraph:

--- a/opengever/meeting/browser/periods.py
+++ b/opengever/meeting/browser/periods.py
@@ -1,5 +1,6 @@
 from Acquisition import aq_inner
 from Acquisition import aq_parent
+from opengever.base.utils import is_manager
 from opengever.tabbedview import GeverTabMixin
 from plone import api
 from plone.dexterity.browser.add import DefaultAddForm
@@ -60,4 +61,4 @@ class PeriodsTab(BrowserView, GeverTabMixin):
             'Modify portal content', obj=self.context)
 
     def is_manager(self):
-        return api.user.has_permission('cmf.ManagePortal')
+        return is_manager()


### PR DESCRIPTION
Thsi PR implements the `ConfigCheckManager` and integrates the results of the config checks in a config-check viewlet for the old UI and provides the check results over a new api endpoint: `@config-checks`.

The checks are only available for managers.

## Example viewlet:
![Bildschirmfoto 2023-01-06 um 11 00 00](https://user-images.githubusercontent.com/557005/210977573-ed18f3f1-e984-484e-9e5c-79f227c7c801.png)

For [CA-5037]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-5037]: https://4teamwork.atlassian.net/browse/CA-5037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ