### PR TITLE
System information endpoint

### DIFF
--- a/changes/CA-5543-2.feature
+++ b/changes/CA-5543-2.feature
@@ -1,0 +1,1 @@
+Expose "dossier_participation_roles" in the @system-information endpoint. [elioschmutz]

--- a/changes/CA-5543-3.feature
+++ b/changes/CA-5543-3.feature
@@ -1,0 +1,1 @@
+Expose "property_sheets" in the @system-information endpoint. [elioschmutz]

--- a/changes/CA-5543.feature
+++ b/changes/CA-5543.feature
@@ -1,0 +1,1 @@
+Introduce new @system-information endpoint. [elioschmutz]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,6 +11,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- Add a new endpoint: ``@system-information`` which provides additional information about the current deployment.
 - ``@tus-upload``: Allow to pass a ``document_date`` metadata header to manually set the documents date
 
 2023.10.0 (2023-06-14)

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,6 +11,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- Expose ``property_sheets`` in the @system-information endpoint.
 - Expose ``dossier_participation_roles`` in the @system-information endpoint.
 - Add a new endpoint: ``@system-information`` which provides additional information about the current deployment.
 - ``@tus-upload``: Allow to pass a ``document_date`` metadata header to manually set the documents date

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,6 +11,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- Expose ``dossier_participation_roles`` in the @system-information endpoint.
 - Add a new endpoint: ``@system-information`` which provides additional information about the current deployment.
 - ``@tus-upload``: Allow to pass a ``document_date`` metadata header to manually set the documents date
 

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -34,6 +34,7 @@ Inhalt:
    propertysheets.rst
    metadata.rst
    config.rst
+   system_information.rst
    favorite.rst
    dashboard.rst
    notifications.rst

--- a/docs/public/dev-manual/api/system_information.rst
+++ b/docs/public/dev-manual/api/system_information.rst
@@ -1,0 +1,24 @@
+.. _system_information:
+
+System Informationen
+====================
+
+Über den ``/@system_information`` Endpoint können Informationen über das System abgeholt werden.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       GET /@system_information HTTP/1.1
+       Accept: application/json
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+          "...": "..."
+      }

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -247,6 +247,14 @@
 
   <plone:service
       method="GET"
+      name="@system-information"
+      for="*"
+      factory=".system_information.SystemInformationGet"
+      permission="zope.Public"
+      />
+
+  <plone:service
+      method="GET"
       name="@accessible-workspaces"
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"
       factory=".accessible_workspaces.AccessibleWorkspacesGet"

--- a/opengever/api/system_information.py
+++ b/opengever/api/system_information.py
@@ -1,6 +1,11 @@
 from opengever.api.dossier_participations import available_roles
 from opengever.api.dossier_participations import primary_participation_roles
+from opengever.propertysheets.api.base import PropertySheetAPIBase
+from opengever.propertysheets.metaschema import IPropertySheetDefinition
+from opengever.propertysheets.storage import PropertySheetSchemaStorage
 from plone.restapi.services import Service
+from plone.restapi.types.interfaces import IJsonSchemaProvider
+from zope.component import getMultiAdapter
 
 
 class SystemInformationGet(Service):
@@ -9,6 +14,7 @@ class SystemInformationGet(Service):
     def reply(self):
         infos = {}
         self.add_dossier_participation_roles(infos)
+        self.add_property_sheet_information(infos)
         return infos
 
     def add_dossier_participation_roles(self, infos):
@@ -19,3 +25,29 @@ class SystemInformationGet(Service):
         for role in available_participation_roles:
             role['primary'] = role.get('token') in primary_participation_role_ids
         infos['dossier_participation_roles'] = available_participation_roles
+
+    def add_property_sheet_information(self, infos):
+        # Get translated assignment values
+        assignments_schema = getMultiAdapter(
+            (IPropertySheetDefinition.get('assignments'), self.context, self.request),
+            IJsonSchemaProvider,).get_schema()
+
+        property_sheet_slot_translations = {}
+        for [slot_id, title] in assignments_schema.get('items').get('choices'):
+            property_sheet_slot_translations[slot_id] = title
+
+        # Then serialize the property-sheets and use the translated assignment title
+        property_sheet_api = PropertySheetAPIBase()
+        property_sheet_api.request = self.request
+        propertysheets = {}
+        for sheet in PropertySheetSchemaStorage().list():
+            serialized_sheet = property_sheet_api.serialize(sheet)
+            serialized_sheet['assignments'] = [
+                {
+                    'id': assignment_id,
+                    'title': property_sheet_slot_translations.get(
+                        assignment_id, assignment_id)
+                } for assignment_id in serialized_sheet.get('assignments')
+            ]
+            propertysheets[sheet.name] = serialized_sheet
+        infos['property_sheets'] = propertysheets

--- a/opengever/api/system_information.py
+++ b/opengever/api/system_information.py
@@ -1,3 +1,5 @@
+from opengever.api.dossier_participations import available_roles
+from opengever.api.dossier_participations import primary_participation_roles
 from plone.restapi.services import Service
 
 
@@ -6,4 +8,14 @@ class SystemInformationGet(Service):
 
     def reply(self):
         infos = {}
+        self.add_dossier_participation_roles(infos)
         return infos
+
+    def add_dossier_participation_roles(self, infos):
+        available_participation_roles = available_roles(self.context)
+        primary_participation_role_ids = {
+            role.get('token') for role
+            in primary_participation_roles(self.context)}
+        for role in available_participation_roles:
+            role['primary'] = role.get('token') in primary_participation_role_ids
+        infos['dossier_participation_roles'] = available_participation_roles

--- a/opengever/api/system_information.py
+++ b/opengever/api/system_information.py
@@ -1,0 +1,9 @@
+from plone.restapi.services import Service
+
+
+class SystemInformationGet(Service):
+    """GEVER system information"""
+
+    def reply(self):
+        infos = {}
+        return infos

--- a/opengever/api/tests/test_system_information.py
+++ b/opengever/api/tests/test_system_information.py
@@ -7,12 +7,25 @@ from plone import api
 class TestSystemInformation(IntegrationTestCase):
 
     @browsing
-    def test_provided_information(self, browser):
+    def test_provided_information_keys(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.portal.absolute_url() + '/@system-information', headers=self.api_headers)
+
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual([
+            u'dossier_participation_roles',
+        ], browser.json.keys())
+
+    @browsing
+    def test_dossier_participation_roles(self, browser):
         self.login(self.manager, browser)
         api.portal.set_registry_record('primary_participation_roles', ['regard'], IDossierParticipants)
 
         self.login(self.regular_user, browser)
         browser.open(self.portal.absolute_url() + '/@system-information', headers=self.api_headers)
 
-        self.assertEqual(browser.status_code, 200)
-        self.assertEqual({}, browser.json)
+        self.assertEqual([
+            {u'active': True, u'token': u'final-drawing', u'primary': False, u'title': u'Final signature'},
+            {u'active': True, u'token': u'regard', u'primary': True, u'title': u'For your information'},
+            {u'active': True, u'token': u'participation', u'primary': False, u'title': u'Participation'}
+        ], browser.json.get('dossier_participation_roles'))

--- a/opengever/api/tests/test_system_information.py
+++ b/opengever/api/tests/test_system_information.py
@@ -1,0 +1,18 @@
+from ftw.testbrowser import browsing
+from opengever.dossier.interfaces import IDossierParticipants
+from opengever.testing import IntegrationTestCase
+from plone import api
+
+
+class TestSystemInformation(IntegrationTestCase):
+
+    @browsing
+    def test_provided_information(self, browser):
+        self.login(self.manager, browser)
+        api.portal.set_registry_record('primary_participation_roles', ['regard'], IDossierParticipants)
+
+        self.login(self.regular_user, browser)
+        browser.open(self.portal.absolute_url() + '/@system-information', headers=self.api_headers)
+
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual({}, browser.json)

--- a/opengever/api/tests/test_system_information.py
+++ b/opengever/api/tests/test_system_information.py
@@ -14,7 +14,8 @@ class TestSystemInformation(IntegrationTestCase):
         self.assertEqual(browser.status_code, 200)
         self.assertEqual([
             u'dossier_participation_roles',
-        ], browser.json.keys())
+            u'property_sheets',
+        ], sorted(browser.json.keys()))
 
     @browsing
     def test_dossier_participation_roles(self, browser):
@@ -29,3 +30,34 @@ class TestSystemInformation(IntegrationTestCase):
             {u'active': True, u'token': u'regard', u'primary': True, u'title': u'For your information'},
             {u'active': True, u'token': u'participation', u'primary': False, u'title': u'Participation'}
         ], browser.json.get('dossier_participation_roles'))
+
+    @browsing
+    def test_property_sheets(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.portal.absolute_url() + '/@system-information', headers=self.api_headers)
+
+        self.assertEqual(
+            [u'dossier_default', u'schema1', u'schema2'],
+            sorted(browser.json.get('property_sheets').keys()))
+
+        self.assertEqual(
+            {
+                u'assignments': [
+                    {
+                        u'id': u'IDocumentMetadata.document_type.directive',
+                        u'title': u'Document (Type: Directive)'
+                    }
+                ],
+                u'fields': [
+                    {
+                        u'available_as_docproperty': False,
+                        u'description': u'',
+                        u'field_type': u'textline',
+                        u'name': u'textline',
+                        u'required': False,
+                        u'title': u'A line of text'
+                    }
+                ],
+                u'id': u'schema2'
+            },
+            browser.json.get('property_sheets').get('schema2'))


### PR DESCRIPTION
This PR introduces a new endpoint `@system-information`:
- `dossier_participation_roles`
- `property_sheets`

![Bildschirmfoto 2023-06-21 um 10 28 56](https://github.com/4teamwork/opengever.core/assets/557005/59156f21-4ae0-413c-9bef-ca0e1cb0bed7)

ℹ️ why not using the already existing `@config` endpoint which already provides some info about the system?
Because the `@config`-endpoint is the main entry endpoint for the `gever-ui` and should be as fast as possible. The endpoint should only provide information which is required to let the ui properly run. The `@system-information`-endpoint is used for a dedicated information-view in the UI. This endpoint can return expensive data because it will not be called often. It should provide the information in a way that the frontend can easily display the data.

For [CA-5543]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-5543]: https://4teamwork.atlassian.net/browse/CA-5543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ