### PR TITLE
Handle extra address lines and use correct address for memberships in address block

### DIFF
--- a/changes/CA-5545.feature
+++ b/changes/CA-5545.feature
@@ -1,0 +1,1 @@
+Handle extra address lines in address block. [njohner]

--- a/changes/CA-5546.bugfix
+++ b/changes/CA-5546.bugfix
@@ -1,0 +1,1 @@
+Use membership's primary address for the address block. [njohner]

--- a/opengever/api/tests/test_templatefolder.py
+++ b/opengever/api/tests/test_templatefolder.py
@@ -437,7 +437,7 @@ class TestDocumentFromTemplatePostWithKubFeatureEnabled(KuBIntegrationTestCase):
         self.assertEqual(u'New d\xf6cument', document.title)
 
         expected_doc_properties = self.expected_doc_properties + [
-            ('ogg.sender.address.block', '4Teamwork\nHerr Jean Dupont\nDammweg 9\n3013 Bern'),
+            ('ogg.sender.address.block', '4Teamwork\nHerr Jean Dupont\nc/o John Doe\nDammweg 9\n3013 Bern'),
             ('ogg.sender.address.city', 'Bern'),
             ('ogg.sender.address.country', 'Schweiz'),
             ('ogg.sender.address.extra_line_1', 'c/o John Doe'),

--- a/opengever/base/addressblock/addressblock.py
+++ b/opengever/base/addressblock/addressblock.py
@@ -38,6 +38,10 @@ class AddressBlockData(object):
         self.street_and_no = kwargs.get('street_and_no')
         self.po_box = kwargs.get('po_box')
 
+        # Extra address lines
+        self.extra_line_1 = kwargs.get('extra_line_1')
+        self.extra_line_2 = kwargs.get('extra_line_2')
+
         # Postal code and city
         self.postal_code = kwargs.get('postal_code')
         self.city = kwargs.get('city')
@@ -85,6 +89,9 @@ class AddressBlockData(object):
                     self.first_name,
                     self.last_name,
                 ))
+
+        lines.append(self.extra_line_1)
+        lines.append(self.extra_line_2)
 
         if self.is_po_box_address():
             # Technically, an address could contain both Street+Number and a

--- a/opengever/base/addressblock/extraction.py
+++ b/opengever/base/addressblock/extraction.py
@@ -77,10 +77,7 @@ class KuBAddressDataExtractor(object):
             last_name = provider.person.get('officialName')
 
         # Localization data (Street or PO Box, Postal Code, City)
-        if is_organization or is_membership:
-            addressed_entity = provider.organization
-        else:
-            addressed_entity = provider.person
+        addressed_entity = provider.membership_person_or_organization
 
         addressed_location = addressed_entity.get('primaryAddress')
         if not addressed_location:

--- a/opengever/base/addressblock/extraction.py
+++ b/opengever/base/addressblock/extraction.py
@@ -90,6 +90,8 @@ class KuBAddressDataExtractor(object):
         house_no = addressed_location.get('houseNumber')
         street_tokens = filter(None, [street, house_no])
         street_and_no = u' '.join(street_tokens)
+        extra_line_1 = addressed_location.get("addressLine1")
+        extra_line_2 = addressed_location.get("addressLine2")
         # XXX: KuB also shows 'dwellingNumber' and 'locality' in API, but
         # there's no way to edit those fields it seems.
 
@@ -111,6 +113,8 @@ class KuBAddressDataExtractor(object):
             first_name=first_name,
             last_name=last_name,
 
+            extra_line_1=extra_line_1,
+            extra_line_2=extra_line_2,
             street_and_no=street_and_no,
             po_box=po_box,
 

--- a/opengever/base/addressblock/tests/test_address_formatting.py
+++ b/opengever/base/addressblock/tests/test_address_formatting.py
@@ -29,6 +29,30 @@ class TestAddressFormatting(TestCase):
         """)
         self.assertEqual(expected, block.format())
 
+    def test_private_address_with_extra_lines(self):
+        block = AddressBlockData(
+            salutation=u'Herr',
+            academic_title=u'Dr.',
+            first_name=u'Fridolin',
+            last_name=u'M\xfcller',
+
+            street_and_no=u'Murtenstrasse 42',
+            postal_code=u'3008',
+            city=u'Bern',
+            extra_line_1=u'c/o John Doe',
+            extra_line_2=u'who knows what comes here'
+        )
+
+        expected = addr(u"""
+        Herr
+        Dr. Fridolin M\xfcller
+        c/o John Doe
+        who knows what comes here
+        Murtenstrasse 42
+        3008 Bern
+        """)
+        self.assertEqual(expected, block.format())
+
     def test_org_address(self):
         block = AddressBlockData(
             org_name=u'Fabasoft 4teamwork AG',
@@ -62,6 +86,30 @@ class TestAddressFormatting(TestCase):
         expected = addr(u"""
         Fabasoft 4teamwork AG
         Herr Dr. Fridolin M\xfcller
+        Dammweg 9
+        3012 Bern
+        """)
+        self.assertEqual(expected, block.format())
+
+    def test_org_address_addressed_to_person_with_extra_lines(self):
+        block = AddressBlockData(
+            salutation=u'Herr',
+            academic_title=u'Dr.',
+            first_name=u'Fridolin',
+            last_name=u'M\xfcller',
+
+            extra_line_1=u'en extra address line',
+            org_name=u'Fabasoft 4teamwork AG',
+
+            street_and_no=u'Dammweg 9',
+            postal_code=u'3012',
+            city=u'Bern',
+        )
+
+        expected = addr(u"""
+        Fabasoft 4teamwork AG
+        Herr Dr. Fridolin M\xfcller
+        en extra address line
         Dammweg 9
         3012 Bern
         """)

--- a/opengever/base/addressblock/tests/test_extraction.py
+++ b/opengever/base/addressblock/tests/test_extraction.py
@@ -107,6 +107,11 @@ class TestKuBEntityAddressExtraction(KuBIntegrationTestCase):
         self.mock_get_by_id(mocker, self.memb_jean_ftw)
         entity = KuBEntity(self.memb_jean_ftw)
 
+        # as the organisation primaryAddress is the same as that of the
+        # the membership, we modify the data, so that we can make sure the
+        # primaryAddress comes from the membership
+        entity.data["primaryAddress"]["addressLine2"] = "membership extra 2"
+
         block = IAddressBlockData(entity)
 
         expected = {
@@ -120,7 +125,7 @@ class TestKuBEntityAddressExtraction(KuBIntegrationTestCase):
             'street_and_no': u'Dammweg 9',
             'po_box': u'',
             'extra_line_1': u'c/o John Doe',
-            'extra_line_2': u'',
+            'extra_line_2': u'membership extra 2',
 
             'postal_code': u'3013',
             'city': u'Bern',

--- a/opengever/base/addressblock/tests/test_extraction.py
+++ b/opengever/base/addressblock/tests/test_extraction.py
@@ -34,6 +34,8 @@ class TestOGDSUserAddressExtraction(IntegrationTestCase):
 
             'street_and_no': u'Murtenstrasse 42',
             'po_box': None,
+            'extra_line_1': None,
+            'extra_line_2': None,
 
             'postal_code': u'3008',
             'city': u'Bern',
@@ -67,6 +69,8 @@ class TestKuBEntityAddressExtraction(KuBIntegrationTestCase):
 
             'street_and_no': u'Teststrasse 43',
             'po_box': u'',
+            'extra_line_1': u'',
+            'extra_line_2': u'',
 
             'postal_code': u'9999',
             'city': u'Bern',
@@ -90,6 +94,8 @@ class TestKuBEntityAddressExtraction(KuBIntegrationTestCase):
 
             'street_and_no': u'Dammweg 9',
             'po_box': u'',
+            'extra_line_1': u'c/o John Doe',
+            'extra_line_2': u'',
 
             'postal_code': u'3013',
             'city': u'Bern',
@@ -113,6 +119,8 @@ class TestKuBEntityAddressExtraction(KuBIntegrationTestCase):
 
             'street_and_no': u'Dammweg 9',
             'po_box': u'',
+            'extra_line_1': u'c/o John Doe',
+            'extra_line_2': u'',
 
             'postal_code': u'3013',
             'city': u'Bern',
@@ -168,6 +176,8 @@ class TestKuBEntityAddressExtraction(KuBIntegrationTestCase):
 
             'street_and_no': u'',
             'po_box': None,
+            'extra_line_1': None,
+            'extra_line_2': None,
 
             'postal_code': None,
             'city': None,

--- a/opengever/kub/tests/test_docprops.py
+++ b/opengever/kub/tests/test_docprops.py
@@ -76,7 +76,7 @@ class TestKuBEntityDocPropertyProvider(KuBIntegrationTestCase):
         entity = KuBEntity(self.org_ftw)
         properties = KuBEntityDocPropertyProvider(entity).get_properties()
         self.assertDictEqual(
-            {'ogg.address.block': u'4Teamwork\nDammweg 9\n3013 Bern',
+            {'ogg.address.block': u'4Teamwork\nc/o John Doe\nDammweg 9\n3013 Bern',
              'ogg.address.city': u'Bern',
              'ogg.address.country': u'Schweiz',
              'ogg.address.extra_line_1': u'c/o John Doe',
@@ -97,7 +97,7 @@ class TestKuBEntityDocPropertyProvider(KuBIntegrationTestCase):
         entity = KuBEntity(self.memb_jean_ftw)
         properties = KuBEntityDocPropertyProvider(entity).get_properties()
         self.assertDictEqual(
-            {'ogg.address.block': u'4Teamwork\nHerr Jean Dupont\nDammweg 9\n3013 Bern',
+            {'ogg.address.block': u'4Teamwork\nHerr Jean Dupont\nc/o John Doe\nDammweg 9\n3013 Bern',
              'ogg.address.city': u'Bern',
              'ogg.address.country': u'Schweiz',
              'ogg.address.extra_line_1': u'c/o John Doe',


### PR DESCRIPTION
For [CA-5545] and [CA-5546]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-5545]: https://4teamwork.atlassian.net/browse/CA-5545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CA-5546]: https://4teamwork.atlassian.net/browse/CA-5546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ