### PR TITLE
Exclude weekends on task deadline calculation

### DIFF
--- a/changes/CA-5251.feature
+++ b/changes/CA-5251.feature
@@ -1,0 +1,1 @@
+Default task deadline calculation will ignore weekends. [elioschmutz]

--- a/docs/public/user-manual/standardablaeufe.rst
+++ b/docs/public/user-manual/standardablaeufe.rst
@@ -30,7 +30,7 @@ c) Auftraggeber
 
 d) Auftragnehmer
 
-e) Frist in Tagen ab Auslösung der Aufgabe
+e) Frist in Arbeitstagen ab Auslösung der Aufgabe
 
 f) Vorselektion: Angabe, ob die Aufgabe automatisch ausgewählt werden
    soll, wenn man den Standardablauf in einem Dossier auslöst.

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -872,7 +872,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
         items = browser.json['items']
         deadlines = list(set(map(lambda x: x['deadline'], items)))
         self.assertEqual(1, len(deadlines))
-        self.assertEqual('2016-09-05T00:00:00Z', deadlines[0])
+        self.assertEqual('2016-09-07T00:00:00Z', deadlines[0])
 
     @browsing
     def test_filter_supports_unicode(self, browser):

--- a/opengever/api/tests/test_process.py
+++ b/opengever/api/tests/test_process.py
@@ -22,75 +22,75 @@ class TestProcessDataPreprocessor(IntegrationTestCase):
         data = {
             "process": {
                 "items": [
-                    {"deadline": date(2022, 03, 01)},
-                    {"deadline": date(2022, 03, 05)},
-                    {"deadline": date(2022, 03, 02)},
+                    {"deadline": date(2022, 3, 1)},
+                    {"deadline": date(2022, 3, 5)},
+                    {"deadline": date(2022, 3, 2)},
                 ]
             }
         }
         processor = ProcessDataPreprocessor(self.dossier, data)
-        with freeze(datetime(2022, 02, 01)):
+        with freeze(datetime(2022, 2, 1)):
             processor.recursive_set_deadlines()
 
-        self.assertEqual(date(2022, 03, 10), data["process"]["deadline"])
+        self.assertEqual(date(2022, 3, 10), data["process"]["deadline"])
 
     def test_deadline_at_least_today_plus_five(self):
         self.login(self.regular_user)
         data = {
             "process": {
                 "items": [
-                    {"deadline": date(2022, 03, 05)},
-                    {"deadline": date(2022, 03, 01)},
-                    {"deadline": date(2022, 03, 02)},
+                    {"deadline": date(2022, 3, 5)},
+                    {"deadline": date(2022, 3, 1)},
+                    {"deadline": date(2022, 3, 2)},
                 ]
             }
         }
         processor = ProcessDataPreprocessor(self.dossier, data)
-        with freeze(datetime(2022, 04, 01)):
+        with freeze(datetime(2022, 4, 1)):
             processor.recursive_set_deadlines()
 
-        self.assertEqual(date(2022, 04, 06), data["process"]["deadline"])
+        self.assertEqual(date(2022, 4, 6), data["process"]["deadline"])
 
     def test_recursive_deadline_propagation(self):
         self.login(self.regular_user)
         data = {
             "process": {
                 "items": [
-                    {"deadline": date(2022, 03, 01)},
+                    {"deadline": date(2022, 3, 1)},
                     {"items": [
-                        {"deadline": date(2022, 03, 10)},
+                        {"deadline": date(2022, 3, 10)},
                         {"items": [
-                            {"deadline": date(2022, 04, 2)},
+                            {"deadline": date(2022, 4, 2)},
                         ]},
                     ]},
                     {"items": [
-                        {"deadline": date(2022, 03, 10)},
-                        {"deadline": date(2022, 03, 05)},
+                        {"deadline": date(2022, 3, 10)},
+                        {"deadline": date(2022, 3, 5)},
                     ]},
                 ]
             }
         }
         processor = ProcessDataPreprocessor(self.dossier, data)
-        with freeze(datetime(2022, 02, 01)):
+        with freeze(datetime(2022, 2, 1)):
             processor.recursive_set_deadlines()
 
         expected_data = {
             "process": {
                 "deadline": date(2022, 4, 17),
                 "items": [
-                    {"deadline": date(2022, 03, 01)},
+                    {"deadline": date(2022, 3, 1)},
                     {"deadline": date(2022, 4, 12),
                      "items": [
-                        {"deadline": date(2022, 03, 10)},
+                        {"deadline": date(2022, 3, 10)},
                         {"deadline": date(2022, 4, 7),
                          "items": [
-                            {"deadline": date(2022, 04, 2)},
+                            {"deadline": date(2022, 4, 2)},
                         ]},
                     ]},
-                    {"deadline": date(2022, 03, 15),
+                    {"deadline": date(2022, 3, 15),
                      "items": [
-                        {"deadline": date(2022, 03, 10)},
-                        {"deadline": date(2022, 03, 05)},
+                        {"deadline": date(2022, 3, 10)},
+                        {"deadline": date(2022, 3, 5)},
                     ]},
                 ]
             }
@@ -124,7 +124,7 @@ class TestProcessPost(IntegrationTestCase):
             }
         }
 
-        with self.observe_children(self.dossier) as children, freeze(datetime(2022, 02, 01)):
+        with self.observe_children(self.dossier) as children, freeze(datetime(2022, 2, 1)):
             browser.open('{}/@process'.format(
                          self.dossier.absolute_url()),
                          data=json.dumps(data),
@@ -200,7 +200,7 @@ class TestProcessPost(IntegrationTestCase):
             }
         }
 
-        with self.observe_children(self.dossier) as children, freeze(datetime(2022, 02, 01)):
+        with self.observe_children(self.dossier) as children, freeze(datetime(2022, 2, 1)):
             browser.open('{}/@process'.format(
                          self.dossier.absolute_url()),
                          data=json.dumps(data),
@@ -274,7 +274,7 @@ class TestProcessPost(IntegrationTestCase):
             }
         }
 
-        with self.observe_children(self.dossier) as children, freeze(datetime(2022, 02, 01)):
+        with self.observe_children(self.dossier) as children, freeze(datetime(2022, 2, 1)):
             browser.open('{}/@process'.format(
                          self.dossier.absolute_url()),
                          data=json.dumps(data),
@@ -332,7 +332,7 @@ class TestProcessPost(IntegrationTestCase):
             }
         }
 
-        with self.observe_children(self.dossier) as children, freeze(datetime(2022, 02, 01)):
+        with self.observe_children(self.dossier) as children, freeze(datetime(2022, 2, 1)):
             browser.open('{}/@process'.format(
                          self.dossier.absolute_url()),
                          data=json.dumps(data),
@@ -413,7 +413,7 @@ class TestProcessPost(IntegrationTestCase):
                 ]
             }
         }
-        with self.observe_children(self.dossier) as children, freeze(datetime(2022, 02, 01)):
+        with self.observe_children(self.dossier) as children, freeze(datetime(2022, 2, 1)):
             browser.open('{}/@process'.format(
                          self.dossier.absolute_url()),
                          data=json.dumps(data),
@@ -532,7 +532,7 @@ class TestProcessPost(IntegrationTestCase):
             }
         }
 
-        with self.observe_children(self.dossier) as children, freeze(datetime(2022, 02, 01)):
+        with self.observe_children(self.dossier) as children, freeze(datetime(2022, 2, 1)):
             browser.open('{}/@process'.format(
                          self.dossier.absolute_url()),
                          data=json.dumps(data),
@@ -548,7 +548,7 @@ class TestProcessPost(IntegrationTestCase):
                           api.content.get_state(subtask_2))
 
         data["start_immediately"] = False
-        with self.observe_children(self.dossier) as children, freeze(datetime(2022, 02, 01)):
+        with self.observe_children(self.dossier) as children, freeze(datetime(2022, 2, 1)):
             browser.open('{}/@process'.format(
                          self.dossier.absolute_url()),
                          data=json.dumps(data),
@@ -594,7 +594,7 @@ class TestProcessPost(IntegrationTestCase):
             }
         }
 
-        with self.observe_children(self.dossier) as children, freeze(datetime(2022, 02, 01)):
+        with self.observe_children(self.dossier) as children, freeze(datetime(2022, 2, 1)):
             browser.open('{}/@process'.format(
                          self.dossier.absolute_url()),
                          data=json.dumps(data),
@@ -646,7 +646,7 @@ class TestProcessPost(IntegrationTestCase):
             }
         }
 
-        with self.observe_children(self.dossier) as children, freeze(datetime(2022, 02, 01)):
+        with self.observe_children(self.dossier) as children, freeze(datetime(2022, 2, 1)):
             browser.open('{}/@process'.format(
                          self.dossier.absolute_url()),
                          data=json.dumps(data),

--- a/opengever/api/tests/test_process.py
+++ b/opengever/api/tests/test_process.py
@@ -17,13 +17,13 @@ import json
 
 class TestProcessDataPreprocessor(IntegrationTestCase):
 
-    def test_deadline_is_the_longest_deadline_of_children_plus_five(self):
+    def test_deadline_is_the_longest_deadline_of_children_plus_five_workdays(self):
         self.login(self.regular_user)
         data = {
             "process": {
                 "items": [
                     {"deadline": date(2022, 3, 1)},
-                    {"deadline": date(2022, 3, 5)},
+                    {"deadline": date(2022, 3, 4)},  # Friday
                     {"deadline": date(2022, 3, 2)},
                 ]
             }
@@ -32,9 +32,9 @@ class TestProcessDataPreprocessor(IntegrationTestCase):
         with freeze(datetime(2022, 2, 1)):
             processor.recursive_set_deadlines()
 
-        self.assertEqual(date(2022, 3, 10), data["process"]["deadline"])
+        self.assertEqual(date(2022, 3, 11), data["process"]["deadline"])
 
-    def test_deadline_at_least_today_plus_five(self):
+    def test_deadline_at_least_today_plus_five_workdays(self):
         self.login(self.regular_user)
         data = {
             "process": {
@@ -46,51 +46,53 @@ class TestProcessDataPreprocessor(IntegrationTestCase):
             }
         }
         processor = ProcessDataPreprocessor(self.dossier, data)
+
+        # Friday
         with freeze(datetime(2022, 4, 1)):
             processor.recursive_set_deadlines()
 
-        self.assertEqual(date(2022, 4, 6), data["process"]["deadline"])
+        self.assertEqual(date(2022, 4, 8), data["process"]["deadline"])
 
     def test_recursive_deadline_propagation(self):
         self.login(self.regular_user)
         data = {
             "process": {
                 "items": [
-                    {"deadline": date(2022, 3, 1)},
+                    {"deadline": date(2022, 3, 1)},  # Tuesday
                     {"items": [
-                        {"deadline": date(2022, 3, 10)},
+                        {"deadline": date(2022, 3, 10)},  # Thursday
                         {"items": [
-                            {"deadline": date(2022, 4, 2)},
+                            {"deadline": date(2022, 4, 4)},  # Monday
                         ]},
                     ]},
                     {"items": [
-                        {"deadline": date(2022, 3, 10)},
-                        {"deadline": date(2022, 3, 5)},
+                        {"deadline": date(2022, 3, 10)},  # Thursday
+                        {"deadline": date(2022, 3, 4)},  # Friday
                     ]},
                 ]
             }
         }
         processor = ProcessDataPreprocessor(self.dossier, data)
-        with freeze(datetime(2022, 2, 1)):
+        with freeze(datetime(2022, 2, 1)):  # Tuesday
             processor.recursive_set_deadlines()
 
         expected_data = {
             "process": {
-                "deadline": date(2022, 4, 17),
+                "deadline": date(2022, 4, 25),  # Monday
                 "items": [
                     {"deadline": date(2022, 3, 1)},
-                    {"deadline": date(2022, 4, 12),
+                    {"deadline": date(2022, 4, 18),  # Monday
                      "items": [
-                        {"deadline": date(2022, 3, 10)},
-                        {"deadline": date(2022, 4, 7),
+                        {"deadline": date(2022, 3, 10)},  # Thursday
+                        {"deadline": date(2022, 4, 11),  # Monday
                          "items": [
-                            {"deadline": date(2022, 4, 2)},
+                            {"deadline": date(2022, 4, 4)},  # Monday
                         ]},
                     ]},
-                    {"deadline": date(2022, 3, 15),
+                    {"deadline": date(2022, 3, 17),  # Thursday
                      "items": [
-                        {"deadline": date(2022, 3, 10)},
-                        {"deadline": date(2022, 3, 5)},
+                        {"deadline": date(2022, 3, 10)},  # Thursday
+                        {"deadline": date(2022, 3, 4)},  # Friday
                     ]},
                 ]
             }
@@ -141,7 +143,7 @@ class TestProcessPost(IntegrationTestCase):
         self.assertEqual('direct-execution', main_task.task_type)
         self.assertEqual('task-state-in-progress',
                          api.content.get_state(main_task))
-        self.assertEqual(date(2022, 3, 6), main_task.deadline)
+        self.assertEqual(date(2022, 3, 8), main_task.deadline)
 
         subtasks = main_task.listFolderContents()
         self.assertEqual(1, len(subtasks))
@@ -235,9 +237,9 @@ class TestProcessPost(IntegrationTestCase):
         # Check deadline propagation
         self.assertEqual(date(2022, 3, 10), subsubtask1.deadline)
         self.assertEqual(date(2022, 3, 12), subsubtask2.deadline)
-        self.assertEqual(date(2022, 3, 17), subtask_container.deadline)
+        self.assertEqual(date(2022, 3, 18), subtask_container.deadline)
         self.assertEqual(date(2022, 3, 1), subtask.deadline)
-        self.assertEqual(date(2022, 3, 22), main_task.deadline)
+        self.assertEqual(date(2022, 3, 25), main_task.deadline)
 
         # check parallel and sequential interfaces
         self.assertTrue(IContainSequentialProcess.providedBy(main_task))

--- a/opengever/api/tests/test_templatefolder.py
+++ b/opengever/api/tests/test_templatefolder.py
@@ -10,6 +10,7 @@ from ftw.testing import freeze
 from opengever.base.response import IResponseContainer
 from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.base.role_assignments import SharingRoleAssignment
+from opengever.base.utils import get_date_with_delta_excluding_weekends
 from opengever.core.testing import toggle_feature
 from opengever.document.docprops import TemporaryDocFile
 from opengever.dossier.behaviors.dossier import IDossier
@@ -1080,7 +1081,8 @@ class TestTriggerTaskTemplatePost(IntegrationTestCase):
 
             main_task = children['added'].pop()
             self.assertEqual(
-                date.today() + timedelta(days=10 + 5), main_task.deadline)
+                get_date_with_delta_excluding_weekends(date.today() + timedelta(days=10), 5),
+                main_task.deadline)
 
     @browsing
     def test_create_parallel_tasks(self, browser):

--- a/opengever/api/tests/test_templatefolder.py
+++ b/opengever/api/tests/test_templatefolder.py
@@ -1626,13 +1626,13 @@ class TestTaskTemplateStructure(IntegrationTestCase):
 
         self.tasktemplate.deadline = 5
 
-        with freeze(datetime(2021, 12, 10)):
+        with freeze(datetime(2021, 12, 10)):  # Friday
             browser.open(
                 '{}/@task-template-structure'.format(
                     self.tasktemplatefolder.absolute_url()),
                 headers=self.api_headers)
 
-        self.assertEqual(u'2021-12-15', browser.json.get('items')[0].get('deadline'))
+        self.assertEqual(u'2021-12-17', browser.json.get('items')[0].get('deadline'))
 
     @browsing
     def test_include_static_is_private_attribute_for_tasktemplates(self, browser):

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -1,6 +1,5 @@
 from copy import deepcopy
 from datetime import date
-from datetime import timedelta
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.bumblebee.interfaces import IBumblebeeDocument
@@ -12,6 +11,7 @@ from hashlib import sha256
 from opengever.base.date_time import utcnow_tz_aware
 from opengever.base.default_values import get_persisted_values_for_obj
 from opengever.base.oguid import Oguid
+from opengever.base.utils import get_date_with_delta_excluding_weekends
 from opengever.contact.tests import create_contacts
 from opengever.inbox import FORWARDING_TASK_TYPE_ID
 from opengever.private.tests import create_members_folder
@@ -216,7 +216,7 @@ TASK_REQUIREDS = {
     'title': DEFAULT_TITLE,
 }
 TASK_DEFAULTS = {
-    'deadline': FROZEN_TODAY + timedelta(days=5),
+    'deadline': get_date_with_delta_excluding_weekends(FROZEN_TODAY, 5),
     'relatedItems': [],
     'informed_principals': [],
     'is_private': False,

--- a/opengever/base/tests/test_utils.py
+++ b/opengever/base/tests/test_utils.py
@@ -1,10 +1,14 @@
+from datetime import date
+from datetime import datetime
 from ftw.builder import Builder
 from ftw.builder import create
+from ftw.testing import freeze
 from ftw.testing import MockTestCase
 from mock import call
 from opengever.base.behaviors.utils import set_attachment_content_disposition
 from opengever.base.utils import escape_html
 from opengever.base.utils import file_checksum
+from opengever.base.utils import get_date_with_delta_excluding_weekends
 from opengever.base.utils import is_administrator
 from opengever.base.utils import is_manager
 from opengever.base.utils import safe_int
@@ -216,3 +220,27 @@ class TestIsManager(IntegrationTestCase):
         self.assertTrue(is_manager(user=self.manager))
         self.login(self.manager)
         self.assertTrue(is_manager())
+
+
+class TestGetDateWithDeltaExcludingWeekends(TestCase):
+
+    def test_get_date_with_delta_excluding_weekends_adds_the_day_offset(self):
+        # Freeze on monday
+        with freeze(datetime(2023, 3, 6, 0, 0)):
+            delta = 4
+            self.assertEqual(
+                date(2023, 3, 10),  # Friday
+                get_date_with_delta_excluding_weekends(datetime.today(), delta).date())
+
+    def test_get_date_with_delta_excluding_weekends_adds_the_day_offset_and_ignores_weekends(self):
+        # Freeze on monday
+        with freeze(datetime(2023, 3, 6, 0, 0)):
+            delta = 5
+            self.assertEqual(
+                date(2023, 3, 13),  # Next monday
+                get_date_with_delta_excluding_weekends(datetime.today(), delta).date())
+
+            delta = 20
+            self.assertEqual(
+                date(2023, 4, 3),  # Monday in one month
+                get_date_with_delta_excluding_weekends(datetime.today(), delta).date())

--- a/opengever/base/utils.py
+++ b/opengever/base/utils.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from opengever.base.exceptions import IncorrectConfigurationError
 from persistent.dict import PersistentDict
 from persistent.list import PersistentList
@@ -325,3 +326,13 @@ def unrestrictedUuidToCatalogBrain(uuid):
         return None
 
     return result[0]
+
+
+def get_date_with_delta_excluding_weekends(start_date, days_delta):
+    calculated_delta = 0
+    end_date = start_date
+    while calculated_delta < days_delta:
+        end_date = end_date + timedelta(days=1)
+        if end_date.weekday() not in [5, 6]:
+            calculated_delta += 1
+    return end_date

--- a/opengever/latex/tests/test_dossiertasks.py
+++ b/opengever/latex/tests/test_dossiertasks.py
@@ -57,7 +57,7 @@ class TestDossierTasksLaTeXView(FunctionalTestCase):
                                    issuer=self.user.userid,
                                    title="task 2"))
 
-        expected_deadline = datetime(2016, 4, 17, 0, 0)
+        expected_deadline = datetime(2016, 4, 19, 0, 0)
 
         with freeze(datetime(2016, 10, 12, 13, 20)):
             api.content.transition(task1, to_state='task-state-resolved')

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -4,7 +4,6 @@ from Acquisition import aq_inner
 from Acquisition import aq_parent
 from collective import dexteritytextindexer
 from datetime import datetime
-from datetime import timedelta
 from ftw.datepicker.widget import DatePickerFieldWidget
 from ftw.keywordwidget.widget import KeywordFieldWidget
 from ftw.tabbedview.interfaces import ITabbedviewUploadable
@@ -15,6 +14,7 @@ from opengever.base.response import IResponseSupported
 from opengever.base.security import as_internal_workflow_transition
 from opengever.base.security import elevated_privileges
 from opengever.base.source import DossierPathSourceBinder
+from opengever.base.utils import get_date_with_delta_excluding_weekends
 from opengever.dossier.utils import get_containing_dossier
 from opengever.dossier.utils import get_main_dossier
 from opengever.globalindex.model.task import Task as TaskModel
@@ -88,7 +88,7 @@ def deadline_default():
         interface=ITaskSettings,
     )
 
-    return (datetime.today() + timedelta(days=offset)).date()
+    return get_date_with_delta_excluding_weekends(datetime.today(), offset).date()
 
 
 class ITask(model.Schema):

--- a/opengever/task/tests/test_activities.py
+++ b/opengever/task/tests/test_activities.py
@@ -448,7 +448,7 @@ class TestTaskActivites(FunctionalTestCase):
         rows = browser.css('table').first.rows
         self.assertEquals(
             [['Task title', u'Unteraufgabe Abkl\xe4rung Fall Meier'],
-             ['Deadline', 'Mar 07, 2015'],
+             ['Deadline', 'Mar 09, 2015'],
              ['Task type', 'To comment'],
              ['Dossier title', 'Dossier XY'],
              ['Main task', u'Abkl\xe4rung Fall Meier'],

--- a/opengever/tasktemplates/browser/tasktemplates.py
+++ b/opengever/tasktemplates/browser/tasktemplates.py
@@ -100,7 +100,7 @@ class TaskTemplates(BaseCatalogListingTab):
 
         {'column': 'period',
          'sortable': False,
-         'column_title': _(u"label_deadline", default=u"Deadline in Days")},
+         'column_title': _(u"label_deadline", default=u"Deadline in workdays")},
 
         {'column': 'preselected',
          'column_title': _(u"label_preselected", default=u"Preselect"),

--- a/opengever/tasktemplates/content/tasktemplate.py
+++ b/opengever/tasktemplates/content/tasktemplate.py
@@ -1,6 +1,6 @@
 from datetime import date
-from datetime import timedelta
 from ftw.keywordwidget.widget import KeywordFieldWidget
+from opengever.base.utils import get_date_with_delta_excluding_weekends
 from opengever.ogds.base.utils import get_current_org_unit
 from opengever.task import util
 from opengever.task.util import update_reponsible_field_data
@@ -79,7 +79,7 @@ class ITaskTemplate(model.Schema):
     )
 
     deadline = schema.Int(
-        title=_(u"label_deadline", default=u"Deadline in Days"),
+        title=_(u"label_deadline", default=u"Deadline in workdays"),
         description=_('help_deadline', default=u""),
         required=True,
     )
@@ -104,7 +104,7 @@ class TaskTemplate(Item):
     implements(ITaskTemplate)
 
     def get_absolute_deadline(self):
-        return date.today() + timedelta(days=self.deadline)
+        return get_date_with_delta_excluding_weekends(date.today(), self.deadline)
 
 
 default_responsible_client = widget.ComputedWidgetAttribute(

--- a/opengever/tasktemplates/locales/de/LC_MESSAGES/opengever.tasktemplates.po
+++ b/opengever/tasktemplates/locales/de/LC_MESSAGES/opengever.tasktemplates.po
@@ -61,7 +61,7 @@ msgstr "Allgemein"
 
 #: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "help_deadline"
-msgstr "Frist in Tagen ab Startdatum der Aufgabe."
+msgstr "Frist in Arbeitstagen ab Startdatum der Aufgabe."
 
 #: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "help_issuer"
@@ -96,11 +96,11 @@ msgstr "Geben Sie eine detaillierte Arbeitsanweisung oder einen Kommentar ein."
 msgid "help_title"
 msgstr "Der Name der Aufgabe."
 
-#. Default: "Deadline in Days"
+#. Default: "Deadline in workdays"
 #: ./opengever/tasktemplates/browser/tasktemplates.py
 #: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "label_deadline"
-msgstr "Frist in Tagen"
+msgstr "Frist in Arbeitstagen"
 
 #. Default: "Issuer"
 #: ./opengever/tasktemplates/browser/tasktemplates.py

--- a/opengever/tasktemplates/locales/en/LC_MESSAGES/opengever.tasktemplates.po
+++ b/opengever/tasktemplates/locales/en/LC_MESSAGES/opengever.tasktemplates.po
@@ -68,10 +68,10 @@ msgstr "Nested TaskTemplateFolders are only supported in the new UI."
 msgid "fieldset_common"
 msgstr "Common"
 
-#. German translation: Frist in Tagen ab Startdatum der Aufgabe.
+#. German translation: Frist in Arbeitstagen ab Startdatum der Aufgabe.
 #: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "help_deadline"
-msgstr "Deadline in days after the task's start date."
+msgstr "Deadline in workdays after the task's start date."
 
 #. German translation: Wählen Sie einen Auftraggeber aus. Sie können auch die interaktiven Benutzer \"Federführender\" oder \"Sachbearbeiter\" auswählen.
 #: ./opengever/tasktemplates/content/tasktemplate.py
@@ -114,12 +114,12 @@ msgstr "Enter detailed instructions or a comment describing the work"
 msgid "help_title"
 msgstr "The task's title"
 
-#. German translation: Frist in Tagen
-#. Default: "Deadline in Days"
+#. German translation: Frist in Arbeitstagen
+#. Default: "Deadline in workdays"
 #: ./opengever/tasktemplates/browser/tasktemplates.py
 #: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "label_deadline"
-msgstr "Deadline in Days"
+msgstr "Deadline in workdays"
 
 #. German translation: Auftraggeber
 #. Default: "Issuer"

--- a/opengever/tasktemplates/locales/fr/LC_MESSAGES/opengever.tasktemplates.po
+++ b/opengever/tasktemplates/locales/fr/LC_MESSAGES/opengever.tasktemplates.po
@@ -63,7 +63,7 @@ msgstr "Général"
 
 #: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "help_deadline"
-msgstr "Délai en jours à partir de la date de début de la tâche."
+msgstr "Délai en jours ouvrables à partir de la date de début de la tâche."
 
 #: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "help_issuer"
@@ -98,11 +98,11 @@ msgstr "Saisie d'une instruction de travail détaillée ou d'un commentaire."
 msgid "help_title"
 msgstr "Nom de la tâche."
 
-#. Default: "Deadline in Days"
+#. Default: "Deadline in workdays"
 #: ./opengever/tasktemplates/browser/tasktemplates.py
 #: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "label_deadline"
-msgstr "Délai en jours"
+msgstr "Délai en jours ouvrables"
 
 #. Default: "Issuer"
 #: ./opengever/tasktemplates/browser/tasktemplates.py

--- a/opengever/tasktemplates/locales/opengever.tasktemplates.pot
+++ b/opengever/tasktemplates/locales/opengever.tasktemplates.pot
@@ -99,7 +99,7 @@ msgstr ""
 msgid "help_title"
 msgstr ""
 
-#. Default: "Deadline in Days"
+#. Default: "Deadline in workdays"
 #: ./opengever/tasktemplates/browser/tasktemplates.py
 #: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "label_deadline"

--- a/opengever/tasktemplates/tasktemplatefolder.py
+++ b/opengever/tasktemplates/tasktemplatefolder.py
@@ -2,6 +2,7 @@ from Acquisition import aq_inner
 from Acquisition import aq_parent
 from datetime import date
 from datetime import timedelta
+from opengever.base.utils import get_date_with_delta_excluding_weekends
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.ogds.base.actor import ActorLookup
 from opengever.ogds.base.actor import INTERACTIVE_ACTOR_CURRENT_USER_ID
@@ -186,14 +187,14 @@ class ProcessDataPreprocessor(object):
                 longest_deadline = max(longest_deadline, deadline)
 
             if data.get("deadline") is None:
-                data["deadline"] = longest_deadline + self.default_deadline_timedelta
+                data["deadline"] = get_date_with_delta_excluding_weekends(
+                    longest_deadline, self.default_deadline_timedelta)
         return data["deadline"]
 
     @property
     def default_deadline_timedelta(self):
-        deadline_timedelta = api.portal.get_registry_record(
+        return api.portal.get_registry_record(
             'deadline_timedelta', interface=ITaskSettings)
-        return timedelta(deadline_timedelta)
 
     def replace_interactive_actors(self, data):
         if ActorLookup(data.get('issuer')).is_interactive_actor():

--- a/opengever/tasktemplates/tests/test_tasktemplate.py
+++ b/opengever/tasktemplates/tests/test_tasktemplate.py
@@ -20,7 +20,7 @@ class TestTaskTemplates(SolrIntegrationTestCase):
         browser.fill(
             {'Title': 'Arbeitsplatz einrichten.',
              'Task type': 'comment',
-             'Deadline in Days': u'10'})
+             'Deadline in workdays': u'10'})
 
         form = browser.find_form_by_field('Responsible')
         form.find_widget('Responsible').fill(self.dossier_responsible)
@@ -95,7 +95,7 @@ class TestTaskTemplates(SolrIntegrationTestCase):
         browser.fill(
             {'Title': 'Arbeitsplatz einrichten.',
              'Task type': 'comment',
-             'Deadline in Days': u'10'})
+             'Deadline in workdays': u'10'})
 
         form = browser.find_form_by_field('Responsible')
         form.find_widget('Responsible').fill('team:1')
@@ -120,7 +120,7 @@ class TestTaskTemplates(SolrIntegrationTestCase):
         browser.fill(
             {'Title': 'Arbeitsplatz einrichten.',
              'Task type': 'comment',
-             'Deadline in Days': u'10'})
+             'Deadline in workdays': u'10'})
 
         form = browser.find_form_by_field('Responsible')
         form.find_widget('Responsible').fill(INTERACTIVE_ACTOR_RESPONSIBLE_ID)
@@ -203,7 +203,7 @@ class TestTaskTemplates(SolrIntegrationTestCase):
         browser.fill(
             {'Title': 'Arbeitsplatz einrichten.',
              'Task type': 'comment',
-             'Deadline in Days': u'10'})
+             'Deadline in workdays': u'10'})
 
         form = browser.find_form_by_field('Responsible')
         form.find_widget('Issuer').fill(INTERACTIVE_ACTOR_RESPONSIBLE_ID)
@@ -223,17 +223,18 @@ class TestTaskTemplates(SolrIntegrationTestCase):
         # Get the cells in the column "deadline".
         cells = [row.css('td').first
                  for row in browser.css('.task-listing tr')
-                 if len(row.css('th')) and row.css('th').first.text == 'Deadline in Days']
+                 if len(row.css('th')) and row.css('th').first.text == 'Deadline in workdays']
 
         self.assertEquals(
             ["10"],
             [cell.text for cell in cells]
         )
 
-    def test_get_absolute_deadline_returns_the_resolved_deadline(self):
+    def test_get_absolute_deadline_returns_the_resolved_deadline_excluding_weekends(self):
         self.login(self.administrator)
 
         self.tasktemplate.deadline = 5
 
-        with freeze(datetime(2021, 12, 10)):
-            self.assertEqual(date(2021, 12, 15), self.tasktemplate.get_absolute_deadline())
+        # Freeze on monday
+        with freeze(datetime(2023, 3, 6, 0, 0)):
+            self.assertEqual(date(2023, 3, 13), self.tasktemplate.get_absolute_deadline())

--- a/opengever/tasktemplates/tests/test_trigger.py
+++ b/opengever/tasktemplates/tests/test_trigger.py
@@ -6,6 +6,7 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser.pages.dexterity import erroneous_fields
 from ftw.testbrowser.pages.statusmessages import error_messages
 from ftw.testbrowser.pages.statusmessages import info_messages
+from opengever.base.utils import get_date_with_delta_excluding_weekends
 from opengever.ogds.base.actor import INTERACTIVE_ACTOR_CURRENT_USER_ID
 from opengever.ogds.base.actor import INTERACTIVE_ACTOR_RESPONSIBLE_ID
 from opengever.tasktemplates.content.tasktemplate import ITaskTemplate
@@ -177,14 +178,16 @@ class TestTriggeringTaskTemplate(IntegrationTestCase):
                           api.content.get_state(main_task))
 
     @browsing
-    def test_main_task_deadline_is_the_highest_template_deadline_plus_five(self, browser):
+    def test_main_task_deadline_is_the_highest_template_deadline_plus_five_working_days(self, browser):
         self.login(self.regular_user, browser=browser)
+
         self.trigger_tasktemplatefolder(
             browser, templates=['Arbeitsplatz einrichten.'])
 
         main_task = self.dossier.listFolderContents()[-1]
         self.assertEquals(
-            date.today() + timedelta(days=10 + 5), main_task.deadline)
+            get_date_with_delta_excluding_weekends(date.today() + timedelta(days=10), 5),
+            main_task.deadline)
 
     @browsing
     def test_all_tasks_are_marked_with_marker_interface(self, browser):


### PR DESCRIPTION
We can configure a relative deadline for tasks and tasktemplates in days.

This PR changes the behavior of the absolute deadline calculation by skipping weekends.

Before this change, a deadline offset of 5 on monday would return the saturday, with this change, it returns the next monday.

For [CA-5251]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-5251]: https://4teamwork.atlassian.net/browse/CA-5251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ