### PR TITLE
Fix check to prevent anonymous users from viewing member portraits:

### DIFF
--- a/changes/CA-5103.bugfix
+++ b/changes/CA-5103.bugfix
@@ -1,0 +1,1 @@
+Fix check to prevent anonymous users from viewing member portraits. [lgraf]

--- a/opengever/base/subscribers.py
+++ b/opengever/base/subscribers.py
@@ -110,7 +110,7 @@ def disallow_anonymous_views_on_site_root(event):
         return
 
     # Block anonymous access to member portraits
-    if event.request.steps[1:3] == ['portal_memberdata', 'portraits']:
+    if '/portal_memberdata/portraits/' in event.request.getURL():
         raise Unauthorized
 
     # Find the first physical / persistent object in the PARENTS


### PR DESCRIPTION
The previous condition worked locally, but did not work in virtual hosting scenarios where the path contains an additional 'virtual_hosting' step.

Follow-up for [CA-5103](https://4teamwork.atlassian.net/browse/CA-5103)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-5103]: https://4teamwork.atlassian.net/browse/CA-5103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ