### PR TITLE
Show specific error page when invitations are no longer valid.

### DIFF
--- a/changes/CA-5277.bugfix
+++ b/changes/CA-5277.bugfix
@@ -1,0 +1,1 @@
+Show specific error page when invitations are no longer valid. [phgross]

--- a/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-11-24 14:02+0000\n"
+"POT-Creation-Date: 2023-02-21 18:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -98,6 +98,11 @@ msgstr "Teammitglied"
 msgid "absent"
 msgstr "abwesend"
 
+#. Default: "This invitation has been cancelled or is invalid."
+#: ./opengever/workspace/participation/browser/templates/invalid_invitation.pt
+msgid "description_invalid_invitation"
+msgstr "Die Einladung wurde zurückgezogen oder ist nicht mehr gültig."
+
 #. Default: "excused"
 #: ./opengever/workspace/workspace_meeting.py
 msgid "excused"
@@ -112,6 +117,11 @@ msgstr "Allgemein"
 #: ./opengever/workspace/browser/templates/meeting_minutes.pt
 msgid "heading_agenda_items"
 msgstr "Traktanden"
+
+#. Default: "This invitation is no longer valid"
+#: ./opengever/workspace/participation/browser/templates/invalid_invitation.pt
+msgid "heading_invalid_invitation"
+msgstr "Diese Einladung ist nicht mehr gültig."
 
 #. Default: "Meeting Minutes: ${title}"
 #: ./opengever/workspace/browser/templates/meeting_minutes.pt

--- a/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-11-24 14:02+0000\n"
+"POT-Creation-Date: 2023-02-21 18:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -117,6 +117,11 @@ msgstr "Member"
 msgid "absent"
 msgstr "absent"
 
+#. Default: "This invitation has been cancelled or is invalid."
+#: ./opengever/workspace/participation/browser/templates/invalid_invitation.pt
+msgid "description_invalid_invitation"
+msgstr "This invitation has been cancelled or is invalid."
+
 #. Default: "excused"
 #: ./opengever/workspace/workspace_meeting.py
 msgid "excused"
@@ -132,6 +137,11 @@ msgstr "Common"
 #: ./opengever/workspace/browser/templates/meeting_minutes.pt
 msgid "heading_agenda_items"
 msgstr "Agenda Items"
+
+#. Default: "This invitation is no longer valid"
+#: ./opengever/workspace/participation/browser/templates/invalid_invitation.pt
+msgid "heading_invalid_invitation"
+msgstr "This invitation is no longer valid"
 
 #. Default: "Meeting Minutes: ${title}"
 #: ./opengever/workspace/browser/templates/meeting_minutes.pt

--- a/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-11-24 14:02+0000\n"
+"POT-Creation-Date: 2023-02-21 18:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -98,6 +98,11 @@ msgstr "Membre du team"
 msgid "absent"
 msgstr "absent"
 
+#. Default: "This invitation has been cancelled or is invalid."
+#: ./opengever/workspace/participation/browser/templates/invalid_invitation.pt
+msgid "description_invalid_invitation"
+msgstr ""
+
 #. Default: "excused"
 #: ./opengever/workspace/workspace_meeting.py
 msgid "excused"
@@ -112,6 +117,11 @@ msgstr "Général"
 #: ./opengever/workspace/browser/templates/meeting_minutes.pt
 msgid "heading_agenda_items"
 msgstr "Points à l'ordre du jour"
+
+#. Default: "This invitation is no longer valid"
+#: ./opengever/workspace/participation/browser/templates/invalid_invitation.pt
+msgid "heading_invalid_invitation"
+msgstr ""
 
 #. Default: "Meeting Minutes: ${title}"
 #: ./opengever/workspace/browser/templates/meeting_minutes.pt

--- a/opengever/workspace/locales/opengever.workspace.pot
+++ b/opengever/workspace/locales/opengever.workspace.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-11-24 14:02+0000\n"
+"POT-Creation-Date: 2023-02-21 18:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -101,6 +101,11 @@ msgstr ""
 msgid "absent"
 msgstr ""
 
+#. Default: "This invitation has been cancelled or is invalid."
+#: ./opengever/workspace/participation/browser/templates/invalid_invitation.pt
+msgid "description_invalid_invitation"
+msgstr ""
+
 #. Default: "excused"
 #: ./opengever/workspace/workspace_meeting.py
 msgid "excused"
@@ -114,6 +119,11 @@ msgstr ""
 #. Default: "Agenda Items"
 #: ./opengever/workspace/browser/templates/meeting_minutes.pt
 msgid "heading_agenda_items"
+msgstr ""
+
+#. Default: "This invitation is no longer valid"
+#: ./opengever/workspace/participation/browser/templates/invalid_invitation.pt
+msgid "heading_invalid_invitation"
 msgstr ""
 
 #. Default: "Meeting Minutes: ${title}"

--- a/opengever/workspace/participation/browser/my_invitations.py
+++ b/opengever/workspace/participation/browser/my_invitations.py
@@ -21,6 +21,7 @@ from plone import api
 from plone.app.uuid.utils import uuidToObject
 from plone.protect.interfaces import IDisableCSRFProtection
 from Products.Five.browser import BrowserView
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from Products.LDAPMultiPlugins.interfaces import ILDAPMultiPlugin
 from urllib import urlencode
 from zExceptions import BadRequest
@@ -125,7 +126,13 @@ class MyWorkspaceInvitations(BrowserView):
         """
         alsoProvides(self.request, IDisableCSRFProtection)
 
-        invitation, payload = self.get_invitation_and_validate_payload()
+        try:
+            invitation, payload = self.get_invitation_and_validate_payload()
+        except BadRequest:
+            self.portal_url = api.portal.get().absolute_url()
+            template = ViewPageTemplateFile('templates/invalid_invitation.pt')
+            return template(self)
+
         with elevated_privileges():
             target_workspace = uuidToObject(invitation['target_uuid'])
 

--- a/opengever/workspace/participation/browser/templates/invalid_invitation.pt
+++ b/opengever/workspace/participation/browser/templates/invalid_invitation.pt
@@ -1,0 +1,59 @@
+<tal:doctype tal:replace="structure string:&lt;!DOCTYPE html&gt;" />
+
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      lang="en"
+      i18n:domain="opengever.workspace"
+      tal:define="portal_url view/portal_url">
+
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+
+    <link rel="stylesheet"
+          tal:attributes="href string:${portal_url}/++theme++plonetheme.teamraum/css/gever/gever.css" />
+    <link rel="stylesheet"
+          tal:attributes="href string:${portal_url}/++theme++plonetheme.teamraum/css/main.css" />
+    <style>
+      body {
+      height: auto;
+      }
+
+      #content {
+      margin: auto auto;
+      width: 75%;
+      position: relative;
+      top: 200px;
+      }
+
+      #header {
+      margin-bottom: 2em;
+      }
+    </style>
+  </head>
+
+  <body>
+
+    <div id="content" class="gever-error-page">
+
+      <h1 class="documentFirstHeading"
+          i18n:translate="heading_invalid_invitation">
+        This invitation is no longer valid
+      </h1>
+
+      <p i18n:translate="description_invalid_invitation">
+        This invitation has been cancelled or is invalid.
+      </p>
+
+      <div class="error-body">
+        <a tal:attributes="href portal_url | python: '/'"
+           i18n:translate="text_back_to_portal"
+           i18n:domain="opengever.base">
+          Back to the portal
+        </a>
+      </div>
+
+    </div>
+  </body>
+</html>

--- a/opengever/workspace/tests/test_my_invitations.py
+++ b/opengever/workspace/tests/test_my_invitations.py
@@ -209,14 +209,21 @@ class TestMyInvitationsView(IntegrationTestCase):
         self.assertEqual(browser.url, self.workspace.absolute_url())
 
     @browsing
-    def test_cannot_accept_invalid_invitation(self, browser):
+    def test_cannot_accept_invalid_invitation_shows_error_page_instead(self, browser):
         self.login(self.regular_user, browser=browser)
         with freeze(FROZEN_NOW):
             payload = serialize_and_sign_payload({'iid': 'someinvalidiid'})
         accept_url = "{}/@@my-invitations/accept?invitation={}".format(
             self.workspace_url, payload)
-        with browser.expect_http_error(400):
-            browser.open(accept_url)
+
+        browser.open(accept_url)
+
+        self.assertEqual(
+            [u'This invitation is no longer valid'],
+            browser.css('h1').text)
+        self.assertEqual(
+            ['This invitation has been cancelled or is invalid.'],
+            browser.css('#content p').text)
 
     @browsing
     def test_accept_declined_invitation_tries_to_redirect_to_workspace(self, browser):


### PR DESCRIPTION
If an invitation is accepted which has been withdrawn/deleted in the meantime, a general error message appears. This is confusing for the user and leads to support requests.

A specific error message is now displayed:
<img width="907" alt="Bildschirmfoto 2023-02-17 um 15 01 55" src="https://user-images.githubusercontent.com/485755/219677811-ee1e11fc-68d9-4043-85d7-92d8a68ffbd5.png">

A simple redirect and showing a status message is not possible, because the @@invitations-view is called directly on the gever backend.

For [CA-5277]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- New translations
  - [x] All msg-strings are unicode


[CA-5277]: https://4teamwork.atlassian.net/browse/CA-5277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ