### PR TITLE
Fix various issues arising when the ContactFolder is missing.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -651,9 +651,6 @@ Objects
     - self.committee_president
     - self.empty_committee
     - self.inactive_committee_participant
-  - self.contactfolder
-    - self.franz_meier
-    - self.hanspeter_duerr
   - self.inbox_container
     - self.inbox
       - self.inbox_document

--- a/changes/CA-5216.bugfix
+++ b/changes/CA-5216.bugfix
@@ -1,0 +1,1 @@
+Fix various issues arising when the ContactFolder is missing. [njohner]

--- a/opengever/api/serializer.py
+++ b/opengever/api/serializer.py
@@ -8,10 +8,8 @@ from opengever.base.interfaces import ISequenceNumber
 from opengever.base.oguid import Oguid
 from opengever.base.response import IResponseContainer
 from opengever.base.response import IResponseSupported
-from opengever.base.sentry import log_msg_to_sentry
 from opengever.base.utils import is_administrator
 from opengever.base.visible_users_and_groups_filter import visible_users_and_groups_filter
-from opengever.contact.utils import get_contactfolder_url
 from opengever.document import is_documentish_portal_type
 from opengever.document.approvals import Approval
 from opengever.document.behaviors import IBaseDocument
@@ -527,22 +525,6 @@ class SerializeSQLModelToJsonSummaryBase(object):
     @property
     def base_url(self):
         return self.request.URL.rsplit("/@")[0]
-
-
-class SerializeContactModelToJsonSummaryBase(SerializeSQLModelToJsonSummaryBase):
-
-    @property
-    def get_url(self):
-        try:
-            base_url = get_contactfolder_url()
-        except Exception as e:
-            log_msg_to_sentry(e.message, request=self.request)
-            return None
-        return '{}/{}/{}'.format(
-            base_url,
-            self.endpoint_name,
-            getattr(self.context, self.id_attribute_name)
-        )
 
 
 @implementer(ISerializeToJsonSummary)

--- a/opengever/api/tests/test_actors.py
+++ b/opengever/api/tests/test_actors.py
@@ -9,6 +9,7 @@ from opengever.base.interfaces import AVATAR_SOURCE_PLONE_ONLY
 from opengever.base.interfaces import AVATAR_SOURCE_PORTAL_ONLY
 from opengever.base.interfaces import IActorSettings
 from opengever.base.model import create_session
+from opengever.contact.tests import create_contacts
 from opengever.ogds.models.user import User
 from opengever.testing import IntegrationTestCase
 from plone import api
@@ -137,6 +138,7 @@ class TestActorsGet(IntegrationTestCase):
 
     @browsing
     def test_actors_response_for_contact(self, browser):
+        create_contacts(self)
         self.login(self.regular_user, browser=browser)
 
         actor_id = 'contact:{}'.format(self.franz_meier.id)
@@ -164,6 +166,7 @@ class TestActorsGet(IntegrationTestCase):
 
     @browsing
     def test_full_representation_for_contact(self, browser):
+        create_contacts(self)
         self.login(self.regular_user, browser=browser)
 
         actor_id = 'contact:{}'.format(self.franz_meier.id)

--- a/opengever/api/tests/test_contact.py
+++ b/opengever/api/tests/test_contact.py
@@ -1,4 +1,5 @@
 from ftw.testbrowser import browsing
+from opengever.contact.tests import create_contacts
 from opengever.testing import IntegrationTestCase
 
 
@@ -6,11 +7,13 @@ class TestContactGet(IntegrationTestCase):
 
     @browsing
     def test_contact_get(self, browser):
+        create_contacts(self)
         self.login(self.regular_user, browser)
 
         browser.open(self.franz_meier, headers=self.api_headers)
 
-        self.assertDictContainsSubset({
+        self.assertDictContainsSubset(
+            {
                 u'@id': u'http://nohost/plone/kontakte/meier-franz',
                 u'@type': u'opengever.contact.contact',
                 u'review_state': u'contact-state-active',

--- a/opengever/api/tests/test_contactfolder.py
+++ b/opengever/api/tests/test_contactfolder.py
@@ -1,4 +1,5 @@
 from ftw.testbrowser import browsing
+from opengever.contact.tests import create_contacts
 from opengever.testing import IntegrationTestCase
 
 
@@ -6,11 +7,13 @@ class TestContactFolderGet(IntegrationTestCase):
 
     @browsing
     def test_contactfolder_get(self, browser):
+        create_contacts(self)
         self.login(self.regular_user, browser)
 
         browser.open(self.contactfolder, headers=self.api_headers)
 
-        self.assertDictContainsSubset({
+        self.assertDictContainsSubset(
+            {
                 u'@id': u'http://nohost/plone/kontakte',
                 u'@type': u'opengever.contact.contactfolder',
                 u'review_state': u'contactfolder-state-active',

--- a/opengever/api/tests/test_dossier_participations.py
+++ b/opengever/api/tests/test_dossier_participations.py
@@ -1,4 +1,5 @@
 from ftw.testbrowser import browsing
+from opengever.contact.tests import create_contacts
 from opengever.dossier.behaviors.participation import IParticipationAware
 from opengever.dossier.interfaces import IDossierParticipants
 from opengever.dossier.participations import IParticipationData
@@ -226,13 +227,7 @@ class TestParticipationsGetWithKubFeatureEnabled(KuBIntegrationTestCase):
                          for item in browser.json['items']])
 
 
-class TestParticipationsPost(IntegrationTestCase):
-
-    def setUp(self):
-        super(TestParticipationsPost, self).setUp()
-        self.valid_participant_id = self.regular_user.getId()
-        with self.login(self.regular_user):
-            self.valid_participant_id2 = 'contact:{}'.format(self.franz_meier.getId())
+class ParticipationsPostTestMixin():
 
     @browsing
     def test_post_participation(self, browser):
@@ -374,8 +369,18 @@ class TestParticipationsPost(IntegrationTestCase):
                           "type": "Unauthorized"}, browser.json)
 
 
+class TestParticipationsPost(IntegrationTestCase, ParticipationsPostTestMixin):
+
+    def setUp(self):
+        super(TestParticipationsPost, self).setUp()
+        create_contacts(self)
+        self.valid_participant_id = self.regular_user.getId()
+        with self.login(self.regular_user):
+            self.valid_participant_id2 = 'contact:{}'.format(self.franz_meier.getId())
+
+
 @requests_mock.Mocker()
-class TestParticipationsPostWithKubFeatureEnabled(KuBIntegrationTestCase, TestParticipationsPost):
+class TestParticipationsPostWithKubFeatureEnabled(KuBIntegrationTestCase, ParticipationsPostTestMixin):
 
     def setUp(self):
         super(TestParticipationsPostWithKubFeatureEnabled, self).setUp()

--- a/opengever/api/tests/test_dossier_participations.py
+++ b/opengever/api/tests/test_dossier_participations.py
@@ -701,22 +701,19 @@ class TestPossibleParticipantsGet(SolrIntegrationTestCase):
 
         expected_json = {u'@id': url,
                          u'items': [{u'title': u'M\xfcller Fr\xe4nzi (franzi.muller)',
-                                     u'token': u'franzi.muller'},
-                                    {u'title': u'Meier Franz (meier.f@example.com)',
-                                     u'token': u'contact:meier-franz'}],
-                         u'items_total': 2}
+                                     u'token': u'franzi.muller'}],
+                         u'items_total': 1}
 
         self.assertEqual(expected_json, browser.json)
 
         handler = IParticipationAware(self.dossier)
-        handler.add_participation('contact:meier-franz', ['regard'])
+        handler.add_participation('franzi.muller', ['regard'])
 
         browser.open(url, method='GET', headers=self.api_headers)
 
         expected_json = {u'@id': url,
-                         u'items': [{u'title': u'M\xfcller Fr\xe4nzi (franzi.muller)',
-                                     u'token': u'franzi.muller'}],
-                         u'items_total': 1}
+                         u'items': [],
+                         u'items_total': 0}
 
         self.assertEqual(expected_json, browser.json)
 
@@ -728,7 +725,7 @@ class TestPossibleParticipantsGet(SolrIntegrationTestCase):
         browser.open(url, method='GET', headers=self.api_headers)
 
         self.assertEqual(5, len(browser.json.get('items')))
-        self.assertEqual(24, browser.json.get('items_total'))
+        self.assertEqual(22, browser.json.get('items_total'))
         self.assertIn('batching', browser.json)
 
 

--- a/opengever/api/tests/test_repository.py
+++ b/opengever/api/tests/test_repository.py
@@ -79,12 +79,7 @@ class TestRepositoryAPI(IntegrationTestCase):
                 u'description': u'',
                 u'title': u'Plone site',
             },
-            u"previous_item": {
-                u"@id": u"http://nohost/plone/kontakte",
-                u"@type": u"opengever.contact.contactfolder",
-                u"description": u"",
-                u"title": u"Contacts"
-            },
+            u"previous_item": {},
             u'reference_number_addendum': None,
             u'relative_path': u'ordnungssystem',
             u'review_state': u'repositoryroot-state-active',

--- a/opengever/api/tests/test_upload_structure.py
+++ b/opengever/api/tests/test_upload_structure.py
@@ -2,6 +2,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from opengever.api.upload_structure import IUploadStructureAnalyser
+from opengever.contact.tests import create_contacts
 from opengever.testing import SolrIntegrationTestCase
 import json
 
@@ -361,6 +362,8 @@ class TestUploadStructure(SolrIntegrationTestCase):
 
     @browsing
     def test_upload_structure_in_contact_folder(self, browser):
+        create_contacts(self)
+        self.commit_solr()
         self.login(self.manager, browser)
 
         # dossier cannot be added in contact folder

--- a/opengever/api/tests/test_vocabularies.py
+++ b/opengever/api/tests/test_vocabularies.py
@@ -1,8 +1,8 @@
 from collective.elephantvocabulary.interfaces import IElephantVocabulary
 from ftw.testbrowser import browsing
 from opengever.api.schema.sources import get_field_by_name
-from opengever.base.behaviors.classification import IClassification
 from opengever.ogds.base.ou_selector import CURRENT_ORG_UNIT_KEY
+from opengever.ogds.models.user import User
 from opengever.testing import IntegrationTestCase
 from opengever.testing import SolrIntegrationTestCase
 from opengever.workspace import WHITELISTED_TEAMRAUM_PORTAL_TYPES
@@ -415,8 +415,9 @@ class TestGetQuerySourcesSolr(SolrIntegrationTestCase):
     def test_get_task_issuer_escaping_for_solr(self, browser):
         self.login(self.secretariat_user, browser)
 
-        self.franz_meier.firstname = 'Super:franz'
-        self.franz_meier.reindexObject()
+        user = User.get("kathi.barfuss")
+        user.firstname = 'Super:franz'
+
         self.commit_solr()
 
         url = self.query_source_url(self.task, 'issuer', query=u'Super:fr')

--- a/opengever/base/tests/test_changed_date.py
+++ b/opengever/base/tests/test_changed_date.py
@@ -6,6 +6,7 @@ from ftw.testbrowser import browsing
 from ftw.testing import freeze
 from opengever.base.behaviors.changed import IChanged
 from opengever.base.indexes import changed_indexer
+from opengever.contact.tests import create_contacts
 from opengever.disposition.interfaces import IAppraisal
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.dossier.behaviors.dossier import IDossier
@@ -329,6 +330,8 @@ class TestChangedUpdateForContact(TestChangedUpdateBase):
 
     @browsing
     def test_changed_is_updated_when_metadata_is_changed(self, browser):
+        create_contacts(self)
+        self.commit_solr()
         self.login(self.administrator, browser)
         with freeze(FREEZING_TIME):
             browser.open(self.franz_meier, view='edit')

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -12,6 +12,7 @@ from hashlib import sha256
 from opengever.base.date_time import utcnow_tz_aware
 from opengever.base.default_values import get_persisted_values_for_obj
 from opengever.base.oguid import Oguid
+from opengever.contact.tests import create_contacts
 from opengever.inbox import FORWARDING_TASK_TYPE_ID
 from opengever.private.tests import create_members_folder
 from opengever.testing import IntegrationTestCase
@@ -1410,6 +1411,10 @@ class TestContactDefaults(TestDefaultsBase):
     type_defaults = CONTACT_DEFAULTS
     form_defaults = CONTACT_FORM_DEFAULTS
     missing_values = CONTACT_MISSING_VALUES
+
+    def setUp(self):
+        super(TestContactDefaults, self).setUp()
+        create_contacts(self)
 
     def get_obj_of_own_type(self):
         return self.franz_meier

--- a/opengever/base/tests/test_gever_state.py
+++ b/opengever/base/tests/test_gever_state.py
@@ -1,6 +1,7 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from opengever.contact.tests import create_contacts
 from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.testing import IntegrationTestCase
 from opengever.testing.readonly import ZODBStorageInReadonlyMode
@@ -76,6 +77,7 @@ class TestGeverStateView(IntegrationTestCase):
 
     @browsing
     def test_properties_action_not_available_on_contactfolder(self, browser):
+        create_contacts(self)
         self.login(self.manager, browser=browser)
 
         browser.open(self.contactfolder)
@@ -85,6 +87,7 @@ class TestGeverStateView(IntegrationTestCase):
 
     @browsing
     def test_properties_action_not_available_for_teams(self, browser):
+        create_contacts(self)
         self.login(self.administrator, browser=browser)
 
         browser.open(self.contactfolder, view='team-1/view')

--- a/opengever/base/tests/test_name_chooser.py
+++ b/opengever/base/tests/test_name_chooser.py
@@ -1,3 +1,4 @@
+from opengever.contact.tests import create_contacts
 from opengever.testing import IntegrationTestCase
 from plone import api
 from plone.app.content.interfaces import INameFromTitle
@@ -96,6 +97,7 @@ class TestNameFromTitleBehavior(IntegrationTestCase):
             'There is a new type with the name chooser behavior.')
 
     def test_name_from_title_behavior_is_implemented_for_all_expected_types(self):
+        create_contacts(self)
         self.login(self.manager)
         for portal_type in EXPECTED_TYPES_WITH_NAME_FROM_TITLE:
             obj = getattr(self, type_to_obj[portal_type])

--- a/opengever/base/tests/test_navigation.py
+++ b/opengever/base/tests/test_navigation.py
@@ -145,12 +145,6 @@ class TestCatalogNavigationTabs(IntegrationTestCase):
             [
                 {
                     'description': '',
-                    'id': 'kontakte',
-                    'name': 'Contacts',
-                    'url': 'http://nohost/plone/kontakte',
-                },
-                {
-                    'description': '',
                     'id': 'ordnungssystem',
                     'name': 'Ordnungssystem',
                     'url': 'http://nohost/plone/ordnungssystem',
@@ -191,12 +185,6 @@ class TestCatalogNavigationTabs(IntegrationTestCase):
         view = self.portal.unrestrictedTraverse('@@portal_tabs_view')
         self.assertEqual(
             [
-                {
-                    'description': '',
-                    'id': 'kontakte',
-                    'name': 'Contacts',
-                    'url': 'http://nohost/plone/kontakte',
-                },
                 {
                     'description': '',
                     'id': 'ordnungssystem',

--- a/opengever/base/tests/test_pasting_allowed.py
+++ b/opengever/base/tests/test_pasting_allowed.py
@@ -1,4 +1,5 @@
 from ftw.testbrowser import browsing
+from opengever.contact.tests import create_contacts
 from opengever.testing import IntegrationTestCase
 
 
@@ -6,6 +7,7 @@ class TestPastingAllowed(IntegrationTestCase):
 
     @browsing
     def test_paste_action_not_displayed_for_contactfolder(self, browser):
+        create_contacts(self)
         self.login(self.regular_user, browser)
         paths = ['/'.join(self.hanspeter_duerr.getPhysicalPath())]
         browser.open(self.contactfolder, data={'paths:list': paths}, view='copy_items')

--- a/opengever/base/tests/test_reference.py
+++ b/opengever/base/tests/test_reference.py
@@ -1,6 +1,7 @@
 from opengever.base.interfaces import IReferenceNumber
 from opengever.base.interfaces import IReferenceNumberFormatter
 from opengever.base.interfaces import IReferenceNumberSettings
+from opengever.contact.tests import create_contacts
 from opengever.testing import IntegrationTestCase
 from plone import api
 from zope.component import queryAdapter
@@ -82,12 +83,14 @@ class TestLocalReferenceNumber(IntegrationTestCase):
             u'eingangskorb_fa', IReferenceNumber(self.inbox).get_local_number())
 
     def test_contactfolder_returns_empty_string(self):
+        create_contacts(self)
         self.login(self.secretariat_user)
 
         self.assertEquals(
             u'', IReferenceNumber(self.contactfolder).get_local_number())
 
     def test_contact_returns_empty_string(self):
+        create_contacts(self)
         self.login(self.regular_user)
 
         self.assertEquals(
@@ -286,12 +289,14 @@ class TestReferenceNumberAdapter(IntegrationTestCase):
                           IReferenceNumber(self.inbox).get_number())
 
     def test_reference_number_for_contactfolder(self):
+        create_contacts(self)
         self.login(self.secretariat_user)
 
         self.assertEquals(u'Client1',
                           IReferenceNumber(self.contactfolder).get_number())
 
     def test_reference_number_for_contact(self):
+        create_contacts(self)
         self.login(self.regular_user)
 
         self.assertEquals(u'Client1',

--- a/opengever/base/tests/test_translated_title.py
+++ b/opengever/base/tests/test_translated_title.py
@@ -13,6 +13,7 @@ from opengever.base.behaviors.translated_title import TRANSLATED_TITLE_PORTAL_TY
 from opengever.base.behaviors.translated_title import TranslatedTitle
 from opengever.base.brain import supports_translated_title
 from opengever.base.solr import OGSolrDocument
+from opengever.contact.tests import create_contacts
 from opengever.testing import IntegrationTestCase
 from opengever.testing import obj2brain
 from opengever.testing import set_preferred_language
@@ -196,6 +197,7 @@ class TestTranslatedTitleFieldsInEditForms(IntegrationTestCase, TranslatedTitleT
     @browsing
     def test_contact_folder_edit_form_only_shows_translated_title_fields_for_active_languages(
             self, browser):
+        create_contacts(self)
         self.login(self.manager, browser=browser)
         self.assert_edit_form_shows_translated_title_fields_only_for_active_languages(
             browser, self.contactfolder)

--- a/opengever/contact/tests/__init__.py
+++ b/opengever/contact/tests/__init__.py
@@ -1,0 +1,48 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.base.model import create_session
+from opengever.base.role_assignments import RoleAssignmentManager
+from opengever.base.role_assignments import SharingRoleAssignment
+
+
+def set_roles(obj, principal, roles):
+    RoleAssignmentManager(obj).add_or_update_assignment(
+        SharingRoleAssignment(principal, roles))
+
+
+def create_contacts(self):
+    self.contactfolder = create(
+        Builder('contactfolder')
+        .having(
+            id='kontakte',
+            title_de=u'Kontakte',
+            title_en=u'Contacts',
+            title_fr=u'Contacts',
+        )
+    )
+
+    set_roles(self.contactfolder, 'fa_users', ['Reader'])
+
+    set_roles(self.contactfolder, 'fa_users', ['Reader', 'Contributor', 'Editor'])
+
+    self.contactfolder.reindexObjectSecurity()
+
+    self.hanspeter_duerr = create(
+        Builder('contact')
+        .within(self.contactfolder)
+        .having(
+            firstname=u'Hanspeter',
+            lastname='D\xc3\xbcrr'.decode('utf-8'),
+        )
+    )
+
+    self.franz_meier = create(
+        Builder('contact')
+        .within(self.contactfolder)
+        .having(
+            firstname=u'Franz',
+            lastname=u'Meier',
+            email=u'meier.f@example.com',
+        )
+    )
+    create_session().flush()

--- a/opengever/contact/tests/test_contact.py
+++ b/opengever/contact/tests/test_contact.py
@@ -1,10 +1,16 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
+from opengever.contact.tests import create_contacts
 from opengever.testing import solr_data_for
 from opengever.testing import SolrIntegrationTestCase
 
 
 class TestContact(SolrIntegrationTestCase):
+
+    def setUp(self):
+        super(TestContact, self).setUp()
+        create_contacts(self)
+        self.commit_solr()
 
     @browsing
     def test_can_add_a_contact(self, browser):

--- a/opengever/contact/tests/test_contactfolder.py
+++ b/opengever/contact/tests/test_contactfolder.py
@@ -1,6 +1,7 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from opengever.contact.interfaces import IContactFolder
+from opengever.contact.tests import create_contacts
 from opengever.testing import add_languages
 from opengever.testing import IntegrationTestCase
 from opengever.testing import SolrIntegrationTestCase
@@ -43,6 +44,11 @@ class TestContactFolder(IntegrationTestCase):
 
 
 class TestLocalContactListing(SolrIntegrationTestCase):
+
+    def setUp(self):
+        super(TestLocalContactListing, self).setUp()
+        create_contacts(self)
+        self.commit_solr()
 
     @browsing
     def test_list_active_contacts(self, browser):

--- a/opengever/contact/tests/test_contactfolder.py
+++ b/opengever/contact/tests/test_contactfolder.py
@@ -12,6 +12,7 @@ class TestContactFolder(IntegrationTestCase):
 
     def setUp(self):
         super(TestContactFolder, self).setUp()
+        create_contacts(self)
         add_languages(['de-ch', 'fr-ch'])
 
     def test_provides_marker_interface(self):

--- a/opengever/contact/tests/test_participation.py
+++ b/opengever/contact/tests/test_participation.py
@@ -1,13 +1,9 @@
-from ftw.builder import Builder
-from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages.statusmessages import error_messages
-from opengever.base.oguid import Oguid
 from opengever.dossier.behaviors.participation import IParticipationAware
 from opengever.kub.interfaces import IKuBSettings
 from opengever.kub.testing import KuBIntegrationTestCase
-from opengever.testing import FunctionalTestCase
 from opengever.testing import IntegrationTestCase
 from plone import api
 from requests_toolbelt.utils import formdata
@@ -57,7 +53,7 @@ class TestRemoveKubParticipation(KuBIntegrationTestCase):
             self.empty_dossier.absolute_url(),
             headers={'Content-Type': 'application/x-www-form-urlencoded'},
             data=formdata.urlencode((original_template, oids, method, )),
-            )
+        )
 
         self.assertEqual(
             ['The Contact and Authorities directory is only supported in the new UI.'],

--- a/opengever/contact/tests/test_service.py
+++ b/opengever/contact/tests/test_service.py
@@ -2,7 +2,6 @@ from ftw.builder import Builder
 from ftw.builder import create
 from opengever.contact import contact_service
 from opengever.testing import FunctionalTestCase
-from plone.app.testing import TEST_USER_ID
 
 
 class TestContactService(FunctionalTestCase):

--- a/opengever/contact/tests/test_tabbed.py
+++ b/opengever/contact/tests/test_tabbed.py
@@ -1,11 +1,16 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages.statusmessages import info_messages
+from opengever.contact.tests import create_contacts
 from opengever.kub.interfaces import IKuBSettings
 from opengever.testing import IntegrationTestCase
 from plone import api
 
 
 class TestContactFolderTabbedView(IntegrationTestCase):
+
+    def setUp(self):
+        super(TestContactFolderTabbedView, self).setUp()
+        create_contacts(self)
 
     @browsing
     def test_shows_local_and_user_tab(self, browser):

--- a/opengever/contact/tests/test_team_listing.py
+++ b/opengever/contact/tests/test_team_listing.py
@@ -1,10 +1,15 @@
 from ftw.testbrowser import browsing
 from opengever.base.model import create_session
+from opengever.contact.tests import create_contacts
 from opengever.ogds.models.team import Team
 from opengever.testing import IntegrationTestCase
 
 
 class TestTeamListing(IntegrationTestCase):
+
+    def setUp(self):
+        super(TestTeamListing, self).setUp()
+        create_contacts(self)
 
     @browsing
     def test_team_listing(self, browser):

--- a/opengever/contact/tests/test_utils.py
+++ b/opengever/contact/tests/test_utils.py
@@ -12,6 +12,5 @@ class TestContactFolderUrl(FunctionalTestCase):
         self.assertEquals(contactfolder.absolute_url(),
                           get_contactfolder_url())
 
-    def test_raises_exception_when_no_contactfolder_exists(self):
-        with self.assertRaises(Exception):
-            get_contactfolder_url()
+    def test_none_when_no_contactfolder_exists(self):
+        self.assertIsNone(get_contactfolder_url())

--- a/opengever/contact/utils.py
+++ b/opengever/contact/utils.py
@@ -19,7 +19,6 @@ def get_contactfolder_url(unrestricted=False):
         result = catalog(object_provides=IContactFolder.__identifier__)
 
     if not result:
-        raise Exception('Contactfolder is missing, GEVER deployment was not '
-                        'correctly set up.')
+        return
 
     return result[0].getURL()

--- a/opengever/ogds/base/actor.py
+++ b/opengever/ogds/base/actor.py
@@ -332,8 +332,10 @@ class TeamActor(Actor):
         self.team = team
 
     def get_profile_url(self):
-        return '{}/team-{}/view'.format(
-            get_contactfolder_url(unrestricted=True), self.team.team_id)
+        contact_folder_url = get_contactfolder_url(unrestricted=True)
+        if contact_folder_url is None:
+            return None
+        return '{}/team-{}/view'.format(contact_folder_url, self.team.team_id)
 
     def corresponds_to(self, user):
         return user in self.team.group.users

--- a/opengever/ogds/base/browser/templates/userdetails_table.pt
+++ b/opengever/ogds/base/browser/templates/userdetails_table.pt
@@ -107,14 +107,19 @@
       </td>
     </tr>
 
-    <tr tal:condition="python:len(teams) > 0 and view.contactfolder_url()">
+    <tr tal:condition="python:len(teams) > 0">
       <th i18n:translate="label_teams">Teams</th>
       <td>
         <ul class="teams">
           <li tal:repeat="team teams">
-            <a class="team"
-               tal:attributes="href string:${view/contactfolder_url}/team-${team/team_id}/view"
-               tal:content="team/title"></a>
+            <tal:block tal:condition="view/contactfolder_url">
+                <a class="team"
+                   tal:attributes="href string:${view/contactfolder_url}/team-${team/team_id}/view"
+                   tal:content="team/title"></a>
+            </tal:block>
+            <tal:block tal:condition="python:not view.contactfolder_url()">
+                <span tal:content="team/title" />
+            </tal:block>
           </li>
         </ul>
       </td>

--- a/opengever/ogds/base/browser/userdetails.py
+++ b/opengever/ogds/base/browser/userdetails.py
@@ -46,11 +46,7 @@ class UserDetails(BrowserView):
         return self
 
     def contactfolder_url(team_id):
-        try:
-            contact_url = get_contactfolder_url()
-            return contact_url
-        except Exception:
-            return ''
+        return get_contactfolder_url() or ''
 
     def groupmembers_url(self, groupid):
         return groupmembers_url(groupid)

--- a/opengever/ogds/base/tests/test_actor.py
+++ b/opengever/ogds/base/tests/test_actor.py
@@ -1,6 +1,7 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from opengever.contact.tests import create_contacts
 from opengever.kub.testing import KUB_RESPONSES
 from opengever.kub.testing import KuBIntegrationTestCase
 from opengever.ogds.base.actor import Actor
@@ -16,6 +17,7 @@ from opengever.ogds.base.actor import NullActor
 from opengever.ogds.base.actor import OGDSGroupActor
 from opengever.ogds.base.actor import OGDSUserActor
 from opengever.ogds.base.actor import TeamActor
+from opengever.ogds.models.user import User
 from opengever.testing import FunctionalTestCase
 from opengever.testing import IntegrationTestCase
 from plone.app.testing import TEST_USER_ID
@@ -47,6 +49,7 @@ class TestActorLookup(IntegrationTestCase):
             actor.get_link(with_icon=True))
 
     def test_contact_actor_lookup(self):
+        create_contacts(self)
         self.login(self.regular_user)
         actor = Actor.lookup('contact:{}'.format(self.franz_meier.id))
 
@@ -90,17 +93,17 @@ class TestActorLookup(IntegrationTestCase):
         self.assertIsInstance(actor, TeamActor)
         self.assertEqual(u'Projekt \xdcberbaung Dorfmatte (Finanz\xe4mt)',
                          actor.get_label())
-        self.assertEqual('http://nohost/plone/kontakte/team-1/view',
+        self.assertEqual('None/team-1/view',
                          actor.get_profile_url())
 
         self.assertEqual(
-            u'<a href="http://nohost/plone/kontakte/team-1/view" '
+            u'<a href="None/team-1/view" '
             u'class="actor-label actor-team">Projekt \xdcberbaung Dorfmatte '
             u'(Finanz\xe4mt)</a>',
             actor.get_link(with_icon=True))
 
         self.assertEqual(
-            u'<a href="http://nohost/plone/kontakte/team-1/view">'
+            u'<a href="None/team-1/view">'
             u'Projekt \xdcberbaung Dorfmatte (Finanz\xe4mt)</a>',
             actor.get_link())
 
@@ -108,7 +111,7 @@ class TestActorLookup(IntegrationTestCase):
         self.login(self.foreign_contributor)
         actor = Actor.lookup('team:1')
         self.assertEqual(
-            u'<a href="http://nohost/plone/kontakte/team-1/view">'
+            u'<a href="None/team-1/view">'
             u'Projekt \xdcberbaung Dorfmatte (Finanz\xe4mt)</a>',
             actor.get_link())
 
@@ -156,13 +159,14 @@ class TestActorLookup(IntegrationTestCase):
     def test_get_link_returns_safe_html(self):
         self.login(self.regular_user)
 
-        self.franz_meier.firstname = u"Foo <b onmouseover=alert('Foo!')>click me!</b>"
-        self.franz_meier.reindexObject()
-        actor = Actor.lookup('contact:meier-franz')
+        user = User.get("kathi.barfuss")
+        user.firstname = "Foo <b onmouseover=alert('Foo!')>click me!</b>"
+
+        actor = Actor.lookup('kathi.barfuss')
 
         self.assertEquals(
-            u'<a href="http://nohost/plone/kontakte/meier-franz">'
-            u'Meier Foo &lt;b onmouseover=alert(&apos;Foo!&apos;)&gt;click me!&lt;/b&gt; (meier.f@example.com)'
+            u'<a href="http://nohost/plone/@@user-details/kathi.barfuss">'
+            u'B\xe4rfuss Foo &lt;b onmouseover=alert(&apos;Foo!&apos;)&gt;click me!&lt;/b&gt; (kathi.barfuss)'
             u'</a>',
             actor.get_link())
 

--- a/opengever/ogds/base/tests/test_actor.py
+++ b/opengever/ogds/base/tests/test_actor.py
@@ -93,26 +93,22 @@ class TestActorLookup(IntegrationTestCase):
         self.assertIsInstance(actor, TeamActor)
         self.assertEqual(u'Projekt \xdcberbaung Dorfmatte (Finanz\xe4mt)',
                          actor.get_label())
-        self.assertEqual('None/team-1/view',
+        self.assertEqual(None,
                          actor.get_profile_url())
-
         self.assertEqual(
-            u'<a href="None/team-1/view" '
-            u'class="actor-label actor-team">Projekt \xdcberbaung Dorfmatte '
-            u'(Finanz\xe4mt)</a>',
+            u'<span class="actor-label actor-team">'
+            u'Projekt \xdcberbaung Dorfmatte (Finanz\xe4mt)</span>',
             actor.get_link(with_icon=True))
 
         self.assertEqual(
-            u'<a href="None/team-1/view">'
-            u'Projekt \xdcberbaung Dorfmatte (Finanz\xe4mt)</a>',
+            u'Projekt \xdcberbaung Dorfmatte (Finanz\xe4mt)',
             actor.get_link())
 
     def test_team_profile_url_for_foreign_user(self):
         self.login(self.foreign_contributor)
         actor = Actor.lookup('team:1')
         self.assertEqual(
-            u'<a href="None/team-1/view">'
-            u'Projekt \xdcberbaung Dorfmatte (Finanz\xe4mt)</a>',
+            u'Projekt \xdcberbaung Dorfmatte (Finanz\xe4mt)',
             actor.get_link())
 
     def test_user_actor_ogds_user(self):

--- a/opengever/ogds/base/tests/test_team_details.py
+++ b/opengever/ogds/base/tests/test_team_details.py
@@ -1,9 +1,14 @@
 from ftw.testbrowser import browsing
+from opengever.contact.tests import create_contacts
 from opengever.ogds.models.team import Team
 from opengever.testing import IntegrationTestCase
 
 
 class TestTeamDetails(IntegrationTestCase):
+
+    def setUp(self):
+        super(TestTeamDetails, self).setUp()
+        create_contacts(self)
 
     @browsing
     def test_title(self, browser):

--- a/opengever/ogds/base/tests/test_team_forms.py
+++ b/opengever/ogds/base/tests/test_team_forms.py
@@ -1,10 +1,15 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages.statusmessages import info_messages
+from opengever.contact.tests import create_contacts
 from opengever.ogds.models.team import Team
 from opengever.testing import IntegrationTestCase
 
 
 class TestTeamAddForm(IntegrationTestCase):
+
+    def setUp(self):
+        super(TestTeamAddForm, self).setUp()
+        create_contacts(self)
 
     @browsing
     def test_add_new_team_form_is_only_available_for_administrators_and_managers(self, browser):
@@ -38,6 +43,10 @@ class TestTeamAddForm(IntegrationTestCase):
 
 
 class TestTeamEditForm(IntegrationTestCase):
+
+    def setUp(self):
+        super(TestTeamEditForm, self).setUp()
+        create_contacts(self)
 
     @browsing
     def test_editing_a_team(self, browser):
@@ -76,6 +85,10 @@ class TestTeamEditForm(IntegrationTestCase):
 
 
 class TestTeamEditAction(IntegrationTestCase):
+
+    def setUp(self):
+        super(TestTeamEditAction, self).setUp()
+        create_contacts(self)
 
     @browsing
     def test_edit_link_is_visible_for_administrators(self, browser):

--- a/opengever/ogds/base/tests/test_userdetails.py
+++ b/opengever/ogds/base/tests/test_userdetails.py
@@ -1,8 +1,8 @@
 from ftw.testbrowser import browsing
+from opengever.contact.tests import create_contacts
 from opengever.ogds.models.group import Group
 from opengever.ogds.models.service import ogds_service
 from opengever.testing import IntegrationTestCase
-from plone import api
 
 
 class TestUserDetails(IntegrationTestCase):
@@ -34,18 +34,6 @@ class TestUserDetails(IntegrationTestCase):
         }, metadata)
 
     @browsing
-    def test_hide_teams_in_user_details_if_contact_folder_does_not_exist(self, browser):
-        with self.login(self.manager):
-            api.content.delete(self.contactfolder)
-
-        self.login(self.regular_user, browser)
-        browser.open(self.portal, view='@@user-details/kathi.barfuss')
-
-        metadata = dict(browser.css('.vertical').first.lists())
-        self.assertIn('Name', metadata)
-        self.assertNotIn('Teams', metadata)
-
-    @browsing
     def test_parentheses_do_not_appear_without_abbreviation(self, browser):
         self.login(self.regular_user, browser)
 
@@ -71,6 +59,7 @@ class TestUserDetails(IntegrationTestCase):
 
     @browsing
     def test_list_all_team_memberships(self, browser):
+        create_contacts(self)
         self.login(self.regular_user, browser)
         browser.open(self.portal, view='@@user-details/kathi.barfuss')
 
@@ -78,6 +67,15 @@ class TestUserDetails(IntegrationTestCase):
             [u'Projekt \xdcberbaung Dorfmatte'], browser.css('.teams li').text)
         self.assertEquals('http://nohost/plone/kontakte/team-1/view',
                           browser.css('.teams a').first.get('href'))
+
+    @browsing
+    def test_hides_team_links_when_contact_folder_is_missing(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.portal, view='@@user-details/kathi.barfuss')
+
+        self.assertEquals(
+            [u'Projekt \xdcberbaung Dorfmatte'], browser.css('.teams li').text)
+        self.assertIsNone(browser.css('.teams a').first_or_none)
 
     @browsing
     def test_lists_group_memberships(self, browser):
@@ -141,13 +139,9 @@ class TestUserDetailsPlain(IntegrationTestCase):
         self.assertEquals([], browser.css('h1'))
 
     @browsing
-    def test_hide_teams_in_user_details_plain_if_contact_folder_does_not_exist(self, browser):
-        with self.login(self.manager):
-            api.content.delete(self.contactfolder)
-
+    def test_hides_team_links_when_contact_folder_is_missing(self, browser):
         self.login(self.regular_user, browser)
         browser.open(self.portal, view='@@user-details-plain/kathi.barfuss')
-
-        metadata = dict(browser.css('.vertical').first.lists())
-        self.assertIn('Name', metadata)
-        self.assertNotIn('Teams', metadata)
+        self.assertEquals(
+            [u'Projekt \xdcberbaung Dorfmatte'], browser.css('.teams li').text)
+        self.assertIsNone(browser.css('.teams a').first_or_none)

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -114,7 +114,6 @@ class OpengeverContentFixture(object):
 
         with self.freeze_at_hour(6):
             self.create_teams()
-            self.create_contacts()
 
         self.create_property_sheets()
 
@@ -626,52 +625,6 @@ class OpengeverContentFixture(object):
             )
             .in_state('repositoryfolder-state-inactive')
         ))
-
-    @staticuid()
-    def create_contacts(self):
-        self.contactfolder = self.register('contactfolder', create(
-            Builder('contactfolder')
-            .having(
-                id='kontakte',
-                title_de=u'Kontakte',
-                title_en=u'Contacts',
-                title_fr=u'Contacts',
-            )
-        ))
-
-        self.set_roles(
-            self.contactfolder, self.org_unit_fa.users_group_id,
-            ['Reader'])
-
-        self.set_roles(
-            self.contactfolder, self.org_unit_fa.users_group_id,
-            ['Reader', 'Contributor', 'Editor'])
-
-        self.contactfolder.reindexObjectSecurity()
-
-        self.hanspeter_duerr = self.register('hanspeter_duerr', create(
-            Builder('contact')
-            .within(self.contactfolder)
-            .having(
-                firstname=u'Hanspeter',
-                lastname='D\xc3\xbcrr'.decode('utf-8'),
-            )
-        ))
-
-        self.franz_meier = self.register('franz_meier', create(
-            Builder('contact')
-            .within(self.contactfolder)
-            .having(
-                firstname=u'Franz',
-                lastname=u'Meier',
-                email=u'meier.f@example.com',
-            )
-        ))
-
-        create(Builder('dummy_clock_tick'))
-        create(Builder('dummy_clock_tick'))
-
-        create_session().flush()
 
     @staticuid()
     def create_templates(self):


### PR DESCRIPTION
With this PR we fix various issues arising when the `ContactFolder` is missing. This should become the standard case in the future, as new deployments get created without a `ContactFolder` and the `ContactFolder` will get deleted for older deployments (migration towards KuB). We therefore delete the `ContactFolder` from the fixture and adapt the tests accordingly. We then fix a few issues so that things don't break down when the `ContactFolder` is missing notably:
- We don't throw an error anymore in `get_contactfolder_url` when the `ContactFolder` is missing
- Modify `get_profile_url` for Team Actors to return None when the `ContactFolder` is missing
- We also readd the list of teams on the userdetails view when the `ContactFolder` is missing. I'm not sure why that got dropped, I think listing the teams without a URL makes more sense than not showing the teams at all.


For [CA-5216]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug

[CA-5216]: https://4teamwork.atlassian.net/browse/CA-5216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ