### PR TITLE
Fix member default for propertysheet fields.

### DIFF
--- a/changes/CA-4911.bugfix
+++ b/changes/CA-4911.bugfix
@@ -1,0 +1,1 @@
+Fix member default gettter for propertysheet fields. [phgross]

--- a/opengever/propertysheets/default_from_member.py
+++ b/opengever/propertysheets/default_from_member.py
@@ -50,6 +50,10 @@ def member_property_default_factory(default_from_member_options):
 
     result = None
     try:
+        # use fallback for anonymous user
+        if member.getUserName() == 'Anonymous User':
+            return fallback
+
         result = member.getProperty(property_name, default=None)
         if not result:
             result = fallback

--- a/opengever/propertysheets/tests/test_default_from_member.py
+++ b/opengever/propertysheets/tests/test_default_from_member.py
@@ -74,6 +74,16 @@ class TestDefaultFromMemberDefaultFactory(IntegrationTestCase):
                     }
                 )))
 
+    def test_returns_fallback_for_unauthorized_requests(self):
+        self.assertEqual(
+            u'<No description>',
+            member_property_default_factory(
+                json.dumps({
+                    'property': 'description',
+                    'fallback': u'<No description>'
+                    }
+                )))
+
     def test_uses_fallback_for_unmapped_value_by_default(self):
         self.login(self.regular_user)
 


### PR DESCRIPTION
During the os migration on a customer system we recognized, that the logs contains a lot of warnings like `WARNING opengever.propertysheets Failed to retrieve property language from member Anonymous User for request <HTTPRequest, URL=xy>: Got: TypeError("getProperty() got an unexpected keyword argument 'default'",)`

The reason is that some calls are done anonymously, we just return the fallback in this case.

For [CA-4911]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)



[CA-4911]: https://4teamwork.atlassian.net/browse/CA-4911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ