### PR TITLE
Make sure to register @ogds-sync file logger only once.

### DIFF
--- a/changes/CA-5516.bugfix
+++ b/changes/CA-5516.bugfix
@@ -1,0 +1,1 @@
+Make sure to register @ogds-sync file logger only once. [njohner]

--- a/opengever/ogds/base/sync/ogds_updater.py
+++ b/opengever/ogds/base/sync/ogds_updater.py
@@ -143,12 +143,17 @@ def sync_ogds(plone, users=True, groups=True, local_groups=False,
 def setup_ogds_sync_logfile(logger):
     """Sets up logging to a rotating var/log/ogds-update.log.
     """
+    handler_name = "ogds_update"
+    for handler in logger.handlers:
+        if isinstance(handler, TimedRotatingFileHandler) and handler.get_name() == handler_name:
+            return
     log_dir = PathFinder().var_log
     file_handler = TimedRotatingFileHandler(
         os.path.join(log_dir, 'ogds-update.log'),
         when='midnight', backupCount=7)
     file_handler.setLevel(logging.INFO)
     file_handler.setFormatter(logging.Formatter(LOG_FORMAT))
+    file_handler.set_name(handler_name)
     logger.addHandler(file_handler)
 
 


### PR DESCRIPTION
Re-registering a file hander every time the ogds sync is called works fine when it is run as a zope control command, but when it is called over the API, i.e. on a running instance, we should only register the file handler once.

For [CA-5516]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-5516]: https://4teamwork.atlassian.net/browse/CA-5516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ