### PR TITLE
Fix translating the title for pdfs created by the @save-minutes-as-pdf API endpoint.

### DIFF
--- a/changes/CA-4097.bugfix
+++ b/changes/CA-4097.bugfix
@@ -1,0 +1,1 @@
+Fix translating the title for pdfs created by the @save-minutes-as-pdf API endpoint. [elioschmutz]

--- a/opengever/api/save_minutes_as_pdf.py
+++ b/opengever/api/save_minutes_as_pdf.py
@@ -39,7 +39,7 @@ class SaveMinutesAsPDFPost(Service):
             u'label_workspace_meeting_minutes',
             default=u'Minutes for ${meeting_title}',
             mapping={'meeting_title': meeting.title}
-        ))
+        ), context=self.request)
 
         filename = "minutes.pdf"
         command = CreateDocumentCommand(self.context, filename, minutes_data,


### PR DESCRIPTION
The document titles of the generated documents have not been translated properly due to a missing parameter.

For [CA-4097]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-4097]: https://4teamwork.atlassian.net/browse/CA-4097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ