### PR TITLE
Always pull latest docker images for testing.

### DIFF
--- a/changes/CA-5463.other
+++ b/changes/CA-5463.other
@@ -1,0 +1,1 @@
+Always pull latest docker images for testing. [njohner]

--- a/opengever/core/docker_testing.py
+++ b/opengever/core/docker_testing.py
@@ -22,7 +22,7 @@ class DockerServiceLayer(Layer):
         base_name = self.image_name.split(':')[0].replace('/', '_')
         self.container_name = '{}_{}'.format(base_name, self.port)
         self.run(
-            'docker run -d -p {}:8080 --name {} {}'.format(
+            'docker run --pull always -d -p {}:8080 --name {} {}'.format(
                 self.port, self.container_name, self.image_name))
         self.wait_until_ready('http://localhost:{}/healthcheck'.format(self.port))
         os.environ[self.service_url_env] = 'http://localhost:{}/'.format(self.port)

--- a/opengever/core/solr_testing.py
+++ b/opengever/core/solr_testing.py
@@ -43,6 +43,8 @@ class SolrServer(object):
         command = [
             'docker',
             'run',
+            '--pull',
+            'always',
             '-d',
             '--rm',
             '-p',

--- a/opengever/dossier/tests/test_move_items.py
+++ b/opengever/dossier/tests/test_move_items.py
@@ -441,6 +441,7 @@ class TestMoveItemsUpdatesIndexAndMetadata(SolrIntegrationTestCase, MoveItemsHel
             u'file_extension',
             u'filename',
             u'filesize',
+            u'related_items',
             u'Subject',
         ]
 


### PR DESCRIPTION
We always want to test against the latest versions of the services and especially of `ogsolr`.

For [CA-5463]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-5463]: https://4teamwork.atlassian.net/browse/CA-5463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ