### PR TITLE
ogcore docker image: Send ftw.upgrade's stats log to /dev/null:

### DIFF
--- a/changes/CA-5405.other
+++ b/changes/CA-5405.other
@@ -1,0 +1,1 @@
+ogcore docker image: Send ftw.upgrade's stats log to /dev/null [lgraf]

--- a/docker/core/Dockerfile
+++ b/docker/core/Dockerfile
@@ -56,6 +56,8 @@ RUN mkdir -p /app/var/log \
  && ln -sf /dev/stdout /app/var/log/instance-json.log \
  && ln -sf /dev/stdout /app/var/log/solr-maintenance.log
 
+RUN ln -sf /dev/null /app/var/log/upgrade_stats.csv
+
 # Patch ftw.bumblebee to use time.time() for timestamp generation
 # datetime.now().strftime('%s') does not return the same on Alpine Linux (musl)
 # https://www.openwall.com/lists/musl/2018/01/18/3


### PR DESCRIPTION
We symlink ftw.upgrade's `upgrade_stats.csv` to /dev/null, because otherwise ftw.upgrade will try to create it during upgrades, and will fail because of insufficient permissions.

Because we don't actually care about the contents of this logfile, we can just discard its content instead of redirecting it somewhere else.

For [CA-5405](https://4teamwork.atlassian.net/browse/CA-5405)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
