### PR TITLE
Add @solrlivesearch endpoint and improve solr configuration. 

### DIFF
--- a/changes/CA-5158.feature
+++ b/changes/CA-5158.feature
@@ -1,0 +1,1 @@
+Add @solrlivesearch endpoint and improve solr configuration. [njohner]

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -653,6 +653,22 @@
   <plone:service
       method="GET"
       for="zope.interface.Interface"
+      factory=".solrsearch.SolrLiveSearchGet"
+      name="@solrlivesearch"
+      permission="zope2.View"
+      />
+
+  <plone:service
+      method="POST"
+      for="zope.interface.Interface"
+      factory=".solrsearch.SolrLiveSearchGet"
+      name="@solrlivesearch"
+      permission="zope2.View"
+      />
+
+  <plone:service
+      method="GET"
+      for="zope.interface.Interface"
       factory=".solrsearch.TeamraumSolrSearchGet"
       name="@teamraum-solrsearch"
       permission="zope2.View"

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -1,4 +1,5 @@
 from ftw.solr.query import make_path_filter
+from opengever.api.solr_query_service import LiveSearchQueryPreprocessingMixin
 from opengever.api.solr_query_service import SolrFieldMapper
 from opengever.api.solr_query_service import SolrQueryBaseService
 from opengever.base.interfaces import ISearchSettings
@@ -117,7 +118,7 @@ class ListingFieldMapper(SolrFieldMapper):
         )
 
 
-class ListingGet(SolrQueryBaseService):
+class ListingGet(LiveSearchQueryPreprocessingMixin, SolrQueryBaseService):
     """List of content items"""
 
     field_mapper = ListingFieldMapper
@@ -129,9 +130,6 @@ class ListingGet(SolrQueryBaseService):
         query = params.get('search', '').strip()
         if not query:
             return '*'
-
-        if not query.endswith('"'):
-            query += '*'
 
         return query
 

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -173,9 +173,9 @@ class SolrQueryBaseService(Service):
 
 OPERATORS = ["and", "or", "&&", "||", "not", "!"]
 IGNORED_TOKENS = ["/"]
-TERM_SPLIT_TOKENS = [",", ";", r"\?", "!", "-", r"\+", "/", "\\\\", r"\|", "<", ">", "=", "%", "#"]
+TERM_SPLIT_TOKENS = [",", ";", r"\?", "!", "-", r"\+", "/", "\\\\", r"\|", "<", ">", "=", "%", "#", "@"]
 term_split_pattern = re.compile("|".join(TERM_SPLIT_TOKENS))
-part_split_pattern = re.compile(r'; |, |\. |@|\s')
+part_split_pattern = re.compile(r'; |, |\. |\s')
 
 
 class LiveSearchQueryPreprocessingMixin(object):
@@ -194,8 +194,9 @@ class LiveSearchQueryPreprocessingMixin(object):
         elif term.startswith("+"):
             prefix = "+"
             term = term.lstrip("+")
-        tokens = ["{}{}*".format(prefix, token.rstrip("*"))
+        tokens = ["{}{}".format(prefix, token)
                   for token in term_split_pattern.split(term)]
+        tokens[-1] = "{}*".format(tokens[-1].rstrip("*"))
         return "({})".format(" ".join(tokens))
 
     @staticmethod

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -173,6 +173,9 @@ class SolrQueryBaseService(Service):
 
 OPERATORS = ["and", "or", "&&", "||", "not", "!"]
 IGNORED_TOKENS = ["/"]
+TERM_SPLIT_TOKENS = [",", ";", r"\?", "!", "-", r"\+", "/", "\\\\", r"\|", "<", ">", "=", "%", "#"]
+term_split_pattern = re.compile("|".join(TERM_SPLIT_TOKENS))
+part_split_pattern = re.compile(r'; |, |\. |@|\s')
 
 
 class LiveSearchQueryPreprocessingMixin(object):
@@ -188,8 +191,11 @@ class LiveSearchQueryPreprocessingMixin(object):
         if term.startswith("-"):
             prefix = "-"
             term = term.lstrip("-")
+        elif term.startswith("+"):
+            prefix = "+"
+            term = term.lstrip("+")
         return ["{}{}*".format(prefix, token.rstrip("*"))
-                for token in term.split("-")]
+                for token in term_split_pattern.split(term)]
 
     @staticmethod
     def _preprocess_phrase(phrase, phrase_prefix):

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -183,9 +183,9 @@ class LiveSearchQueryPreprocessingMixin(object):
     @staticmethod
     def _preprocess_term(term):
         if term.lower() in OPERATORS:
-            return [term]
+            return term
         if term in IGNORED_TOKENS:
-            return []
+            return None
         prefix = ""
         term = term.rstrip(";,.")
         if term.startswith("-"):
@@ -194,8 +194,9 @@ class LiveSearchQueryPreprocessingMixin(object):
         elif term.startswith("+"):
             prefix = "+"
             term = term.lstrip("+")
-        return ["{}{}*".format(prefix, token.rstrip("*"))
-                for token in term_split_pattern.split(term)]
+        tokens = ["{}{}*".format(prefix, token.rstrip("*"))
+                  for token in term_split_pattern.split(term)]
+        return "({})".format(" ".join(tokens))
 
     @staticmethod
     def _preprocess_phrase(phrase, phrase_prefix):
@@ -215,10 +216,10 @@ class LiveSearchQueryPreprocessingMixin(object):
                 else:
                     following_phrase_prefix = ""
 
-                terms = filter(None, re.split(r'; |, |\. |@|\s', part))
+                terms = filter(None, part_split_pattern.split(part))
                 for term in terms:
-                    preprocessed_query.extend(self._preprocess_term(term))
+                    preprocessed_query.append(self._preprocess_term(term))
             else:
                 preprocessed_query.append(
                     self._preprocess_phrase(part, following_phrase_prefix))
-        return " ".join(preprocessed_query)
+        return " ".join(filter(None, preprocessed_query))

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -172,6 +172,7 @@ class SolrQueryBaseService(Service):
 
 
 OPERATORS = ["and", "or", "&&", "||", "not", "!"]
+IGNORED_TOKENS = ["/"]
 
 
 class LiveSearchQueryPreprocessingMixin(object):
@@ -180,6 +181,8 @@ class LiveSearchQueryPreprocessingMixin(object):
     def _preprocess_term(term):
         if term.lower() in OPERATORS:
             return [term]
+        if term in IGNORED_TOKENS:
+            return []
         prefix = ""
         term = term.rstrip(";,.")
         if term.startswith("-"):

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -196,7 +196,13 @@ class LiveSearchQueryPreprocessingMixin(object):
             term = term.lstrip("+")
         tokens = ["{}{}".format(prefix, token)
                   for token in term_split_pattern.split(term)]
-        tokens[-1] = "{}*".format(tokens[-1].rstrip("*"))
+
+        # Handle bracket and add wildcard to last token
+        last_token = tokens[-1]
+        n_brackets = len(last_token) - len(last_token.rstrip(")"))
+        last_token = last_token.rstrip(")") + "*" + n_brackets * ")"
+        tokens[-1] = last_token
+
         return "({})".format(" ".join(tokens))
 
     @staticmethod

--- a/opengever/api/solrsearch.py
+++ b/opengever/api/solrsearch.py
@@ -335,7 +335,7 @@ class SolrLiveSearchGet(SolrSearchGet):
         preprocessed_query = []
         parts = query.split('"')
         for i, part in enumerate(parts):
-            if i%2 == 0:
+            if i % 2 == 0 or i == len(parts) - 1:
                 if part.endswith("-"):
                     following_phrase_prefix = "-"
                     part = part.rstrip("-")

--- a/opengever/api/solrsearch.py
+++ b/opengever/api/solrsearch.py
@@ -328,19 +328,29 @@ class SolrLiveSearchGet(SolrSearchGet):
                 for token in term.split("-")]
 
     @staticmethod
-    def _preprocess_phrase(phrase):
-        return '"{}"'.format(phrase)
+    def _preprocess_phrase(phrase, phrase_prefix):
+        return '{}"{}"'.format(phrase_prefix, phrase)
 
     def preprocess_query(self, query):
         preprocessed_query = []
         parts = query.split('"')
         for i, part in enumerate(parts):
             if i%2 == 0:
+                if part.endswith("-"):
+                    following_phrase_prefix = "-"
+                    part = part.rstrip("-")
+                elif part.endswith("+"):
+                    following_phrase_prefix = "+"
+                    part = part.rstrip("+")
+                else:
+                    following_phrase_prefix = ""
+
                 terms = filter(None, re.split(r'; |, |\. |@|\s', part))
                 for term in terms:
                     preprocessed_query.extend(self._preprocess_term(term))
             else:
-                preprocessed_query.append(self._preprocess_phrase(part))
+                preprocessed_query.append(
+                    self._preprocess_phrase(part, following_phrase_prefix))
         return " ".join(preprocessed_query)
 
     def reply(self):

--- a/opengever/api/solrsearch.py
+++ b/opengever/api/solrsearch.py
@@ -326,6 +326,7 @@ class SolrLiveSearchGet(SolrSearchGet):
         if term.lower() in OPERATORS:
             return [term]
         prefix = ""
+        term = term.rstrip(";,.")
         if term.startswith("-"):
             prefix = "-"
             term = term.lstrip("-")

--- a/opengever/api/solrsearch.py
+++ b/opengever/api/solrsearch.py
@@ -331,6 +331,11 @@ class SolrLiveSearchGet(SolrSearchGet):
                                        for token in word.split("-")])
         return " ".join(preprocessed_query)
 
+    def reply(self):
+        if self.request_payload.get("only_preprocess_query"):
+            return {"preprocessed_query": self.extract_query(self.request_payload)}
+        return super(SolrLiveSearchGet, self).reply()
+
 
 class TeamraumSolrSearchGet(Service):
 

--- a/opengever/api/solrsearch.py
+++ b/opengever/api/solrsearch.py
@@ -319,16 +319,19 @@ class SolrLiveSearchGet(SolrSearchGet):
     """
 
     @staticmethod
-    def preprocess_query(query):
+    def _preprocess_term(term):
+        prefix = ""
+        if term.startswith("-"):
+            prefix = "-"
+            term = term.lstrip("-")
+        return ["{}{}*".format(prefix, token.rstrip("*"))
+                for token in term.split("-")]
+
+    def preprocess_query(self, query):
         preprocessed_query = []
-        words = filter(None, re.split(r'; |, |\. |@|\s', query))
-        for word in words:
-            prefix = ""
-            if word.startswith("-"):
-                prefix = "-"
-                word = word.lstrip("-")
-            preprocessed_query.extend(["{}{}*".format(prefix, token.rstrip("*"))
-                                       for token in word.split("-")])
+        terms = filter(None, re.split(r'; |, |\. |@|\s', query))
+        for term in terms:
+            preprocessed_query.extend(self._preprocess_term(term))
         return " ".join(preprocessed_query)
 
     def reply(self):

--- a/opengever/api/solrsearch.py
+++ b/opengever/api/solrsearch.py
@@ -327,11 +327,20 @@ class SolrLiveSearchGet(SolrSearchGet):
         return ["{}{}*".format(prefix, token.rstrip("*"))
                 for token in term.split("-")]
 
+    @staticmethod
+    def _preprocess_phrase(phrase):
+        return '"{}"'.format(phrase)
+
     def preprocess_query(self, query):
         preprocessed_query = []
-        terms = filter(None, re.split(r'; |, |\. |@|\s', query))
-        for term in terms:
-            preprocessed_query.extend(self._preprocess_term(term))
+        parts = query.split('"')
+        for i, part in enumerate(parts):
+            if i%2 == 0:
+                terms = filter(None, re.split(r'; |, |\. |@|\s', part))
+                for term in terms:
+                    preprocessed_query.extend(self._preprocess_term(term))
+            else:
+                preprocessed_query.append(self._preprocess_phrase(part))
         return " ".join(preprocessed_query)
 
     def reply(self):

--- a/opengever/api/solrsearch.py
+++ b/opengever/api/solrsearch.py
@@ -314,12 +314,17 @@ class SolrSearchGet(SolrQueryBaseService):
         return data
 
 
+OPERATORS = ["and", "or", "&&", "||", "not", "!"]
+
+
 class SolrLiveSearchGet(SolrSearchGet):
     """REST API endpoint for querying Solr
     """
 
     @staticmethod
     def _preprocess_term(term):
+        if term.lower() in OPERATORS:
+            return [term]
         prefix = ""
         if term.startswith("-"):
             prefix = "-"

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -150,7 +150,7 @@ class TestListingEndpointWithSolr(IntegrationTestCase):
         browser.open(self.repository_root, view=view,
                      headers=self.api_headers)
         query = self.solr.search.call_args[1]["query"]
-        self.assertEqual('feedb\xc3\xa4ck*', query)
+        self.assertEqual('(feedb\xc3\xa4ck*)', query)
 
     @browsing
     def test_sort_on_existing_field(self, browser):

--- a/opengever/api/tests/test_solrsearch.py
+++ b/opengever/api/tests/test_solrsearch.py
@@ -853,7 +853,7 @@ class TestSolrSearchGet(SolrIntegrationTestCase):
 
         browser.open(url, method='GET', headers=self.api_headers)
 
-        self.assertEqual(
+        self.assertItemsEqual(
             [
                 u'http://nohost/plone/private/kathi-barfuss/dossier-15',
                 u'http://nohost/plone/private/kathi-barfuss',
@@ -876,7 +876,7 @@ class TestSolrSearchGet(SolrIntegrationTestCase):
 
         browser.open(url, method='GET', headers=self.api_headers)
 
-        self.assertEqual(
+        self.assertItemsEqual(
             [
                 u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/dossier-2/document-24',
                 u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/dossier-2',

--- a/opengever/api/tests/test_solrsearch.py
+++ b/opengever/api/tests/test_solrsearch.py
@@ -1554,6 +1554,35 @@ class TestSolrLiveSearchGet(SolrIntegrationTestCase):
             [item["title"] for item in livesearch["items"]])
 
     @browsing
+    def test_livesearch_splits_terms_at_other_special_characters(self, browser):
+        self.login(self.regular_user, browser=browser)
+        self.document.title = "Taktische"
+        self.document.reindexObject(idxs=["Title"])
+        self.subdocument.title = "Taktische/Banane"
+        self.subdocument.reindexObject(idxs=["Title"])
+        self.subsubdocument.title = "Taktische?Banane"
+        self.subsubdocument.reindexObject(idxs=["Title"])
+        self.commit_solr()
+
+        query = {"q": "Title:taktische/ba"}
+        search = self.solr_search(browser, query)
+        livesearch = self.solr_livesearch(browser, query)
+        self.assertEqual(0, search["items_total"])
+        self.assertEqual(2, livesearch["items_total"])
+        self.assertItemsEqual(
+            [u'Taktische/Banane', "Taktische?Banane"],
+            [item["title"] for item in livesearch["items"]])
+
+        query = {"q": "Title:taktische?ba"}
+        search = self.solr_search(browser, query)
+        livesearch = self.solr_livesearch(browser, query)
+        self.assertEqual(0, search["items_total"])
+        self.assertEqual(2, livesearch["items_total"])
+        self.assertItemsEqual(
+            [u'Taktische/Banane', "Taktische?Banane"],
+            [item["title"] for item in livesearch["items"]])
+
+    @browsing
     def test_livesearch_handles_trailing_special_characters(self, browser):
         self.login(self.regular_user, browser=browser)
         self.document.title = "dotted.title.without.spaces"

--- a/opengever/api/tests/test_solrsearch.py
+++ b/opengever/api/tests/test_solrsearch.py
@@ -1498,3 +1498,11 @@ class TestSolrLiveSearchGet(SolrIntegrationTestCase):
              u'Arbeitsplatz einrichten.'],
             [item["title"] for item in livesearch["items"]])
 
+    @browsing
+    def test_only_preprocess_query(self, browser):
+        self.login(self.regular_user, browser=browser)
+        query="only_preprocess_query=true&q=some word-with-hyhpen"
+        self.solr_livesearch(browser, query)
+        self.assertEqual(
+            {u'preprocessed_query': u'some* word* with* hyhpen*'},
+            browser.json)

--- a/opengever/api/tests/test_solrsearch.py
+++ b/opengever/api/tests/test_solrsearch.py
@@ -1702,3 +1702,16 @@ class TestSolrLiveSearchGet(SolrIntegrationTestCase):
         self.assertEqual(
             {u'preprocessed_query': u'some* word* with* hyhpen*'},
             browser.json)
+
+
+class TestSolrLiveSearchPost(TestSolrLiveSearchGet):
+
+    def solr_search(self, browser, query):
+        url = u'{}/@solrsearch'.format(self.portal.absolute_url())
+        browser.open(url, method='POST', data=json.dumps(query), headers=self.api_headers)
+        return browser.json
+
+    def solr_livesearch(self, browser, query):
+        url = u'{}/@solrlivesearch'.format(self.portal.absolute_url())
+        browser.open(url, method='POST', data=json.dumps(query), headers=self.api_headers)
+        return browser.json

--- a/opengever/api/tests/test_solrsearch.py
+++ b/opengever/api/tests/test_solrsearch.py
@@ -1552,6 +1552,41 @@ class TestSolrLiveSearchGet(SolrIntegrationTestCase):
             [item["title"] for item in livesearch["items"]])
 
     @browsing
+    def test_livesearch_handles_trailing_special_characters(self, browser):
+        self.login(self.regular_user, browser=browser)
+        self.document.title="dotted.title.without.spaces"
+        self.document.reindexObject(idxs=["Title"])
+        self.commit_solr()
+
+        query = {"q": "dotted.title."}
+        self.assertEqual(0, self.solr_search(browser, query)["items_total"])
+        self.assertEqual(1, self.solr_livesearch(browser, query)["items_total"])
+
+        self.document.title="dotted. title. with. spaces"
+        self.document.reindexObject(idxs=["Title"])
+        self.commit_solr()
+
+        query = {"q": "dotted. title."}
+        self.assertEqual(1, self.solr_search(browser, query)["items_total"])
+        self.assertEqual(1, self.solr_livesearch(browser, query)["items_total"])
+
+        self.document.title="dashed-title-without-spaces"
+        self.document.reindexObject(idxs=["Title"])
+        self.commit_solr()
+
+        query = {"q": "dashed-title-"}
+        self.assertEqual(1, self.solr_search(browser, query)["items_total"])
+        self.assertEqual(1, self.solr_livesearch(browser, query)["items_total"])
+
+        self.document.title="dashed- title- with- spaces"
+        self.document.reindexObject(idxs=["Title"])
+        self.commit_solr()
+
+        query = {"q": "dashed- title-"}
+        self.assertEqual(1, self.solr_search(browser, query)["items_total"])
+        self.assertEqual(1, self.solr_livesearch(browser, query)["items_total"])
+
+    @browsing
     def test_stemming_does_not_work_in_live_search_but_it_does_not_matter(self, browser):
         """As stemming happened during indexing, and as we keep also the whole
         token, it does not matter that stemming does not happen during query.

--- a/opengever/api/tests/test_solrsearch.py
+++ b/opengever/api/tests/test_solrsearch.py
@@ -1423,6 +1423,22 @@ class TestSolrLiveSearchGet(SolrIntegrationTestCase):
             [self.subdocument.absolute_url()],
             [item["@id"] for item in browser.json[u'items']])
 
+    @browsing
+    def test_livesearch_preserves_phrase_exclusion(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        self.document.title = "Banane Taktische"
+        self.document.reindexObject(idxs=["Title"])
+        self.subdocument.title = "Taktische Banane"
+        self.subdocument.reindexObject(idxs=["Title"])
+        self.commit_solr()
+
+        url = u'{}/@solrlivesearch?q=banane -"Taktische Banane"'.format(self.portal.absolute_url())
+        browser.open(url, method='GET', headers=self.api_headers)
+        self.assertEqual(1, browser.json["items_total"])
+        self.assertItemsEqual(
+            [self.document.absolute_url()],
+            [item["@id"] for item in browser.json[u'items']])
 
     @browsing
     def test_livesearch_splits_hyphenated_terms(self, browser):

--- a/opengever/api/tests/test_solrsearch.py
+++ b/opengever/api/tests/test_solrsearch.py
@@ -1462,6 +1462,25 @@ class TestSolrLiveSearchGet(SolrIntegrationTestCase):
             [item["title"] for item in livesearch[u'items']])
 
     @browsing
+    def test_livesearch_handles_or_whilst_splitting_terms(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        self.document.title = "md-103"
+        self.document.reindexObject(idxs=["Title"])
+        self.subdocument.title = "md-104"
+        self.subdocument.reindexObject(idxs=["Title"])
+        self.subsubdocument.title = "md-105"
+        self.subsubdocument.reindexObject(idxs=["Title"])
+        self.commit_solr()
+
+        query = {"q": "md-103 or md-104"}
+        livesearch = self.solr_livesearch(browser, query)
+        self.assertEqual(2, livesearch["items_total"])
+        self.assertItemsEqual(
+            [u'md-103', u'md-104'],
+            [item["title"] for item in livesearch[u'items']])
+
+    @browsing
     def test_livesearch_preserves_phrases(self, browser):
         self.login(self.regular_user, browser=browser)
 
@@ -1791,7 +1810,7 @@ class TestSolrLiveSearchGet(SolrIntegrationTestCase):
         query = {"q": "some word-with-hyhpen", "only_preprocess_query": "true"}
         self.solr_livesearch(browser, query)
         self.assertEqual(
-            {u'preprocessed_query': u'some* word* with* hyhpen*'},
+            {u'preprocessed_query': u'(some*) (word* with* hyhpen*)'},
             browser.json)
 
 

--- a/opengever/api/tests/test_solrsearch.py
+++ b/opengever/api/tests/test_solrsearch.py
@@ -1424,6 +1424,23 @@ class TestSolrLiveSearchGet(SolrIntegrationTestCase):
             [item["@id"] for item in browser.json[u'items']])
 
     @browsing
+    def test_livesearch_does_not_preserve_unfinished_phrases(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        self.document.title = "Banane Taktische"
+        self.document.reindexObject(idxs=["Title"])
+        self.subdocument.title = "Taktische Banane"
+        self.subdocument.reindexObject(idxs=["Title"])
+        self.commit_solr()
+
+        url = u'{}/@solrlivesearch?q="Taktische Bana'.format(self.portal.absolute_url())
+        browser.open(url, method='GET', headers=self.api_headers)
+        self.assertEqual(2, browser.json["items_total"])
+        self.assertItemsEqual(
+            [self.document.absolute_url(), self.subdocument.absolute_url()],
+            [item["@id"] for item in browser.json[u'items']])
+
+    @browsing
     def test_livesearch_preserves_phrase_exclusion(self, browser):
         self.login(self.regular_user, browser=browser)
 

--- a/opengever/api/tests/test_solrsearch.py
+++ b/opengever/api/tests/test_solrsearch.py
@@ -1407,6 +1407,24 @@ class TestSolrLiveSearchGet(SolrIntegrationTestCase):
             [item["title"] for item in livesearch["items"]])
 
     @browsing
+    def test_livesearch_preserves_phrases(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        self.document.title = "Banane Taktische"
+        self.document.reindexObject(idxs=["Title"])
+        self.subdocument.title = "Taktische Banane"
+        self.subdocument.reindexObject(idxs=["Title"])
+        self.commit_solr()
+
+        url = u'{}/@solrlivesearch?q="Taktische Banane"'.format(self.portal.absolute_url())
+        browser.open(url, method='GET', headers=self.api_headers)
+        self.assertEqual(1, browser.json["items_total"])
+        self.assertItemsEqual(
+            [self.subdocument.absolute_url()],
+            [item["@id"] for item in browser.json[u'items']])
+
+
+    @browsing
     def test_livesearch_splits_hyphenated_terms(self, browser):
         self.login(self.regular_user, browser=browser)
         self.document.title="Taktische"

--- a/opengever/api/tests/test_solrsearch.py
+++ b/opengever/api/tests/test_solrsearch.py
@@ -466,7 +466,7 @@ class TestSolrSearchGet(SolrIntegrationTestCase):
             u'labels_custom_field_strings',
             u'age_custom_field_int',
             u'short_note_custom_field_string',
-            ], facet_counts.keys())
+        ], facet_counts.keys())
 
         expected = {
             u'color_custom_field_string': {
@@ -908,7 +908,7 @@ class TestSolrSearchGet(SolrIntegrationTestCase):
         filters = [
             'path_parent:/inbox',
             'path_parent:/private',
-            ]
+        ]
         solrsearch.add_path_parent_filters(filters)
 
         self.assertEqual(
@@ -1118,7 +1118,7 @@ class TestSolrSearchGet(SolrIntegrationTestCase):
             update_changed_date(self.document, None)
             self.document.reindexObject(idxs=["Title"])
 
-        with freeze(datetime.today()-timedelta(1)):
+        with freeze(datetime.today() - timedelta(1)):
             self.subdocument.title = "Banane"
             update_changed_date(self.subdocument, None)
             self.subdocument.reindexObject(idxs=["Title"])
@@ -1513,9 +1513,9 @@ class TestSolrLiveSearchGet(SolrIntegrationTestCase):
     @browsing
     def test_livesearch_splits_hyphenated_terms(self, browser):
         self.login(self.regular_user, browser=browser)
-        self.document.title="Taktische"
+        self.document.title = "Taktische"
         self.document.reindexObject(idxs=["Title"])
-        self.subdocument.title="Taktische-Banane"
+        self.subdocument.title = "Taktische-Banane"
         self.subdocument.reindexObject(idxs=["Title"])
         self.commit_solr()
 
@@ -1554,7 +1554,7 @@ class TestSolrLiveSearchGet(SolrIntegrationTestCase):
     @browsing
     def test_livesearch_handles_trailing_special_characters(self, browser):
         self.login(self.regular_user, browser=browser)
-        self.document.title="dotted.title.without.spaces"
+        self.document.title = "dotted.title.without.spaces"
         self.document.reindexObject(idxs=["Title"])
         self.commit_solr()
 
@@ -1562,7 +1562,7 @@ class TestSolrLiveSearchGet(SolrIntegrationTestCase):
         self.assertEqual(0, self.solr_search(browser, query)["items_total"])
         self.assertEqual(1, self.solr_livesearch(browser, query)["items_total"])
 
-        self.document.title="dotted. title. with. spaces"
+        self.document.title = "dotted. title. with. spaces"
         self.document.reindexObject(idxs=["Title"])
         self.commit_solr()
 
@@ -1570,7 +1570,7 @@ class TestSolrLiveSearchGet(SolrIntegrationTestCase):
         self.assertEqual(1, self.solr_search(browser, query)["items_total"])
         self.assertEqual(1, self.solr_livesearch(browser, query)["items_total"])
 
-        self.document.title="dashed-title-without-spaces"
+        self.document.title = "dashed-title-without-spaces"
         self.document.reindexObject(idxs=["Title"])
         self.commit_solr()
 
@@ -1578,7 +1578,7 @@ class TestSolrLiveSearchGet(SolrIntegrationTestCase):
         self.assertEqual(1, self.solr_search(browser, query)["items_total"])
         self.assertEqual(1, self.solr_livesearch(browser, query)["items_total"])
 
-        self.document.title="dashed- title- with- spaces"
+        self.document.title = "dashed- title- with- spaces"
         self.document.reindexObject(idxs=["Title"])
         self.commit_solr()
 
@@ -1689,7 +1689,7 @@ class TestSolrLiveSearchGet(SolrIntegrationTestCase):
     @browsing
     def test_querying_filenames(self, browser):
         self.login(self.regular_user, browser=browser)
-        self.document.title="20221121_some_file-name"
+        self.document.title = "20221121_some_file-name"
         self.document.reindexObject(idxs=["Title", "filename"])
         self.commit_solr()
 

--- a/opengever/api/tests/test_solrsearch.py
+++ b/opengever/api/tests/test_solrsearch.py
@@ -1754,11 +1754,11 @@ class TestSolrLiveSearchGet(SolrIntegrationTestCase):
         livesearch = self.solr_livesearch(browser, query)
         self.assertEqual(2, livesearch["items_total"])
         self.assertItemsEqual(
-            [u'Client1 11-1.1.1-23'],
+            [u'Client1 11-1.1.1', u'Client1 11-1.1.1-23'],
             [item["reference_number"] for item in livesearch["items"]])
         self.assertEqual(2, search["items_total"])
         self.assertItemsEqual(
-            [livesearch["items"]],
+            [u'Client1 11-1.1.1', u'Client1 11-1.1.1-23'],
             [item["reference_number"] for item in search["items"]])
 
     @browsing

--- a/opengever/api/tests/test_solrsearch.py
+++ b/opengever/api/tests/test_solrsearch.py
@@ -1436,6 +1436,8 @@ class TestSolrLiveSearchGet(SolrIntegrationTestCase):
             [u'Taktische-Banane'],
             [item["title"] for item in livesearch["items"]])
 
+        # Note that adding a wildcard to normal search does not lead to the
+        # expected behavior for the customer
         query = "q=Title:taktische-banane*"
         search = self.solr_search(browser, query)
         livesearch = self.solr_livesearch(browser, query)

--- a/opengever/api/tests/test_solrsearch.py
+++ b/opengever/api/tests/test_solrsearch.py
@@ -1481,6 +1481,35 @@ class TestSolrLiveSearchGet(SolrIntegrationTestCase):
             [item["title"] for item in livesearch[u'items']])
 
     @browsing
+    def test_livesearch_handles_brackets(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        self.document.title = "Apfel"
+        self.document.reindexObject(idxs=["Title"])
+        self.subdocument.title = "Taktische Banane"
+        self.subdocument.reindexObject(idxs=["Title"])
+        self.subsubdocument.title = "Taktische Banane und Apfel"
+        self.subsubdocument.reindexObject(idxs=["Title"])
+        self.empty_document.title = "Banane und Apfel"
+        self.empty_document.reindexObject(idxs=["Title"])
+        self.commit_solr()
+
+        query = {"q": "(Apfel AND Banane) OR Taktische"}
+        livesearch = self.solr_livesearch(browser, query)
+
+        self.assertEqual(3, livesearch["items_total"])
+        self.assertItemsEqual(
+            [u'Taktische Banane und Apfel', u'Taktische Banane', u'Banane und Apfel'],
+            [item["title"] for item in livesearch[u'items']])
+
+        query = {"q": "(Apfel OR Banane) AND Taktische"}
+        livesearch = self.solr_livesearch(browser, query)
+        self.assertEqual(2, livesearch["items_total"])
+        self.assertItemsEqual(
+            [u'Taktische Banane und Apfel', u'Taktische Banane'],
+            [item["title"] for item in livesearch[u'items']])
+
+    @browsing
     def test_livesearch_preserves_phrases(self, browser):
         self.login(self.regular_user, browser=browser)
 

--- a/opengever/api/tests/test_solrsearch.py
+++ b/opengever/api/tests/test_solrsearch.py
@@ -1661,22 +1661,6 @@ class TestSolrLiveSearchGet(SolrIntegrationTestCase):
         search = self.solr_search(browser, query)
         livesearch = self.solr_livesearch(browser, query)
 
-        # For some reason the /* that appears in the preprocessed query
-        # leads to finding all kind of stuff
-        self.assertEqual(36, livesearch["items_total"])
-        self.assertItemsEqual(
-            u'Client1 1.1 / 14', livesearch["items"][0]["reference_number"])
-        self.assertEqual(2, search["items_total"])
-        self.assertItemsEqual(
-            [u'Client1 1.1 / 14', u'Client1 1.1 / 1 / 14'],
-            [item["reference_number"] for item in search["items"]])
-
-        # without the / it works as expected. We could clean that up in
-        # the preprocessing of the query
-        query = {"q": "Client1 1.1 14", "fl": "@id,reference_number"}
-        search = self.solr_search(browser, query)
-        livesearch = self.solr_livesearch(browser, query)
-
         self.assertEqual(2, livesearch["items_total"])
         self.assertItemsEqual(
             [u'Client1 1.1 / 14', u'Client1 1.1 / 1 / 14'],

--- a/opengever/api/upload_structure.py
+++ b/opengever/api/upload_structure.py
@@ -73,7 +73,6 @@ class DefaultUploadStructureAnalyser(object):
 
     def find_possible_duplicates(self, files):
         solr = getUtility(ISolrSearch)
-
         if not self.duplicate_search_root:
             self.structure['possible_duplicates'] = {}
             return
@@ -89,7 +88,7 @@ class DefaultUploadStructureAnalyser(object):
 
         quoted_filenames = ['"{}"'.format(el) for el in normalized_filenames.values()]
         filters.append(
-            u'filename:({})'.format(' or '.join(quoted_filenames))
+            u'filename:({})'.format(' OR '.join(quoted_filenames))
         )
 
         resp = solr.search(

--- a/opengever/core/solr_testing.py
+++ b/opengever/core/solr_testing.py
@@ -51,7 +51,7 @@ class SolrServer(object):
             'SOLR_CORES=testing functionaltesting testserver',
             '--name',
             self.container_name,
-            '4teamwork/ogsolr:edismax',
+            '4teamwork/ogsolr:latest',
             'solr-foreground',
         ]
 

--- a/opengever/core/upgrades/20230323120723_reindex_metadata_field/upgrade.py
+++ b/opengever/core/upgrades/20230323120723_reindex_metadata_field/upgrade.py
@@ -1,0 +1,17 @@
+from ftw.upgrade import UpgradeStep
+from opengever.core.upgrade import NightlyIndexer
+from opengever.document.behaviors import IBaseDocument
+
+
+class ReindexMetadataField(UpgradeStep):
+    """Reindex metadata field.
+    """
+
+    deferrable = True
+
+    def __call__(self):
+        query = {'object_provides': IBaseDocument.__identifier__}
+
+        with NightlyIndexer(idxs=["metadata"], index_in_solr_only=True) as indexer:
+            for brain in self.brains(query, 'Queueing metadata reindexing jobs.'):
+                indexer.add_by_brain(brain)

--- a/opengever/officeconnector/tests/test_api_dossier_attach.py
+++ b/opengever/officeconnector/tests/test_api_dossier_attach.py
@@ -298,6 +298,9 @@ class TestOfficeconnectorDossierAPIWithAttach(OCSolrIntegrationTestCase):
             }
         raw_token = oc_url.split(':')[-1]
         token = jwt.decode(raw_token, JWT_SIGNING_SECRET_PLONE, algorithms=('HS256',))
+        payloads = self.fetch_document_attach_payloads(browser, raw_token, token)
+
+        self.assertItemsEqual(token.pop('documents'), expected_token.pop('documents'))
         self.assertEqual(expected_token, token)
 
         expected_payloads = [
@@ -326,8 +329,7 @@ class TestOfficeconnectorDossierAPIWithAttach(OCSolrIntegrationTestCase):
                 u'version': None,
                 },
             ]
-        payloads = self.fetch_document_attach_payloads(browser, raw_token, token)
-        self.assertEqual(payloads, expected_payloads)
+        self.assertItemsEqual(payloads, expected_payloads)
 
     @browsing
     def test_attach_many_to_email_inactive(self, browser):
@@ -364,6 +366,9 @@ class TestOfficeconnectorDossierAPIWithAttach(OCSolrIntegrationTestCase):
             }
         raw_token = oc_url.split(':')[-1]
         token = jwt.decode(raw_token, JWT_SIGNING_SECRET_PLONE, algorithms=('HS256',))
+        payloads = self.fetch_document_attach_payloads(browser, raw_token, token)
+
+        self.assertItemsEqual(token.pop('documents'), expected_token.pop('documents'))
         self.assertEqual(expected_token, token)
 
         expected_payloads = [
@@ -390,8 +395,7 @@ class TestOfficeconnectorDossierAPIWithAttach(OCSolrIntegrationTestCase):
                 u'version': None,
                 },
             ]
-        payloads = self.fetch_document_attach_payloads(browser, raw_token, token)
-        self.assertEqual(payloads, expected_payloads)
+        self.assertItemsEqual(payloads, expected_payloads)
 
     @browsing
     def test_attach_many_to_email_resolved(self, browser):
@@ -428,6 +432,9 @@ class TestOfficeconnectorDossierAPIWithAttach(OCSolrIntegrationTestCase):
             }
         raw_token = oc_url.split(':')[-1]
         token = jwt.decode(raw_token, JWT_SIGNING_SECRET_PLONE, algorithms=('HS256',))
+        payloads = self.fetch_document_attach_payloads(browser, raw_token, token)
+
+        self.assertItemsEqual(token.pop('documents'), expected_token.pop('documents'))
         self.assertEqual(expected_token, token)
 
         expected_payloads = [
@@ -454,8 +461,7 @@ class TestOfficeconnectorDossierAPIWithAttach(OCSolrIntegrationTestCase):
                 u'version': None,
                 },
             ]
-        payloads = self.fetch_document_attach_payloads(browser, raw_token, token)
-        self.assertEqual(payloads, expected_payloads)
+        self.assertItemsEqual(payloads, expected_payloads)
 
     @browsing
     def test_attach_multiple_documents_sets_flags(self, browser):
@@ -593,8 +599,9 @@ class TestOfficeconnectorDossierAPIWithAttach(OCSolrIntegrationTestCase):
         raw_token = url.split(':')[-1]
         token = jwt.decode(raw_token, JWT_SIGNING_SECRET_PLONE, algorithms=('HS256',))
         with self.login(self.regular_user):
-            self.assertEqual([IUUID(self.document), IUUID(self.subdocument), IUUID(self.mail_eml)],
-                             token['documents'])
+            self.assertItemsEqual(
+                [IUUID(self.document), IUUID(self.subdocument), IUUID(self.mail_eml)],
+                token['documents'])
 
     @browsing
     def test_attach_multiple_documents_does_not_set_links_flag(self, browser):

--- a/opengever/officeconnector/tests/test_api_mail_attach.py
+++ b/opengever/officeconnector/tests/test_api_mail_attach.py
@@ -117,6 +117,9 @@ class TestOfficeconnectorMailAPIWithAttach(OCSolrIntegrationTestCase):
         }
         raw_token = oc_url.split(":")[-1]
         token = jwt.decode(raw_token, JWT_SIGNING_SECRET_PLONE, algorithms=('HS256',))
+        payloads = self.fetch_document_attach_payloads(browser, raw_token, token)
+
+        self.assertItemsEqual(token.pop('documents'), expected_token.pop('documents'))
         self.assertEqual(expected_token, token)
 
         expected_payloads = [
@@ -146,8 +149,7 @@ class TestOfficeconnectorMailAPIWithAttach(OCSolrIntegrationTestCase):
             },
         ]
 
-        payloads = self.fetch_document_attach_payloads(browser, raw_token, token)
-        self.assertEqual(expected_payloads, payloads)
+        self.assertItemsEqual(expected_payloads, payloads)
 
     @browsing
     def test_checkout_checkin(self, browser):

--- a/solr-conf/managed-schema
+++ b/solr-conf/managed-schema
@@ -158,7 +158,7 @@
     <field name="is_subtasktemplatefolder" type="boolean" indexed="true" stored="false" />
     <field name="issuer" type="string" indexed="true" stored="false" />
     <field name="lastname" type="string" indexed="true" stored="false" />
-    <field name="metadata" type="text" indexed="true" stored="true"/>
+    <field name="metadata" type="text_general" indexed="true" stored="true"/>
     <field name="object_provides" type="string" indexed="true" stored="false" multiValued="true"/>
     <field name="period" type="pint" indexed="true" stored="false" />
     <field name="phone_office" type="string" indexed="true" stored="false" />

--- a/solr-conf/solrconfig.xml
+++ b/solr-conf/solrconfig.xml
@@ -784,6 +784,7 @@
       <str name="uf">* -allowedRolesAndUsers -_query_</str>
       <bool name="lowercaseOperators">true</bool>
       <str name="mm">3&lt;75%</str>
+      <str name="bq">{!func}recip(ms(NOW,changed),3.858e-10,10,1)</str>
     </lst>
     <!-- If the default list of SearchComponents is not desired, that
          list can either be overridden completely, or components can be

--- a/solr-conf/solrconfig.xml
+++ b/solr-conf/solrconfig.xml
@@ -783,6 +783,7 @@
       <!-- Do not allow querying allowedRolesAndUsers or embedded queries -->
       <str name="uf">* -allowedRolesAndUsers -_query_</str>
       <bool name="lowercaseOperators">true</bool>
+      <str name="mm">3&lt;75%</str>
     </lst>
     <!-- If the default list of SearchComponents is not desired, that
          list can either be overridden completely, or components can be

--- a/solr-conf/solrconfig.xml
+++ b/solr-conf/solrconfig.xml
@@ -707,6 +707,7 @@
     <lst name="defaults">
       <str name="echoParams">explicit</str>
       <int name="rows">10</int>
+      <str name="q.op">AND</str>
       <!-- Default search field
          <str name="df">text</str>
         -->
@@ -783,7 +784,6 @@
       <!-- Do not allow querying allowedRolesAndUsers or embedded queries -->
       <str name="uf">* -allowedRolesAndUsers -_query_</str>
       <bool name="lowercaseOperators">true</bool>
-      <str name="mm">3&lt;75%</str>
       <str name="bq">{!func}recip(ms(NOW,changed),3.858e-10,10,1)</str>
     </lst>
     <!-- If the default list of SearchComponents is not desired, that


### PR DESCRIPTION
The behavior of the livesearch in Gever is currently pretty confusing, as only searches for full tokens will lead to results. This typically leads to having 0 results after typing a few characters, but results will appear again later, once a word is complete.
We propose here to fix this by specifically adding wildcards to the terms of the query and doing some tokenization as it will not happen for wildcard queries.

I also switch the default operator the `AND`, IMO this is the expected behavior, getting fewer results when searching for more terms (this is also what google does). I had to set the `q.op` parameter and not the `mm`, as this otherwise prevents from using operators in the queries.

I've also added boosting of recently `changed` objects, which got lost when we switched to the edismax parser. I think it is ok to use `changed` which is defined for all relevant portal types (everything except `ContactFolder`, `TemplateFolder`, `InboxContainer`, `CommitteeContainer`, `PrivateFolder`, `PrivateRoot`, `RepositoryRoot`, `WorkspaceRoot`).

I also add the possibility to simply retrieve the preprocessed query, which could be used when the user hits enter in the livesearch to jump to a normal search with the preprocessed query and display that to the user.

I also switch the metadata field type to `text_general`. Having the same tokenization for metadata as for other text fields
that are queried by default allows consistent results for the @LiveSearch endpoint, notably to query reference numbers when using the grouped_by_three formatter. Indeed the reference number of all objects except documents and mails is in the `SearchableText`, but for documents and mails it's only in the `metadata`

Tests are failing because we would need to build and use a new image of solr to include the changes in solr configuration.

For [CA-5477] and [CA-5158]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-5158]: https://4teamwork.atlassian.net/browse/CA-5158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CA-5477]: https://4teamwork.atlassian.net/browse/CA-5477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ