### PR TITLE
Fix portrait removal for users with mail address as userid.

### DIFF
--- a/changes/CA-5831.bugfix
+++ b/changes/CA-5831.bugfix
@@ -1,0 +1,1 @@
+Fix portrait removal for users with mail address as userid. [phgross]

--- a/opengever/api/users.py
+++ b/opengever/api/users.py
@@ -65,10 +65,8 @@ class GeverUsersPatch(UsersPatch):
             return
 
         if 'portrait' in data and portrait is None:
-            user = self._get_user(self._get_user_id)
             portal_membership = api.portal.get_tool('portal_membership')
-            safe_id = portal_membership._getSafeMemberId(user.getId())
-            portal_membership.deletePersonalPortrait(str(safe_id))
+            portal_membership.deletePersonalPortrait(str(self._get_user_id))
 
 
 @implementer(ISerializeToJson)


### PR DESCRIPTION
The problem was a security check in deletePersonalPortrait method. With the current implementation the userid was "normalized" twice. And the safeId ist not the same as the current user id, which led to Unauthorized raised.
The safeId inside our own API endpoint is unnecessary and can be removed, MembershipTools implementation already takes care of that.

I was not able to provide a specific test for the mail situation in reasonable time
For [CA-5831]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- Bug fixed:
  - [x] Resolved any Sentry issues caused by this bug (Unauthorized is not raised to sentry)

[CA-5831]: https://4teamwork.atlassian.net/browse/CA-5831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ