### PR TITLE
Fix workspace invitation redirects for already accepted invitations.

### DIFF
--- a/changes/CA-5546.bugfix
+++ b/changes/CA-5546.bugfix
@@ -1,1 +1,1 @@
-Use membership's primary address for the address block. [njohner]
+Fix workspace invitation redirects for already accepted invitations. [phgross]

--- a/opengever/workspace/participation/browser/my_invitations.py
+++ b/opengever/workspace/participation/browser/my_invitations.py
@@ -141,7 +141,7 @@ class MyWorkspaceInvitations(BrowserView):
                 return self.request.RESPONSE.redirect(target_workspace.absolute_url())
             elif not payload.get("no_redirect"):
                 params = {'next': target_workspace.absolute_url()}
-                redirect_url = "{}/login?{}".format(
+                redirect_url = "{}?{}".format(
                     get_gever_portal_url(), urlencode(params))
                 return self.request.RESPONSE.redirect(redirect_url)
 

--- a/opengever/workspace/tests/test_my_invitations.py
+++ b/opengever/workspace/tests/test_my_invitations.py
@@ -131,7 +131,7 @@ class TestMyInvitationsView(IntegrationTestCase):
             callback_payload)
 
     @browsing
-    def test_accept_accepted_invitation_when_not_signed_in_redirects_to_login_form(self, browser):
+    def test_accept_accepted_invitation_when_not_signed_in_redirects_to_portal_with_next_parameter(self, browser):
         self.maxDiff = None
         with freeze(FROZEN_NOW):
             self.login(self.regular_user, browser=browser)
@@ -142,9 +142,9 @@ class TestMyInvitationsView(IntegrationTestCase):
             with browser.expect_http_error():
                 browser.open(self.accept_url)
 
-            # check that we get redirected to login
+            # check that we get redirected to portal
             parsed_url = urlparse.urlparse(browser.url)
-            self.assertEqual('/portal/login', parsed_url.path)
+            self.assertEqual('/portal', parsed_url.path)
 
             params = urlparse.parse_qs(parsed_url.query)
             self.assertDictEqual({'next': [self.workspace_url]}, params)


### PR DESCRIPTION
No longer redirect to the login page and redirect to the portal page instead. Because only the portal page, redirects to external authentication service, like secure-connect.

In addition to #7610 we also need adjust the portal redirect for already accepted invitations.
 
Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-5170]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-5170]: https://4teamwork.atlassian.net/browse/CA-5170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ