### PR TITLE
Provides a "WWW-Authenticate" response header for unauthorized requests to the @scan-in endpoint.

### DIFF
--- a/changes/CA-5239.other
+++ b/changes/CA-5239.other
@@ -1,0 +1,1 @@
+Provides a "WWW-Authenticate" response header for unauthorized requests to the @scan-in endpoint. [elioschmutz]

--- a/opengever/api/tests/test_scanin.py
+++ b/opengever/api/tests/test_scanin.py
@@ -226,3 +226,12 @@ class TestScanIn(IntegrationTestCase):
 
         expected_message = 'The scan-in destination does not exist.'
         self.assertIn(expected_message, browser.json.get('error').get('message'))
+
+    @browsing
+    def test_scanin_provides_www_authenticate_header_if_401(self, browser):
+        with browser.expect_http_error(code=401):
+            browser.open(self.portal.absolute_url() + '/@scan-in',
+                         method='POST',
+                         headers={'Accept': 'application/json'})
+
+        self.assertEqual('Basic', browser.headers.get('www-authenticate'))

--- a/opengever/base/subscribers.py
+++ b/opengever/base/subscribers.py
@@ -47,6 +47,10 @@ ALLOWED_ENDPOINTS = set([
     'wopi',
 ])
 
+BASIC_AUTH_ENDPOINTS = [
+    'POST_application_json_@scan-in'
+]
+
 
 def disable_plone_protect(obj, event):
     """Disables plone.protect for requests beginning an edit.
@@ -126,6 +130,9 @@ def disallow_anonymous_views_on_site_root(event):
     views = filter(IBrowserView.providedBy, event.request['PARENTS'])
     if len(views) > 0 and views[0].__name__ in ALLOWED_ENDPOINTS:
         return
+
+    if endpoint_name in BASIC_AUTH_ENDPOINTS:
+        event.request.response['WWW-Authenticate'] = 'Basic'
 
     raise Unauthorized
 


### PR DESCRIPTION
This PR adds the `WWW-Authenticate` response header for unauthorized requests to the `@scan-in` endpoint.

Two notes to the reviewer:

1. The header could be added automatically by the `IChallengePlugin` of the PAS by plone by default. The `HTTPBasicAuthHelper` Plugin would already add the header. But we never reach this code even if the plugin is activated. We do not use the `challenge`-method of the `IChallengePlugins`s at this point .
2. The response object would provide a `addHeader`: `response.addHeader('WWW-Authenticate', 'Basic')`. But this is not compatible with the testbrowser of `ftw.testbrowser` which provides its own `TestResponse` object. I implemented a direct key assignment for the header. Otherwise we'd need to ship a new version of `ftw.testbrowser` to make it compatible in testing.

See https://docs.plone.org/4/en/old-reference-manuals/pluggable_authentication_service/challenges.html for more infos about the `IChallengePlugin` of in plone pas.

For [CA-5239]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-5239]: https://4teamwork.atlassian.net/browse/CA-5239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ