### PR TITLE
Add duplicate-strategies to the @globalindex endpoint.

### DIFF
--- a/changes/CA-5446.feature
+++ b/changes/CA-5446.feature
@@ -1,0 +1,1 @@
+Add duplicate-strategies to the @globalindex endpoint. [elioschmutz]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -12,6 +12,8 @@ Breaking Changes
 Other Changes
 ^^^^^^^^^^^^^
 
+- Add duplicate-strategies to the ``@globalindex`` endpoint.
+
 2023.4.0 (2023-03-09)
 ---------------------
 

--- a/docs/public/dev-manual/api/globalindex.rst
+++ b/docs/public/dev-manual/api/globalindex.rst
@@ -84,6 +84,17 @@ Facetten
 ~~~~~~~~
 - ``facets``: Liste von Feldern für die Facetten Wertebereiche zurückgegeben werden sollen.
 
+Duplikate
+~~~~~~~~~
+Bei mandantenübergreifenden Aufgaben wird nur eine der beiden Aufgabe zurückgebeben. Über die ``duplicate_strategy`` option kann gesteuert werden,
+welche Aufgabe bei Aufgaben-Pärchen zurückgegeben werden soll.
+
+Folgende Strategien stehen zur Verfügung:
+- ``duplicate_strategy``:
+  - ``local`` (Standard): Gibt immer die Aufgabe vom aktuellen Mandanten zurück. Wenn sich das Pärchen auf anderen Mandanten befindet, wird keine der beiden Aufgaben zurückgegeben.
+  - ``predecessor_task``: Gibt immer die Haupt-Aufgabe zurück, unabhängig davon, auf welchem Manden man sich aktuell befindet.
+  - ``successor_task``: Gibt immer die Nachfolge-Aufgabe zurück, unabhängig davon, auf welchem Manden man sich aktuell befindet.
+
 
 **Beispiel: Filtern nach erledigten und abgeschlossenen Aufgaben:**
 
@@ -111,4 +122,11 @@ Facetten
   .. sourcecode:: http
 
     GET /@globalindex?facets:list=review_state&facets:list=responsible HTTP/1.1
+    Accept: application/json
+
+**Beispiel: Bei Duplikaten immer die Hauptaufgabe zurückgeben:**
+
+  .. sourcecode:: http
+
+    GET /@globalindex?duplicate_strategy=predecessor_task HTTP/1.1
     Accept: application/json

--- a/opengever/api/globalindex.py
+++ b/opengever/api/globalindex.py
@@ -1,6 +1,7 @@
 from opengever.api.ogdslistingbase import OGDSListingBaseService
 from opengever.api.solr_query_service import DEFAULT_SORT_INDEX
 from opengever.base.helpers import display_name
+from opengever.globalindex.model.task import AVOID_DUPLICATES_STRATEGY_LOCAL
 from opengever.globalindex.model.task import Task
 from opengever.ogds.models.group import Group
 from opengever.ogds.models.group import groups_users
@@ -79,4 +80,6 @@ class GlobalIndexGet(OGDSListingBaseService):
         return query
 
     def get_base_query(self):
-        return Task.query.restrict().avoid_duplicates()
+        strategy = self.request.form.get('duplicate_strategy',
+                                         AVOID_DUPLICATES_STRATEGY_LOCAL)
+        return Task.query.restrict().avoid_duplicates(strategy=strategy)

--- a/opengever/globalindex/model/task.py
+++ b/opengever/globalindex/model/task.py
@@ -591,16 +591,13 @@ class TaskQuery(BaseQuery):
                 TaskPrincipal.principal.in_(principals))
         return self.filter(Task.task_id.in_(principal_query))
 
-    def avoid_duplicates(self, admin_unit_id=None):
+    def avoid_duplicates(self):
         """Avoid duplicates and only list one task if a task has a successor.
 
-        If a task has a successor task, list only the task that is on a
-        specified admin unit. Hence, for tasks with a successor, the query
+        If a task has a successor task, list only the task that is on the
+        current admin unit. Hence, for tasks with a successor, the query
         will by default only return tasks that are on the local admin unit.
         """
-        if admin_unit_id is None:
-            admin_unit_id = get_current_admin_unit().id()
-
         return self.filter(
             or_(
                 and_(Task.predecessor == None, Task.successors == None),  # noqa

--- a/opengever/globalindex/model/task.py
+++ b/opengever/globalindex/model/task.py
@@ -566,6 +566,11 @@ class Task(Base):
             return main_task.title
 
 
+AVOID_DUPLICATES_STRATEGY_LOCAL = 'local'
+AVOID_DUPLICATES_STRATEGY_SUCCESSOR_TASK = 'successor_task'
+AVOID_DUPLICATES_STRATEGY_PREDECESSOR_TASK = 'predecessor_task'
+
+
 class TaskQuery(BaseQuery):
 
     roles_allowed_to_see_tasks = ('Manager', 'Administrator', 'LimitedAdmin', 'Reader')
@@ -591,19 +596,48 @@ class TaskQuery(BaseQuery):
                 TaskPrincipal.principal.in_(principals))
         return self.filter(Task.task_id.in_(principal_query))
 
-    def avoid_duplicates(self):
+    def avoid_duplicates(self, strategy=AVOID_DUPLICATES_STRATEGY_LOCAL):
         """Avoid duplicates and only list one task if a task has a successor.
 
+        Available strategies are:
+
+        local (default):
         If a task has a successor task, list only the task that is on the
         current admin unit. Hence, for tasks with a successor, the query
         will by default only return tasks that are on the local admin unit.
+
+        successor_task:
+        If a task has a successor task, always return the successor task
+
+        predecessor_task:
+        If a task has a predecessor, always return the predecessor task
         """
-        return self.filter(
-            or_(
-                and_(Task.predecessor == None, Task.successors == None),  # noqa
-                Task.admin_unit_id == get_current_admin_unit().id()
+        if strategy == AVOID_DUPLICATES_STRATEGY_LOCAL:
+            return self.filter(
+                or_(
+                    and_(Task.predecessor == None, Task.successors == None),  # noqa
+                    Task.admin_unit_id == get_current_admin_unit().id()
+                )
             )
-        )
+
+        if strategy == AVOID_DUPLICATES_STRATEGY_SUCCESSOR_TASK:
+            return self.filter(
+                or_(
+                    and_(Task.predecessor == None, Task.successors == None),  # noqa
+                    Task.predecessor != None  # noqa
+                )
+            )
+
+        elif strategy == AVOID_DUPLICATES_STRATEGY_PREDECESSOR_TASK:
+            return self.filter(
+                or_(
+                    and_(Task.predecessor == None, Task.successors == None),  # noqa
+                    Task.successors != None  # noqa
+                )
+            )
+
+        else:
+            raise NotImplementedError()
 
     def users_tasks(self, userid):
         """Returns query which List all tasks where the given user,

--- a/opengever/globalindex/tests/test_query.py
+++ b/opengever/globalindex/tests/test_query.py
@@ -3,9 +3,11 @@ from ftw.builder import create
 from opengever.base.oguid import Oguid
 from opengever.base.security import elevated_privileges
 from opengever.globalindex.model.task import Task
+from opengever.ogds.base.interfaces import IAdminUnitConfiguration
 from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.testing import IntegrationTestCase
 from opengever.testing import obj2brain
+from plone.registry.interfaces import IRegistry
 from sqlalchemy.orm.exc import NoResultFound
 from zope.app.intid.interfaces import IIntIds
 from zope.component import getUtility
@@ -244,3 +246,49 @@ class TestTaskQueries(IntegrationTestCase):
         self.assertEqual(
             [],
             Task.query.subtasks_by_task(self.expired_task.get_sql_object()).all())
+
+    def test_avoid_duplicates_returns_all_single_unit_tasks(self):
+        self.login(self.regular_user)
+
+        self.assertEqual(
+            set([]),
+            set(Task.query.all()) - set(Task.query.avoid_duplicates().all()))
+
+    def test_avoid_duplicates_excludes_task_on_remote_system_if_a_task_has_predecessor(self):
+        self.login(self.regular_user)
+        create(Builder('admin_unit').id('remote').having(title='Remote'))
+        registry = getUtility(IRegistry)
+        proxy = registry.forInterface(IAdminUnitConfiguration)
+
+        successor = Task.query.all()[0]
+        predecessor = Task.query.all()[1]
+
+        successor.predecessor = predecessor
+        predecessor.admin_unit_id = 'remote'
+
+        self.assertEqual(
+            set([predecessor]),
+            set(Task.query.all()) - set(Task.query.avoid_duplicates().all()))
+
+        proxy.current_unit_id = u'remote'
+
+        self.assertEqual(
+            set([successor]),
+            set(Task.query.all()) - set(Task.query.avoid_duplicates().all()))
+
+    def test_avoid_duplicates_excludes_task_pair_if_on_a_third_admin_unit(self):
+        self.login(self.regular_user)
+        create(Builder('admin_unit').id('unit-3').having(title='Remote'))
+        registry = getUtility(IRegistry)
+        proxy = registry.forInterface(IAdminUnitConfiguration)
+        proxy.current_unit_id = u'unit-3'
+
+        successor = Task.query.all()[0]
+        predecessor = Task.query.all()[1]
+
+        successor.predecessor = predecessor
+        predecessor.admin_unit_id = 'unit-2'
+
+        self.assertEqual(
+            set([successor, predecessor]),
+            set(Task.query.all()) - set(Task.query.avoid_duplicates().all()))


### PR DESCRIPTION
This PR implements an additional option called `duplicate_strategy` for the `@globalindex` endpoint.

This options allows us to change the behavior of which task should be returned for successor/predecessor task pairs.

We need this, because we sometimes need to change this behavior depending on the purpose of the request.

One use case is i.e. to get all tasks which I issued. In that case, I usually want the `predecessor_task` strategy which would always return the main task if there is also a predecessor task.

Providing this feature allows us to fix an issue in the frontend where the user does not see his tasks if requesting the `@globalindex` endpoint from a third admin unit.

For [CA-5446]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-5446]: https://4teamwork.atlassian.net/browse/CA-5446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ