### PR TITLE
Fix flaky test for task deadline default values.

### DIFF
--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -3,7 +3,7 @@ from Acquisition import aq_base
 from Acquisition import aq_inner
 from Acquisition import aq_parent
 from collective import dexteritytextindexer
-from datetime import datetime
+from datetime import date
 from ftw.datepicker.widget import DatePickerFieldWidget
 from ftw.keywordwidget.widget import KeywordFieldWidget
 from ftw.tabbedview.interfaces import ITabbedviewUploadable
@@ -88,7 +88,7 @@ def deadline_default():
         interface=ITaskSettings,
     )
 
-    return get_date_with_delta_excluding_weekends(datetime.today(), offset).date()
+    return get_date_with_delta_excluding_weekends(date.today(), offset)
 
 
 class ITask(model.Schema):


### PR DESCRIPTION
`datetime.today().date()` does not always return the same date as `date.today()`. We now consistently use date.today() for all deadline calculations.
I could have fixed the tests, but we already calculate the deadline for tasktemplates using `date.today()`, so decided to make it consistent instead.

This should fix the failing nightly build tests, see https://ci.4teamwork.ch/builds/555422/tasks/1097389

## Checklist
- [ ] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)