### PR TITLE
Reindex maybe not properly indexed files

### DIFF
--- a/changes/CA-5726.other
+++ b/changes/CA-5726.other
@@ -1,0 +1,1 @@
+Reindex maybe not properly indexed files. [elioschmutz]

--- a/opengever/core/upgrades/20230504163300_reindex_not_properly_indexed_files/upgrade.py
+++ b/opengever/core/upgrades/20230504163300_reindex_not_properly_indexed_files/upgrade.py
@@ -1,0 +1,37 @@
+from ftw.solr.interfaces import ISolrSearch
+from ftw.upgrade import ProgressLogger
+from ftw.upgrade import UpgradeStep
+from opengever.base.solr import OGSolrDocument
+from opengever.core.upgrade import NightlyIndexer
+from zope.component import getUtility
+
+
+class ReindexNotProperlyIndexedFiles(UpgradeStep):
+    """Reindex not properly indexed files.
+    """
+
+    deferrable = True
+
+    def __call__(self):
+        self.install_upgrade_profile()
+        self.reindex()
+
+    def reindex(self):
+        solr = getUtility(ISolrSearch)
+        fq = [
+            "portal_type:(opengever.document.document OR ftw.mail.mail)",
+            "-filename:['' TO *]"]
+        fl = ['filename', 'path']
+
+        nrows = solr.search(fq=fq, rows=0).num_found
+        resp = solr.search(fq=fq, fl=fl, rows=nrows)
+
+        with NightlyIndexer(idxs=[], index_in_solr_only=True) as indexer:
+            for doc in ProgressLogger('Maybe reindex not properly indexed files', resp.docs):
+                obj = OGSolrDocument(doc).getObject()
+
+                # We still need to check if the filename is really empty becuase the
+                # query will return docs with a filename beginning with an empty string.:
+                # Example: {u'filename': u' my-filename.docx'}
+                if not doc.get('filename') and obj.get_filename():
+                    indexer.add_by_obj(obj)


### PR DESCRIPTION
This PR reindexes files which may be not properly indexed.

The index is out of sync for files, mainly the filename index. Because we do not really know all the indexes which could be out of sync, we'll just reindex the full object.

The reason why these files where not properly indexed is not yet fully clear. It could have happened when introducing the `filename` index

Since most of the files are properly indexed, we do not use a nightly job for this upgradestep.

Slack-Reference: https://4teamwork.slack.com/archives/C01BHEGBVU1/p1683206204789769

## Before
![Bildschirmfoto 2023-05-04 um 17 07 23](https://user-images.githubusercontent.com/557005/236254158-b3f59a09-1856-4733-9408-9d9070fbfe0a.png)

## After
![Bildschirmfoto 2023-05-04 um 17 18 04](https://user-images.githubusercontent.com/557005/236254204-bebbf588-979f-4b6d-85c5-0cf55892ea66.png)

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-5726]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-5726]: https://4teamwork.atlassian.net/browse/CA-5726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ