### PR TITLE
Hide and skip inactive users in the @watchers endpoints.

### DIFF
--- a/changes/CA-5400.bugfix
+++ b/changes/CA-5400.bugfix
@@ -1,0 +1,1 @@
+Hide and skip inactive users in the @watchers endpoints. [phgross]

--- a/opengever/activity/model/activity.py
+++ b/opengever/activity/model/activity.py
@@ -8,6 +8,7 @@ from opengever.base.model import USER_ID_LENGTH
 from opengever.base.model import UTCDateTime
 from opengever.base.types import UnicodeCoercingText
 from opengever.ogds.base.actor import Actor
+from opengever.ogds.models.user import User
 from opengever.ogds.models.user_settings import UserSettings
 from plone.restapi.serializer.converters import json_compatible
 from sqlalchemy import Column
@@ -77,6 +78,11 @@ class Activity(Base, Translatable):
         for userid in userids:
             if (self.is_current_user(userid) and not
                     self.user_wants_own_action_notifications(userid)):
+                continue
+
+            # Skip inactive users
+            user = User.query.get(userid)
+            if user and not user.active:
                 continue
 
             notifications.append(

--- a/opengever/activity/sources.py
+++ b/opengever/activity/sources.py
@@ -14,6 +14,8 @@ class PossibleWatchersSource(AssignedUsersSource):
     available.
     """
 
+    search_only_active_users = True
+
     @property
     def base_query(self):
         query = super(PossibleWatchersSource, self).base_query

--- a/opengever/activity/tests/test_notification_center.py
+++ b/opengever/activity/tests/test_notification_center.py
@@ -437,6 +437,29 @@ class TestAddActivity(IntegrationTestCase):
         self.assertEquals(1, Notification.query.by_user('hugo').count())
         self.assertEquals(1, Notification.query.by_user('peter').count())
 
+    def test_does_not_create_notification_for_inactive_users(self):
+        peter_user = create(Builder('ogds_user').id('peter'))
+        peter = create(Builder('watcher').having(actorid='peter'))
+
+        create(Builder('ogds_user').id('hugo'))
+        hugo = create(Builder('watcher').having(actorid='hugo'))
+
+        peter_user.active = False
+
+        create(Builder('resource').oguid('fd:123').watchers([hugo, peter]))
+
+        self.center.add_activity(
+            Oguid('fd', '123'),
+            'TASK_ADDED',
+            {'en': 'Kennzahlen 2014 erfassen'},
+            {'en': 'Task accepted'},
+            {'en': 'Task bla added by Peter'},
+            'peter',
+            {'en': None})
+
+        self.assertEquals(1, Notification.query.by_user('hugo').count())
+        self.assertEquals(0, Notification.query.by_user('peter').count())
+
 
 class TestNotificationHandling(IntegrationTestCase):
 

--- a/opengever/activity/tests/test_notification_center.py
+++ b/opengever/activity/tests/test_notification_center.py
@@ -385,11 +385,11 @@ class TestAddActivity(IntegrationTestCase):
             {'en': 'Task bla added by Hugo'},
             'hugo.boss',
             {'en': None},
-            notification_recipients=[peter, nadja]).get('activity')
+            notification_recipients=['peter', 'nadja']).get('activity')
 
         self.assertEqual(2, len(activity.notifications))
         self.assertEqual(['peter', 'nadja'],
-                         [notification.userid.actorid for notification in activity.notifications])
+                         [notification.userid for notification in activity.notifications])
 
     def test_does_not_create_notification_for_actor_if_notify_own_actions_disabled(self):
         create(Builder('ogds_user').id('peter'))

--- a/opengever/api/tests/test_external_activities.py
+++ b/opengever/api/tests/test_external_activities.py
@@ -196,7 +196,7 @@ class TestExternalActivitiesPost(IntegrationTestCase):
 
         activity = Activity.query.all()[-1]
         self.assertItemsEqual(
-            [user.userid for user in group.users],
+            [user.userid for user in group.users if user.active],
             [notification.userid for notification in activity.notifications],
         )
 
@@ -361,8 +361,9 @@ class TestExternalActivitiesPost(IntegrationTestCase):
             }], browser.json['errors'])
 
         activity = Activity.query.all()[-1]
+
         self.assertItemsEqual(
-            [user.userid for user in group.users],
+            [user.userid for user in group.users if user.active],
             [notification.userid for notification in activity.notifications],
         )
 

--- a/opengever/api/watchers.py
+++ b/opengever/api/watchers.py
@@ -39,8 +39,10 @@ class Watchers(object):
         roles = set()
         watchers_and_roles = defaultdict(list)
         for subscription in self.center.get_subscriptions(self.context):
-            watchers_and_roles[subscription.watcher.actorid].append(subscription.role)
-            roles.add(subscription.role)
+            actor = ActorLookup(subscription.watcher.actorid).lookup()
+            if actor.is_active:
+                watchers_and_roles[subscription.watcher.actorid].append(subscription.role)
+                roles.add(subscription.role)
 
         portal_url = api.portal.get().absolute_url()
         referenced_users = []


### PR DESCRIPTION
Inactive users are no longer displayed as observers and are also no longer available for selection.

For [CA-5400]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-5400]: https://4teamwork.atlassian.net/browse/CA-5400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ