### PR TITLE
Re-enable forbidding tus-replace when document is locked by another user.

### DIFF
--- a/changes/CA-5107.other
+++ b/changes/CA-5107.other
@@ -1,0 +1,1 @@
+- Re-enable forbidding tus-replace when document is locked by another user. [njohner]

--- a/opengever/api/tests/test_tus.py
+++ b/opengever/api/tests/test_tus.py
@@ -1,5 +1,4 @@
 from base64 import b64encode
-from datetime import datetime
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
@@ -11,7 +10,6 @@ from plone import api
 from Products.CMFCore.utils import getToolByName
 from Products.MimetypesRegistry.MimeTypeItem import MimeTypeItem
 from six import BytesIO
-from unittest import skipIf
 
 
 UPLOAD_DATA = b"abcdefgh"
@@ -168,11 +166,6 @@ class TestTUSUpload(IntegrationTestCase):
         self.login(self.regular_user, browser)
         self.assert_tus_replace_fails(self.document, browser)
 
-    @skipIf(
-        datetime.now() < datetime(2023, 4, 1),
-        "Lock verification temporary disabled, because it's not yet works correctly. "
-        "Will be fixed with https://4teamwork.atlassian.net/browse/CA-5107",
-    )
     @browsing
     def test_cannot_replace_document_if_lock_token_not_provided(self, browser):
         self.login(self.regular_user, browser)

--- a/opengever/api/tus.py
+++ b/opengever/api/tus.py
@@ -84,9 +84,8 @@ class UploadPatch(GeverUploadPatch):
         if self.context.has_file() and not manager.is_checked_out_by_current_user():
             raise Forbidden("Document not checked out.")
 
-        # Check will be fixed with https://4teamwork.atlassian.net/browse/CA-5107
-        # if manager.is_locked_by_other():
-        #     raise Forbidden("Document is locked.")
+        if manager.is_locked_by_other():
+            raise Forbidden("Document is locked.")
 
         if self.is_proposal_document_upload() or self.is_proposal_template_upload():
             tus_upload = self.tus_upload()


### PR DESCRIPTION
This will only work with OfficeConnector version 1.17.1 or higher.

See https://github.com/4teamwork/OfficeConnector/pull/395

For [CA-5107]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)