### PR TITLE
Handle long dossier and subdossier titles in task sync.

### DIFF
--- a/changes/CA-5248.bugfix
+++ b/changes/CA-5248.bugfix
@@ -1,0 +1,1 @@
+Handle long dossier and subdossier titles in task sync. [njohner]

--- a/opengever/globalindex/tests/test_task_sql_syncer.py
+++ b/opengever/globalindex/tests/test_task_sql_syncer.py
@@ -164,3 +164,11 @@ class TestTaskSQLSyncer(IntegrationTestCase):
 
         self.assertEqual(added_task.get_sql_object(),
                          successor.tasktemplate_predecessor)
+
+    def test_sql_task_sync_handles_long_dossier_title(self):
+        self.login(self.regular_user)
+        self.dossier.title = u'\xe4\xf6' * 300
+
+        notify(ObjectModifiedEvent(self.task))
+        sql_task = self.task.get_sql_object()
+        self.assertEqual(512, len(sql_task.containing_dossier))


### PR DESCRIPTION
Tasks were broken when in a dossier or subdossier with a title longer than 512 characters, as the corresponding column in the task model was limited to 512 characters. With this PR we truncate the dossier and subdossier titles to the maximal allowed length when syncing a task. 

For [CA-5248]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-5248]: https://4teamwork.atlassian.net/browse/CA-5248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ