### PR TITLE
Fix handling of trailing wildcard in query preprocessing.

### DIFF
--- a/changes/CA-5477.bugfix
+++ b/changes/CA-5477.bugfix
@@ -1,0 +1,1 @@
+Fix handling of trailing wildcard in query preprocessing. [njohner]

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -203,7 +203,9 @@ class LiveSearchQueryPreprocessingMixin(object):
         last_token = last_token.rstrip(")").rstrip("*") + "*" + n_brackets * ")"
         tokens[-1] = last_token
 
-        return "({})".format(" ".join(tokens))
+        if len(tokens) > 1:
+            return "({})".format(" ".join(tokens))
+        return tokens[0]
 
     @staticmethod
     def _preprocess_phrase(phrase, phrase_prefix):

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -200,7 +200,7 @@ class LiveSearchQueryPreprocessingMixin(object):
         # Handle bracket and add wildcard to last token
         last_token = tokens[-1]
         n_brackets = len(last_token) - len(last_token.rstrip(")"))
-        last_token = last_token.rstrip(")") + "*" + n_brackets * ")"
+        last_token = last_token.rstrip(")").rstrip("*") + "*" + n_brackets * ")"
         tokens[-1] = last_token
 
         return "({})".format(" ".join(tokens))

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -150,7 +150,7 @@ class TestListingEndpointWithSolr(IntegrationTestCase):
         browser.open(self.repository_root, view=view,
                      headers=self.api_headers)
         query = self.solr.search.call_args[1]["query"]
-        self.assertEqual('(feedb\xc3\xa4ck*)', query)
+        self.assertEqual('feedb\xc3\xa4ck*', query)
 
     @browsing
     def test_sort_on_existing_field(self, browser):

--- a/opengever/api/tests/test_solrsearch.py
+++ b/opengever/api/tests/test_solrsearch.py
@@ -4,6 +4,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testing import freeze
+from opengever.api.solr_query_service import LiveSearchQueryPreprocessingMixin
 from opengever.api.solrsearch import SolrSearchGet
 from opengever.base.handlers import update_changed_date
 from opengever.base.interfaces import IReferenceNumberSettings
@@ -14,6 +15,7 @@ from plone import api
 from plone.uuid.interfaces import IUUID
 from Products.CMFCore.utils import getToolByName
 from unittest import skip
+from unittest import TestCase
 from urllib import urlencode
 from zope.component import getMultiAdapter
 import json
@@ -1871,3 +1873,12 @@ class TestSolrLiveSearchPost(TestSolrLiveSearchGet):
         url = u'{}/@solrlivesearch'.format(self.portal.absolute_url())
         browser.open(url, method='POST', data=json.dumps(query), headers=self.api_headers)
         return browser.json
+
+
+class TestSolrLiveSearchQueryPreprocessing(TestCase):
+
+    def test_preprocessing_handles_trailing_wildcard(self):
+        preprocessor = LiveSearchQueryPreprocessingMixin()
+        self.assertEqual("(*)", preprocessor.preprocess_query("*"))
+        self.assertEqual("(my* hyphenated word*)", preprocessor.preprocess_query("my*-hyphenated-word*"))
+        self.assertEqual("(my*) (oh*) (my*)", preprocessor.preprocess_query("my* oh my*"))


### PR DESCRIPTION
With commit https://github.com/4teamwork/opengever.core/pull/7683/commits/fbb504ae641cc8aaac129780ffa48bd3a96ef99a, I broke handling of trailing wildcards, this leads to queries for listings where the query is simply `*` to query solr with `**`. For some reason such queries are much slower. With this PR we fix handling of trailing wildcards to avoid this issue.

For [CA-5477]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-5477]: https://4teamwork.atlassian.net/browse/CA-5477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ