### PR TITLE
Change history order in the disposition removal protocol.

### DIFF
--- a/changes/CA-5630.bugfix
+++ b/changes/CA-5630.bugfix
@@ -1,0 +1,1 @@
+Change history order in the disposition removal protocol. [phgross]

--- a/opengever/disposition/browser/removal_protocol.py
+++ b/opengever/disposition/browser/removal_protocol.py
@@ -116,7 +116,8 @@ class RemovalProtocolLaTeXView(MakoLaTeXView):
                 self.context.get_dossier_representations()),
             'label_history': translate(
                 _('label_history', default="History"), context=self.request),
-            'history': history_listener.get_listing(self.context.get_history())
+            'history': history_listener.get_listing(
+                reversed(self.context.get_history()))
         }
 
     def get_disposition_metadata(self):


### PR DESCRIPTION
Starting with the earliest entry and ends with the latest, makes more sense.
<img width="554" alt="Bildschirmfoto 2023-04-12 um 09 46 12" src="https://user-images.githubusercontent.com/485755/231388510-05ac46e6-9001-46f1-82d6-7f1f5f9e8491.png">

I have waived a test. We currently have no way to parse back the latex table, so it would be too time-consuming.

For [CA-5630]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-5630]: https://4teamwork.atlassian.net/browse/CA-5630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ