### PR TITLE
Speed-up upgrade step reindexing workspace documents'workflow.

### DIFF
--- a/changes/CA-5556.other
+++ b/changes/CA-5556.other
@@ -1,0 +1,1 @@
+Speed-up upgrade steps reindexing workspace documents'workflow. [njohner]

--- a/opengever/core/upgrades/20221115154555_add_task_responsible_role/upgrade.py
+++ b/opengever/core/upgrades/20221115154555_add_task_responsible_role/upgrade.py
@@ -1,5 +1,6 @@
 from ftw.upgrade import UpgradeStep
 from opengever.core.upgrade import NightlyWorkflowSecurityUpdater
+from opengever.workspace import is_workspace_feature_enabled
 
 
 class AddTaskResponsibleRole(UpgradeStep):
@@ -13,14 +14,19 @@ class AddTaskResponsibleRole(UpgradeStep):
                 ['opengever_dossier_workflow'])
 
         with NightlyWorkflowSecurityUpdater(reindex_security=False) as updater:
-            updater.update(
-                ['opengever_workspace_todolist',
-                 'opengever_period_workflow',
-                 'opengever_committee_workflow',
-                 'opengever_workspace_root',
-                 'opengever_workspace',
-                 'opengever_workspace_document',
-                 'opengever_workspace_todo',
-                 'opengever_committeecontainer_workflow',
-                 'opengever_workspace_folder',
-                 'opengever_workspace_meeting'])
+            to_update = []
+            if is_workspace_feature_enabled():
+                to_update = [
+                    'opengever_workspace_todolist',
+                    'opengever_workspace_root',
+                    'opengever_workspace',
+                    'opengever_workspace_document',
+                    'opengever_workspace_todo',
+                    'opengever_workspace_folder',
+                    'opengever_workspace_meeting']
+            else:
+                to_update = [
+                    'opengever_period_workflow',
+                    'opengever_committee_workflow',
+                    'opengever_committeecontainer_workflow']
+            updater.update(to_update)

--- a/opengever/core/upgrades/20230105124325_update_workflows/upgrade.py
+++ b/opengever/core/upgrades/20230105124325_update_workflows/upgrade.py
@@ -1,4 +1,5 @@
 from ftw.upgrade import UpgradeStep
+from opengever.workspace import is_workspace_feature_enabled
 
 
 class UpdateWorkflows(UpgradeStep):
@@ -7,14 +8,18 @@ class UpdateWorkflows(UpgradeStep):
 
     def __call__(self):
         self.install_upgrade_profile()
-        self.update_workflow_security(
-            ['opengever_workspace_todolist',
-             'opengever_committeecontainer_workflow',
-             'opengever_committee_workflow',
-             'opengever_workspace_folder',
-             'opengever_workspace',
-             'opengever_workspace_document',
-             'opengever_workspace_root',
-             'opengever_workspace_todo',
-             'opengever_period_workflow'],
-            reindex_security=False)
+        if is_workspace_feature_enabled():
+            to_update = [
+                'opengever_workspace_todolist',
+                'opengever_workspace_folder',
+                'opengever_workspace',
+                'opengever_workspace_document',
+                'opengever_workspace_root',
+                'opengever_workspace_todo']
+        else:
+            to_update = [
+                'opengever_committeecontainer_workflow',
+                'opengever_committee_workflow',
+                'opengever_period_workflow']
+
+        self.update_workflow_security(to_update, reindex_security=False)


### PR DESCRIPTION
When modifying the workflow of workspace documents, we should avoid reindexing the security for all Gever documents...

We modify two upgrade steps here to create the list of workflows to reindex depending on whether the deployment is a Gever or a Teamraum.

One upgrade step is in Gever version 2022.24.0, the other in 2023.1.0 so we do not need to backport this for SG, but only for the LTS release (for on Prem update).

For [CA-5556]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-5556]: https://4teamwork.atlassian.net/browse/CA-5556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ