### PR TITLE
Handle broken references when generating the meeting minutes PDF.

### DIFF
--- a/changes/CA-5312.bugfix
+++ b/changes/CA-5312.bugfix
@@ -1,0 +1,1 @@
+Handle broken references when generating the meeting minutes PDF. [njohner]

--- a/opengever/workspace/browser/meeting_pdf.py
+++ b/opengever/workspace/browser/meeting_pdf.py
@@ -62,7 +62,7 @@ class MeetingMinutesPDFView(BrowserView):
             obj = item.getObject()
             text = obj.text.output if obj.text else ''
             decision = obj.decision.output if obj.decision else ''
-            related_items = [item.to_object for item in obj.relatedItems]
+            related_items = [item.to_object for item in obj.relatedItems if item.to_object]
             data['agenda_items'].append({
                 'number': '{}. '.format(i + 1),
                 'title': obj.Title(),

--- a/opengever/workspace/tests/test_meeting_minutes.py
+++ b/opengever/workspace/tests/test_meeting_minutes.py
@@ -1,6 +1,8 @@
 from ftw.testbrowser import browsing
+from opengever.base.interfaces import IDeleter
 from opengever.core.testing import WEASYPRINT_SERVICE_INTEGRATION_TESTING
 from opengever.testing import IntegrationTestCase
+from opengever.trash.trash import ITrasher
 from opengever.workspace.browser.meeting_pdf import MeetingMinutesPDFView
 from zope.globalrequest import getRequest
 
@@ -8,6 +10,8 @@ from zope.globalrequest import getRequest
 class TestMeetingMinutes(IntegrationTestCase):
 
     layer = WEASYPRINT_SERVICE_INTEGRATION_TESTING
+
+    features = ('workspace', )
 
     @browsing
     def test_meeting_minutes_pdf_view_returns_a_pdf(self, browser):
@@ -28,3 +32,19 @@ class TestMeetingMinutes(IntegrationTestCase):
         self.assertEqual(['Teamraumdokument'], browser.css('ul.related_items a').text)
         self.assertEqual(self.workspace_document.absolute_url(),
                          browser.css('ul.related_items a')[0].get('href'))
+
+    @browsing
+    def test_meeting_minutes_html_handles_broken_relations(self, browser):
+        self.login(self.workspace_member, browser)
+
+        # We delete the document referenced by the agendaitem
+        ITrasher(self.workspace_document).trash()
+        deleter = IDeleter(self.workspace_document)
+        deleter.delete()
+
+        view = MeetingMinutesPDFView(self.workspace_meeting, getRequest())
+        html = view.meeting_minutes_html()
+        browser.parse(html)
+
+        self.assertEqual(['Decision:'], browser.css('h3').text)
+        self.assertEqual([], browser.css('ul.related_items a').text)


### PR DESCRIPTION
Agendaitem in workspace meetings can reference documents, which can be deleted, so that the reference ends up being broken. With this PR we now handle broken references by simply skipping them.

For [CA-5312]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-5312]: https://4teamwork.atlassian.net/browse/CA-5312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ