### PR TITLE
Escape invalid characters in the sheet title of disposition exports.

### DIFF
--- a/changes/CA-5629.bugfix
+++ b/changes/CA-5629.bugfix
@@ -1,0 +1,1 @@
+Escape invalid characters in the sheet title of disposition exports. [phgross]

--- a/opengever/disposition/browser/excel_export.py
+++ b/opengever/disposition/browser/excel_export.py
@@ -7,12 +7,14 @@ from opengever.base.reporter import StringTranslater
 from opengever.base.reporter import XLSReporter
 from opengever.disposition import _
 from opengever.dossier import _ as dossier_mf
+from openpyxl.workbook.child import INVALID_TITLE_REGEX
 from plone import api
 from plone.i18n.normalizer.interfaces import IIDNormalizer
 from Products.Five.browser import BrowserView
 from zope.component import getUtility
 from zope.globalrequest import getRequest
 from zope.i18n import translate
+import re
 
 
 def readable_appraisal(value):
@@ -101,4 +103,4 @@ class DispositionExcelExport(BrowserView):
         """Returns current disposition title. Crop it to 30 characters
         because openpyxl only accepts sheet titles with max 30 characters.
         """
-        return self.context.title[:30]
+        return re.sub(INVALID_TITLE_REGEX, '', self.context.title[:30])

--- a/opengever/disposition/tests/test_excel_export.py
+++ b/opengever/disposition/tests/test_excel_export.py
@@ -77,3 +77,18 @@ class TestDispositionExcelExport(IntegrationTestCase):
             "content-disposition").split(";")[1].split("=")[1])
         expected = "liste_evaluations_angebot-31-8-2016.xlsx"
         self.assertEquals(expected, fname)
+
+    @browsing
+    def test_escape_invalid_chars_in_sheet_title(self, browser):
+        self.login(self.records_manager, browser)
+        self.disposition.title = u'Angebot 06.04.2023: Rechtsdienst'
+        browser.open(self.disposition, view='download_excel')
+
+        data = browser.contents
+        with NamedTemporaryFile(suffix='.xlsx') as tmpfile:
+            tmpfile.write(data)
+            tmpfile.flush()
+            workbook = load_workbook(tmpfile.name)
+
+            self.assertEquals([u'Angebot 06.04.2023 Rechtsdien'],
+                              [sheet.title for sheet in workbook.worksheets])


### PR DESCRIPTION
Excel does not allow some characters in their sheet title, so we need to escape them.

For [CA-5629], solves https://sentry.4teamwork.ch/organizations/sentry/issues/105601/?project=17&query=is%3Aunresolved+valueerror&statsPeriod=14d

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- Bug fixed:
  - [x] Resolved any Sentry issues caused by this bug

[CA-5629]: https://4teamwork.atlassian.net/browse/CA-5629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ