### PR TITLE
Improve logging for maintenance jobs.

### DIFF
--- a/changes/CA-5702.other
+++ b/changes/CA-5702.other
@@ -1,0 +1,1 @@
+Improve logging of nightly maintenance jobs. [njohner]

--- a/opengever/nightlyjobs/runner.py
+++ b/opengever/nightlyjobs/runner.py
@@ -161,7 +161,7 @@ class NightlyJobRunner(object):
         self.update_last_run_timestamp()
 
         for provider_name, provider in self.job_providers.items():
-            self.log.info('Executing jobs for provider %r' % provider_name)
+            self.log.info('Executing %s jobs for provider %r' % (len(provider), provider_name))
             for job in provider:
                 try:
                     self.interrupt_if_necessary()
@@ -199,7 +199,8 @@ class NightlyJobRunner(object):
 
     def process_task_queue(self):
         queue = self._task_queue.queue
-
+        if queue.qsize() == 0:
+            return
         self.log.info('Processing %d task queue jobs...' % queue.qsize())
         request = getRequest()
         alsoProvides(request, ITaskQueueLayer)


### PR DESCRIPTION
Nightly job execution spams the logs with way too much trash. We try to improve this here by logging only every 5000 jobs of the same type, but also by indicating total number of executed and remaining jobs. We also log when we switch to a new job type. Finally we avoid logging that we are processing the task queue for every job, although there never is anything to process...

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-5702]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-5702]: https://4teamwork.atlassian.net/browse/CA-5702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ