### PR TITLE
Add upgrade step that fixes order of IPropertiesPlugin PAS plugins.

### DIFF
--- a/changes/CA-5036.bugfix
+++ b/changes/CA-5036.bugfix
@@ -1,0 +1,1 @@
+Add upgrade step that fixes order of IPropertiesPlugin PAS plugins. [lgraf]

--- a/opengever/core/upgrades/20230109145141_fix_order_of_i_properties_plugin_pas_plugins/upgrade.py
+++ b/opengever/core/upgrades/20230109145141_fix_order_of_i_properties_plugin_pas_plugins/upgrade.py
@@ -1,0 +1,14 @@
+from ftw.upgrade import UpgradeStep
+from plone import api
+from Products.PluggableAuthService.interfaces.plugins import IPropertiesPlugin
+
+
+class FixOrderOfIPropertiesPluginPASPlugins(UpgradeStep):
+    """Fix order of IPropertiesPlugin PAS plugins.
+    """
+
+    def __call__(self):
+        acl_users = api.portal.get_tool('acl_users')
+        plugins = acl_users.plugins
+
+        plugins.movePluginsTop(IPropertiesPlugin, ('ldap',))


### PR DESCRIPTION
Add upgrade step that fixes order of IPropertiesPlugin PAS plugins by ensuring the `ldap` plugin is always at the top.

For [CA-5036](https://4teamwork.atlassian.net/browse/CA-5036)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)



[CA-5036]: https://4teamwork.atlassian.net/browse/CA-5036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ