### PR TITLE
Allow to define a custom dossier resolution precondition.

### DIFF
--- a/changes/CA-5228.feature
+++ b/changes/CA-5228.feature
@@ -1,0 +1,1 @@
+Allow to define a custom dossier resolution precondition. [njohner]

--- a/opengever/core/upgrades/20230209144650_add_resolver_custom_precondition_registry_fields/registry.xml
+++ b/opengever/core/upgrades/20230209144650_add_resolver_custom_precondition_registry_fields/registry.xml
@@ -1,0 +1,3 @@
+<registry purge="False">
+  <records interface="opengever.dossier.interfaces.IDossierResolveProperties" />
+</registry>

--- a/opengever/core/upgrades/20230209144650_add_resolver_custom_precondition_registry_fields/upgrade.py
+++ b/opengever/core/upgrades/20230209144650_add_resolver_custom_precondition_registry_fields/upgrade.py
@@ -1,0 +1,10 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddResolverCustomPreconditionRegistryFields(UpgradeStep):
+    """Add resolver_custom_precondition and
+    resolver_custom_precondition_error_text_de registry fields.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -22,6 +22,7 @@ from opengever.dossier.interfaces import IDossierResolveProperties
 from opengever.meeting import is_meeting_feature_enabled
 from opengever.meeting import OPEN_PROPOSAL_STATES
 from opengever.ogds.base.actor import Actor
+from opengever.propertysheets.utils import get_custom_properties
 from opengever.task import OPEN_TASK_STATES
 from opengever.task.task import ITask
 from opengever.workspaceclient import is_workspace_client_feature_enabled
@@ -599,6 +600,10 @@ class DossierContainer(Container):
                 interfaces=[IDossierJournalPDFMarker],
                 **kwargs).execute()
             document.reindexObject(idxs=['object_provides'])
+
+    @property
+    def custom_properties(self):
+        return get_custom_properties(self)
 
 
 @implementer(IConstrainTypeDecider)

--- a/opengever/dossier/interfaces.py
+++ b/opengever/dossier/interfaces.py
@@ -236,6 +236,22 @@ class IDossierResolveProperties(Interface):
         default='strict'
     )
 
+    resolver_custom_precondition = schema.TextLine(
+        title=u"Custom dossier resolution precondition.",
+        description=u'Tales expression defining a precondition checked when '
+                    u'resolving a dossier. When returning True, the dossier can '
+                    u'be closed, when returning False, resolving the dossier '
+                    u'will fail.',
+        default=u''
+    )
+
+    resolver_custom_precondition_error_text_de = schema.TextLine(
+        title=u"Error text for the resolver_custom_precondition",
+        description=u'Error text displayed when the resolver_custom_precondition '
+                    u'returns False.',
+        default=u''
+    )
+
     use_changed_for_end_date = schema.Bool(
         title=u"Use the 'changed' date for earliest possible end date",
         description=u'When True, changed will be used in the calculation of '

--- a/opengever/dossier/resolve.py
+++ b/opengever/dossier/resolve.py
@@ -19,6 +19,8 @@ from opengever.dossier.resolve_lock import ResolveLock
 from opengever.dossier.statusmessage_mixin import DossierResolutionStatusmessageMixin
 from opengever.task.task import ITask
 from plone import api
+from Products.CMFCore.Expression import createExprContext
+from Products.CMFCore.Expression import Expression
 from Products.CMFCore.utils import getToolByName
 from Products.Five.browser import BrowserView
 from zope.annotation import IAnnotations
@@ -524,7 +526,23 @@ class ResolveConditions(object):
         if not self.context.has_valid_startdate():
             errors.append(NO_START_DATE)
 
+        if not self.check_custom_precondition():
+            errors.append(api.portal.get_registry_record(
+                'resolver_custom_precondition_error_text_de', IDossierResolveProperties))
+
         return errors
+
+    def check_custom_precondition(self):
+        resolver_custom_precondition = api.portal.get_registry_record(
+            'resolver_custom_precondition', IDossierResolveProperties)
+
+        if not resolver_custom_precondition:
+            return True
+
+        portal = api.portal.get()
+        ec = createExprContext(folder=self.context, portal=portal, object=self.context)
+        expr = Expression(resolver_custom_precondition)
+        return expr(ec)
 
     def check_end_dates(self):
         """Recursively check if the dossier has a valid end date."""

--- a/opengever/dossier/tests/test_resolve.py
+++ b/opengever/dossier/tests/test_resolve.py
@@ -994,6 +994,44 @@ class TestResolveConditions(IntegrationTestCase, ResolveTestHelper):
         self.assert_success(self.resolvable_dossier, browser,
                             ['Dossier has been resolved succesfully.'])
 
+    @browsing
+    def test_resolving_is_cancelled_when_custom_precondition_is_not_satisfied(self, browser):
+        api.portal.set_registry_record(
+            'resolver_custom_precondition_error_text_de',
+            u'custom precondition not satisfied',
+            IDossierResolveProperties)
+
+        api.portal.set_registry_record(
+            'resolver_custom_precondition',
+            u'python:object.is_subdossier()',
+            IDossierResolveProperties)
+
+        self.login(self.secretariat_user, browser)
+
+        self.resolve(self.resolvable_dossier, browser)
+
+        self.assert_not_resolved(self.resolvable_dossier)
+        self.assert_errors(self.resolvable_dossier, browser,
+                           ['custom precondition not satisfied'])
+
+    @browsing
+    def test_resolving_when_custom_precondition_is_satisfied(self, browser):
+        api.portal.set_registry_record(
+            'resolver_custom_precondition_error_text_de',
+            u'custom precondition not satisfied',
+            IDossierResolveProperties)
+
+        api.portal.set_registry_record(
+            'resolver_custom_precondition',
+            u'python:not object.is_subdossier()',
+            IDossierResolveProperties)
+
+        self.login(self.secretariat_user, browser)
+
+        self.resolve(self.resolvable_dossier, browser)
+
+        self.assert_resolved(self.resolvable_dossier)
+
 
 class TestResolveConditionsRESTAPI(ResolveTestHelperRESTAPI, TestResolveConditions):
 

--- a/opengever/dossier/tests/test_resolve.py
+++ b/opengever/dossier/tests/test_resolve.py
@@ -16,6 +16,7 @@ from opengever.base.behaviors.changed import IChanged
 from opengever.base.tests.byline_base_test import TestBylineBase
 from opengever.document.interfaces import IDossierTasksPDFMarker
 from opengever.dossier import nightly_after_resolve_job
+from opengever.dossier.behaviors.customproperties import IDossierCustomProperties
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.interfaces import IDossierResolveProperties
 from opengever.dossier.nightly_after_resolve_job import ExecuteNightlyAfterResolveJobs
@@ -1030,6 +1031,32 @@ class TestResolveConditions(IntegrationTestCase, ResolveTestHelper):
 
         self.resolve(self.resolvable_dossier, browser)
 
+        self.assert_resolved(self.resolvable_dossier)
+
+    @browsing
+    def test_can_use_custom_properties_in_custom_dossier_resolution_precondition(self, browser):
+        api.portal.set_registry_record(
+            'resolver_custom_precondition_error_text_de',
+            u'custom precondition not satisfied',
+            IDossierResolveProperties)
+
+        api.portal.set_registry_record(
+            'resolver_custom_precondition',
+            u'python:object.custom_properties.get("additional_title")',
+            IDossierResolveProperties)
+
+        self.login(self.secretariat_user, browser)
+
+        self.resolve(self.resolvable_dossier, browser)
+        self.assert_not_resolved(self.resolvable_dossier)
+        self.assert_errors(self.resolvable_dossier, browser,
+                           ['custom precondition not satisfied'])
+
+        IDossierCustomProperties(self.resolvable_dossier).custom_properties = {
+            "IDossier.default": {"additional_title": "I have an additional title"},
+        }
+
+        self.resolve(self.resolvable_dossier, browser)
         self.assert_resolved(self.resolvable_dossier)
 
 


### PR DESCRIPTION
We introduce 2 registry records allowing to define an additional dossier resolution rule and the related error thrown when the rule is broken. The rule is a TALES expression. In order to make custom properties available in the custom resolve condition, I had to add custom properties as a property on the dossier.

For [CA-5228]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-5228]: https://4teamwork.atlassian.net/browse/CA-5228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ