### PR TITLE
@tus-upload can directly set a custom document_date.

### DIFF
--- a/changes/CA-5001.feature
+++ b/changes/CA-5001.feature
@@ -1,0 +1,1 @@
+@tus-upload can directly set a custom document_date. [elioschmutz]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,6 +11,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- ``@tus-upload``: Allow to pass a ``document_date`` metadata header to manually set the documents date
 
 2023.10.0 (2023-06-14)
 ----------------------

--- a/opengever/api/tests/test_tus.py
+++ b/opengever/api/tests/test_tus.py
@@ -1,4 +1,5 @@
 from base64 import b64encode
+from datetime import date
 from datetime import datetime
 from ftw.builder import Builder
 from ftw.builder import create
@@ -313,3 +314,20 @@ class TestTUSUpload(IntegrationTestCase):
         doc = self.assert_tus_upload_succeeds(
             self.dossier, browser, upload_metadata=upload_metadata)
         self.assertEqual('text/plain', doc.content_type())
+
+    @browsing
+    def test_tus_upload_can_set_document_date(self, browser):
+        self.login(self.regular_user, browser)
+        upload_metadata = UPLOAD_METADATA + ',document_date MjAxNS0wOC0yMQ=='
+        doc = self.assert_tus_upload_succeeds(self.dossier, browser, upload_metadata=upload_metadata)
+        self.assertEqual(date(2015, 8, 21), doc.document_date)
+
+    @browsing
+    def test_tus_replace_does_not_update_document_date(self, browser):
+        self.login(self.regular_user, browser)
+        self.checkout(self.document, browser)
+
+        current_date = self.document.document_date
+        upload_metadata = UPLOAD_METADATA + ',document_date MjAxNS0wOC0yMQ=='
+        self.assert_tus_replace_succeeds(self.document, browser, headers={"Upload-Metadata": upload_metadata})
+        self.assertEqual(current_date, self.document.document_date)


### PR DESCRIPTION
This PR extends the `@tus-upload` endpoint to allow a `document_date` within the `Upload-Metadata`-header to directly set a custom document date.

For [CA-5001]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-5001]: https://4teamwork.atlassian.net/browse/CA-5001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ