### PR TITLE
Hide copy, move and edit items actions for workspace guests on document listings.

### DIFF
--- a/changes/CA-5929.feature
+++ b/changes/CA-5929.feature
@@ -1,0 +1,1 @@
+Hide copy, move and edit items actions for workspace guests on document listings. [njohner]

--- a/opengever/document/actions.py
+++ b/opengever/document/actions.py
@@ -132,6 +132,15 @@ class TemplateDocumentListingActions(BaseDocumentListingActions):
 
 class WorkspaceDocumentListingActions(BaseDocumentListingActions):
 
+    def is_copy_items_available(self):
+        return api.user.has_permission('Add portal content', obj=self.context)
+
+    def is_edit_items_available(self):
+        return api.user.has_permission('Modify portal content', obj=self.context)
+
+    def is_move_items_available(self):
+        return api.user.has_permission('Add portal content', obj=self.context)
+
     def is_delete_available(self):
         return False
 

--- a/opengever/document/tests/test_actions.py
+++ b/opengever/document/tests/test_actions.py
@@ -79,10 +79,16 @@ class TestDocumentListingActions(IntegrationTestCase):
         self.assertIn(u'delete', self.get_actions(self.templates))
         self.assertIn(u'delete', self.get_actions(self.dossiertemplate))
 
-    def test_document_actions_for_workspace_and_workspace_folder(self):
+    def test_document_actions_in_workspace_and_workspace_folder_for_member(self):
         self.login(self.workspace_member)
         expected_actions = [u'edit_items', u'attach_documents', u'copy_items', u'move_items',
                             u'zip_selected', u'export_documents', u'trash_content']
+        self.assertEqual(expected_actions, self.get_actions(self.workspace))
+        self.assertEqual(expected_actions, self.get_actions(self.workspace_folder))
+
+    def test_document_actions_in_workspace_and_workspace_folder_for_guest(self):
+        self.login(self.workspace_guest)
+        expected_actions = [u'attach_documents', u'zip_selected', u'export_documents']
         self.assertEqual(expected_actions, self.get_actions(self.workspace))
         self.assertEqual(expected_actions, self.get_actions(self.workspace_folder))
 


### PR DESCRIPTION
Note that I can't rely on the `Copy or Move` permission which is inherited from somewhere for everyone. Modifying that permission would not work either as we typically want a user to have the `Copy or Move` on contexts he can see, while here we want to couple showing the "copy_items" action with the user being member on the context, i.e. having some sort of "Edit" permission.

For [CA-5929]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-5929]: https://4teamwork.atlassian.net/browse/CA-5929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ