### PR TITLE
Improve workspace deleter tests.

### DIFF
--- a/opengever/workspace/tests/test_deleter.py
+++ b/opengever/workspace/tests/test_deleter.py
@@ -9,14 +9,14 @@ class TestWorkspaceDeleter(IntegrationTestCase):
     features = ('workspace', )
 
     def test_may_not_delete_document_outside_workspace_root(self):
-        self.login(self.manager)
+        self.login(self.workspace_member)
         ITrasher(self.document).trash()
         deleter = IDeleter(self.document)
         with self.assertRaises(Forbidden):
             deleter.verify_may_delete()
 
     def test_document_may_only_be_delete_when_trashed(self):
-        self.login(self.manager)
+        self.login(self.workspace_member)
         deleter = IDeleter(self.workspace_document)
         with self.assertRaises(Forbidden):
             deleter.verify_may_delete()
@@ -25,7 +25,7 @@ class TestWorkspaceDeleter(IntegrationTestCase):
         deleter.verify_may_delete()
 
     def test_folder_may_only_be_deleted_when_trashed(self):
-        self.login(self.manager)
+        self.login(self.workspace_member)
         deleter = IDeleter(self.workspace_folder)
         with self.assertRaises(Forbidden):
             deleter.verify_may_delete()


### PR DESCRIPTION
Workspace deleter tests did not have the workspace feature activated when they were written (https://github.com/4teamwork/opengever.core/commit/7cfedb5beceeef8ff66283a6b91438e5f26dac79) so that we were actually testing against the wrong permission. We therefore had to use manager permissions to delete objects, when in fact workspace members are allowed to delete documents. So we switch here to testing with a workspace member.

There is no related issue for this, I just stumbled across this error while working on https://github.com/4teamwork/opengever.core/pull/7668

## Checklist 
- [ ] Changelog entry -> no CL entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira) -> no issue