### PR TITLE
Disallow anonymous access to member portraits.

### DIFF
--- a/changes/CA-5103.bugfix
+++ b/changes/CA-5103.bugfix
@@ -1,0 +1,1 @@
+Disallow anonymous access to member portraits. [lgraf]

--- a/opengever/base/subscribers.py
+++ b/opengever/base/subscribers.py
@@ -103,9 +103,15 @@ def disallow_anonymous_views_on_site_root(event):
 
        The same applies for tabbed_view attributes of a tabbed_view that is
        displayed for the portal root.
+
+       In addition, disallow access to member portraits for Anonymous users.
     """
     if getSecurityManager().getUser() != nobody:
         return
+
+    # Block anonymous access to member portraits
+    if event.request.steps[1:3] == ['portal_memberdata', 'portraits']:
+        raise Unauthorized
 
     # Find the first physical / persistent object in the PARENTS
     # by filtering all non-persist parents (views, widgets, ...).

--- a/opengever/base/tests/test_anonymous.py
+++ b/opengever/base/tests/test_anonymous.py
@@ -1,4 +1,5 @@
 from ftw.testbrowser import browsing
+from OFS.Image import Image
 from opengever.testing import IntegrationTestCase
 from unittest import skip
 
@@ -30,3 +31,21 @@ class TestAnonymousAccess(IntegrationTestCase):
 
         self.assertEquals(self.portal.absolute_url() + '/@@search',
                           browser.url)
+
+    @browsing
+    def test_anonymous_cannot_access_member_portraits(self, browser):
+        userid = self.regular_user.getId()
+        img = Image(id=userid, file='', title='')
+        self.portal.portal_memberdata._setPortrait(img, userid)
+        with browser.expect_unauthorized():
+            browser.open(self.portal, view='portal_memberdata/portraits/%s' % userid)
+
+    @browsing
+    def test_authenticated_can_access_member_portraits(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        userid = self.regular_user.getId()
+        img = Image(id=userid, file='', title='')
+        self.portal.portal_memberdata._setPortrait(img, userid)
+        browser.open(self.portal, view='portal_memberdata/portraits/%s' % userid)
+        self.assertEqual(200, browser.status_code)


### PR DESCRIPTION
This disallows access to member portraits via `<portal>/portal_memberdata/portraits/<userid>` for anonymous users.

The `portraits` attribute on `MemberDataTool` instance at `portal_memberdata` is a [direct instance of a BTreeFolder2](https://github.com/plone/Products.PlonePAS/blob/9ec4a950ff47057254a1f206f55f44fb9b7a72fc/src/Products/PlonePAS/tools/memberdata.py#L40) that can be traversed to.

Because of that, it's challenging to add additional permission checks to the `MemberDataTool`, especially because even Anonymous users have the `View` permission on the Plone site root anyway.

Therefore I disallowed access to member portraits on the traversal level, in our already existing `IPubAfterTraversal` hook.

For [CA-5103](https://4teamwork.atlassian.net/browse/CA-5103)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)




[CA-5103]: https://4teamwork.atlassian.net/browse/CA-5103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ