### PR TITLE
Remove deprecated journal and task pdf marker interfaces.

### DIFF
--- a/changes/CA-5229.other
+++ b/changes/CA-5229.other
@@ -1,0 +1,1 @@
+Remove deprecated journal and task pdf marker interfaces. [njohner]

--- a/opengever/dossier/interfaces.py
+++ b/opengever/dossier/interfaces.py
@@ -268,24 +268,6 @@ class IDossierResolveProperties(Interface):
     )
 
 
-"""
-These two interfaces have been moved and renamed to
-opengever.document.interfaces.IDossierTasksPDFMarker and
-opengever.document.interfaces.IDossierJournalPDFMarker
-Once leftovers have been cleaned up with upgrade step
-opengever/core/upgrades/20181101074702_add_automatically_generated_document_interface
-they can be deleted here (the upgrade step too)
-"""
-
-
-class IDossierTasksPdfMarker(Interface):
-    """Depraceted marker Interface for dossier tasks list document."""
-
-
-class IDossierJournalPdfMarker(Interface):
-    """Deprecated marker Interface for dossier journal document."""
-
-
 class IDossierType(Interface):
     """plone.app.registry schema for the dossier types setting."""
 


### PR DESCRIPTION
These interfaces are not needed anymore, since the upgrade step cleaning the leftovers has itself been deleted from gever long ago.

For [CA-5229]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-5229]: https://4teamwork.atlassian.net/browse/CA-5229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ