### PR TITLE
Add workspace document urls in document serialization.

### DIFF
--- a/changes/CA-5562.feature
+++ b/changes/CA-5562.feature
@@ -1,0 +1,1 @@
+Add workspace document urls in document serialization. [phgross]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,6 +11,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- Add ``workspace_document_urls`` in document serialization.
 
 
 2023.7.0 (2023-04-19)

--- a/opengever/api/document.py
+++ b/opengever/api/document.py
@@ -77,6 +77,7 @@ class SerializeDocumentToJson(GeverSerializeToJson):
             'current_version_id': obj.get_current_version_id(
                 missing_as_zero=True),
             'teamraum_connect_links': ILinkedDocuments(obj).serialize(),
+            'workspace_document_urls': ILinkedDocuments(obj).get_workspace_document_urls(),
             'creator': serialize_actor_id_to_json_summary(obj.Creator()),
         }
 

--- a/opengever/api/tests/test_document.py
+++ b/opengever/api/tests/test_document.py
@@ -278,6 +278,22 @@ class TestDocumentSerializer(IntegrationTestCase):
               u'version_id': 1}],
             browser.json['@components']['approvals'])
 
+    @browsing
+    def test_document_serialization_contains_workspace_document_links(self, browser):
+        self.login(self.workspace_member, browser)
+
+        adapter = ILinkedDocuments(self.document)
+        adapter.link_workspace_document(IUUID(self.workspace_document))
+        adapter.link_workspace_document(IUUID(self.workspace_folder_document))
+
+        with self.env(TEAMRAUM_URL='https://example.com/teamraum'):
+            browser.open(self.document, headers={'Accept': 'application/json'})
+
+            self.assertEqual(
+                [u'https://example.com/teamraum/redirect-to-uuid/createworkspace00000000000000003',
+                 u'https://example.com/teamraum/redirect-to-uuid/createworkspace00000000000000005'],
+                browser.json["workspace_document_urls"])
+
 
 class TestDocumentPost(IntegrationTestCase):
 

--- a/opengever/testing/test_case.py
+++ b/opengever/testing/test_case.py
@@ -36,6 +36,7 @@ from zope.component import getUtility
 from zope.i18n import translate
 from zope.interface import alsoProvides
 import json
+import os
 import transaction
 import unittest
 
@@ -118,6 +119,18 @@ class TestCase(unittest.TestCase):
         reminders['after'] = obj.get_reminders()
         reminders['added'] = [r for r in reminders['after'] if r not in reminders['before']]
         reminders['removed'] = [r for r in reminders['before'] if r not in reminders['after']]
+
+    @contextmanager
+    def env(self, **env):
+        """Temporary set env variables.
+        """
+        original = os.environ.copy()
+        os.environ.update(env)
+        try:
+            yield
+        finally:
+            os.environ.clear()
+            os.environ.update(original)
 
 
 class FunctionalTestCase(TestCase):

--- a/opengever/workspaceclient/linked_documents.py
+++ b/opengever/workspaceclient/linked_documents.py
@@ -1,4 +1,5 @@
 from opengever.document.behaviors import IBaseDocument
+from opengever.workspaceclient.client import WorkspaceClient
 from opengever.workspaceclient.interfaces import ILinkedDocuments
 from operator import itemgetter
 from persistent.list import PersistentList
@@ -79,3 +80,8 @@ class LinkedDocuments(object):
         if persistent:
             return annotations.setdefault(self.storage_key, PersistentMapping())
         return dict(annotations.get(self.storage_key, {}))
+
+    def get_workspace_document_urls(self):
+        return [
+            '/'.join([WorkspaceClient().workspace_url, 'redirect-to-uuid', doc.get('UID')])
+            for doc in self.linked_workspace_documents]

--- a/opengever/workspaceclient/tests/__init__.py
+++ b/opengever/workspaceclient/tests/__init__.py
@@ -10,7 +10,6 @@ from opengever.workspaceclient.session import SESSION_STORAGE
 from plone import api
 from zope.component import queryUtility
 from zope.ramcache.interfaces.ram import IRAMCache
-import os
 import transaction
 
 
@@ -58,18 +57,6 @@ class FunctionalWorkspaceClientTestCase(SolrFunctionalTestCase):
 
         self.enable_feature()
         self.invalidate_cache()
-
-    @contextmanager
-    def env(self, **env):
-        """Temporary set env variables.
-        """
-        original = os.environ.copy()
-        os.environ.update(env)
-        try:
-            yield
-        finally:
-            os.environ.clear()
-            os.environ.update(original)
 
     def enable_feature(self, enabled=True):
         api.portal.set_registry_record(


### PR DESCRIPTION
This is needed for displaying the links to the workspace documents on the GEVER side.

For [CA-5562]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- API change:
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))

[CA-5562]: https://4teamwork.atlassian.net/browse/CA-5562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ