### PR TITLE
Improve search behavior for english and french content.

### DIFF
--- a/changes/CA-5898.bugfix
+++ b/changes/CA-5898.bugfix
@@ -1,0 +1,1 @@
+Improve search behavior for english and french content. [phgross]

--- a/opengever/core/upgrade.py
+++ b/opengever/core/upgrade.py
@@ -416,6 +416,9 @@ class UIDMaintenanceJobContextManagerMixin(MaintenanceJobContextManagerMixin):
     def add_by_brain(self, brain):
         self._add_by_key(brain.UID)
 
+    def add_by_solr_document(self, doc):
+        self._add_by_key(doc.get('UID'))
+
 
 class NightlyIndexer(UIDMaintenanceJobContextManagerMixin):
 

--- a/opengever/core/upgrades/20230608115956_reindex_french_and_german_content_in_solr/upgrade.py
+++ b/opengever/core/upgrades/20230608115956_reindex_french_and_german_content_in_solr/upgrade.py
@@ -1,0 +1,36 @@
+from ftw.solr.interfaces import ISolrSearch
+from ftw.upgrade import ProgressLogger
+from ftw.upgrade import UpgradeStep
+from opengever.core.upgrade import NightlyIndexer
+from zope.component import getUtility
+
+
+class ReindexFrenchAndGermanContentInSolr(UpgradeStep):
+    """Reindex french and german content in solr.
+    """
+
+    deferrable = True
+
+    def __call__(self):
+        self.reindex()
+
+    def reindex(self):
+        solr = getUtility(ISolrSearch)
+        fq = [
+            "SearchableText_fr:['' TO *] "
+            "OR title_fr:['' TO *] "
+            "OR Description_fr:['' TO *] "
+            "OR Title_fr:['' TO *] "
+            "OR SearchableText_en:['' TO *] "
+            "OR title_en:['' TO *] "
+            "OR Description_en:['' TO *] "
+            "OR Title_en:['' TO *]"
+        ]
+
+        fl = ['UID']
+        nrows = solr.search(fq=fq, rows=0).num_found
+        resp = solr.search(fq=fq, fl=fl, rows=nrows)
+
+        with NightlyIndexer(idxs=[], index_in_solr_only=True) as indexer:
+            for doc in ProgressLogger('Reindex french or english content', resp.docs):
+                indexer.add_by_solr_document(doc)

--- a/solr-conf/managed-schema
+++ b/solr-conf/managed-schema
@@ -373,6 +373,7 @@
                 words="lang/stopwords_en.txt"
                 /> -->
         <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="true" />
         <filter class="solr.EnglishPossessiveFilterFactory"/>
         <filter class="solr.KeywordRepeatFilterFactory" />
         <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
@@ -438,6 +439,7 @@
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.KeywordRepeatFilterFactory" />
         <!-- <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_fr.txt" format="snowball" /> -->
+        <filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="true" />
         <filter class="solr.FrenchLightStemFilterFactory"/>
         <!-- less aggressive: <filter class="solr.FrenchMinimalStemFilterFactory"/> -->
         <!-- more aggressive: <filter class="solr.SnowballPorterFilterFactory" language="French"/> -->


### PR DESCRIPTION
Make text analysation accent insensitive by adding the asciifoldingfilterfactory which normalize non-asccii characters.

Provides an upgradestep which reindex content detected as french or english content overnight.

For [CA-5764](https://4teamwork.atlassian.net/browse/CA-5764)

Needs backport to LTS 2023.6.x

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- Upgrade-Steps:
  - [x] Make it deferrable if possible
  - [x] Execute as much as possible conditionally


[CA-5895]: https://4teamwork.atlassian.net/browse/CA-5895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CA-5764]: https://4teamwork.atlassian.net/browse/CA-5764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ