### PR TITLE
Index related items for documents and tasks

### DIFF
--- a/changes/CA-5463.feature
+++ b/changes/CA-5463.feature
@@ -1,0 +1,1 @@
+Index document and task related items in solr. [njohner]

--- a/opengever/base/utils.py
+++ b/opengever/base/utils.py
@@ -328,6 +328,25 @@ def unrestrictedUuidToCatalogBrain(uuid):
     return result[0]
 
 
+def unrestrictedPathToCatalogBrain(path):
+    """Given a path, attempt to return a catalog brain.
+    """
+
+    site = getSite()
+    if site is None:
+        return None
+
+    catalog = api.portal.get_tool('portal_catalog')
+    if catalog is None:
+        return None
+
+    result = catalog.unrestrictedSearchResults(path=path)
+    if len(result) != 1:
+        return None
+
+    return result[0]
+
+
 def get_date_with_delta_excluding_weekends(start_date, days_delta):
     calculated_delta = 0
     end_date = start_date

--- a/opengever/core/upgrades/20230524173623_add_related_items_solr_index/upgrade.py
+++ b/opengever/core/upgrades/20230524173623_add_related_items_solr_index/upgrade.py
@@ -1,0 +1,18 @@
+from ftw.upgrade import UpgradeStep
+from opengever.core.upgrade import NightlyIndexer
+from opengever.document.document import IDocumentSchema
+
+
+class AddRelatedItemsSolrIndex(UpgradeStep):
+    """Add related items solr index.
+    """
+
+    deferrable = True
+
+    def __call__(self):
+        query = {'object_provides': IDocumentSchema.__identifier__}
+
+        with NightlyIndexer(idxs=["related_items"],
+                            index_in_solr_only=True) as indexer:
+            for brain in self.brains(query, 'Index related_items in Solr'):
+                indexer.add_by_brain(brain)

--- a/opengever/core/upgrades/20230524173623_add_related_items_solr_index/upgrade.py
+++ b/opengever/core/upgrades/20230524173623_add_related_items_solr_index/upgrade.py
@@ -1,6 +1,7 @@
 from ftw.upgrade import UpgradeStep
 from opengever.core.upgrade import NightlyIndexer
 from opengever.document.document import IDocumentSchema
+from opengever.task.task import ITask
 
 
 class AddRelatedItemsSolrIndex(UpgradeStep):
@@ -10,7 +11,8 @@ class AddRelatedItemsSolrIndex(UpgradeStep):
     deferrable = True
 
     def __call__(self):
-        query = {'object_provides': IDocumentSchema.__identifier__}
+        query = {'object_provides': [IDocumentSchema.__identifier__,
+                                     ITask.__identifier__]}
 
         with NightlyIndexer(idxs=["related_items"],
                             index_in_solr_only=True) as indexer:

--- a/opengever/core/upgrades/20230524173623_add_related_items_solr_index/upgrade.py
+++ b/opengever/core/upgrades/20230524173623_add_related_items_solr_index/upgrade.py
@@ -1,5 +1,6 @@
 from ftw.upgrade import UpgradeStep
 from opengever.core.upgrade import NightlyIndexer
+from opengever.document.behaviors.related_docs import IRelatedDocuments
 from opengever.document.document import IDocumentSchema
 from opengever.task.task import ITask
 
@@ -11,10 +12,15 @@ class AddRelatedItemsSolrIndex(UpgradeStep):
     deferrable = True
 
     def __call__(self):
-        query = {'object_provides': [IDocumentSchema.__identifier__,
-                                     ITask.__identifier__]}
+        query_tasks = {'object_provides': ITask.__identifier__}
+        query_docs = {'object_provides': IDocumentSchema.__identifier__}
 
         with NightlyIndexer(idxs=["related_items"],
                             index_in_solr_only=True) as indexer:
-            for brain in self.brains(query, 'Index related_items in Solr'):
-                indexer.add_by_brain(brain)
+            for obj in self.objects(query_tasks, 'Index related_items in Solr for tasks'):
+                if ITask(obj).relatedItems:
+                    indexer.add_by_obj(obj)
+
+            for obj in self.objects(query_docs, 'Index related_items in Solr for documents'):
+                if IRelatedDocuments(obj).relatedItems:
+                    indexer.add_by_obj(obj)

--- a/opengever/document/configure.zcml
+++ b/opengever/document/configure.zcml
@@ -374,6 +374,11 @@
       name="containing_dossier"
       />
 
+  <adapter
+      factory=".indexers.related_items"
+      name="related_items"
+      />
+
   <adapter factory=".document.UploadValidator" />
 
   <adapter factory=".fileactions.BaseDocumentFileActions" />

--- a/opengever/document/indexers.py
+++ b/opengever/document/indexers.py
@@ -7,10 +7,12 @@ from opengever.base.behaviors.classification import IClassificationMarker
 from opengever.base.interfaces import IReferenceNumber
 from opengever.base.interfaces import ISequenceNumber
 from opengever.base.utils import ensure_str
+from opengever.base.utils import unrestrictedPathToCatalogBrain
 from opengever.document.approvals import IApprovalList
 from opengever.document.behaviors import IBaseDocument
 from opengever.document.behaviors.customproperties import IDocumentCustomProperties
 from opengever.document.behaviors.metadata import IDocumentMetadata
+from opengever.document.behaviors.related_docs import IRelatedDocuments
 from opengever.document.document import IDocumentSchema
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.document.interfaces import IDocumentIndexer
@@ -262,3 +264,10 @@ def containing_dossier_title(obj):
     languages = api.portal.get_tool('portal_languages').getSupportedLanguages()
     titles = [templatefolder.Title(language.split('-')[0]) for language in languages]
     return ' / '.join(titles)
+
+
+@indexer(IDocumentSchema)
+def related_items(obj):
+    brains = [unrestrictedPathToCatalogBrain(rel.to_path)
+              for rel in IRelatedDocuments(obj).relatedItems]
+    return [brain.UID for brain in brains if brain]

--- a/opengever/document/indexers.py
+++ b/opengever/document/indexers.py
@@ -269,5 +269,5 @@ def containing_dossier_title(obj):
 @indexer(IDocumentSchema)
 def related_items(obj):
     brains = [unrestrictedPathToCatalogBrain(rel.to_path)
-              for rel in IRelatedDocuments(obj).relatedItems]
+              for rel in IRelatedDocuments(obj).relatedItems if not rel.isBroken()]
     return [brain.UID for brain in brains if brain]

--- a/opengever/document/tests/test_indexers.py
+++ b/opengever/document/tests/test_indexers.py
@@ -1,7 +1,6 @@
 from datetime import date
 from ftw.builder import Builder
 from ftw.builder import create
-from ftw.solr.interfaces import ISolrSettings
 from ftw.testing import freeze
 from opengever.activity import notification_center
 from opengever.activity.roles import WATCHER_ROLE
@@ -27,11 +26,9 @@ from plone import api
 from plone.app.testing import TEST_USER_NAME
 from plone.dexterity.utils import createContentInContainer
 from plone.namedfile.file import NamedBlobFile
-from plone.registry.interfaces import IRegistry
 from zope.annotation.interfaces import IAnnotations
 from zope.component import getAdapter
 from zope.component import getMultiAdapter
-from zope.component import queryUtility
 import datetime
 import pytz
 
@@ -450,12 +447,7 @@ class SolrDocumentIndexer(SolrIntegrationTestCase):
 
         copied_doc = api.content.copy(self.document, target=self.subdossier)
 
-        # We need to execute the update commands but avoid extracting from the
-        # blob, which fails as the zope transaction is not committed.
-        registry = queryUtility(IRegistry)
-        settings = registry.forInterface(ISolrSettings)
-        settings.enable_updates_in_post_commit_hook = False
-        self.commit_solr(after_commit=True)
+        self.commit_solr(avoid_blob_extraction=True)
 
         indexed_value = solr_data_for(copied_doc, 'approval_state')
         self.assertEqual(APPROVED_IN_CURRENT_VERSION, indexed_value)
@@ -480,12 +472,7 @@ class SolrDocumentIndexer(SolrIntegrationTestCase):
 
         copied_doc = api.content.copy(self.document, target=self.subdossier)
 
-        # We need to execute the update commands but avoid extracting from the
-        # blob, which fails as the zope transaction is not committed.
-        registry = queryUtility(IRegistry)
-        settings = registry.forInterface(ISolrSettings)
-        settings.enable_updates_in_post_commit_hook = False
-        self.commit_solr(after_commit=True)
+        self.commit_solr(avoid_blob_extraction=True)
 
         indexed_value = solr_data_for(copied_doc, 'approval_state')
         self.assertEqual(None, indexed_value)

--- a/opengever/dossier/tests/test_copy_dossier.py
+++ b/opengever/dossier/tests/test_copy_dossier.py
@@ -1,16 +1,13 @@
 from ftw.builder import Builder
 from ftw.builder import create
-from ftw.solr.interfaces import ISolrSettings
 from OFS.interfaces import IObjectWillBeRemovedEvent
 from opengever.base.interfaces import IReferenceNumberPrefix
 from opengever.testing import SolrIntegrationTestCase
 from opengever.testing.event_recorder import get_recorded_events
 from opengever.testing.event_recorder import register_event_recorder
 from plone import api
-from plone.registry.interfaces import IRegistry
 from zope.app.intid.interfaces import IIntIds
 from zope.component import getUtility
-from zope.component import queryUtility
 
 
 class TestCopyDossiers(SolrIntegrationTestCase):
@@ -58,12 +55,7 @@ class TestCopyDossiers(SolrIntegrationTestCase):
         dossier_copy = api.content.copy(
             source=self.subdossier, target=self.leaf_repofolder)
 
-        # We need to execute the update commands but avoid extracting from the
-        # blob, which fails as the zope transaction is not committed.
-        registry = queryUtility(IRegistry)
-        settings = registry.forInterface(ISolrSettings)
-        settings.enable_updates_in_post_commit_hook = False
-        self.commit_solr(after_commit=True)
+        self.commit_solr(avoid_blob_extraction=True)
 
         subdossier_copy = api.content.find(
             context=dossier_copy, portal_type='opengever.dossier.businesscasedossier',

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -1,6 +1,5 @@
 from ftw.builder import Builder
 from ftw.builder import create
-from ftw.solr.interfaces import ISolrSettings
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import editbar
 from ftw.testbrowser.pages import factoriesmenu
@@ -24,13 +23,11 @@ from opengever.testing.event_recorder import register_event_recorder
 from plone import api
 from plone.locking.interfaces import ILockable
 from plone.protect import createToken
-from plone.registry.interfaces import IRegistry
 from requests_toolbelt.utils import formdata
 from StringIO import StringIO
 from zc.relation.interfaces import ICatalog
 from zExceptions import Unauthorized
 from zope.component import getUtility
-from zope.component import queryUtility
 import json
 
 
@@ -155,10 +152,7 @@ class TestProposalSolr(SolrIntegrationTestCase):
 
         statusmessages.assert_no_error_messages()
 
-        registry = queryUtility(IRegistry)
-        settings = registry.forInterface(ISolrSettings)
-        settings.enable_updates_in_post_commit_hook = False
-        self.commit_solr(after_commit=True)
+        self.commit_solr(avoid_blob_extraction=True)
 
         self.assertIn('external_edit', browser.css('.redirector').first.text,
                       'External editor should have been triggered.')

--- a/opengever/task/configure.zcml
+++ b/opengever/task/configure.zcml
@@ -200,6 +200,11 @@
       name="watchers"
       />
 
+  <adapter
+      factory=".indexers.related_items"
+      name="related_items"
+      />
+
   <subscriber
       for="opengever.task.task.ITask
            zope.lifecycleevent.interfaces.IObjectAddedEvent"

--- a/opengever/task/indexers.py
+++ b/opengever/task/indexers.py
@@ -1,6 +1,7 @@
 from collective import dexteritytextindexer
 from opengever.activity import notification_center
 from opengever.activity.roles import WATCHER_ROLE
+from opengever.base.utils import unrestrictedPathToCatalogBrain
 from opengever.task.task import ITask
 from plone import api
 from plone.indexer import indexer
@@ -62,3 +63,10 @@ def watchers(obj):
     center = notification_center()
     watchers = center.get_watchers(obj, role=WATCHER_ROLE)
     return [watcher.actorid for watcher in watchers]
+
+
+@indexer(ITask)
+def related_items(obj):
+    brains = [unrestrictedPathToCatalogBrain(rel.to_path)
+              for rel in ITask(obj).relatedItems if not rel.isBroken()]
+    return [brain.UID for brain in brains if brain]

--- a/opengever/task/tests/test_indexer.py
+++ b/opengever/task/tests/test_indexer.py
@@ -1,9 +1,16 @@
+from ftw.testbrowser import browsing
 from opengever.activity import notification_center
 from opengever.activity.roles import WATCHER_ROLE
+from opengever.task.task import ITask
 from opengever.testing import IntegrationTestCase
 from opengever.testing import obj2brain
 from opengever.testing import solr_data_for
 from opengever.testing import SolrIntegrationTestCase
+from plone import api
+from plone.app.relationfield.event import update_behavior_relations
+from z3c.relationfield.relation import RelationValue
+from zope.component import getUtility
+from zope.intid import IIntIds
 
 
 class TestTaskIndexers(IntegrationTestCase):
@@ -68,3 +75,50 @@ class TestTaskSolrIndexer(SolrIntegrationTestCase):
         self.task.reindexObject()
         self.commit_solr()
         self.assertTrue(solr_data_for(self.task, 'is_completed'))
+
+    @browsing
+    def test_related_items_is_updated_when_forward_relations_are_modified(self, browser):
+        self.login(self.administrator, browser)
+        api.content.transition(
+            obj=self.task, transition='task-transition-in-progress-cancelled')
+        api.content.transition(
+            obj=self.task, transition='task-transition-cancelled-open')
+
+        self.assertItemsEqual(
+            [self.document],
+            [rel.to_object for rel in ITask(self.task).relatedItems])
+        self.assertItemsEqual(
+            [self.document.UID()],
+            solr_data_for(self.task, 'related_items'))
+
+        browser.open(self.task, view='edit')
+        browser.fill({'Related items': [self.document.absolute_url_path(),
+                                        self.subdocument.absolute_url_path()]})
+        browser.find('Save').click()
+
+        self.commit_solr()
+        self.assertItemsEqual(
+            [self.document, self.subdocument],
+            [rel.to_object for rel in ITask(self.task).relatedItems])
+        self.assertItemsEqual(
+            [self.document.UID(), self.subdocument.UID()],
+            solr_data_for(self.task, 'related_items'))
+
+    @browsing
+    def test_related_items_is_updated_when_related_item_is_deleted(self, browser):
+        self.login(self.regular_user, browser)
+
+        self.assertEqual(
+            [self.document],
+            [rel.to_object for rel in ITask(self.task).relatedItems])
+        self.assertEqual([self.document.UID()],
+                         solr_data_for(self.task, 'related_items'))
+
+        with self.login(self.manager):
+            api.content.delete(self.document)
+
+        self.commit_solr()
+        # Deletion is handled in an event handler.
+        relations = ITask(self.task).relatedItems
+        self.assertEqual(0, len(relations))
+        self.assertEqual(None, solr_data_for(self.task, 'related_items'))

--- a/solr-conf/managed-schema
+++ b/solr-conf/managed-schema
@@ -166,6 +166,7 @@
     <field name="public_trial" type="string" indexed="true" stored="false" />
     <field name="receipt_date" type="pdate" indexed="true" stored="false" />
     <field name="reference" type="string" indexed="true" stored="false" />
+    <field name="related_items" type="string" indexed="false" stored="true" multiValued="true" />
     <field name="sortable_reference" type="string" indexed="true" stored="false" />
     <field name="responsible" type="string" indexed="true" stored="false" />
     <field name="retention_expiration" type="pdate" indexed="true" stored="false" />


### PR DESCRIPTION
With this PR we index related items for documents and tasks in Solr. This can be used for example to display contained and related documents of a task (see test `test_get_related_and_contained_documents`).

Tests are failing because we would need to build and use a new image of solr to include the changes in solr configuration.

For [CA-5463]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- Upgrade-Steps:
  - [x] Make it deferrable if possible
  - [x] Execute as much as possible conditionally
- New functionality:
  - [ ] for `document` also works for `mail` -> mails do not have related items.
  - [x] for `task` also works for `forwarding`

[CA-5463]: https://4teamwork.atlassian.net/browse/CA-5463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ