### PR TITLE
Add a comment for the ech0147 import function

### DIFF
--- a/opengever/ech0147/utils.py
+++ b/opengever/ech0147/utils.py
@@ -108,6 +108,13 @@ def create_document(container, document, zipfile):
         try:
             zipinfo = zipfile.getinfo(file_.pathFileName)
         except KeyError:
+            # This error is generally raised if a file is referenced in the
+            # .xml file but does not exist in the zipfile.
+            #
+            # Another known reason for this case is a path normalization done by pyxb
+            # which changes the given path in the .xml file. Thus the file itself
+            # can no longer be found.
+            # See https://github.com/4teamwork/opengever.core/pull/7720#issuecomment-1539660053
             raise ValueError('Missing file {}'.format(file_.pathFileName))
 
         file_field = IDocumentSchema['file']


### PR DESCRIPTION
This PR adds a comment to give a pointer of a special pyxb implementation when importing an ech0147 zip file.

For [CA-5751]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-5751]: https://4teamwork.atlassian.net/browse/CA-5751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ