### PR TITLE
Improve performance of @notifications endpoint.

### DIFF
--- a/changes/CA-5939.other
+++ b/changes/CA-5939.other
@@ -1,0 +1,1 @@
+Improve performance of @notifications endpoint. [njohner]

--- a/opengever/activity/center.py
+++ b/opengever/activity/center.py
@@ -141,7 +141,7 @@ class NotificationCenter(object):
 
         return errors
 
-    def get_users_notifications(self, userid, only_unread=False, limit=None, badge_only=False):
+    def get_users_notifications(self, userid, only_unread=False, badge_only=False):
         query = Notification.query.by_user(userid)
         if only_unread:
             query = query.filter(Notification.is_read == false())
@@ -150,7 +150,7 @@ class NotificationCenter(object):
 
         query = query.join(
             Notification.activity).order_by(desc(Activity.created))
-        return query.limit(limit).all()
+        return query
 
     def count_users_unread_notifications(self, userid, badge_only=False):
         query = Notification.query.by_user(userid)
@@ -318,11 +318,10 @@ class PloneNotificationCenter(NotificationCenter):
         return super(PloneNotificationCenter, self).count_users_unread_notifications(
             api.user.get_current().getId(), badge_only)
 
-    def get_current_users_notifications(self, only_unread=False, limit=None, badge_only=False):
+    def get_current_users_notifications(self, only_unread=False, badge_only=False):
         return super(PloneNotificationCenter, self).get_users_notifications(
             api.user.get_current().getId(),
             only_unread=only_unread,
-            limit=limit,
             badge_only=badge_only)
 
 
@@ -375,11 +374,11 @@ class DisabledNotificationCenter(NotificationCenter):
                      notification_recipients=None, external_resource_url=None):
         pass
 
-    def get_users_notifications(self, userid, only_unread=False, limit=None, badge_only=False):
-        return []
+    def get_users_notifications(self, userid, only_unread=False, badge_only=False):
+        return Notification.query.filter(false())
 
     def mark_notification_as_read(self, notification_id):
         pass
 
     def get_current_users_notifications(self, only_unread=False, limit=None, badge_only=False):
-        return []
+        return Notification.query.filter(false())

--- a/opengever/activity/center.py
+++ b/opengever/activity/center.py
@@ -148,8 +148,7 @@ class NotificationCenter(object):
         if badge_only:
             query = query.filter(Notification.is_badge == true())
 
-        query = query.join(
-            Notification.activity).order_by(desc(Activity.created))
+        query = query.order_by(desc(Notification.notification_id))
         return query
 
     def count_users_unread_notifications(self, userid, badge_only=False):

--- a/opengever/activity/tests/test_notification_center.py
+++ b/opengever/activity/tests/test_notification_center.py
@@ -535,13 +535,13 @@ class TestNotificationHandling(IntegrationTestCase):
         self.center.mark_notification_as_read(notifications[0].notification_id)
 
         peters_notifications = self.center.get_users_notifications('peter', only_unread=True)
-        self.assertEquals(2, len(peters_notifications))
+        self.assertEquals(2, peters_notifications.count())
 
-    def test_get_users_notifications_retuns_empty_list_when_no_notifications_for_this_user_exists(self):
+    def test_get_users_notifications_when_no_notifications_for_this_user_exists(self):
         create(Builder('watcher').having(actorid='franz'))
 
         self.assertEquals([],
-                          self.center.get_users_notifications('franz'))
+                          self.center.get_users_notifications('franz').all())
 
     def test_mark_notification_as_read(self):
         notification = Notification.query.by_user('peter').first()

--- a/opengever/api/notifications.py
+++ b/opengever/api/notifications.py
@@ -1,8 +1,8 @@
 from opengever.activity import notification_center
 from opengever.activity.model.notification import Notification
+from opengever.api.batch import SQLHypermediaBatch
 from opengever.readonly import is_in_readonly_mode
 from plone import api
-from plone.restapi.batching import HypermediaBatch
 from plone.restapi.deserializer import json_body
 from plone.restapi.services import Service
 from sqlalchemy.sql.expression import false
@@ -56,7 +56,9 @@ class NotificationsGet(Service):
 
     def get_user_notifications(self):
         notifications = self.center.get_current_users_notifications(badge_only=True)
-        batch = HypermediaBatch(self.request, notifications)
+        batch = SQLHypermediaBatch(self.request,
+                                   notifications,
+                                   unique_sort_key='id')
 
         result = {
             '@id': batch.canonical_url,

--- a/opengever/api/tests/test_notifications.py
+++ b/opengever/api/tests/test_notifications.py
@@ -15,7 +15,7 @@ class TestNotificationsGet(IntegrationTestCase):
     features = ('activity', )
 
     @browsing
-    def test_list_all_notifications_for_the_given_userid(self, browser):
+    def test_returns_notifications_for_the_given_userid(self, browser):
         self.login(self.administrator, browser=browser)
 
         center = notification_center()
@@ -101,10 +101,10 @@ class TestNotificationsGet(IntegrationTestCase):
         self.login(self.regular_user, browser=browser)
 
         batch_size = 2
-        url = '{}/@notifications/{}?b_size={}'.format(
+        base_url = '{}/@notifications/{}'.format(
             self.portal.absolute_url(),
-            self.regular_user.getId(),
-            batch_size)
+            self.regular_user.getId())
+        url = '{}?b_size={}'.format(base_url, batch_size)
 
         browser.open(url, method='GET', headers={'Accept': 'application/json'})
 
@@ -112,6 +112,13 @@ class TestNotificationsGet(IntegrationTestCase):
 
         self.assertEquals(5, browser.json.get('items_total'))
         self.assertEquals(2, len(browser.json.get('items')))
+        self.assertDictEqual(
+            {"@id": url,
+             "first": '{}?b_start=0&b_size={}'.format(base_url, batch_size),
+             "last": '{}?b_start=4&b_size={}'.format(base_url, batch_size),
+             "next": '{}?b_start=2&b_size={}'.format(base_url, batch_size)},
+            browser.json.get('batching')
+        )
 
         url = browser.json.get('batching').get('last')
         browser.open(url, method='GET', headers={'Accept': 'application/json'})


### PR DESCRIPTION
We now avoid getting all the users notifications from the OGDS DB, instead only getting the batch we actually want.
This should dramatically increase the performance of the `@notifications` endpoint for users with a large number of notifications (there is a user in SG with 150'000 notifications). Note that slow requests on the OGDS will block all other users from all tenants, so this is a critical fix which we will backport to our LTS and to the SG release.

For a user with 70'000 notifications, performance improvement was from 2s to 300ms.

For [CA-5939]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-5939]: https://4teamwork.atlassian.net/browse/CA-5939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ