### PR TITLE
Nj/ca 5229/first end date

### DIFF
--- a/changes/CA-5228.feature
+++ b/changes/CA-5228.feature
@@ -1,0 +1,1 @@
+Allow to define custom dossier resolution rules. [njohner]

--- a/opengever/core/upgrades/20230209144650_add_resolver_custom_rule_registry_fields/registry.xml
+++ b/opengever/core/upgrades/20230209144650_add_resolver_custom_rule_registry_fields/registry.xml
@@ -1,0 +1,3 @@
+<registry purge="False">
+  <records interface="opengever.dossier.interfaces.IDossierResolveProperties" />
+</registry>

--- a/opengever/core/upgrades/20230209144650_add_resolver_custom_rule_registry_fields/upgrade.py
+++ b/opengever/core/upgrades/20230209144650_add_resolver_custom_rule_registry_fields/upgrade.py
@@ -1,0 +1,10 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddResolverCustomRuleRegistryFields(UpgradeStep):
+    """Add resolver_custom_rule and resolver_custom_rule_error_text_de
+    registry fields.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -23,6 +23,7 @@ from opengever.meeting import is_meeting_feature_enabled
 from opengever.meeting import OPEN_PROPOSAL_STATES
 from opengever.ogds.base.actor import Actor
 from opengever.propertysheets.utils import get_custom_properties
+from opengever.propertysheets.utils import set_custom_property
 from opengever.task import OPEN_TASK_STATES
 from opengever.task.task import ITask
 from opengever.workspaceclient import is_workspace_client_feature_enabled
@@ -604,6 +605,9 @@ class DossierContainer(Container):
     @property
     def custom_properties(self):
         return get_custom_properties(self)
+
+    def set_custom_property(self, fieldname, value):
+        set_custom_property(self, fieldname, value)
 
 
 @implementer(IConstrainTypeDecider)

--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -22,6 +22,7 @@ from opengever.dossier.interfaces import IDossierResolveProperties
 from opengever.meeting import is_meeting_feature_enabled
 from opengever.meeting import OPEN_PROPOSAL_STATES
 from opengever.ogds.base.actor import Actor
+from opengever.propertysheets.utils import get_custom_properties
 from opengever.task import OPEN_TASK_STATES
 from opengever.task.task import ITask
 from opengever.workspaceclient import is_workspace_client_feature_enabled
@@ -599,6 +600,10 @@ class DossierContainer(Container):
                 interfaces=[IDossierJournalPDFMarker],
                 **kwargs).execute()
             document.reindexObject(idxs=['object_provides'])
+
+    @property
+    def custom_properties(self):
+        return get_custom_properties(self)
 
 
 @implementer(IConstrainTypeDecider)

--- a/opengever/dossier/interfaces.py
+++ b/opengever/dossier/interfaces.py
@@ -236,6 +236,21 @@ class IDossierResolveProperties(Interface):
         default='strict'
     )
 
+    resolver_custom_rule = schema.TextLine(
+        title=u"Custom dossier resolution rule.",
+        description=u'Tales expression defining a rule checked when closing a'
+                    u' dossier, when returning True, the dossier can be closed'
+                    u', when returning False, closing the dossier will fail.',
+        default=u''
+    )
+
+    resolver_custom_rule_error_text_de = schema.TextLine(
+        title=u"Error text for the resolver_custom_rule",
+        description=u'Error text displayed when the resolver_custom_rule '
+                    u'returns False.',
+        default=u''
+    )
+
     use_changed_for_end_date = schema.Bool(
         title=u"Use the 'changed' date for earliest possible end date",
         description=u'When True, changed will be used in the calculation of '

--- a/opengever/dossier/tests/test_resolve.py
+++ b/opengever/dossier/tests/test_resolve.py
@@ -994,6 +994,44 @@ class TestResolveConditions(IntegrationTestCase, ResolveTestHelper):
         self.assert_success(self.resolvable_dossier, browser,
                             ['Dossier has been resolved succesfully.'])
 
+    @browsing
+    def test_resolving_is_cancelled_when_custom_rule_is_broken(self, browser):
+        api.portal.set_registry_record(
+            'resolver_custom_rule_error_text_de',
+            u'custom rule broken',
+            IDossierResolveProperties)
+
+        api.portal.set_registry_record(
+            'resolver_custom_rule',
+            u'python:object.is_subdossier()',
+            IDossierResolveProperties)
+
+        self.login(self.secretariat_user, browser)
+
+        self.resolve(self.resolvable_dossier, browser)
+
+        self.assert_not_resolved(self.resolvable_dossier)
+        self.assert_errors(self.resolvable_dossier, browser,
+                           ['custom rule broken'])
+
+    @browsing
+    def test_resolving_when_custom_rule_is_satisfied(self, browser):
+        api.portal.set_registry_record(
+            'resolver_custom_rule_error_text_de',
+            u'custom rule broken',
+            IDossierResolveProperties)
+
+        api.portal.set_registry_record(
+            'resolver_custom_rule',
+            u'python:not object.is_subdossier()',
+            IDossierResolveProperties)
+
+        self.login(self.secretariat_user, browser)
+
+        self.resolve(self.resolvable_dossier, browser)
+
+        self.assert_resolved(self.resolvable_dossier)
+
 
 class TestResolveConditionsRESTAPI(ResolveTestHelperRESTAPI, TestResolveConditions):
 

--- a/opengever/propertysheets/utils.py
+++ b/opengever/propertysheets/utils.py
@@ -45,3 +45,29 @@ def get_custom_properties(obj, docprops_only=False):
                 data[name] = custom_properties[slot].get(name)
 
     return data
+
+
+def set_custom_property(obj, fieldname, value):
+    customprops_behavior = get_customproperties_behavior(obj)
+    if customprops_behavior is None:
+        raise Exception
+
+    custom_props = get_custom_properties(obj)
+
+    field = getFields(customprops_behavior).get('custom_properties')
+    active_slot = field.get_active_assignment_slot(obj)
+    for slot in [active_slot, field.default_slot]:
+        if slot is None:
+            continue
+
+        definition = PropertySheetSchemaStorage().query(slot)
+        if not definition:
+            continue
+
+        if fieldname in definition.get_fieldnames():
+            if slot not in custom_props:
+                custom_props[slot] = {}
+            custom_props[slot][fieldname] = value
+            break
+
+    field.set(field.interface(obj), custom_props)


### PR DESCRIPTION
_PR-Description: should contain all the information necessary for an outsider to understand the change without looking at the code or the issue!_

- _Why the change is necessary_
- _What the goal of the change is_
- _How change is achieved (e.g. design decisions)_
- _The author should advertise and sell the change in the PR body_

_Screenshot: whenever useful, but only as a visual aid._


Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-XXXX]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
