### PR TITLE
Empty subdossiers can be deleted even if the main dossier is linked with a workspace

### DIFF
--- a/changes/CA-5506.bugfix
+++ b/changes/CA-5506.bugfix
@@ -1,0 +1,1 @@
+Empty subdossiers can be deleted even if the main dossier is linked with a workspace. [elioschmutz]

--- a/opengever/base/browser/folder_buttons_availability.py
+++ b/opengever/base/browser/folder_buttons_availability.py
@@ -178,5 +178,5 @@ class FolderButtonsAvailabilityView(BrowserView):
         if not self._can_use_workspace_client():
             return False
 
-        linked_workspaces_manager = ILinkedWorkspaces(self.context.get_main_dossier())
+        linked_workspaces_manager = ILinkedWorkspaces(self.context)
         return linked_workspaces_manager.has_linked_workspaces()

--- a/opengever/dossier/tests/test_actions.py
+++ b/opengever/dossier/tests/test_actions.py
@@ -153,7 +153,7 @@ class TestWorkspaceClientDossierContextActions(FunctionalWorkspaceClientTestCase
         with self.workspace_client_env():
             self.link_workspace(self.dossier)
             subdossier = create(Builder('dossier').within(self.dossier))
-            expected_actions = [u'copy_documents_to_workspace', u'document_with_template', u'edit',
+            expected_actions = [u'copy_documents_to_workspace', u'delete', u'document_with_template', u'edit',
                                 u'export_pdf', u'list_workspaces', u'pdf_dossierdetails',
                                 u'zipexport']
 


### PR DESCRIPTION
This PR fixes an issue where it was not possible to remove empty subdossiers if the main dossier was linked to a workspace.

For [CA-5506]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-5506]: https://4teamwork.atlassian.net/browse/CA-5506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ