### PR TITLE
Fix LDAP properties plugin upgrade step to work in deployments without LDAP.

### DIFF
--- a/changes/CA-5355.bugfix
+++ b/changes/CA-5355.bugfix
@@ -1,0 +1,1 @@
+Fix LDAP properties plugin upgrade step to work in deployments without LDAP. [lgraf]

--- a/opengever/core/upgrades/20230109145141_fix_order_of_i_properties_plugin_pas_plugins/upgrade.py
+++ b/opengever/core/upgrades/20230109145141_fix_order_of_i_properties_plugin_pas_plugins/upgrade.py
@@ -11,4 +11,5 @@ class FixOrderOfIPropertiesPluginPASPlugins(UpgradeStep):
         acl_users = api.portal.get_tool('acl_users')
         plugins = acl_users.plugins
 
-        plugins.movePluginsTop(IPropertiesPlugin, ('ldap',))
+        if 'ldap' in plugins.listPluginIds(IPropertiesPlugin):
+            plugins.movePluginsTop(IPropertiesPlugin, ('ldap',))


### PR DESCRIPTION
This upgrade step assumed that there's always an `ldap` plugin in GEVER deployments. This is not the case anymore however for policyless deployments, so it broke upgrades on those.

For [CA-5355](https://4teamwork.atlassian.net/browse/CA-5355)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)



[CA-5355]: https://4teamwork.atlassian.net/browse/CA-5355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ