### PR TITLE
Reindex the reference number of mails during move operations.

### DIFF
--- a/changes/CA-5274.bugfix
+++ b/changes/CA-5274.bugfix
@@ -1,0 +1,1 @@
+Reindex the reference number of mails during move operations. [njohner]

--- a/opengever/core/upgrades/20230208123453_reindex_mail_reference_numbers/upgrade.py
+++ b/opengever/core/upgrades/20230208123453_reindex_mail_reference_numbers/upgrade.py
@@ -1,0 +1,16 @@
+from ftw.upgrade import UpgradeStep
+from opengever.core.upgrade import NightlyIndexer
+
+
+class ReindexMailReferenceNumbers(UpgradeStep):
+    """Reindex mail reference numbers.
+    """
+
+    deferrable = True
+
+    def __call__(self):
+        query = {'portal_type': 'ftw.mail.mail'}
+
+        with NightlyIndexer(idxs=["reference", "sortable_reference", "metadata"]) as indexer:
+            for brain in self.brains(query, 'Queueing mail reference number reindexing job'):
+                indexer.add_by_brain(brain)

--- a/opengever/document/configure.zcml
+++ b/opengever/document/configure.zcml
@@ -174,9 +174,9 @@
       />
 
   <subscriber
-      for="opengever.document.document.IDocumentSchema
+      for="opengever.document.behaviors.IBaseDocument
            zope.lifecycleevent.IObjectMovedEvent"
-      handler=".handlers.document_moved_or_added"
+      handler=".handlers.document_or_mail_moved_or_added"
       />
 
   <subscriber

--- a/opengever/document/handlers.py
+++ b/opengever/document/handlers.py
@@ -7,6 +7,7 @@ from opengever.document.activities import DocumentTitleChangedActivity
 from opengever.document.activities import DocumenVersionCreatedActivity
 from opengever.document.archival_file import ArchivalFileConverter
 from opengever.document.docprops import DocPropertyWriter
+from opengever.document.document import IDocumentSchema
 from opengever.document.interfaces import ITemplateDocumentMarker
 from opengever.dossier.templatefolder.utils import is_directly_within_template_folder
 from plone.app.workflow.interfaces import ILocalrolesModifiedEvent
@@ -51,13 +52,18 @@ def before_documend_checked_in(context, event):
     _update_docproperties(context, raise_on_error=False)
 
 
-def document_moved_or_added(context, event):
+def document_or_mail_moved_or_added(context, event):
     if IObjectRemovedEvent.providedBy(event):
         return
 
     if IObjectMovedEvent.providedBy(event):
         context.reindexObject(idxs=["reference", "sortable_reference", "metadata"])
 
+    if IDocumentSchema.providedBy(context):
+        document_moved_or_added(context, event)
+
+
+def document_moved_or_added(context, event):
     if context.REQUEST.get(DISABLE_DOCPROPERTY_UPDATE_FLAG):
         return
 


### PR DESCRIPTION
It seems we had only registered an event handler to reindex the reference number of moved documents but not for mails.

For [CA-5274]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- Upgrade-Steps:
  - [x] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally

[CA-5274]: https://4teamwork.atlassian.net/browse/CA-5274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ