### PR TITLE
Fix removing unused reference number

### DIFF
--- a/opengever/api/tests/test_reference_numbers.py
+++ b/opengever/api/tests/test_reference_numbers.py
@@ -1,10 +1,14 @@
+from ftw.builder import Builder
+from ftw.builder import create
 from ftw.testbrowser import browsing
 from opengever.base.adapters import ReferenceNumberPrefixAdpater
+from opengever.repository.deleter import RepositoryDeleter
 from opengever.repository.interfaces import IDuringRepositoryDeletion
 from opengever.testing import IntegrationTestCase
 from plone import api
 from zope.interface import alsoProvides
 from zope.interface import noLongerProvides
+import json
 
 
 class TestReferenceNumbersGet(IntegrationTestCase):
@@ -136,4 +140,92 @@ class TestReferenceNumbersDelete(IntegrationTestCase):
             [{u'active': True,
               u'prefix': u'3',
               u'title': u'Vertr\xe4ge und Vereinbarungen'}],
+            browser.json)
+
+    @browsing
+    def test_unlocks_inactive_number_wich_is_used_by_removed_content(self, browser):
+        self.login(self.administrator, browser)
+
+        def get_numbers(obj):
+            return browser.open(obj, view="@reference-numbers",
+                                method='GET', headers=self.api_headers).json
+
+        # Create a new repository with a reponumber 2
+        repofolder = create(
+            Builder('repository')
+            .within(self.branch_repofolder)
+            .having(title_de=u'Child', title_fr=u'Child', title_en=u'Child')
+        )
+
+        self.assertEqual(
+            [{u'active': True,
+              u'prefix': u'1',
+              u'title': u'Vertr\xe4ge und Vereinbarungen'},
+             {u'active': True,
+              u'prefix': u'2',
+              u'title': 'Child'}],
+            get_numbers(self.branch_repofolder))
+
+        # Removing it will set the number 2 to inactive
+        RepositoryDeleter(repofolder).delete()
+
+        self.assertEqual(
+            [{u'active': True,
+              u'prefix': u'1',
+              u'title': u'Vertr\xe4ge und Vereinbarungen'},
+             {u'active': False,
+              u'prefix': u'2',
+              u'title': None}],
+            get_numbers(self.branch_repofolder))
+
+        # And the number can be removed from the reference number manager
+        browser.open(self.branch_repofolder,
+                     view="@reference-numbers/2",
+                     method='DELETE',
+                     headers=self.api_headers)
+
+        self.assertEqual(
+            [{u'active': True,
+              u'prefix': u'1',
+              u'title': u'Vertr\xe4ge und Vereinbarungen'}],
+            get_numbers(self.branch_repofolder))
+
+        # Moving an existing repofolder (or a new one) to the number 2
+        browser.open(
+            self.leaf_repofolder, method='PATCH', headers=self.api_headers,
+            data=json.dumps({'reference_number_prefix': '2'}))
+
+        self.assertEqual(
+            [{u'active': False,
+              u'prefix': u'1',
+              u'title': u'Vertr\xe4ge und Vereinbarungen'},
+             {u'active': True,
+              u'prefix': u'2',
+              u'title': u'Vertr\xe4ge und Vereinbarungen'}],
+            get_numbers(self.branch_repofolder))
+
+        # And back to the previous value will inactivate the 2 again
+        browser.open(
+            self.leaf_repofolder, method='PATCH', headers=self.api_headers,
+            data=json.dumps({'reference_number_prefix': '1'}))
+
+        self.assertEqual(
+            [{u'active': True,
+              u'prefix': u'1',
+              u'title': u'Vertr\xe4ge und Vereinbarungen'},
+             {u'active': False,
+              u'prefix': u'2',
+              u'title': u'Vertr\xe4ge und Vereinbarungen'}],
+            get_numbers(self.branch_repofolder))
+
+        # And should be removeable again
+        with browser.expect_http_error(code=400):
+            browser.open(self.branch_repofolder,
+                         view="@reference-numbers/2",
+                         method='DELETE',
+                         headers=self.api_headers)
+
+        self.assertEqual(
+            {u'type': u'BadRequest',
+             u'message': u'Number still in use.'},
             browser.json)

--- a/opengever/api/tests/test_reference_numbers.py
+++ b/opengever/api/tests/test_reference_numbers.py
@@ -117,7 +117,7 @@ class TestReferenceNumbersDelete(IntegrationTestCase):
         self.assertEqual(
             [{u'active': False,
               u'prefix': u'1',
-              u'title': u'Vertr\xe4ge und Vereinbarungen'},
+              u'title': None},
              {u'active': True,
               u'prefix': u'3',
               u'title': u'Vertr\xe4ge und Vereinbarungen'}],
@@ -198,7 +198,7 @@ class TestReferenceNumbersDelete(IntegrationTestCase):
         self.assertEqual(
             [{u'active': False,
               u'prefix': u'1',
-              u'title': u'Vertr\xe4ge und Vereinbarungen'},
+              u'title': None},
              {u'active': True,
               u'prefix': u'2',
               u'title': u'Vertr\xe4ge und Vereinbarungen'}],
@@ -215,17 +215,17 @@ class TestReferenceNumbersDelete(IntegrationTestCase):
               u'title': u'Vertr\xe4ge und Vereinbarungen'},
              {u'active': False,
               u'prefix': u'2',
-              u'title': u'Vertr\xe4ge und Vereinbarungen'}],
+              u'title': None}],
             get_numbers(self.branch_repofolder))
 
         # And should be removeable again
-        with browser.expect_http_error(code=400):
-            browser.open(self.branch_repofolder,
-                         view="@reference-numbers/2",
-                         method='DELETE',
-                         headers=self.api_headers)
+        browser.open(self.branch_repofolder,
+                     view="@reference-numbers/2",
+                     method='DELETE',
+                     headers=self.api_headers)
 
         self.assertEqual(
-            {u'type': u'BadRequest',
-             u'message': u'Number still in use.'},
-            browser.json)
+            [{u'active': True,
+              u'prefix': u'1',
+              u'title': u'Vertr\xe4ge und Vereinbarungen'}],
+            get_numbers(self.branch_repofolder))


### PR DESCRIPTION
🚧 

For [CA-5690]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-5690]: https://4teamwork.atlassian.net/browse/CA-5690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ