### PR TITLE
Fix docproperty collector for custom_properties with a list as value.

### DIFF
--- a/changes/CA-5635.bugfix
+++ b/changes/CA-5635.bugfix
@@ -1,0 +1,1 @@
+Fix docproperty collector for custom_properties with a list as value. [phgross]

--- a/opengever/dossier/docprops.py
+++ b/opengever/dossier/docprops.py
@@ -51,7 +51,7 @@ class DocPropertyProvider(BaseDocPropertyProvider):
             key_with_prefix = u"cp.{}".format(key)
             if isinstance(value, date):
                 custom_properties[key_with_prefix] = self._as_datetime(value)
-            elif isinstance(value, set):
+            elif isinstance(value, set) or isinstance(value, list):
                 custom_properties[key_with_prefix] = u', '.join(value)
             elif isinstance(value, unicode):
                 custom_properties[key_with_prefix] = value.replace(u'\n', u' ')

--- a/opengever/dossier/tests/test_default_doc_property_adapters.py
+++ b/opengever/dossier/tests/test_default_doc_property_adapters.py
@@ -14,6 +14,7 @@ from opengever.dossier.tests import EXPECTED_DOSSIER_PROPERTIES
 from opengever.dossier.tests import EXPECTED_PROPOSALDOC_PROPERTIES
 from opengever.dossier.tests import EXPECTED_TASKDOC_PROPERTIES
 from opengever.dossier.tests import EXPECTED_USER_DOC_PROPERTIES
+from opengever.propertysheets.utils import set_custom_property
 from opengever.testing import IntegrationTestCase
 from zope.component import getAdapter
 import json
@@ -134,6 +135,12 @@ class TestDocProperties(IntegrationTestCase):
 
         self.assertEqual(expected_properties,
                          dossier_adapter.get_properties())
+
+        # handle lists correctly
+        set_custom_property(self.dossier, 'labels', value=['Gamma'])
+        self.assertEqual(
+            u'Gamma',
+            dossier_adapter.get_properties().get('ogg.dossier.cp.labels'))
 
     @browsing
     def test_doc_properties_for_document_with_custom_fields(self, browser):


### PR DESCRIPTION
In some case, custom_properties of the type `multiple_choice` provide a value from type `list` and not `set`. The current implementation does not handle this case, which leads in an `Unsupported type <type 'list'>` exception when creating or updating docprops for a document.

For [CA-5635]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- Bug fixed:
  - [x] Resolved any Sentry issues caused by this bug --> error is catched and not written to sentry.


[CA-5635]: https://4teamwork.atlassian.net/browse/CA-5635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ