### PR TITLE
Workspace touched date

### DIFF
--- a/changes/CA-4875.feature
+++ b/changes/CA-4875.feature
@@ -1,0 +1,1 @@
+Add touched date index for workspaces. [elioschmutz]

--- a/docs/schema-dumps/opengever.dossier.businesscasedossier.schema.json
+++ b/docs/schema-dumps/opengever.dossier.businesscasedossier.schema.json
@@ -44,13 +44,6 @@
             "description": "",
             "_zope_schema_type": "Date"
         },
-        "touched": {
-            "type": "string",
-            "title": "\u00c4nderungsdatum des Dossiers oder seines Inhalts",
-            "format": "date",
-            "description": "",
-            "_zope_schema_type": "Date"
-        },
         "responsible": {
             "type": "string",
             "title": "Federf\u00fchrend",
@@ -249,6 +242,13 @@
             "title": "Benutzerdefinierte Felder",
             "description": "Enth\u00e4lt die Daten f\u00fcr die benutzerdefinierten Felder.",
             "_zope_schema_type": "PropertySheetField"
+        },
+        "touched": {
+            "type": "string",
+            "title": "\u00c4nderungsdatum des Objektes oder seines Inhalts",
+            "format": "date",
+            "description": "",
+            "_zope_schema_type": "Date"
         }
     },
     "required": [
@@ -262,7 +262,6 @@
         "keywords",
         "start",
         "end",
-        "touched",
         "responsible",
         "external_reference",
         "filing_prefix",
@@ -285,6 +284,7 @@
         "custody_period",
         "date_of_cassation",
         "date_of_submission",
-        "custom_properties"
+        "custom_properties",
+        "touched"
     ]
 }

--- a/docs/schema-dumps/opengever.workspace.workspace.schema.json
+++ b/docs/schema-dumps/opengever.workspace.workspace.schema.json
@@ -54,6 +54,13 @@
             "title": "Beschreibung",
             "description": "",
             "_zope_schema_type": "Text"
+        },
+        "touched": {
+            "type": "string",
+            "title": "\u00c4nderungsdatum des Objektes oder seines Inhalts",
+            "format": "date",
+            "description": "",
+            "_zope_schema_type": "Date"
         }
     },
     "required": [
@@ -67,6 +74,7 @@
         "hide_members_for_guests",
         "changed",
         "title",
-        "description"
+        "description",
+        "touched"
     ]
 }

--- a/opengever/base/behaviors/configure.zcml
+++ b/opengever/base/behaviors/configure.zcml
@@ -111,4 +111,11 @@
       for="plone.dexterity.interfaces.IDexterityContent"
       />
 
+  <plone:behavior
+      title="Touched"
+      description="Date of last object or content modification"
+      provides=".touched.ITouched"
+      for="plone.dexterity.interfaces.IDexterityContent"
+      />
+
 </configure>

--- a/opengever/base/behaviors/touched.py
+++ b/opengever/base/behaviors/touched.py
@@ -1,0 +1,25 @@
+from opengever.base import _
+from plone.autoform import directives as form
+from plone.autoform.interfaces import IFormFieldProvider
+from plone.supermodel import model
+from zope import schema
+from zope.interface import alsoProvides
+
+
+class ITouched(model.Schema):
+    """ ITouched contains the touched field tracking
+    when an object or its content was last modified.
+    """
+
+    # Omitted because it must not be updated manually, only by event handlers.
+    form.omitted('touched')
+    touched = schema.Date(
+        title=_(u'label_touched',
+                default=u'Date of modification of the object or its content'),
+        required=False,
+        readonly=True,
+        default=None,
+    )
+
+
+alsoProvides(ITouched, IFormFieldProvider)

--- a/opengever/base/configure.zcml
+++ b/opengever/base/configure.zcml
@@ -497,6 +497,11 @@
       name="getObjPositionInParent"
       />
 
+  <adapter
+      factory=".indexes.touched_indexer"
+      name="touched"
+      />
+
   <utility factory=".sequence.SequenceNumber" />
 
   <adapter factory=".quickupload.OGQuickUploadCapableFileFactory" />

--- a/opengever/base/configure.zcml
+++ b/opengever/base/configure.zcml
@@ -390,6 +390,48 @@
       handler=".touched.handle_object_touched"
       />
 
+  <subscriber
+      for="plone.dexterity.interfaces.IDexterityContent
+           zope.lifecycleevent.interfaces.IObjectModifiedEvent"
+      handler=".handlers.update_touched_date"
+      />
+
+  <subscriber
+      for="plone.dexterity.interfaces.IDexterityContent
+           zope.lifecycleevent.interfaces.IObjectAddedEvent"
+      handler=".handlers.update_touched_date"
+      />
+
+  <subscriber
+      for="plone.dexterity.interfaces.IDexterityContent
+           zope.lifecycleevent.interfaces.IObjectRemovedEvent"
+      handler=".handlers.update_touched_date"
+      />
+
+  <subscriber
+      for="plone.dexterity.interfaces.IDexterityContent
+           zope.lifecycleevent.interfaces.IObjectMovedEvent"
+      handler=".handlers.update_touched_date_for_move_event"
+      />
+
+  <subscriber
+      for="opengever.meeting.proposal.IBaseProposal
+           Products.CMFCore.interfaces.IActionSucceededEvent"
+      handler=".handlers.update_touched_date"
+      />
+
+  <subscriber
+      for="opengever.dossier.behaviors.dossier.IDossierMarker
+           Products.CMFCore.interfaces.IActionSucceededEvent"
+      handler=".handlers.update_touched_date"
+      />
+
+  <subscriber
+      for="opengever.task.task.ITask
+           Products.CMFCore.interfaces.IActionSucceededEvent"
+      handler=".handlers.update_touched_date"
+      />
+
   <adapter
       factory=".indexes.referenceIndexer"
       name="reference"

--- a/opengever/base/handlers.py
+++ b/opengever/base/handlers.py
@@ -4,6 +4,7 @@ from datetime import date
 from DateTime import DateTime
 from ftw.upgrade.helpers import update_security_for
 from opengever.base.behaviors.changed import IChanged
+from opengever.base.behaviors.touched import ITouched
 from opengever.base.date_time import utcnow_tz_aware
 from opengever.base.favorite import FavoriteManager
 from opengever.base.model import create_session
@@ -12,8 +13,6 @@ from opengever.base.oguid import Oguid
 from opengever.base.security import reindex_object_security_without_children
 from opengever.base.touched import ObjectTouchedEvent
 from opengever.base.touched import should_track_touches
-from opengever.dossier.behaviors.dossier import IDossier
-from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.indexers import TYPES_WITH_CONTAINING_SUBDOSSIER_INDEX
 from opengever.dossier.utils import supports_is_subdossier
 from opengever.globalindex.handlers.task import sync_task
@@ -256,8 +255,8 @@ def update_changed_date(context, event):
 def update_touched_date(obj, event):
     today = date.today()
     while obj and not IPloneSiteRoot.providedBy(obj):
-        if IDossierMarker.providedBy(obj) and IDossier(obj).touched != today:
-            IDossier(obj).touched = today
+        if ITouched.providedBy(obj) and ITouched(obj).touched != today:
+            ITouched(obj).touched = today
             # Prevent reindexing all indexes by indexing `UID` too.
             obj.reindexObject(idxs=['UID', 'touched'])
         obj = aq_parent(aq_inner(obj))

--- a/opengever/base/indexes.py
+++ b/opengever/base/indexes.py
@@ -3,6 +3,7 @@ from Acquisition import aq_inner
 from Acquisition import aq_parent
 from opengever.base.behaviors.changed import IChanged
 from opengever.base.behaviors.changed import IChangedMarker
+from opengever.base.behaviors.touched import ITouched
 from opengever.base.behaviors.translated_title import ITranslatedTitle
 from opengever.base.behaviors.translated_title import ITranslatedTitleSupport
 from opengever.base.interfaces import IReferenceNumber
@@ -160,3 +161,8 @@ def getObjPositionInParent(obj):
             return
         return ploneGetObjPositionInParent(obj)()
     return None
+
+
+@indexer(ITouched)
+def touched_indexer(obj):
+    return ITouched(obj).touched

--- a/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-01-09 15:05+0000\n"
+"POT-Creation-Date: 2023-01-10 12:25+0000\n"
 "PO-Revision-Date: 2014-09-04 01:03+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -422,6 +422,11 @@ msgstr "Titel (englisch)"
 #: ./opengever/base/behaviors/translated_title.py
 msgid "label_title_fr"
 msgstr "Titel (französisch)"
+
+#. Default: "Date of modification of the object or its content"
+#: ./opengever/base/behaviors/touched.py
+msgid "label_touched"
+msgstr "Änderungsdatum des Objektes oder seines Inhalts"
 
 #. Default: "limited-public"
 #: opengever/repository/classification.py

--- a/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-05-06 13:47+0000\n"
+"POT-Creation-Date: 2023-01-09 15:05+0000\n"
 "PO-Revision-Date: 2014-09-04 01:03+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"

--- a/opengever/base/locales/en/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/en/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-01-09 15:05+0000\n"
+"POT-Creation-Date: 2023-01-10 12:25+0000\n"
 "PO-Revision-Date: 2014-09-04 01:03+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -507,6 +507,11 @@ msgstr "Title (English)"
 #: ./opengever/base/behaviors/translated_title.py
 msgid "label_title_fr"
 msgstr "Title (French)"
+
+#. Default: "Date of modification of the object or its content"
+#: ./opengever/base/behaviors/touched.py
+msgid "label_touched"
+msgstr "Modification date of object or its content"
 
 #. German translation: Eingeschränkt öffentlich
 #. Default: "limited-public"

--- a/opengever/base/locales/en/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/en/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-05-06 13:47+0000\n"
+"POT-Creation-Date: 2023-01-09 15:05+0000\n"
 "PO-Revision-Date: 2014-09-04 01:03+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"

--- a/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-01-09 15:05+0000\n"
+"POT-Creation-Date: 2023-01-10 12:25+0000\n"
 "PO-Revision-Date: 2017-11-29 10:53+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-base/fr/>\n"
@@ -421,6 +421,11 @@ msgstr "Titre (anglais)"
 #: ./opengever/base/behaviors/translated_title.py
 msgid "label_title_fr"
 msgstr "Titre (français)"
+
+#. Default: "Date of modification of the object or its content"
+#: ./opengever/base/behaviors/touched.py
+msgid "label_touched"
+msgstr "Date de modification de l'objet ou de son contenu"
 
 #. Default: "limited-public"
 #: opengever/repository/classification.py

--- a/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-05-06 13:47+0000\n"
+"POT-Creation-Date: 2023-01-09 15:05+0000\n"
 "PO-Revision-Date: 2017-11-29 10:53+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-base/fr/>\n"

--- a/opengever/base/locales/opengever.base.pot
+++ b/opengever/base/locales/opengever.base.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-01-09 15:05+0000\n"
+"POT-Creation-Date: 2023-01-10 12:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -418,6 +418,11 @@ msgstr ""
 #. Default: "Title (French)"
 #: ./opengever/base/behaviors/translated_title.py
 msgid "label_title_fr"
+msgstr ""
+
+#. Default: "Date of modification of the object or its content"
+#: ./opengever/base/behaviors/touched.py
+msgid "label_touched"
 msgstr ""
 
 #: opengever/repository/classification.py

--- a/opengever/base/locales/opengever.base.pot
+++ b/opengever/base/locales/opengever.base.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-05-06 13:47+0000\n"
+"POT-Creation-Date: 2023-01-09 15:05+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/opengever/bundle/schemas/dossiers.schema.json
+++ b/opengever/bundle/schemas/dossiers.schema.json
@@ -65,16 +65,6 @@
                     "description": "",
                     "_zope_schema_type": "Date"
                 },
-                "touched": {
-                    "type": [
-                        "null",
-                        "string"
-                    ],
-                    "title": "\u00c4nderungsdatum des Dossiers oder seines Inhalts",
-                    "format": "date",
-                    "description": "",
-                    "_zope_schema_type": "Date"
-                },
                 "responsible": {
                     "type": "string",
                     "title": "Federf\u00fchrend",
@@ -349,6 +339,16 @@
                     "description": "Enth\u00e4lt die Daten f\u00fcr die benutzerdefinierten Felder.",
                     "_zope_schema_type": "PropertySheetField"
                 },
+                "touched": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "title": "\u00c4nderungsdatum des Objektes oder seines Inhalts",
+                    "format": "date",
+                    "description": "",
+                    "_zope_schema_type": "Date"
+                },
                 "review_state": {
                     "type": "string",
                     "enum": [
@@ -452,7 +452,6 @@
                 "keywords",
                 "start",
                 "end",
-                "touched",
                 "responsible",
                 "external_reference",
                 "filing_prefix",
@@ -475,7 +474,8 @@
                 "custody_period",
                 "date_of_cassation",
                 "date_of_submission",
-                "custom_properties"
+                "custom_properties",
+                "touched"
             ]
         },
         "permission": {

--- a/opengever/bundle/schemas/workspaces.schema.json
+++ b/opengever/bundle/schemas/workspaces.schema.json
@@ -82,6 +82,16 @@
                     "description": "",
                     "_zope_schema_type": "Text"
                 },
+                "touched": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "title": "\u00c4nderungsdatum des Objektes oder seines Inhalts",
+                    "format": "date",
+                    "description": "",
+                    "_zope_schema_type": "Date"
+                },
                 "review_state": {
                     "type": "string",
                     "enum": [
@@ -139,7 +149,8 @@
                 "hide_members_for_guests",
                 "changed",
                 "title",
-                "description"
+                "description",
+                "touched"
             ]
         },
         "permission": {

--- a/opengever/core/profiles/default/types/opengever.dossier.businesscasedossier.xml
+++ b/opengever/core/profiles/default/types/opengever.dossier.businesscasedossier.xml
@@ -42,6 +42,7 @@
     <element value="opengever.mail.behaviors.ISendableDocsContainer" />
     <element value="opengever.dossier.behaviors.protect_dossier.IProtectDossier" />
     <element value="opengever.dossier.behaviors.customproperties.IDossierCustomProperties" />
+    <element value="opengever.base.behaviors.touched.ITouched" />
   </property>
 
   <!-- View information -->

--- a/opengever/core/profiles/default/types/opengever.meeting.meetingdossier.xml
+++ b/opengever/core/profiles/default/types/opengever.meeting.meetingdossier.xml
@@ -41,6 +41,7 @@
     <element value="plone.app.lockingbehavior.behaviors.ILocking" />
     <element value="opengever.mail.behaviors.ISendableDocsContainer" />
     <element value="opengever.dossier.behaviors.customproperties.IDossierCustomProperties" />
+    <element value="opengever.base.behaviors.touched.ITouched" />
   </property>
 
   <!-- View information -->

--- a/opengever/core/profiles/default/types/opengever.private.dossier.xml
+++ b/opengever/core/profiles/default/types/opengever.private.dossier.xml
@@ -35,6 +35,7 @@
     <element value="opengever.sharing.behaviors.IDossier" />
     <element value="plone.app.lockingbehavior.behaviors.ILocking" />
     <element value="opengever.mail.behaviors.ISendableDocsContainer" />
+    <element value="opengever.base.behaviors.touched.ITouched" />
   </property>
 
   <!-- View information -->

--- a/opengever/core/profiles/default/types/opengever.workspace.todo.xml
+++ b/opengever/core/profiles/default/types/opengever.workspace.todo.xml
@@ -23,6 +23,7 @@
     <element value="collective.dexteritytextindexer.behavior.IDexterityTextIndexer" />
     <element value="opengever.workspace.behaviors.namefromtitle.IToDoNameFromTitle" />
     <element value="opengever.base.behaviors.sequence.ISequenceNumberBehavior" />
+    <element value="opengever.base.behaviors.changed.IChanged" />
   </property>
 
   <!-- View information -->

--- a/opengever/core/profiles/default/types/opengever.workspace.todolist.xml
+++ b/opengever/core/profiles/default/types/opengever.workspace.todolist.xml
@@ -25,6 +25,7 @@
     <element value="collective.dexteritytextindexer.behavior.IDexterityTextIndexer" />
     <element value="opengever.base.behaviors.sequence.ISequenceNumberBehavior" />
     <element value="opengever.workspace.behaviors.namefromtitle.IToDoListNameFromTitle" />
+    <element value="opengever.base.behaviors.changed.IChanged" />
   </property>
 
   <!-- View information -->

--- a/opengever/core/profiles/default/types/opengever.workspace.workspace.xml
+++ b/opengever/core/profiles/default/types/opengever.workspace.workspace.xml
@@ -36,6 +36,7 @@
     <element value="opengever.mail.behaviors.ISendableDocsContainer" />
     <element value="opengever.tabbedview.interfaces.ITabbedViewEnabled" />
     <element value="plone.app.lockingbehavior.behaviors.ILocking" />
+    <element value="opengever.base.behaviors.touched.ITouched" />
   </property>
 
   <!-- View information -->

--- a/opengever/core/tests/test_relations.py
+++ b/opengever/core/tests/test_relations.py
@@ -63,6 +63,7 @@ EXPECTED_INTERFACES = [
     'opengever.base.behaviors.classification.IClassificationMarker',
     'opengever.base.behaviors.lifecycle.ILifeCycleMarker',
     'opengever.base.behaviors.sequence.ISequenceNumberBehavior',
+    'opengever.base.behaviors.touched.ITouched',
     'opengever.base.behaviors.translated_title.ITranslatedTitleSupport',
     'opengever.base.response.IResponseSupported',
     'opengever.disposition.disposition.IDispositionSchema',

--- a/opengever/core/upgrades/20230110082930_add_i_touched_behavior/types/opengever.dossier.businesscasedossier.xml
+++ b/opengever/core/upgrades/20230110082930_add_i_touched_behavior/types/opengever.dossier.businesscasedossier.xml
@@ -1,0 +1,8 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="opengever.dossier.businesscasedossier" meta_type="Dexterity FTI" i18n:domain="opengever.core">
+
+  <!-- Enabled behaviors -->
+  <property name="behaviors" purge="False">
+    <element value="opengever.base.behaviors.touched.ITouched" />
+  </property>
+
+</object>

--- a/opengever/core/upgrades/20230110082930_add_i_touched_behavior/types/opengever.meeting.meetingdossier.xml
+++ b/opengever/core/upgrades/20230110082930_add_i_touched_behavior/types/opengever.meeting.meetingdossier.xml
@@ -1,0 +1,8 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="opengever.meeting.meetingdossier" meta_type="Dexterity FTI" i18n:domain="opengever.core">
+
+  <!-- Enabled behaviors -->
+  <property name="behaviors" purge="False">
+    <element value="opengever.base.behaviors.touched.ITouched" />
+  </property>
+
+</object>

--- a/opengever/core/upgrades/20230110082930_add_i_touched_behavior/types/opengever.private.dossier.xml
+++ b/opengever/core/upgrades/20230110082930_add_i_touched_behavior/types/opengever.private.dossier.xml
@@ -1,0 +1,8 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="opengever.private.dossier" meta_type="Dexterity FTI" i18n:domain="opengever.core">
+
+  <!-- Enabled behaviors -->
+  <property name="behaviors" purge="False">
+    <element value="opengever.base.behaviors.touched.ITouched" />
+  </property>
+
+</object>

--- a/opengever/core/upgrades/20230110082930_add_i_touched_behavior/types/opengever.workspace.todo.xml
+++ b/opengever/core/upgrades/20230110082930_add_i_touched_behavior/types/opengever.workspace.todo.xml
@@ -1,0 +1,8 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="opengever.workspace.todo" meta_type="Dexterity FTI" i18n:domain="opengever.core">
+
+  <!-- enabled behaviors -->
+  <property name="behaviors" purge="False">
+    <element value="opengever.base.behaviors.changed.IChanged" />
+  </property>
+
+</object>

--- a/opengever/core/upgrades/20230110082930_add_i_touched_behavior/types/opengever.workspace.todolist.xml
+++ b/opengever/core/upgrades/20230110082930_add_i_touched_behavior/types/opengever.workspace.todolist.xml
@@ -1,0 +1,8 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="opengever.workspace.todolist" meta_type="Dexterity FTI" i18n:domain="opengever.core">
+
+  <!-- enabled behaviors -->
+  <property name="behaviors" purge="False">
+    <element value="opengever.base.behaviors.changed.IChanged" />
+  </property>
+
+</object>

--- a/opengever/core/upgrades/20230110082930_add_i_touched_behavior/types/opengever.workspace.workspace.xml
+++ b/opengever/core/upgrades/20230110082930_add_i_touched_behavior/types/opengever.workspace.workspace.xml
@@ -1,0 +1,8 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="opengever.workspace.workspace" meta_type="Dexterity FTI" i18n:domain="opengever.core">
+
+  <!-- Enabled behaviors -->
+  <property name="behaviors" purge="False">
+    <element value="opengever.base.behaviors.touched.ITouched" />
+  </property>
+
+</object>

--- a/opengever/core/upgrades/20230110082930_add_i_touched_behavior/upgrade.py
+++ b/opengever/core/upgrades/20230110082930_add_i_touched_behavior/upgrade.py
@@ -1,4 +1,5 @@
 from ftw.upgrade import UpgradeStep
+from opengever.base.behaviors.changed import IChanged
 from opengever.base.behaviors.touched import ITouched
 from opengever.dossier.behaviors.dossier import IDossier
 
@@ -10,6 +11,7 @@ class AddITouchedBehavior(UpgradeStep):
     def __call__(self):
         self.install_upgrade_profile()
         self.migrate_touched_to_new_behavior()
+        self.index_changed_on_todos_and_todo_lists()
         self.index_touched_on_worskspaces()
 
     def migrate_touched_to_new_behavior(self):
@@ -39,3 +41,10 @@ class AddITouchedBehavior(UpgradeStep):
             )[0].changed
 
             obj.reindexObject(idxs=['UID', 'touched'])
+
+    def index_changed_on_todos_and_todo_lists(self):
+        query = {'object_provides': ['opengever.workspace.interfaces.IToDo',
+                                     'opengever.workspace.interfaces.IToDoList']}
+        for obj in self.objects(query, "Index changed on todos and todolists."):
+            IChanged(obj).changed = obj.modified()
+            obj.reindexObject(idxs=['UID', 'changed'])

--- a/opengever/core/upgrades/20230110082930_add_i_touched_behavior/upgrade.py
+++ b/opengever/core/upgrades/20230110082930_add_i_touched_behavior/upgrade.py
@@ -10,6 +10,7 @@ class AddITouchedBehavior(UpgradeStep):
     def __call__(self):
         self.install_upgrade_profile()
         self.migrate_touched_to_new_behavior()
+        self.index_touched_on_worskspaces()
 
     def migrate_touched_to_new_behavior(self):
         TOUCHED_ANNOTATIONS_KEY = '{}.touched'.format(IDossier.__identifier__)
@@ -22,3 +23,19 @@ class AddITouchedBehavior(UpgradeStep):
                 # fast. So there is also no need for a nightly upgrade step.
                 ITouched(obj).touched = dossier_schema.__dict__['annotations'].get(TOUCHED_ANNOTATIONS_KEY)
                 del dossier_schema.__dict__['annotations'][TOUCHED_ANNOTATIONS_KEY]
+
+    def index_touched_on_worskspaces(self):
+        query = {'object_provides': 'opengever.workspace.interfaces.IWorkspace'}
+        for obj in self.objects(query, "Index touched on workspaces."):
+            # Get the last changed object within the workspace or the workspace
+            # itself to determine the current touched date.
+            ITouched(obj).touched = self.catalog_unrestricted_search(
+                {
+                    'path': {'query': '/'.join(obj.getPhysicalPath())},
+                    'sort_on': 'changed',
+                    'sort_order': 'descending',
+                    'sort_limit': 1
+                }
+            )[0].changed
+
+            obj.reindexObject(idxs=['UID', 'touched'])

--- a/opengever/core/upgrades/20230110082930_add_i_touched_behavior/upgrade.py
+++ b/opengever/core/upgrades/20230110082930_add_i_touched_behavior/upgrade.py
@@ -1,0 +1,24 @@
+from ftw.upgrade import UpgradeStep
+from opengever.base.behaviors.touched import ITouched
+from opengever.dossier.behaviors.dossier import IDossier
+
+
+class AddITouchedBehavior(UpgradeStep):
+    """Add i touched behavior.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()
+        self.migrate_touched_to_new_behavior()
+
+    def migrate_touched_to_new_behavior(self):
+        TOUCHED_ANNOTATIONS_KEY = '{}.touched'.format(IDossier.__identifier__)
+        query = {'object_provides': 'opengever.dossier.behaviors.dossier.IDossierMarker'}
+        for obj in self.objects(query, "Migrate touched from IDossier to ITouched."):
+            dossier_schema = IDossier(obj)
+            if TOUCHED_ANNOTATIONS_KEY in dossier_schema.__dict__['annotations']:
+                # We do not need to reindex because the field value does not change.
+                # Reassigning the value to the new behavior is enough and
+                # fast. So there is also no need for a nightly upgrade step.
+                ITouched(obj).touched = dossier_schema.__dict__['annotations'].get(TOUCHED_ANNOTATIONS_KEY)
+                del dossier_schema.__dict__['annotations'][TOUCHED_ANNOTATIONS_KEY]

--- a/opengever/dossier/behaviors/dossier.py
+++ b/opengever/dossier/behaviors/dossier.py
@@ -3,6 +3,7 @@ from ftw.datepicker.widget import DatePickerFieldWidget
 from ftw.keywordwidget.field import ChoicePlus
 from ftw.keywordwidget.widget import KeywordFieldWidget
 from ftw.tabbedview.interfaces import ITabbedviewUploadable
+from opengever.base import _ as base_mf
 from opengever.base.source import RepositoryPathSourceBinder
 from opengever.base.vocabulary import wrap_vocabulary
 from opengever.dossier import _

--- a/opengever/dossier/behaviors/dossier.py
+++ b/opengever/dossier/behaviors/dossier.py
@@ -3,7 +3,6 @@ from ftw.datepicker.widget import DatePickerFieldWidget
 from ftw.keywordwidget.field import ChoicePlus
 from ftw.keywordwidget.widget import KeywordFieldWidget
 from ftw.tabbedview.interfaces import ITabbedviewUploadable
-from opengever.base import _ as base_mf
 from opengever.base.source import RepositoryPathSourceBinder
 from opengever.base.vocabulary import wrap_vocabulary
 from opengever.dossier import _
@@ -108,16 +107,6 @@ class IDossier(model.Schema):
     end = schema.Date(
         title=_(u'label_end', default=u'Closing Date'),
         required=False,
-    )
-
-    # Omitted because it must not be updated manually, only by event handlers.
-    form.omitted('touched')
-    touched = schema.Date(
-        title=_(u'label_touched',
-                default=u'Date of modification of the dossier or its content'),
-        required=False,
-        readonly=True,
-        default=None,
     )
 
     form.widget('responsible', KeywordFieldWidget, async=True)

--- a/opengever/dossier/configure.zcml
+++ b/opengever/dossier/configure.zcml
@@ -234,11 +234,6 @@
       />
 
   <adapter
-      factory=".indexers.dossier_touched_indexer"
-      name="touched"
-      />
-
-  <adapter
       factory=".indexers.participations"
       name="participations"
       />

--- a/opengever/dossier/configure.zcml
+++ b/opengever/dossier/configure.zcml
@@ -249,48 +249,6 @@
       />
 
   <subscriber
-      for="plone.dexterity.interfaces.IDexterityContent
-           zope.lifecycleevent.interfaces.IObjectModifiedEvent"
-      handler=".handlers.update_dossier_touched_date"
-      />
-
-  <subscriber
-      for="plone.dexterity.interfaces.IDexterityContent
-           zope.lifecycleevent.interfaces.IObjectAddedEvent"
-      handler=".handlers.update_dossier_touched_date"
-      />
-
-  <subscriber
-      for="plone.dexterity.interfaces.IDexterityContent
-           zope.lifecycleevent.interfaces.IObjectRemovedEvent"
-      handler=".handlers.update_dossier_touched_date"
-      />
-
-  <subscriber
-      for="plone.dexterity.interfaces.IDexterityContent
-           zope.lifecycleevent.interfaces.IObjectMovedEvent"
-      handler=".handlers.update_dossier_touched_date_for_move_event"
-      />
-
-  <subscriber
-      for="opengever.meeting.proposal.IBaseProposal
-           Products.CMFCore.interfaces.IActionSucceededEvent"
-      handler=".handlers.update_dossier_touched_date"
-      />
-
-  <subscriber
-      for="opengever.dossier.behaviors.dossier.IDossierMarker
-           Products.CMFCore.interfaces.IActionSucceededEvent"
-      handler=".handlers.update_dossier_touched_date"
-      />
-
-  <subscriber
-      for="opengever.task.task.ITask
-           Products.CMFCore.interfaces.IActionSucceededEvent"
-      handler=".handlers.update_dossier_touched_date"
-      />
-
-  <subscriber
       for="opengever.dossier.behaviors.dossier.IDossierMarker
            OFS.interfaces.IObjectWillBeMovedEvent"
       handler=".handlers.initalize_new_reference_number"

--- a/opengever/dossier/handlers.py
+++ b/opengever/dossier/handlers.py
@@ -163,6 +163,7 @@ def purge_reference_number_mappings(copied_dossier, event):
     prefix_adapter = IReferenceNumberPrefix(copied_dossier)
     prefix_adapter.purge_mappings()
 
+
 def move_connected_teamraum_to_main_dossier(obj, event):
     """If a dossier with linked workspaces gets moved into a dossier,
     the workspace link needs to be updated and moved to the new main dossier.

--- a/opengever/dossier/indexers.py
+++ b/opengever/dossier/indexers.py
@@ -1,7 +1,6 @@
 from Acquisition import aq_inner
 from Acquisition import aq_parent
 from collective import dexteritytextindexer
-from opengever.base.behaviors.touched import ITouched
 from opengever.base.interfaces import IReferenceNumber
 from opengever.base.interfaces import ISequenceNumber
 from opengever.base.response import IResponseContainer
@@ -252,11 +251,6 @@ class SearchableTextExtender(object):
                         searchable.append(ensure_str(value))
 
         return ' '.join(searchable)
-
-
-@indexer(IDossierMarker)
-def dossier_touched_indexer(obj):
-    return ITouched(obj).touched
 
 
 class ParticipationIndexHelper(object):

--- a/opengever/dossier/indexers.py
+++ b/opengever/dossier/indexers.py
@@ -1,6 +1,7 @@
 from Acquisition import aq_inner
 from Acquisition import aq_parent
 from collective import dexteritytextindexer
+from opengever.base.behaviors.touched import ITouched
 from opengever.base.interfaces import IReferenceNumber
 from opengever.base.interfaces import ISequenceNumber
 from opengever.base.response import IResponseContainer
@@ -255,7 +256,7 @@ class SearchableTextExtender(object):
 
 @indexer(IDossierMarker)
 def dossier_touched_indexer(obj):
-    return IDossier(obj).touched
+    return ITouched(obj).touched
 
 
 class ParticipationIndexHelper(object):

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2022-12-22 17:22+0000\n"
+"POT-Creation-Date: 2023-01-09 15:05+0000\n"
 "PO-Revision-Date: 2017-05-23 04:53+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -140,25 +140,9 @@ msgstr "Nicht alle benötigten Felder wurden ausgefüllt."
 msgid "Participants"
 msgstr "Beteiligungen"
 
-#: ./opengever/dossier/browser/overview.py
-msgid "Participations"
-msgstr "Beteiligungen"
-
-#: ./opengever/dossier/templatefolder/form.py
-msgid "Select document"
-msgstr "Dokument auswählen"
-
 #: ./opengever/dossier/dossiertemplate/form.py
 msgid "Select dossiertemplate"
 msgstr "Vorlage auswählen"
-
-#: ./opengever/dossier/templatefolder/form.py
-msgid "Select recipient address"
-msgstr "Empfänger-Adresse auswählen"
-
-#: ./opengever/dossier/templatefolder/form.py
-msgid "Select sender address"
-msgstr "Absender-Adresse auswählen"
 
 #: ./opengever/dossier/dossiertemplate/menu.py
 #: ./opengever/dossier/menu.py
@@ -519,11 +503,6 @@ msgstr "${item} wurde verschoben."
 msgid "label_addable_dossier_templates"
 msgstr "Erlaubte Dossiervorlagen"
 
-#. Default: "Address"
-#: ./opengever/dossier/templatefolder/form.py
-msgid "label_address"
-msgstr "Adresse"
-
 #. Default: "Protected Objects"
 #: ./opengever/dossier/browser/tabbed.py
 msgid "label_blocked_local_roles"
@@ -668,20 +647,10 @@ msgstr "Journal"
 msgid "label_keywords"
 msgstr "Schlagwörter"
 
-#. Default: "Label"
-#: ./opengever/dossier/templatefolder/form.py
-msgid "label_label"
-msgstr "Label"
-
 #. Default: "Linked Dossiers"
 #: ./opengever/dossier/browser/overview.py
 msgid "label_linked_dossiers"
 msgstr "Verlinkte Dossiers"
-
-#. Default: "Mail-Address"
-#: ./opengever/dossier/templatefolder/form.py
-msgid "label_mail_address"
-msgstr "Mail Addresse"
 
 #. Default: "Meeting Templates"
 #: ./opengever/dossier/browser/tabbed.py
@@ -749,16 +718,6 @@ msgstr "Beteiligungen"
 msgid "label_participation"
 msgstr "Beteiligung"
 
-#. Default: "Participations"
-#: ./opengever/dossier/browser/tabbed.py
-msgid "label_participations"
-msgstr "Beteiligungen"
-
-#. Default: "Phonenumber"
-#: ./opengever/dossier/templatefolder/form.py
-msgid "label_phonenumber"
-msgstr "Telefonnummer"
-
 #. Default: "Predefined Keywords"
 #: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "label_predefined_keywords"
@@ -783,11 +742,6 @@ msgstr "Lesend"
 #: ./opengever/dossier/behaviors/protect_dossier.py
 msgid "label_reading_and_writing"
 msgstr "Lesend & schreibend"
-
-#. Default: "Recipient"
-#: ./opengever/dossier/templatefolder/form.py
-msgid "label_recipient"
-msgstr "Empfänger"
 
 #. Default: "Reference Number"
 #: ./opengever/dossier/behaviors/dossier.py
@@ -826,11 +780,6 @@ msgstr "Rollen"
 #: ./opengever/dossier/browser/tabbed.py
 msgid "label_sablon_templates"
 msgstr "Sablon Vorlagen"
-
-#. Default: "Sender"
-#: ./opengever/dossier/templatefolder/form.py
-msgid "label_sender"
-msgstr "Absender"
 
 #. Default: "Sequence Number"
 #: ./opengever/dossier/viewlets/byline.py
@@ -895,11 +844,6 @@ msgstr "Änderungsdatum des Dossiers oder seines Inhalts"
 #: ./opengever/dossier/browser/tabbed.py
 msgid "label_trash"
 msgstr "Papierkorb"
-
-#. Default: "URL"
-#: ./opengever/dossier/templatefolder/form.py
-msgid "label_url"
-msgstr "URL"
 
 #. Default: "State"
 #: ./opengever/dossier/project_templates/byline.pt

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2023-01-09 15:05+0000\n"
+"POT-Creation-Date: 2023-01-10 12:25+0000\n"
 "PO-Revision-Date: 2017-05-23 04:53+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -834,11 +834,6 @@ msgstr "Titel"
 #: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "label_title_help"
 msgstr "Titelhilfe"
-
-#. Default: "Date of modification of the dossier or its content"
-#: ./opengever/dossier/behaviors/dossier.py
-msgid "label_touched"
-msgstr "Änderungsdatum des Dossiers oder seines Inhalts"
 
 #. Default: "Trash"
 #: ./opengever/dossier/browser/tabbed.py

--- a/opengever/dossier/locales/en/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/en/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2022-12-22 17:22+0000\n"
+"POT-Creation-Date: 2023-01-09 15:05+0000\n"
 "PO-Revision-Date: 2017-05-23 04:53+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -168,29 +168,10 @@ msgstr "Some required fields are missing."
 msgid "Participants"
 msgstr "Participants"
 
-#. German translation: Beteiligungen
-#: ./opengever/dossier/browser/overview.py
-msgid "Participations"
-msgstr "Participations"
-
-#. German translation: Dokument auswählen
-#: ./opengever/dossier/templatefolder/form.py
-msgid "Select document"
-msgstr "Select document"
-
 #. German translation: Vorlage auswählen
 #: ./opengever/dossier/dossiertemplate/form.py
 msgid "Select dossiertemplate"
 msgstr "Select dossier template"
-
-#. German translation: Empfänger-Adresse auswählen
-#: ./opengever/dossier/templatefolder/form.py
-msgid "Select recipient address"
-msgstr "Select recipient address"
-
-#: ./opengever/dossier/templatefolder/form.py
-msgid "Select sender address"
-msgstr "Select sender address"
 
 #. German translation: Subdossier
 #: ./opengever/dossier/dossiertemplate/menu.py
@@ -639,12 +620,6 @@ msgstr "${item} was moved."
 msgid "label_addable_dossier_templates"
 msgstr "Addable dossier templates"
 
-#. German translation: Adresse
-#. Default: "Address"
-#: ./opengever/dossier/templatefolder/form.py
-msgid "label_address"
-msgstr "Address"
-
 #. German translation: Geschützte Objekte
 #. Default: "Protected Objects"
 #: ./opengever/dossier/browser/tabbed.py
@@ -814,23 +789,11 @@ msgstr "Journal"
 msgid "label_keywords"
 msgstr "Keywords"
 
-#. German translation: Label
-#. Default: "Label"
-#: ./opengever/dossier/templatefolder/form.py
-msgid "label_label"
-msgstr "Label"
-
 #. German translation: Verlinkte Dossiers
 #. Default: "Linked Dossiers"
 #: ./opengever/dossier/browser/overview.py
 msgid "label_linked_dossiers"
 msgstr "Linked dossiers"
-
-#. German translation: Mail Addresse
-#. Default: "Mail-Address"
-#: ./opengever/dossier/templatefolder/form.py
-msgid "label_mail_address"
-msgstr "Email address"
 
 #. German translation: Sitzungsvorlagen
 #. Default: "Meeting Templates"
@@ -909,18 +872,6 @@ msgstr "Participants"
 msgid "label_participation"
 msgstr "Participation"
 
-#. German translation: Beteiligungen
-#. Default: "Participations"
-#: ./opengever/dossier/browser/tabbed.py
-msgid "label_participations"
-msgstr "Participations"
-
-#. German translation: Telefonnummer
-#. Default: "Phonenumber"
-#: ./opengever/dossier/templatefolder/form.py
-msgid "label_phonenumber"
-msgstr "Phone number"
-
 #. German translation: Schlagwörter vorausfüllen
 #. Default: "Predefined Keywords"
 #: ./opengever/dossier/dossiertemplate/behaviors.py
@@ -950,12 +901,6 @@ msgstr "Read only access"
 #: ./opengever/dossier/behaviors/protect_dossier.py
 msgid "label_reading_and_writing"
 msgstr "Read/Write access"
-
-#. German translation: Empfänger
-#. Default: "Recipient"
-#: ./opengever/dossier/templatefolder/form.py
-msgid "label_recipient"
-msgstr "Recipient"
 
 #. German translation: Aktenzeichen
 #. Default: "Reference Number"
@@ -1001,11 +946,6 @@ msgstr "Roles"
 #: ./opengever/dossier/browser/tabbed.py
 msgid "label_sablon_templates"
 msgstr "Sablon templates"
-
-#. Default: "Sender"
-#: ./opengever/dossier/templatefolder/form.py
-msgid "label_sender"
-msgstr "Sender"
 
 #. German translation: Laufnummer
 #. Default: "Sequence Number"
@@ -1083,12 +1023,6 @@ msgstr "Modification date of dossier or its content"
 #: ./opengever/dossier/browser/tabbed.py
 msgid "label_trash"
 msgstr "Trash"
-
-#. German translation: URL
-#. Default: "URL"
-#: ./opengever/dossier/templatefolder/form.py
-msgid "label_url"
-msgstr "URL"
 
 #. German translation: Status
 #. Default: "State"

--- a/opengever/dossier/locales/en/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/en/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2023-01-09 15:05+0000\n"
+"POT-Creation-Date: 2023-01-10 12:25+0000\n"
 "PO-Revision-Date: 2017-05-23 04:53+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -1011,12 +1011,6 @@ msgstr "Title"
 #: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "label_title_help"
 msgstr "Title hint"
-
-#. German translation: Änderungsdatum des Dossiers oder seines Inhalts
-#. Default: "Date of modification of the dossier or its content"
-#: ./opengever/dossier/behaviors/dossier.py
-msgid "label_touched"
-msgstr "Modification date of dossier or its content"
 
 #. German translation: Papierkorb
 #. Default: "Trash"

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-12-22 17:22+0000\n"
+"POT-Creation-Date: 2023-01-09 15:05+0000\n"
 "PO-Revision-Date: 2017-12-03 11:16+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/fr/>\n"
@@ -139,25 +139,9 @@ msgstr "Un ou plusieurs des champs requis n'ont pas été remplis."
 msgid "Participants"
 msgstr "Participants"
 
-#: ./opengever/dossier/browser/overview.py
-msgid "Participations"
-msgstr "Participations"
-
-#: ./opengever/dossier/templatefolder/form.py
-msgid "Select document"
-msgstr "Choisir un dossier"
-
 #: ./opengever/dossier/dossiertemplate/form.py
 msgid "Select dossiertemplate"
 msgstr "Choisir un modèle"
-
-#: ./opengever/dossier/templatefolder/form.py
-msgid "Select recipient address"
-msgstr "Choisir l'adresse du destinataire"
-
-#: ./opengever/dossier/templatefolder/form.py
-msgid "Select sender address"
-msgstr "Choisir l'adresse de l'expéditeur"
 
 #: ./opengever/dossier/dossiertemplate/menu.py
 #: ./opengever/dossier/menu.py
@@ -517,11 +501,6 @@ msgstr "${item} a été déplacé."
 msgid "label_addable_dossier_templates"
 msgstr "Modèles de dossier autorisés"
 
-#. Default: "Address"
-#: ./opengever/dossier/templatefolder/form.py
-msgid "label_address"
-msgstr "Adresse"
-
 #. Default: "Protected Objects"
 #: ./opengever/dossier/browser/tabbed.py
 msgid "label_blocked_local_roles"
@@ -666,20 +645,10 @@ msgstr "Historique"
 msgid "label_keywords"
 msgstr "Mots-clés"
 
-#. Default: "Label"
-#: ./opengever/dossier/templatefolder/form.py
-msgid "label_label"
-msgstr "label"
-
 #. Default: "Linked Dossiers"
 #: ./opengever/dossier/browser/overview.py
 msgid "label_linked_dossiers"
 msgstr "Dossiers liés"
-
-#. Default: "Mail-Address"
-#: ./opengever/dossier/templatefolder/form.py
-msgid "label_mail_address"
-msgstr "Adresse e-mail"
 
 #. Default: "Meeting Templates"
 #: ./opengever/dossier/browser/tabbed.py
@@ -747,16 +716,6 @@ msgstr "Participants"
 msgid "label_participation"
 msgstr "Participation"
 
-#. Default: "Participations"
-#: ./opengever/dossier/browser/tabbed.py
-msgid "label_participations"
-msgstr "Participations"
-
-#. Default: "Phonenumber"
-#: ./opengever/dossier/templatefolder/form.py
-msgid "label_phonenumber"
-msgstr "Numéro de téléphone"
-
 #. Default: "Predefined Keywords"
 #: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "label_predefined_keywords"
@@ -781,11 +740,6 @@ msgstr "lecture"
 #: ./opengever/dossier/behaviors/protect_dossier.py
 msgid "label_reading_and_writing"
 msgstr "lecture et écriture"
-
-#. Default: "Recipient"
-#: ./opengever/dossier/templatefolder/form.py
-msgid "label_recipient"
-msgstr "Destinataire"
 
 #. Default: "Reference Number"
 #: ./opengever/dossier/behaviors/dossier.py
@@ -824,11 +778,6 @@ msgstr "Rôles"
 #: ./opengever/dossier/browser/tabbed.py
 msgid "label_sablon_templates"
 msgstr "Modèles Sablon"
-
-#. Default: "Sender"
-#: ./opengever/dossier/templatefolder/form.py
-msgid "label_sender"
-msgstr "Expéditeur"
 
 #. Default: "Sequence Number"
 #: ./opengever/dossier/viewlets/byline.py
@@ -893,11 +842,6 @@ msgstr "Date de modification du dossier ou de son contenu"
 #: ./opengever/dossier/browser/tabbed.py
 msgid "label_trash"
 msgstr "Corbeille"
-
-#. Default: "URL"
-#: ./opengever/dossier/templatefolder/form.py
-msgid "label_url"
-msgstr "Adresse URL"
 
 #. Default: "State"
 #: ./opengever/dossier/project_templates/byline.pt

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-01-09 15:05+0000\n"
+"POT-Creation-Date: 2023-01-10 12:25+0000\n"
 "PO-Revision-Date: 2017-12-03 11:16+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/fr/>\n"
@@ -832,11 +832,6 @@ msgstr "Titre"
 #: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "label_title_help"
 msgstr "Aide pour le choix du titre"
-
-#. Default: "Date of modification of the dossier or its content"
-#: ./opengever/dossier/behaviors/dossier.py
-msgid "label_touched"
-msgstr "Date de modification du dossier ou de son contenu"
 
 #. Default: "Trash"
 #: ./opengever/dossier/browser/tabbed.py

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-01-09 15:05+0000\n"
+"POT-Creation-Date: 2023-01-10 12:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -830,11 +830,6 @@ msgstr ""
 #. Default: "Title help"
 #: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "label_title_help"
-msgstr ""
-
-#. Default: "Date of modification of the dossier or its content"
-#: ./opengever/dossier/behaviors/dossier.py
-msgid "label_touched"
 msgstr ""
 
 #. Default: "Trash"

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-12-22 17:22+0000\n"
+"POT-Creation-Date: 2023-01-09 15:05+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -140,24 +140,8 @@ msgstr ""
 msgid "Participants"
 msgstr ""
 
-#: ./opengever/dossier/browser/overview.py
-msgid "Participations"
-msgstr ""
-
-#: ./opengever/dossier/templatefolder/form.py
-msgid "Select document"
-msgstr ""
-
 #: ./opengever/dossier/dossiertemplate/form.py
 msgid "Select dossiertemplate"
-msgstr ""
-
-#: ./opengever/dossier/templatefolder/form.py
-msgid "Select recipient address"
-msgstr ""
-
-#: ./opengever/dossier/templatefolder/form.py
-msgid "Select sender address"
 msgstr ""
 
 #: ./opengever/dossier/dossiertemplate/menu.py
@@ -516,11 +500,6 @@ msgstr ""
 msgid "label_addable_dossier_templates"
 msgstr ""
 
-#. Default: "Address"
-#: ./opengever/dossier/templatefolder/form.py
-msgid "label_address"
-msgstr ""
-
 #. Default: "Protected Objects"
 #: ./opengever/dossier/browser/tabbed.py
 msgid "label_blocked_local_roles"
@@ -665,19 +644,9 @@ msgstr ""
 msgid "label_keywords"
 msgstr ""
 
-#. Default: "Label"
-#: ./opengever/dossier/templatefolder/form.py
-msgid "label_label"
-msgstr ""
-
 #. Default: "Linked Dossiers"
 #: ./opengever/dossier/browser/overview.py
 msgid "label_linked_dossiers"
-msgstr ""
-
-#. Default: "Mail-Address"
-#: ./opengever/dossier/templatefolder/form.py
-msgid "label_mail_address"
 msgstr ""
 
 #. Default: "Meeting Templates"
@@ -746,16 +715,6 @@ msgstr ""
 msgid "label_participation"
 msgstr ""
 
-#. Default: "Participations"
-#: ./opengever/dossier/browser/tabbed.py
-msgid "label_participations"
-msgstr ""
-
-#. Default: "Phonenumber"
-#: ./opengever/dossier/templatefolder/form.py
-msgid "label_phonenumber"
-msgstr ""
-
 #. Default: "Predefined Keywords"
 #: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "label_predefined_keywords"
@@ -779,11 +738,6 @@ msgstr ""
 #. Default: "Reading and writing"
 #: ./opengever/dossier/behaviors/protect_dossier.py
 msgid "label_reading_and_writing"
-msgstr ""
-
-#. Default: "Recipient"
-#: ./opengever/dossier/templatefolder/form.py
-msgid "label_recipient"
 msgstr ""
 
 #. Default: "Reference Number"
@@ -822,11 +776,6 @@ msgstr ""
 #. Default: "Sablon Templates"
 #: ./opengever/dossier/browser/tabbed.py
 msgid "label_sablon_templates"
-msgstr ""
-
-#. Default: "Sender"
-#: ./opengever/dossier/templatefolder/form.py
-msgid "label_sender"
 msgstr ""
 
 #. Default: "Sequence Number"
@@ -891,11 +840,6 @@ msgstr ""
 #. Default: "Trash"
 #: ./opengever/dossier/browser/tabbed.py
 msgid "label_trash"
-msgstr ""
-
-#. Default: "URL"
-#: ./opengever/dossier/templatefolder/form.py
-msgid "label_url"
 msgstr ""
 
 #. Default: "State"

--- a/opengever/dossier/tests/test_touched.py
+++ b/opengever/dossier/tests/test_touched.py
@@ -3,7 +3,7 @@ from ftw.builder.builder import Builder
 from ftw.builder.builder import create
 from ftw.testbrowser import browsing
 from ftw.testing import freeze
-from opengever.dossier.behaviors.dossier import IDossier
+from opengever.base.behaviors.touched import ITouched
 from opengever.testing import SolrIntegrationTestCase
 from plone import api
 
@@ -16,7 +16,7 @@ class TestDossierTouched(SolrIntegrationTestCase):
         with freeze(datetime(2020, 6, 12)):
             dossier = create(Builder("dossier")
                              .within(self.leaf_repofolder))
-            self.assertEqual("2020-06-12", str(IDossier(dossier).touched))
+            self.assertEqual("2020-06-12", str(ITouched(dossier).touched))
 
     @browsing
     def test_touched_date_is_only_updated_when_set_to_different_date(self, browser):
@@ -26,79 +26,79 @@ class TestDossierTouched(SolrIntegrationTestCase):
         with freeze(datetime(2020, 6, 12)):
             browser.open(self.dossier, view="edit")
             browser.fill({u"Title": "First modification"}).save()
-            self.assertEqual("2020-06-12", str(IDossier(self.dossier).touched))
+            self.assertEqual("2020-06-12", str(ITouched(self.dossier).touched))
 
             browser.open(self.dossier, view="edit")
             browser.fill({u"Title": "Modification on the same day"}).save()
-            self.assertEqual("2020-06-12", str(IDossier(self.dossier).touched))
+            self.assertEqual("2020-06-12", str(ITouched(self.dossier).touched))
 
         # Modifications on the next day will change the "touched" date.
         with freeze(datetime(2020, 6, 13)):
             browser.open(self.dossier, view="edit")
             browser.fill({u"Title": "Modification on the next day"}).save()
-            self.assertEqual("2020-06-13", str(IDossier(self.dossier).touched))
+            self.assertEqual("2020-06-13", str(ITouched(self.dossier).touched))
 
     @browsing
     def test_modifying_content_touches_all_dossiers_in_path(self, browser):
         self.login(self.administrator, browser=browser)
 
-        self.assertEqual("2016-08-31", str(IDossier(self.dossier).touched))
-        self.assertEqual("2016-08-31", str(IDossier(self.subdossier).touched))
+        self.assertEqual("2016-08-31", str(ITouched(self.dossier).touched))
+        self.assertEqual("2016-08-31", str(ITouched(self.subdossier).touched))
 
         with freeze(datetime(2020, 6, 12)):
             browser.open(self.subdocument, view="edit")
             browser.fill({u"Title": "Modified subdocument"}).save()
-            self.assertEqual("2020-06-12", str(IDossier(self.dossier).touched))
-            self.assertEqual("2020-06-12", str(IDossier(self.subdossier).touched))
+            self.assertEqual("2020-06-12", str(ITouched(self.dossier).touched))
+            self.assertEqual("2020-06-12", str(ITouched(self.subdossier).touched))
 
     @browsing
     def test_adding_content_touches_all_dossiers_in_path(self, browser):
         self.login(self.administrator, browser=browser)
 
-        self.assertEqual("2016-08-31", str(IDossier(self.dossier).touched))
-        self.assertEqual("2016-08-31", str(IDossier(self.subdossier).touched))
+        self.assertEqual("2016-08-31", str(ITouched(self.dossier).touched))
+        self.assertEqual("2016-08-31", str(ITouched(self.subdossier).touched))
 
         with freeze(datetime(2020, 6, 12)):
             create(Builder('document').within(self.subdossier))
-            self.assertEqual("2020-06-12", str(IDossier(self.dossier).touched))
-            self.assertEqual("2020-06-12", str(IDossier(self.subdossier).touched))
+            self.assertEqual("2020-06-12", str(ITouched(self.dossier).touched))
+            self.assertEqual("2020-06-12", str(ITouched(self.subdossier).touched))
 
     @browsing
     def test_deleting_content_touches_all_dossiers_in_path(self, browser):
         self.login(self.manager, browser=browser)
 
-        self.assertEqual("2016-08-31", str(IDossier(self.dossier).touched))
-        self.assertEqual("2016-08-31", str(IDossier(self.subdossier).touched))
-        self.assertEqual("2016-08-31", str(IDossier(self.subsubdossier).touched))
+        self.assertEqual("2016-08-31", str(ITouched(self.dossier).touched))
+        self.assertEqual("2016-08-31", str(ITouched(self.subdossier).touched))
+        self.assertEqual("2016-08-31", str(ITouched(self.subsubdossier).touched))
 
         with freeze(datetime(2020, 6, 12)):
             api.content.delete(obj=self.subsubdocument)
-            self.assertEqual("2020-06-12", str(IDossier(self.dossier).touched))
-            self.assertEqual("2020-06-12", str(IDossier(self.subdossier).touched))
-            self.assertEqual("2020-06-12", str(IDossier(self.subsubdossier).touched))
+            self.assertEqual("2020-06-12", str(ITouched(self.dossier).touched))
+            self.assertEqual("2020-06-12", str(ITouched(self.subdossier).touched))
+            self.assertEqual("2020-06-12", str(ITouched(self.subsubdossier).touched))
 
     @browsing
     def test_moving_content_touches_all_dossiers_in_path(self, browser):
         self.login(self.administrator, browser=browser)
 
-        self.assertEqual("2016-08-31", str(IDossier(self.dossier).touched))
-        self.assertEqual("2016-08-31", str(IDossier(self.subdossier).touched))
-        self.assertEqual("2016-08-31", str(IDossier(self.subdossier2).touched))
+        self.assertEqual("2016-08-31", str(ITouched(self.dossier).touched))
+        self.assertEqual("2016-08-31", str(ITouched(self.subdossier).touched))
+        self.assertEqual("2016-08-31", str(ITouched(self.subdossier2).touched))
 
         with freeze(datetime(2020, 6, 12)):
             api.content.move(source=self.subdocument, target=self.subdossier2)
-            self.assertEqual("2020-06-12", str(IDossier(self.dossier).touched))
-            self.assertEqual("2020-06-12", str(IDossier(self.subdossier).touched))
-            self.assertEqual("2020-06-12", str(IDossier(self.subdossier2).touched))
+            self.assertEqual("2020-06-12", str(ITouched(self.dossier).touched))
+            self.assertEqual("2020-06-12", str(ITouched(self.subdossier).touched))
+            self.assertEqual("2020-06-12", str(ITouched(self.subdossier2).touched))
 
     @browsing
     def test_moving_content_does_not_touch_children_of_moved_object(self, browser):
         self.login(self.administrator, browser=browser)
 
-        self.assertEqual("2016-08-31", str(IDossier(self.dossier).touched))
-        self.assertEqual("2016-08-31", str(IDossier(self.subdossier).touched))
-        self.assertEqual("2016-08-31", str(IDossier(self.subdossier2).touched))
-        self.assertEqual("2016-08-31", str(IDossier(self.subsubdossier).touched))
+        self.assertEqual("2016-08-31", str(ITouched(self.dossier).touched))
+        self.assertEqual("2016-08-31", str(ITouched(self.subdossier).touched))
+        self.assertEqual("2016-08-31", str(ITouched(self.subdossier2).touched))
+        self.assertEqual("2016-08-31", str(ITouched(self.subsubdossier).touched))
 
         with freeze(datetime(2020, 6, 12)), self.observe_children(self.subdossier2) as children:
             api.content.move(source=self.subdossier, target=self.subdossier2)
@@ -112,36 +112,36 @@ class TestDossierTouched(SolrIntegrationTestCase):
         self.assertEqual(1, len(subdossiers))
         moved_subsubdossier = subdossiers[0].getObject()
 
-        self.assertEqual("2020-06-12", str(IDossier(self.dossier).touched))
-        self.assertEqual("2020-06-12", str(IDossier(moved_subdossier).touched))
-        self.assertEqual("2020-06-12", str(IDossier(self.subdossier2).touched))
-        self.assertEqual("2016-08-31", str(IDossier(moved_subsubdossier).touched))
+        self.assertEqual("2020-06-12", str(ITouched(self.dossier).touched))
+        self.assertEqual("2020-06-12", str(ITouched(moved_subdossier).touched))
+        self.assertEqual("2020-06-12", str(ITouched(self.subdossier2).touched))
+        self.assertEqual("2016-08-31", str(ITouched(moved_subsubdossier).touched))
 
     @browsing
     def test_modifying_proposal_touches_containing_dossier(self, browser):
         self.activate_feature('meeting')
 
         self.login(self.administrator, browser)
-        self.assertEqual("2016-08-31", str(IDossier(self.empty_dossier).touched))
+        self.assertEqual("2016-08-31", str(ITouched(self.empty_dossier).touched))
 
         with freeze(datetime(2020, 6, 12)):
             proposal = create(Builder('proposal')
                               .within(self.empty_dossier)
                               .titled(u'My Proposal')
                               .having(committee=self.committee.load_model()))
-            self.assertEqual("2020-06-12", str(IDossier(self.empty_dossier).touched))
+            self.assertEqual("2020-06-12", str(ITouched(self.empty_dossier).touched))
 
         with freeze(datetime(2020, 6, 13)):
             browser.open(proposal, view="edit")
             browser.fill({u"Title": "Modified proposal"}).save()
-            self.assertEqual("2020-06-13", str(IDossier(self.empty_dossier).touched))
+            self.assertEqual("2020-06-13", str(ITouched(self.empty_dossier).touched))
 
     @browsing
     def test_changing_state_of_proposal_touches_containing_dossier(self, browser):
         self.activate_feature('meeting')
 
         self.login(self.administrator, browser)
-        self.assertEqual("2016-08-31", str(IDossier(self.empty_dossier).touched))
+        self.assertEqual("2016-08-31", str(ITouched(self.empty_dossier).touched))
 
         with freeze(datetime(2020, 6, 12)):
             proposal = create(Builder('proposal')
@@ -149,7 +149,7 @@ class TestDossierTouched(SolrIntegrationTestCase):
                               .titled(u'My Proposal')
                               .having(committee=self.committee.load_model()))
             self.assert_workflow_state('proposal-state-active', proposal)
-            self.assertEqual("2020-06-12", str(IDossier(self.empty_dossier).touched))
+            self.assertEqual("2020-06-12", str(ITouched(self.empty_dossier).touched))
 
         with freeze(datetime(2020, 6, 13)):
             browser.open(proposal, view='tabbedview_view-overview')
@@ -157,27 +157,27 @@ class TestDossierTouched(SolrIntegrationTestCase):
             browser.click_on("Confirm")
             self.assert_workflow_state('proposal-state-cancelled', proposal)
 
-            self.assertEqual("2020-06-13", str(IDossier(self.empty_dossier).touched))
+            self.assertEqual("2020-06-13", str(ITouched(self.empty_dossier).touched))
 
     @browsing
     def test_changing_state_of_subdossier_touches_containing_dossier(self, browser):
         self.login(self.administrator, browser)
-        self.assertEqual("2016-08-31", str(IDossier(self.dossier).touched))
-        self.assertEqual("2016-08-31", str(IDossier(self.subdossier).touched))
+        self.assertEqual("2016-08-31", str(ITouched(self.dossier).touched))
+        self.assertEqual("2016-08-31", str(ITouched(self.subdossier).touched))
         self.assert_workflow_state('dossier-state-active', self.subdossier)
 
         with freeze(datetime(2020, 6, 12)):
             browser.open(self.subdossier)
             browser.click_on("Resolve")
             self.assert_workflow_state('dossier-state-resolved', self.subdossier)
-            self.assertEqual("2020-06-12", str(IDossier(self.dossier).touched))
-            self.assertEqual("2020-06-12", str(IDossier(self.subdossier).touched))
+            self.assertEqual("2020-06-12", str(ITouched(self.dossier).touched))
+            self.assertEqual("2020-06-12", str(ITouched(self.subdossier).touched))
 
     @browsing
     def test_changing_state_of_task_touches_containing_dossier(self, browser):
         self.login(self.administrator, browser)
         self.set_workflow_state('task-state-open', self.task)  # So we can cancel it later.
-        self.assertEqual("2016-08-31", str(IDossier(self.dossier).touched))
+        self.assertEqual("2016-08-31", str(ITouched(self.dossier).touched))
 
         with freeze(datetime(2020, 6, 13)):
             browser.open(self.task)
@@ -185,4 +185,4 @@ class TestDossierTouched(SolrIntegrationTestCase):
             browser.click_on("Save")
 
             self.assert_workflow_state('task-state-cancelled', self.task)
-            self.assertEqual("2020-06-13", str(IDossier(self.dossier).touched))
+            self.assertEqual("2020-06-13", str(ITouched(self.dossier).touched))

--- a/opengever/workspace/tests/test_workspace_touched.py
+++ b/opengever/workspace/tests/test_workspace_touched.py
@@ -1,0 +1,64 @@
+from datetime import datetime
+from ftw.builder.builder import Builder
+from ftw.builder.builder import create
+from ftw.testbrowser import browsing
+from ftw.testing import freeze
+from opengever.base.behaviors.touched import ITouched
+from opengever.testing import SolrIntegrationTestCase
+from plone import api
+
+
+class TestWorkspaceTouched(SolrIntegrationTestCase):
+
+    features = ('workspace',)
+
+    @browsing
+    def test_touched_date_is_set_correctly_on_new_workspace(self, browser):
+        self.login(self.workspace_admin, browser)
+        with freeze(datetime(2020, 6, 12)):
+            workspace = create(Builder("workspace")
+                               .within(self.workspace_root))
+            self.assertEqual("2020-06-12", str(ITouched(workspace).touched))
+
+    @browsing
+    def test_modifying_content_touches_the_workspaces_in_path(self, browser):
+        self.login(self.workspace_admin, browser=browser)
+
+        self.assertEqual("2016-08-31", str(ITouched(self.workspace).touched))
+
+        with freeze(datetime(2020, 6, 12)):
+            browser.open(self.workspace_folder_document, view="edit")
+            browser.fill({u"Title": "Modified subdocument"}).save()
+            self.assertEqual("2020-06-12", str(ITouched(self.workspace).touched))
+
+    @browsing
+    def test_adding_content_touches_the_workspaces_in_path(self, browser):
+        self.login(self.workspace_admin, browser=browser)
+
+        self.assertEqual("2016-08-31", str(ITouched(self.workspace).touched))
+
+        with freeze(datetime(2020, 6, 12)):
+            create(Builder('document').within(self.workspace_folder))
+            self.assertEqual("2020-06-12", str(ITouched(self.workspace).touched))
+
+    @browsing
+    def test_deleting_content_touches_the_workspaces_in_path(self, browser):
+        self.login(self.manager, browser=browser)
+
+        self.assertEqual("2016-08-31", str(ITouched(self.workspace).touched))
+
+        with freeze(datetime(2020, 6, 12)):
+            api.content.delete(obj=self.workspace_folder_document)
+            self.assertEqual("2020-06-12", str(ITouched(self.workspace).touched))
+
+    @browsing
+    def test_moving_content_touches_the_workspaces_in_path(self, browser):
+        self.login(self.workspace_admin, browser=browser)
+        new_workspace = create(Builder("workspace")
+                               .within(self.workspace_root))
+        self.assertEqual("2016-08-31", str(ITouched(self.workspace).touched))
+
+        with freeze(datetime(2020, 6, 12)):
+            api.content.move(source=self.workspace_folder_document, target=new_workspace)
+            self.assertEqual("2020-06-12", str(ITouched(self.workspace).touched))
+            self.assertEqual("2020-06-12", str(ITouched(new_workspace).touched))


### PR DESCRIPTION
This PR adds the touched date index for workspaces.

The `touched` field was only implemented for dossiers. In this PR, we refactor out the field into its own schema behavior called `ITouched`. We then generally use this behavior for dossiers and workspaces.

The indexer method is now also registered for all `IDexterityContent` objects and will only return the date if the `ITouched` behavior is provided. This makes the implementation more generic and reusable for different content types.

The upgradestep in this PR is not implemented as a nightly upgrade step because migrating the dossiers `touched` filed does not require a reindex, so this is blazing fast. For setting the initial touched date for workspaces we only need to reindex workspaces. There are no deployments with a huge amount of workspaces.

For [CA-4875]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-4875]: https://4teamwork.atlassian.net/browse/CA-4875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ