### PR TITLE
Towncrier: Add Jira issue when generating changelog.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ filename = "HISTORY.rst"
 directory = "changes/"
 template = "towncrier.rst"
 underlines = ["-", ""]
+issue_format = "[{issue}]"
 
 [[tool.towncrier.type]]
 directory = "feature"

--- a/towncrier.rst
+++ b/towncrier.rst
@@ -13,7 +13,7 @@
 
 {% if definitions[category]['showcontent'] %}
 {% for text, values in sections[section][category].items() %}
-- {{ text }}
+- {{ text }}{{ issue }}
 {% endfor %}
 
 {% else %}


### PR DESCRIPTION
This configures towncrier to add the Jira issue number when generating the changelog from the news fragements.

The issue number is the part of the news fragment filename left to the extension, e.g. `CA-4567` from `CA-4567.bugfix`.

It will (should) produce a HISTORY.rst that looks like this in its raw form:

```rst
2023.6.0 (2023-04-10)
---------------------

New features:

- Add @solrlivesearch endpoint and improve solr configuration. [njohner][CA-3456]
- Use Bcc when sharing content in Teamraum with all participants. [njohner][CA-4567]
- Handle extra address lines in address block. [njohner][CA-1234]
```

and is rendered like this:

---

![Screenshot 2023-04-11 at 11 59 05](https://user-images.githubusercontent.com/405124/231127621-369e28ca-9a30-4242-a6d0-9eda59752b2a.png)

---

I decided not to actually link the Jira issue, because this would significantly clutter the raw RST. 

## Checklist

- [ ] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-3456]: https://4teamwork.atlassian.net/browse/CA-3456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CA-4567]: https://4teamwork.atlassian.net/browse/CA-4567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CA-1234]: https://4teamwork.atlassian.net/browse/CA-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ