### PR TITLE
Improve workspace client

### DIFF
--- a/changes/CA-5508.other
+++ b/changes/CA-5508.other
@@ -1,0 +1,1 @@
+Refine the workspace-client to improve debugging. [elioschmutz]

--- a/opengever/base/browser/folder_buttons_availability.py
+++ b/opengever/base/browser/folder_buttons_availability.py
@@ -132,6 +132,7 @@ class FolderButtonsAvailabilityView(BrowserView):
     def is_unlink_workspace_available(self):
         return (self._is_main_dossier()
                 and self._can_unlink_workspace()
+                and self._can_use_workspace_client()
                 and self._has_linked_workspaces())
 
     def is_move_items_available(self):
@@ -175,8 +176,5 @@ class FolderButtonsAvailabilityView(BrowserView):
         return not self._is_template_area()
 
     def _has_linked_workspaces(self):
-        if not self._can_use_workspace_client():
-            return False
-
         linked_workspaces_manager = ILinkedWorkspaces(self.context)
         return linked_workspaces_manager.has_linked_workspaces()

--- a/opengever/workspaceclient/client.py
+++ b/opengever/workspaceclient/client.py
@@ -14,18 +14,17 @@ class WorkspaceClient(object):
     REST API. It is instantiated for the current logged in user.
     """
 
-    def __init__(self):
+    @property
+    def session(self):
+        """We always need to invoke a new workspace-session. Otherwise it is
+        possible to dispatch a request with another users session.
+        """
         if not is_workspace_client_feature_available():
             raise WorkspaceClientFeatureNotEnabled()
 
         if not self.workspace_url:
             raise WorkspaceURLMissing()
 
-    @property
-    def session(self):
-        """We always need to invoke a new workspace-session. Otherwise it is
-        possible to dispatch a request with another users session.
-        """
         if not api.user.has_permission('opengever.workspaceclient: Use Workspace Client'):
             raise Unauthorized("User does not have permission to use the WorkspaceClient")
         return WorkspaceSession(self.workspace_url,

--- a/opengever/workspaceclient/linked_workspaces.py
+++ b/opengever/workspaceclient/linked_workspaces.py
@@ -499,7 +499,7 @@ class LinkedWorkspaces(object):
     def has_linked_workspaces(self):
         """Returns true if the current context has linked workspaces
         """
-        return self.list().get('items_total', 0) > 0
+        return self.number_of_linked_workspaces() > 0
 
     def move_workspace_links_to_main_dossier(self):
         """Called by event handler when a dossier gets moved in to a subdossier.

--- a/opengever/workspaceclient/tests/test_client.py
+++ b/opengever/workspaceclient/tests/test_client.py
@@ -13,14 +13,16 @@ import transaction
 class TestWorkspaceClient(FunctionalWorkspaceClientTestCase):
 
     def test_raises_an_error_if_using_the_client_with_disabled_feature(self):
+        client = WorkspaceClient()
         self.enable_feature(False)
         with self.assertRaises(WorkspaceClientFeatureNotEnabled):
-            WorkspaceClient()
+            client.get('/')
 
     def test_raises_an_error_if_the_workspace_url_is_not_configured(self):
+        client = WorkspaceClient()
         with self.env(TEAMRAUM_URL=''):
             with self.assertRaises(WorkspaceURLMissing):
-                WorkspaceClient()
+                client.get('/')
 
     def test_raises_an_error_if_user_lacks_neccesary_permissions(self):
         with self.workspace_client_env() as client:

--- a/opengever/workspaceclient/tests/test_linked_workspaces.py
+++ b/opengever/workspaceclient/tests/test_linked_workspaces.py
@@ -423,14 +423,13 @@ class TestLinkedWorkspaces(FunctionalWorkspaceClientTestCase):
             self.assertFalse(ILockable(mail).locked())
 
     def test_has_linked_workspaces(self):
-        with self.workspace_client_env():
-            manager = ILinkedWorkspaces(self.dossier)
+        manager = ILinkedWorkspaces(self.dossier)
 
-            self.assertFalse(manager.has_linked_workspaces())
+        self.assertFalse(manager.has_linked_workspaces())
 
-            manager.storage.add(self.workspace.UID())
+        manager.storage.add(self.workspace.UID())
 
-            self.assertTrue(manager.has_linked_workspaces())
+        self.assertTrue(manager.has_linked_workspaces())
 
     def test_list_documents_in_linked_workspace_raises_if_workspace_is_not_linked(self):
         with self.workspace_client_env():


### PR DESCRIPTION
This PR improves the following points:

- We do no longer validate the configuration if initializing the `WorkspaceClient`. We do it if we really need a session to make requests to the remote system. This makes debugging much easier and it allows us to use non remote system related methods for the `WorkspaceClient` or the `LinkedWorkspaces`. 
- We do no longer use the workspace client to determine if a dossier is linked to a workspace but the `LinkedWorkspacesStorage` instead. This makes it possible to check if there are linked workspaces even if we do not have access to the remote system

For [CA-5508]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-5508]: https://4teamwork.atlassian.net/browse/CA-5508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ