### PR TITLE
Fix ech0160 when submitting disposition if there are umlauts in a repository title.

### DIFF
--- a/changes/CA-5850.bugfix
+++ b/changes/CA-5850.bugfix
@@ -1,0 +1,1 @@
+Fix ech0160 when submitting disposition if there are umlauts in a repository title. [elioschmutz]

--- a/opengever/disposition/ech0160/model/repository.py
+++ b/opengever/disposition/ech0160/model/repository.py
@@ -35,7 +35,7 @@ class Repository(object):
     def binding(self):
         """Return XML binding"""
         os = arelda.ordnungssystemGeverSIP()
-        os.name = self.obj.Title()
+        os.name = self.obj.Title().decode('utf8')
 
         if self.obj.version:
             os.generation = self.obj.version


### PR DESCRIPTION
## Before
https://github.com/4teamwork/opengever.core/assets/557005/5056dc3f-371f-4326-ad9c-6b52c573f34a

## After
https://github.com/4teamwork/opengever.core/assets/557005/8b7d3372-dd15-47aa-abf9-1940434e3ef1

For [CA-5850]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-5850]: https://4teamwork.atlassian.net/browse/CA-5850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ