### PR TITLE
Prevent finalization if document is referenced by a pending approval task

### DIFF
--- a/changes/CA-5570.bugfix
+++ b/changes/CA-5570.bugfix
@@ -1,0 +1,1 @@
+Prevent document finalization if document is referenced by a pending approval task. [phgross]

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -372,7 +372,8 @@ class Document(Item, BaseDocumentMixin):
                 self, transition='document-transition-initialize')
 
     def is_finalize_allowed(self):
-        return not self.is_checked_out()
+        return not self.is_checked_out() and \
+            not self.is_referenced_by_pending_approval_task()
 
     def is_referenced_by_pending_approval_task(self):
         tasks = self.related_items(include_forwardrefs=False, include_backrefs=True, tasks_only=True)

--- a/opengever/document/tests/test_document_workflow.py
+++ b/opengever/document/tests/test_document_workflow.py
@@ -81,6 +81,18 @@ class TestDocumentWorkflow(IntegrationTestCase):
         self.assertEquals(Document.active_state,
                           api.content.get_state(obj=self.document))
 
+    def test_document_cannot_be_finalized_if_is_referenced_by_pending_approval_task(self):
+        self.login(self.administrator)
+        self.task_in_protected_dossier.task_type = 'approval'
+
+        with self.assertRaises(InvalidParameterError):
+            api.content.transition(
+                obj=self.protected_document_with_task,
+                transition=Document.finalize_transition)
+
+        self.assertEquals(Document.active_state,
+                          api.content.get_state(obj=self.document))
+
     def test_limited_admin_can_reopen_finalized_document(self):
         with self.login(self.manager):
             api.content.transition(obj=self.subdocument,


### PR DESCRIPTION
Reopen a finalized document is only possible, if there are no pending approval tasks. Therefore the finalization of a document should only be possible if there is not already referenced by pending approval tasks. Otherwise this leads to issues like [CA-5570]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-5570]: https://4teamwork.atlassian.net/browse/CA-5570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ