### PR TITLE
Fix OGDS sync logging of modified group memberships.

### DIFF
--- a/changes/OGDS-SYNC.bugfix
+++ b/changes/OGDS-SYNC.bugfix
@@ -1,0 +1,1 @@
+Fix OGDS sync logging of modified group memberships. [njohner]

--- a/opengever/ogds/base/sync/ogds_updater.py
+++ b/opengever/ogds/base/sync/ogds_updater.py
@@ -334,8 +334,11 @@ class OGDSUpdater(object):
                     in ldap_group_members[groupid]
                 ]
 
-                for userid in ldap_group_members[groupid]:
-                    logger.info('Added user %s into group %s.', userid, groupid)
+                for userid in diff:
+                    if userid in ogds_group_members.get(groupid, set()):
+                        logger.info('Removed user %s from group %s.', userid, groupid)
+                    else:
+                        logger.info('Added user %s into group %s.', userid, groupid)
                 modified_count += 1
 
         for deleted in deleted_mappings:


### PR DESCRIPTION
OGDS sync was logging that it had added all group members of a group when a single member was added or removed. This clutters the logs and makes it pretty confusing, as if tons of new users had been added.

## Checklist
- [x] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira) -> no story