### PR TITLE
Touch workspace if todo review state changed

### DIFF
--- a/opengever/base/configure.zcml
+++ b/opengever/base/configure.zcml
@@ -427,6 +427,12 @@
       />
 
   <subscriber
+      for="opengever.workspace.interfaces.IToDo
+           Products.CMFCore.interfaces.IActionSucceededEvent"
+      handler=".handlers.update_touched_date"
+      />
+
+  <subscriber
       for="opengever.task.task.ITask
            Products.CMFCore.interfaces.IActionSucceededEvent"
       handler=".handlers.update_touched_date"

--- a/opengever/workspace/tests/test_workspace_touched.py
+++ b/opengever/workspace/tests/test_workspace_touched.py
@@ -62,3 +62,15 @@ class TestWorkspaceTouched(SolrIntegrationTestCase):
             api.content.move(source=self.workspace_folder_document, target=new_workspace)
             self.assertEqual("2020-06-12", str(ITouched(self.workspace).touched))
             self.assertEqual("2020-06-12", str(ITouched(new_workspace).touched))
+
+    @browsing
+    def test_changing_state_of_todo_touches_the_workspace(self, browser):
+        self.login(self.workspace_admin, browser=browser)
+
+        self.assertEqual("2016-08-31", str(ITouched(self.workspace).touched))
+
+        with freeze(datetime(2020, 6, 12)):
+            browser.open(
+                self.todo, method='POST', headers=self.api_headers,
+                view="@workflow/opengever_workspace_todo--TRANSITION--complete--active_completed")
+            self.assertEqual("2020-06-12", str(ITouched(self.workspace).touched))


### PR DESCRIPTION
This is a follow-up PR for #7655 

The workspace touched date needs to update if the review-state of todos have been changed.

For [CA-4875]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry (follow-up pr. CL not required
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-4875]: https://4teamwork.atlassian.net/browse/CA-4875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ