### PR TITLE
Defer TUS lock test by another 6 months.

### DIFF
--- a/opengever/api/tests/test_tus.py
+++ b/opengever/api/tests/test_tus.py
@@ -169,7 +169,7 @@ class TestTUSUpload(IntegrationTestCase):
         self.assert_tus_replace_fails(self.document, browser)
 
     @skipIf(
-        datetime.now() < datetime(2023, 4, 1),
+        datetime.now() < datetime(2023, 10, 1),
         "Lock verification temporary disabled, because it's not yet works correctly. "
         "Will be fixed with https://4teamwork.atlassian.net/browse/CA-5107",
     )


### PR DESCRIPTION
This has now been fixed in OfficeConnector, but we cannot reintroduce the check in opgenver.core before all customers have a new version of OfficeConnector installed.

## Checklist
- [ ] Changelog entry: No CL
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira): No Jira