### PR TITLE
Massively improve performance of @recently-touched endpoint.

### DIFF
--- a/changes/CA-5921.other
+++ b/changes/CA-5921.other
@@ -1,0 +1,1 @@
+Massively improve performance of @recently-touched endpoint. [njohner]

--- a/changes/CA-5921_2.other
+++ b/changes/CA-5921_2.other
@@ -1,0 +1,1 @@
+Avoid ever getting the searchableText from solr. [njohner]

--- a/opengever/api/navigation.py
+++ b/opengever/api/navigation.py
@@ -96,6 +96,7 @@ class Navigation(object):
                 filters=make_filters(
                     object_provides=root_interface.__identifier__),
                 sort='path asc',
+                fl=["path"],
             )
             roots = [OGSolrDocument(d) for d in response.docs]
 

--- a/opengever/api/tasktree.py
+++ b/opengever/api/tasktree.py
@@ -112,7 +112,8 @@ class TaskTree(object):
     def task_tree(self):
         main_task = self.get_main_task()
         path = '/'.join(main_task.getPhysicalPath())
-        resp = self.solr.search(filters=make_path_filter(path, 0))
+        resp = self.solr.search(filters=make_path_filter(path, 0),
+                                fl=self.fieldlist)
 
         if not resp.docs:
             return []

--- a/opengever/api/tests/test_navigation.py
+++ b/opengever/api/tests/test_navigation.py
@@ -169,7 +169,7 @@ class TestNavigation(SolrIntegrationTestCase):
             [item.get('uid') for item in items])
 
     @browsing
-    def test_lookup_propper_root_if_root_interface_is_within_content_interfaces(self, browser):
+    def test_lookup_proper_root_if_root_interface_is_within_content_interfaces(self, browser):
         self.login(self.workspace_member, browser)
         params = [
             ('root_interface', 'opengever.dossier.businesscase.IBusinessCaseDossier'),
@@ -186,6 +186,24 @@ class TestNavigation(SolrIntegrationTestCase):
             self.dossier.UID(),
             browser.json.get('tree')[0].get('uid'),
             "The root-object needs to be the last IBusinessCaseDossier")
+
+    @browsing
+    def test_lookup_proper_root_if_root_is_not_within_acquisition_chain_of_context(self, browser):
+        self.login(self.regular_user, browser)
+        params = [
+            ('root_interface', 'opengever.repository.repositoryroot.IRepositoryRoot'),
+            ('content_interfaces', 'opengever.repository.interfaces.IRepositoryFolder'),
+            ('include_root', True)
+        ]
+
+        browser.open(
+            self.private_dossier.absolute_url() + '/@navigation?{}'.format(urlencode(params)),
+            headers={'Accept': 'application/json'},
+        )
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual(
+            self.repository_root.UID(),
+            browser.json.get('tree')[0].get('uid'))
 
     @browsing
     def test_raises_bad_request_when_not_existing_root_interface_provided(self, browser):

--- a/opengever/api/tests/test_tasktree.py
+++ b/opengever/api/tests/test_tasktree.py
@@ -3,7 +3,6 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testing import freeze
-from opengever.base.model import create_session
 from opengever.testing import SolrIntegrationTestCase
 import json
 

--- a/opengever/api/transfer.py
+++ b/opengever/api/transfer.py
@@ -202,7 +202,7 @@ class TransferDossierPost(ExtractOldNewUserMixin, Service):
                      'responsible': old_userid,
                      'review_state': DOSSIER_STATES_OPEN}
             dossiers_to_transfer = [OGSolrDocument(doc).getObject() for doc in
-                                    solr.search(filters=make_filters(**query)).docs]
+                                    solr.search(filters=make_filters(**query), fl=["path"]).docs]
         else:
             dossiers_to_transfer = [self.context]
 

--- a/opengever/base/solr/__init__.py
+++ b/opengever/base/solr/__init__.py
@@ -5,9 +5,9 @@ from opengever.base.solr.contentlisting import OGSolrDocument
 from zope.component import getUtility
 
 
-def solr_doc_from_uuid(uuid):
+def solr_doc_from_uuid(uuid, fields):
     solr = getUtility(ISolrSearch)
-    resp = solr.search(filters=("UID:{}".format(uuid)))
+    resp = solr.search(filters=("UID:{}".format(uuid)), fl=fields)
     if not resp.docs:
         return None
     return OGSolrDocument(resp.docs[0])

--- a/opengever/ogds/base/sources.py
+++ b/opengever/ogds/base/sources.py
@@ -454,7 +454,8 @@ class UsersContactsInboxesSource(AllUsersInboxesAndTeamsSource):
         solr = getUtility(ISolrSearch)
         query = u'text:{}*'.format(escape(safe_unicode(query_string)))
         filters = [u'object_provides:{}'.format(IContact.__identifier__)]
-        resp = solr.search(query=query, filters=filters)
+        resp = solr.search(query=query, filters=filters,
+                           fl=['email', 'id', 'Title'])
         for result in resp.docs:
             self.terms.append(self.getTerm(solr_doc=result))
 
@@ -760,7 +761,8 @@ class AllEmailContactsAndUsersSource(UsersContactsInboxesSource):
         solr = getUtility(ISolrSearch)
         query = u'text:{}*'.format(query_string)
         filters = u'object_provides:{}'.format(IContact.__identifier__)
-        resp = solr.search(query=query, filters=filters)
+        resp = solr.search(query=query, filters=filters,
+                           fl=['email', 'email2', 'id', 'Title'])
         for result in resp.docs:
             if 'email' in result:
                 self.terms.append(self.getTerm(solr_doc=result))

--- a/opengever/tabbedview/catalog_source.py
+++ b/opengever/tabbedview/catalog_source.py
@@ -178,9 +178,7 @@ class GeverCatalogTableSource(FilteredTableSourceMixin, CatalogTableSource):
         if self.select_all:
             fl = ['path']
         else:
-            fl = ['UID', 'getIcon', 'portal_type', 'path', 'id',
-                  'bumblebee_checksum']
-            fl = fl + [c['column'] for c in self.config.columns if c['column']]
+            fl = self._query_fields
         params = {
             'fl': fl,
             'q.op': 'AND',
@@ -206,6 +204,13 @@ class GeverCatalogTableSource(FilteredTableSourceMixin, CatalogTableSource):
         )
 
         return BatchableSolrResults(resp)
+
+    @property
+    def _query_fields(self):
+        fl = ['UID', 'getIcon', 'portal_type', 'path', 'id',
+              'bumblebee_checksum']
+        fl = fl + [c['column'] for c in self.config.columns if c['column']]
+        return fl
 
 
 class BatchableSolrResults:

--- a/opengever/task/browser/related_documents.py
+++ b/opengever/task/browser/related_documents.py
@@ -75,7 +75,7 @@ class RelatedDocumentsCatalogTableSource(GeverCatalogTableSource):
 
             if obj.portal_type in ['opengever.document.document', 'ftw.mail.mail']:
 
-                brain = solr_doc_from_uuid(IUUID(obj))
+                brain = solr_doc_from_uuid(IUUID(obj), self._query_fields)
 
                 if not brain:
                     # the document is trashed

--- a/opengever/task/tests/test_related_documents_tab.py
+++ b/opengever/task/tests/test_related_documents_tab.py
@@ -1,6 +1,4 @@
 from ftw.testbrowser import browsing
-from opengever.task.browser.related_documents import RelatedDocumentsCatalogTableSource
-from opengever.testing import IntegrationTestCase
 from opengever.testing import SolrIntegrationTestCase
 
 


### PR DESCRIPTION
For the `@recently-touched` endpoint, I tested locally with a large Excel file (the one causing issues in SG), and request time went from 41seconds to 50ms.

We also set the `fl` parameters for all solr searches made in opengever.core, except the ones where we set `rows=0`, as it doesn't make any performance difference in such queries (typically facet queries).

I have also made changes to `ftw.solr` to log warnings when we query solr without specifying `fl`.

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-5921]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-5921]: https://4teamwork.atlassian.net/browse/CA-5921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ