### PR TITLE
Fix ordering of subtasks in @tasktree for nested task processes.

### DIFF
--- a/changes/CA-5160.bugfix
+++ b/changes/CA-5160.bugfix
@@ -1,0 +1,1 @@
+Fix ordering of subtasks in @tasktree endpoint for nested task processes. [njohner]

--- a/opengever/api/tasktree.py
+++ b/opengever/api/tasktree.py
@@ -26,7 +26,8 @@ class TaskTree(object):
         self.request = request
         self.solr = getUtility(ISolrSearch)
         self.fieldlist = [
-            'Title', 'portal_type', 'path', 'review_state', 'object_provides']
+            'Title', 'portal_type', 'path', 'review_state', 'object_provides',
+            'has_sametype_children']
 
     def __call__(self, expand=False):
         result = {
@@ -92,6 +93,8 @@ class TaskTree(object):
 
     def recursive_query(self, item, docs):
         docs.append(item)
+        if not item.get("has_sametype_children"):
+            return
         filters = make_filters(
             path={
                 'query': item.get("path"),


### PR DESCRIPTION
Subtasks in sequential tasks are ordered according to position in parent while they are ordered according to creation date in parallel tasks. For nested tasktemplates, with a mixture of parallel and sequential processes, the ordering was broken as it was determined once and for all on the main task. This is fixed here by determining the sort order for subtasks at each nesting level.

For [CA-5160]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-5160]: https://4teamwork.atlassian.net/browse/CA-5160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ