### PR TITLE
Dossier templates can reference document templates.

### DIFF
--- a/changes/CA-4519-2.feature
+++ b/changes/CA-4519-2.feature
@@ -1,0 +1,1 @@
+Whitelist the related_items field for the @listing endpoint. [elioschmutz]

--- a/changes/CA-4519-3.feature
+++ b/changes/CA-4519-3.feature
@@ -1,0 +1,1 @@
+@listing-stats: Allow POST requests against the endpoint. [elioschmutz]

--- a/changes/CA-4519-3.other
+++ b/changes/CA-4519-3.other
@@ -1,0 +1,1 @@
+@listing-stats: No longer escapes querie-chars to allow complex queries . [elioschmutz]

--- a/changes/CA-4519.feature
+++ b/changes/CA-4519.feature
@@ -1,0 +1,1 @@
+Dossier templates can reference document templates. [elioschmutz]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -12,6 +12,7 @@ Breaking Changes
 Other Changes
 ^^^^^^^^^^^^^
 - Whitelist the ``related_items`` field for the ``@listing`` endpoint
+- ``@listing-stats``: Allow POST requests against the endpoint. This allows us to get around the length-limit of GET requests.
 
 2023.9.0 (2023-05-30)
 ---------------------

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -13,6 +13,7 @@ Other Changes
 ^^^^^^^^^^^^^
 - Whitelist the ``related_items`` field for the ``@listing`` endpoint
 - ``@listing-stats``: Allow POST requests against the endpoint. This allows us to get around the length-limit of GET requests.
+- ``@listing-stats``: No longer escapes querie-chars to allow complex queries
 
 2023.9.0 (2023-05-30)
 ---------------------

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,7 +11,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
-
+- Whitelist the ``related_items`` field for the ``@listing`` endpoint
 
 2023.9.0 (2023-05-30)
 ---------------------

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -547,6 +547,14 @@
       />
 
   <plone:service
+      method="POST"
+      for="Products.CMFCore.interfaces.IFolderish"
+      factory=".listing_stats.ListingStatsGet"
+      name="@listing-stats"
+      permission="zope2.View"
+      />
+
+  <plone:service
       method="GET"
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"
       factory=".ogdsuserlisting.OGDSUserListingGet"

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -31,6 +31,7 @@ OTHER_ALLOWED_FIELDS = set([
     'trashed',
     'UID',
     'watchers',
+    'related_items',
 ])
 
 ALLOWED_ORDER_GROUP_FIELDS = set([

--- a/opengever/api/listing_stats.py
+++ b/opengever/api/listing_stats.py
@@ -1,6 +1,7 @@
 from ftw.solr.interfaces import ISolrSearch
 from ftw.solr.query import escape
 from opengever.api.listing import FILTERS
+from opengever.api.solr_query_service import RequestPayloadMixin
 from opengever.base.interfaces import IOpengeverBaseLayer
 from plone.restapi.interfaces import IExpandableElement
 from plone.restapi.services import Service
@@ -19,7 +20,7 @@ def get_path_depth(context):
 
 @implementer(IExpandableElement)
 @adapter(Interface, IOpengeverBaseLayer)
-class ListingStats(object):
+class ListingStats(object, RequestPayloadMixin):
     """Returns a facet pivot of the current object.
 
     The format is based on the solr facet pivot format:

--- a/opengever/api/listing_stats.py
+++ b/opengever/api/listing_stats.py
@@ -44,8 +44,7 @@ class ListingStats(object, RequestPayloadMixin):
     def __init__(self, context, request):
         self.context = context
         self.request = request
-
-        queries = self.request.form.get("queries", [])
+        queries = self.request_payload.get("queries", [])
         if isinstance(queries, basestring):
             queries = [queries]
         self.facet_queries = [self._escape_query(query) for query in queries]
@@ -54,7 +53,7 @@ class ListingStats(object, RequestPayloadMixin):
 
     @staticmethod
     def _escape_query(query):
-        return u":".join(escape(safe_unicode(el)) for el in query.split(":"))
+        return u":".join(safe_unicode(el) for el in query.split(":"))
 
     def __call__(self, expand=False):
         result = {

--- a/opengever/api/tests/test_listing_stats.py
+++ b/opengever/api/tests/test_listing_stats.py
@@ -292,3 +292,18 @@ class TestListingStatsPost(SolrIntegrationTestCase):
              u'queries': {u'depth:1': 4}
              },
             self.get_facet_by_value(browser.json['facet_pivot']['listing_name'], 'documents'))
+
+    @browsing
+    def test_listing_stats_pivot_queries_supports_complex_queries(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(
+            '{}/@listing-stats'.format(self.repository_root.absolute_url()),
+            data=json.dumps({'queries': ['UID:({} OR {})'.format(
+                self.document.UID(), self.subdocument.UID())]}),
+            method='POST',
+            headers=self.api_headers
+        )
+
+        self.assertDictEqual(
+            {u'UID:(createtreatydossiers000000000002 OR createtreatydossiers000000000017)': 2},
+            self.get_facet_by_value(browser.json['facet_pivot']['listing_name'], 'documents').get('queries'))

--- a/opengever/api/tests/test_listing_stats.py
+++ b/opengever/api/tests/test_listing_stats.py
@@ -3,9 +3,10 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from opengever.api.listing import FILTERS
 from opengever.testing.integration_test_case import SolrIntegrationTestCase
+import json
 
 
-class TestListingStats(SolrIntegrationTestCase):
+class TestListingStatsGet(SolrIntegrationTestCase):
 
     features = ['solr']
 
@@ -261,5 +262,33 @@ class TestListingStats(SolrIntegrationTestCase):
              u'field': u'listing_name',
              u'value': u'documents',
              u'queries': {u'Title_de:Vertr\xe4ge': 7}
+             },
+            self.get_facet_by_value(browser.json['facet_pivot']['listing_name'], 'documents'))
+
+
+class TestListingStatsPost(SolrIntegrationTestCase):
+    """The POST endpoint should behave exactly the same as the GET endpoint. We do not
+    copy all the tests of 'TestListingStatsGet'.
+    """
+
+    features = ['solr']
+
+    def get_facet_by_value(self, pivot, value):
+        return filter(lambda p: p.get('value') == value, pivot)[0]
+
+    @browsing
+    def test_listing_stats_pivot_queries_supports_depth(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(
+            '{}/@listing-stats'.format(self.dossier.absolute_url()),
+            data=json.dumps({'queries': ['depth:1']}),
+            method='POST',
+            headers=self.api_headers
+        )
+        self.assertDictEqual(
+            {u'count': 12,
+             u'field': u'listing_name',
+             u'value': u'documents',
+             u'queries': {u'depth:1': 4}
              },
             self.get_facet_by_value(browser.json['facet_pivot']['listing_name'], 'documents'))

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -376,6 +376,7 @@ DOSSIER_TEMPLATE_DEFAULTS = {
     'description': u'',
     'keywords': (),
     'predefined_keywords': True,
+    'related_documents': [],
     'restrict_keywords': False,
     'title_help': u'',
 }

--- a/opengever/core/tests/test_relations.py
+++ b/opengever/core/tests/test_relations.py
@@ -139,6 +139,7 @@ EXPECTED_INTERFACES = [
 EXPECTED_TYPES_WITH_RELATIONS = [
     'opengever.document.document',
     'opengever.dossier.businesscasedossier',
+    'opengever.dossier.dossiertemplate',
     'opengever.repository.repositoryfolder',
     'opengever.task.task',
     'opengever.inbox.forwarding',

--- a/opengever/dossier/dossiertemplate/behaviors.py
+++ b/opengever/dossier/dossiertemplate/behaviors.py
@@ -88,6 +88,7 @@ class IDossierTemplate(model.Schema):
             u'keywords',
             u'dossier_type',
             u'checklist',
+            u'related_documents',
         ],
     )
 
@@ -108,6 +109,24 @@ class IDossierTemplate(model.Schema):
         source=wrap_vocabulary(
             'opengever.dossier.dossier_types',
             hidden_terms_from_registry='opengever.dossier.interfaces.IDossierType.hidden_dossier_types'),
+        required=False,
+    )
+
+    related_documents = RelationList(
+        title=_(u'label_related_documents',
+                default=u'Related documents'),
+        default=list(),
+        missing_value=list(),
+        value_type=RelationChoice(
+            title=u'Related document templates',
+            source=SolrObjPathSourceBinder(
+                object_provides=("opengever.document.interfaces.ITemplateDocumentMarker", ),
+                navigation_tree_query={
+                    'object_provides':
+                    ['opengever.dossier.templatefolder.interfaces.ITemplateFolder',
+                     'opengever.document.document.IDocumentSchema']
+                }),
+        ),
         required=False,
     )
 

--- a/opengever/dossier/dossiertemplate/configure.zcml
+++ b/opengever/dossier/dossiertemplate/configure.zcml
@@ -23,6 +23,11 @@
       name="IDossierTemplate"
       />
 
+  <adapter
+      factory=".indexers.related_items"
+      name="related_items"
+      />
+
   <browser:page
       for="opengever.repository.interfaces.IRepositoryFolder"
       name="dossier_with_template"

--- a/opengever/dossier/dossiertemplate/form.py
+++ b/opengever/dossier/dossiertemplate/form.py
@@ -203,6 +203,12 @@ class CreateDossierContentFromTemplateMixin(object):
     def recursive_content_creation(self, template_obj, target_container):
         responsible = IDossier(target_container).responsible
 
+        for related_document_template in IDossierTemplate(
+                template_obj).related_documents:
+            template = related_document_template.to_object
+            CreateDocumentFromTemplateCommand(
+                target_container, template, template.title).execute()
+
         for child_obj in template_obj.listFolderContents():
             if IDossierTemplateSchema.providedBy(child_obj):
                 dossier = CreateDossierFromTemplateCommand(

--- a/opengever/dossier/dossiertemplate/indexers.py
+++ b/opengever/dossier/dossiertemplate/indexers.py
@@ -1,5 +1,6 @@
 from collective import dexteritytextindexer
 from opengever.base.interfaces import ISequenceNumber
+from opengever.base.utils import unrestrictedPathToCatalogBrain
 from opengever.dossier.dossiertemplate.behaviors import IDossierTemplate
 from opengever.dossier.dossiertemplate.behaviors import IDossierTemplateMarker
 from plone.indexer import indexer
@@ -53,3 +54,10 @@ class DossierTemplateSearchableTextExtender(object):
 @indexer(IDossierTemplateMarker)
 def is_subdossier(obj):
     return obj.is_subdossier()
+
+
+@indexer(IDossierTemplateMarker)
+def related_items(obj):
+    brains = [unrestrictedPathToCatalogBrain(rel.to_path)
+              for rel in IDossierTemplate(obj).related_documents if not rel.isBroken()]
+    return [brain.UID for brain in brains if brain]

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2023-02-06 14:57+0000\n"
+"POT-Creation-Date: 2023-06-02 12:52+0000\n"
 "PO-Revision-Date: 2017-05-23 04:53+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -753,6 +753,11 @@ msgstr "Lesend & schreibend"
 #: ./opengever/dossier/viewlets/byline.py
 msgid "label_reference_number"
 msgstr "Aktenzeichen"
+
+#. Default: "Related documents"
+#: ./opengever/dossier/dossiertemplate/behaviors.py
+msgid "label_related_documents"
+msgstr "Zugehörige Dokumente"
 
 #. Default: "Related Dossier"
 #: ./opengever/dossier/behaviors/dossier.py

--- a/opengever/dossier/locales/en/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/en/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2023-02-06 14:57+0000\n"
+"POT-Creation-Date: 2023-06-02 12:52+0000\n"
 "PO-Revision-Date: 2017-05-23 04:53+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -913,6 +913,11 @@ msgstr "Read/Write access"
 #: ./opengever/dossier/viewlets/byline.py
 msgid "label_reference_number"
 msgstr "Reference number"
+
+#. Default: "Related documents"
+#: ./opengever/dossier/dossiertemplate/behaviors.py
+msgid "label_related_documents"
+msgstr ""
 
 #. German translation: Verwandte Dossiers
 #. Default: "Related Dossier"

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-02-06 14:57+0000\n"
+"POT-Creation-Date: 2023-06-02 12:52+0000\n"
 "PO-Revision-Date: 2017-12-03 11:16+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/fr/>\n"
@@ -751,6 +751,11 @@ msgstr "lecture et écriture"
 #: ./opengever/dossier/viewlets/byline.py
 msgid "label_reference_number"
 msgstr "Numéro de référence"
+
+#. Default: "Related documents"
+#: ./opengever/dossier/dossiertemplate/behaviors.py
+msgid "label_related_documents"
+msgstr ""
 
 #. Default: "Related Dossier"
 #: ./opengever/dossier/behaviors/dossier.py

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-02-06 14:57+0000\n"
+"POT-Creation-Date: 2023-06-02 12:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -749,6 +749,11 @@ msgstr ""
 #: ./opengever/dossier/behaviors/dossier.py
 #: ./opengever/dossier/viewlets/byline.py
 msgid "label_reference_number"
+msgstr ""
+
+#. Default: "Related documents"
+#: ./opengever/dossier/dossiertemplate/behaviors.py
+msgid "label_related_documents"
 msgstr ""
 
 #. Default: "Related Dossier"

--- a/opengever/dossier/tests/test_dossier_template.py
+++ b/opengever/dossier/tests/test_dossier_template.py
@@ -37,7 +37,7 @@ class TestDossierTemplateSchema(unittest.TestCase):
     def test_idossiertemplate_fields_almost_all_match_idossier_fields(self):
         idossiertemplate_fields = {
             fieldname for fieldname, field in getFieldsInOrder(IDossierTemplate)
-            if fieldname != 'comments'
+            if fieldname not in ['comments', 'related_documents']
         }
         idossier_fields = {
             fieldname for fieldname, field in getFieldsInOrder(IDossier)
@@ -88,7 +88,8 @@ class TestDossierTemplate(IntegrationTestCase):
 
         browser.open(self.templates)
         factoriesmenu.add('Dossier template')
-        browser.fill({'Title': 'Template'}).submit()
+        browser.fill({'Title': 'Template'})
+        browser.click_on('Save')
 
         self.assertEquals(['Item created'], info_messages())
         self.assertEquals(['Template'], browser.css('h1').text)
@@ -107,7 +108,8 @@ class TestDossierTemplate(IntegrationTestCase):
         browser.open(self.dossiertemplate)
 
         factoriesmenu.add('Subdossier')
-        browser.fill({'Title': 'Template'}).submit()
+        browser.fill({'Title': 'Template'})
+        browser.click_on('Save')
 
         self.assertTrue(IDossierTemplateSchema.providedBy(browser.context))
 
@@ -159,7 +161,6 @@ class TestDossierTemplate(IntegrationTestCase):
         self.login(self.administrator, browser=browser)
         browser.open(self.templates)
         factoriesmenu.add('Dossier template')
-
         self.assertEqual([
             u'Title hint',
             u'Title',
@@ -168,6 +169,8 @@ class TestDossierTemplate(IntegrationTestCase):
             u'Prefill keywords',
             u'Restrict keywords',
             u'Dossier type',
+            u'Related documents',
+            u'',  # label of the relation text field
             u'Filing number prefix'],
             browser.css('#content fieldset label').text
         )
@@ -185,6 +188,8 @@ class TestDossierTemplate(IntegrationTestCase):
             u'Prefill keywords',
             u'Restrict keywords',
             u'Dossier type',
+            u'Related documents',
+            u'',  # label of the relation text field
             u'Filing number prefix'],
             browser.css('#content fieldset label').text
         )
@@ -195,7 +200,6 @@ class TestDossierTemplate(IntegrationTestCase):
         self.login(self.administrator, browser=browser)
         browser.open(self.templates)
         factoriesmenu.add('Dossier template')
-
         self.assertEqual([
             u'Title hint',
             u'Title',
@@ -205,6 +209,8 @@ class TestDossierTemplate(IntegrationTestCase):
             u'Restrict keywords',
             u'Dossier type',
             u'Checklist',
+            u'Related documents',
+            u'',  # label of the relation text field
             u'Filing number prefix'],
             browser.css('#content fieldset label').text
         )
@@ -223,6 +229,8 @@ class TestDossierTemplate(IntegrationTestCase):
             u'Restrict keywords',
             u'Dossier type',
             u'Checklist',
+            u'Related documents',
+            u'',  # label of the relation text field
             u'Filing number prefix'],
             browser.css('#content fieldset label').text
         )
@@ -263,7 +271,8 @@ class TestDossierTemplateWithSolr(SolrIntegrationTestCase):
 
         browser.open(self.dossiertemplate)
         browser.find('Edit').click()
-        browser.fill({'Title': 'Edited Template'}).submit()
+        browser.fill({'Title': 'Edited Template'})
+        browser.click_on('Save')
 
         self.assertEquals(['Changes saved'], info_messages())
         self.assertEquals(['Edited Template'], browser.css('h1').text)
@@ -745,7 +754,8 @@ class TestSubDossierTemplateHandling(IntegrationTestCase):
 
         browser.open(self.subdossiertemplate)
         factoriesmenu.add('Subdossier')
-        browser.fill({'Title': u'Sub Sub Template'}).submit()
+        browser.fill({'Title': u'Sub Sub Template'})
+        browser.click_on('Save')
 
         self.assertEquals(['Item created'], info_messages())
         self.assertEqual(u'Sub Sub Template', browser.context.title)


### PR DESCRIPTION
This PR extends the dossier template schema with a `related_documents` field. It allows document templates as references which will be created as new documents when adding a new dossier from a dossier template.

For [CA-4519]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-4517]: https://4teamwork.atlassian.net/browse/CA-4517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CA-4519]: https://4teamwork.atlassian.net/browse/CA-4519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ