### PR TITLE
Use the IPropertiesPlugin for the ldap config check

### DIFF
--- a/opengever/base/config_checks/checks.py
+++ b/opengever/base/config_checks/checks.py
@@ -1,7 +1,7 @@
 from opengever.base.interfaces import IConfigCheck
 from opengever.bundle.ldap import LDAP_PLUGIN_META_TYPES
 from plone import api
-from Products.PluggableAuthService.interfaces.plugins import IAuthenticationPlugin
+from Products.PluggableAuthService.interfaces.plugins import IPropertiesPlugin
 from zope.component import adapter
 from zope.interface import implementer
 from zope.interface import Interface
@@ -25,21 +25,21 @@ class BaseCheck(object):
 
 @implementer(IConfigCheck)
 @adapter(Interface)
-class LDAPPluginOrderCheck(BaseCheck):
+class LDAPPropertiesPluginOrderCheck(BaseCheck):
 
     def check(self):
         is_first_entry = True
         for plugin_id, plugin in self.get_plugins():
             if plugin.meta_type in LDAP_PLUGIN_META_TYPES and not is_first_entry:
                 return self.config_error(
-                    title='LDAP authentication plugin with the ID: "{}" is not at the '
+                    title='LDAP properties plugin with the ID: "{}" is not at the '
                           'first position'.format(plugin_id),
                     description='Move the active ldap plugin from '
-                                '/acl_users/plugins/manage_plugins > "Authentication Plugins" '
+                                '/acl_users/plugins/manage_plugins > "Properties Plugins" '
                                 'to the first position. This is required to properly lookup '
                                 'user metadata from the ldap.')
 
             is_first_entry = False
 
     def get_plugins(self):
-        return api.portal.get_tool('acl_users').plugins.listPlugins(IAuthenticationPlugin)
+        return api.portal.get_tool('acl_users').plugins.listPlugins(IPropertiesPlugin)

--- a/opengever/base/config_checks/configure.zcml
+++ b/opengever/base/config_checks/configure.zcml
@@ -4,7 +4,7 @@
     i18n_domain="opengever.base">
 
   <adapter
-      factory=".checks.LDAPPluginOrderCheck"
-      name="ldap-plugin-order"
+      factory=".checks.LDAPPropertiesPluginOrderCheck"
+      name="ldap-properties-plugin-order"
       />
 </configure>

--- a/opengever/base/tests/test_config_checks.py
+++ b/opengever/base/tests/test_config_checks.py
@@ -6,7 +6,7 @@ from opengever.base.interfaces import IConfigCheck
 from opengever.bundle.ldap import LDAP_PLUGIN_META_TYPES
 from opengever.testing import IntegrationTestCase
 from plone import api
-from Products.PluggableAuthService.interfaces.plugins import IAuthenticationPlugin
+from Products.PluggableAuthService.interfaces.plugins import IPropertiesPlugin
 from zope.component import adapter
 from zope.component import getSiteManager
 from zope.interface import implementer
@@ -48,9 +48,9 @@ class TestConfigCheckManager(IntegrationTestCase):
 
         self.assertEqual(0, len(ConfigCheckManager().check_all()))
 
-        # Set the meta-type of the last auth plugin to an ldap plugin meta type
+        # Set the meta-type of the last properties plugin to an ldap plugin meta type
         # to simulate a bad plugin order
-        plugins = api.portal.get_tool('acl_users').plugins.listPlugins(IAuthenticationPlugin)
+        plugins = api.portal.get_tool('acl_users').plugins.listPlugins(IPropertiesPlugin)
         plugins[-1][1].meta_type = LDAP_PLUGIN_META_TYPES[0]
 
         self.assertEqual(1, len(ConfigCheckManager().check_all()))


### PR DESCRIPTION
This is a follow-up PR for #7651 and changes the "ldap order check" config-check by using the `IProperties` plugin instead the `IAuthentication` plugin.

@tinagerber thanks for your input!

For [CA-5037]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry (not required, same release)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-5037]: https://4teamwork.atlassian.net/browse/CA-5037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ