### PR TITLE
Workspace navigation

### DIFF
--- a/changes/CA-5584-2.other
+++ b/changes/CA-5584-2.other
@@ -1,0 +1,1 @@
+Register workspaces as a main_dossiers for the main-dossier expansion. [elioschmutz]

--- a/changes/CA-5584.other
+++ b/changes/CA-5584.other
@@ -1,0 +1,1 @@
+@navigation endpoint excludes trashed items. [elioschmutz]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,6 +11,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- ``@navigation`` endpoint excludes trashed items.
 
 - Add new ``@validate-repository`` endpoint.
 

--- a/opengever/api/navigation.py
+++ b/opengever/api/navigation.py
@@ -110,6 +110,7 @@ class Navigation(object):
         query = {
             'object_provides': [i.__identifier__ for i in content_interfaces],
             'path_parent': '/'.join(root.getPhysicalPath()),
+            'trashed': 'false',
         }
 
         review_states = self.request.form.get('review_state', [])

--- a/opengever/api/tests/test_workspace.py
+++ b/opengever/api/tests/test_workspace.py
@@ -58,3 +58,14 @@ class TestWorkspaceSerializer(IntegrationTestCase):
 
         browser.open(self.workspace, headers=self.api_headers)
         self.assertFalse(browser.json['can_access_members'])
+
+    @browsing
+    def test_workspace_serialization_contains_main_dossier(self, browser):
+        self.login(self.workspace_member, browser)
+        browser.open(
+            self.workspace.absolute_url() + '?expand=main-dossier',
+            headers={'Accept': 'application/json'}).json
+
+        self.assertEquals(
+            self.workspace.title,
+            browser.json['@components']['main-dossier']['title'])

--- a/opengever/dossier/utils.py
+++ b/opengever/dossier/utils.py
@@ -4,6 +4,7 @@ from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.dossiertemplate.behaviors import IDossierTemplateMarker
 from opengever.dossier.dossiertemplate.behaviors import IDossierTemplateSchema
 from opengever.inbox.inbox import IInbox
+from opengever.workspace.interfaces import IWorkspace
 from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
 import unicodedata
 
@@ -35,14 +36,15 @@ def find_parent_dossier(content):
 
 
 def get_main_dossier(obj):
-    """Helper method which returns the main dossier (or inbox) of the given
-    object.
-    If the given object is not storred inside a dossier it returns None."""
+    """Helper method which returns the main dossier/workspace (or inbox) of
+    the given object.
+    If the given object is not storred inside any main content it returns None."""
 
     dossier = None
     while obj and not IPloneSiteRoot.providedBy(obj):
         if IDossierMarker.providedBy(obj) or \
            IInbox.providedBy(obj) or \
+           IWorkspace.providedBy(obj) or \
            IDossierTemplateSchema.providedBy(obj):
             dossier = obj
 


### PR DESCRIPTION
This PR:

- extends the `@navigation` endpoint by always excluding trashed items. Currently, we do not have any use case where we need or want to display trashed navigation items
- register a `workspace` as a main-dossier.

For [CA-5584]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-5584]: https://4teamwork.atlassian.net/browse/CA-5584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ