### PR TITLE
Allow to define a custom dossier resolution after transition hook.

### DIFF
--- a/changes/CA-5229.feature
+++ b/changes/CA-5229.feature
@@ -1,0 +1,1 @@
+Allow to define a custom dossier resolution after transition hook. [njohner]

--- a/opengever/core/upgrades/20230214171647_add_resolver_custom_after_transition_hook_registry_field/registry.xml
+++ b/opengever/core/upgrades/20230214171647_add_resolver_custom_after_transition_hook_registry_field/registry.xml
@@ -1,0 +1,3 @@
+<registry purge="False">
+  <records interface="opengever.dossier.interfaces.IDossierResolveProperties" />
+</registry>

--- a/opengever/core/upgrades/20230214171647_add_resolver_custom_after_transition_hook_registry_field/upgrade.py
+++ b/opengever/core/upgrades/20230214171647_add_resolver_custom_after_transition_hook_registry_field/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddResolverCustomAfterTransitionHookRegistryField(UpgradeStep):
+    """Add resolver_custom_after_transition_hook registry field.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -606,8 +606,8 @@ class DossierContainer(Container):
     def custom_properties(self):
         return get_custom_properties(self)
 
-    def set_custom_property(self, fieldname, value):
-        set_custom_property(self, fieldname, value)
+    def set_custom_property(self, fieldname, value, reindex=False):
+        set_custom_property(self, fieldname, value, reindex)
 
 
 @implementer(IConstrainTypeDecider)

--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -23,6 +23,7 @@ from opengever.meeting import is_meeting_feature_enabled
 from opengever.meeting import OPEN_PROPOSAL_STATES
 from opengever.ogds.base.actor import Actor
 from opengever.propertysheets.utils import get_custom_properties
+from opengever.propertysheets.utils import set_custom_property
 from opengever.task import OPEN_TASK_STATES
 from opengever.task.task import ITask
 from opengever.workspaceclient import is_workspace_client_feature_enabled
@@ -604,6 +605,9 @@ class DossierContainer(Container):
     @property
     def custom_properties(self):
         return get_custom_properties(self)
+
+    def set_custom_property(self, fieldname, value):
+        set_custom_property(self, fieldname, value)
 
 
 @implementer(IConstrainTypeDecider)

--- a/opengever/dossier/interfaces.py
+++ b/opengever/dossier/interfaces.py
@@ -252,6 +252,13 @@ class IDossierResolveProperties(Interface):
         default=u''
     )
 
+    resolver_custom_after_transition_hook = schema.TextLine(
+        title=u"Custom dossier resolution after transition hook.",
+        description=u'Tales expression defining an after transition hook'
+                    u'executing when resolving a dossier.',
+        default=u''
+    )
+
     use_changed_for_end_date = schema.Bool(
         title=u"Use the 'changed' date for earliest possible end date",
         description=u'When True, changed will be used in the calculation of '

--- a/opengever/dossier/resolve.py
+++ b/opengever/dossier/resolve.py
@@ -102,6 +102,19 @@ class ResolveDossierTransitionExtender(TransitionExtender):
 
     def after_transition_hook(self, transition, disable_sync, transition_params):
         AfterResolveJobs(self.context).execute()
+        self.execute_custom_after_transition_hook(transition, transition_params)
+
+    def execute_custom_after_transition_hook(self, transition, transition_params):
+        custom_after_transition_hook = api.portal.get_registry_record(
+            'resolver_custom_after_transition_hook', IDossierResolveProperties)
+
+        if not custom_after_transition_hook:
+            return
+
+        portal = api.portal.get()
+        ec = createExprContext(folder=self.context, portal=portal, object=self.context)
+        expr = Expression(custom_after_transition_hook)
+        expr(ec)
 
 
 class LockingResolveManager(object):

--- a/opengever/dossier/tests/test_resolve.py
+++ b/opengever/dossier/tests/test_resolve.py
@@ -22,6 +22,8 @@ from opengever.dossier.interfaces import IDossierResolveProperties
 from opengever.dossier.nightly_after_resolve_job import ExecuteNightlyAfterResolveJobs
 from opengever.dossier.resolve import AfterResolveJobs
 from opengever.dossier.resolve_lock import ResolveLock
+from opengever.propertysheets.storage import PropertySheetSchemaStorage
+from opengever.propertysheets.utils import get_custom_properties
 from opengever.testing import IntegrationTestCase
 from opengever.testing.helpers import index_data_for
 from opengever.testing.patch import TempMonkeyPatch
@@ -286,6 +288,31 @@ class TestResolvingDossiers(IntegrationTestCase, ResolveTestHelper):
         self.assertEqual(
             u'Journal of dossier A resolvable main dossier, Feb 25, 2016 12 00 AM.pdf',
             journal_pdf.get_filename())
+
+    @browsing
+    def test_can_set_custom_properties_in_custom_after_transition_hook(self, browser):
+        self.login(self.manager)
+        PropertySheetSchemaStorage().clear()
+
+        create(
+            Builder("property_sheet_schema")
+            .named("schema2")
+            .assigned_to_slots(u"IDossier.default")
+            .with_field("date", u"date", u"Choose a date", u"", True)
+        )
+
+        api.portal.set_registry_record(
+            'resolver_custom_after_transition_hook',
+            u'python:object.set_custom_property("date", object.earliest_possible_end_date())',
+            IDossierResolveProperties)
+
+        self.login(self.secretariat_user, browser)
+
+        self.assertEqual({}, get_custom_properties(self.resolvable_dossier))
+        self.resolve(self.resolvable_dossier, browser)
+        self.assert_resolved(self.resolvable_dossier)
+        self.assertEqual({'date': date(2016, 8, 31)},
+                         get_custom_properties(self.resolvable_dossier))
 
 
 class TestResolvingDossiersRESTAPI(ResolveTestHelperRESTAPI, TestResolvingDossiers):

--- a/opengever/propertysheets/utils.py
+++ b/opengever/propertysheets/utils.py
@@ -45,3 +45,27 @@ def get_custom_properties(obj, docprops_only=False):
                 data[name] = custom_properties[slot].get(name)
 
     return data
+
+
+def set_custom_property(obj, fieldname, value):
+    customprops_behavior = get_customproperties_behavior(obj)
+    adapted = customprops_behavior(obj, None)
+    custom_props = adapted.custom_properties or {}
+
+    field = getFields(customprops_behavior).get('custom_properties')
+    active_slot = field.get_active_assignment_slot(obj)
+    for slot in [active_slot, field.default_slot]:
+        if slot is None:
+            continue
+
+        definition = PropertySheetSchemaStorage().query(slot)
+        if not definition:
+            continue
+
+        if fieldname in definition.get_fieldnames():
+            if slot not in custom_props:
+                custom_props[slot] = {}
+            custom_props[slot][fieldname] = value
+            break
+
+    field.set(field.interface(obj), custom_props)


### PR DESCRIPTION
SPDAG want to track the first resolution date on their dossiers. To avoid adding a new metadata field which will only be used by them but pollute all other deployments, we are adding the tools necessary to implement the desired behaviour with custom-fields. We are therefore introducing a registry entry `resolver_custom_after_transition_hook` allowing to define a TALES expression that will be executed in a post transition hook when resolving a dossier.

The actual field, upgrade step and Tales expressions that allow to define the desired behaviour for SPDAG are [defined in their policy](https://github.com/4teamwork/opengever.spdag/pull/30).


Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-5229](https://4teamwork.atlassian.net/browse/CA-5229)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)



[CA-5229]: https://4teamwork.atlassian.net/browse/CA-5229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ