### PR TITLE
Fix Notification views in frontend by sorting unread notifications first in @notifications endpoint.

### DIFF
--- a/changes/CA-5959.bugfix
+++ b/changes/CA-5959.bugfix
@@ -1,0 +1,1 @@
+Sort unread notifications first in @notifications endpoint. [njohner]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -12,6 +12,7 @@ Breaking Changes
 Other Changes
 ^^^^^^^^^^^^^
 - ``@tus-upload``: Allow to pass a ``document_date`` metadata header to manually set the documents date
+- ``@notifications``: GET now returns unread notifications sorted first.
 
 2023.10.0 (2023-06-14)
 ----------------------

--- a/opengever/activity/center.py
+++ b/opengever/activity/center.py
@@ -148,7 +148,8 @@ class NotificationCenter(object):
         if badge_only:
             query = query.filter(Notification.is_badge == true())
 
-        query = query.order_by(desc(Notification.notification_id))
+        query = query.order_by(Notification.is_read).order_by(
+            desc(Notification.notification_id))
         return query
 
     def count_users_unread_notifications(self, userid, badge_only=False):

--- a/opengever/activity/tests/test_notification_center.py
+++ b/opengever/activity/tests/test_notification_center.py
@@ -543,6 +543,19 @@ class TestNotificationHandling(IntegrationTestCase):
         self.assertEquals([],
                           self.center.get_users_notifications('franz').all())
 
+    def test_get_users_notifications_are_sorted_unread_first(self):
+        notifications = self.center.get_users_notifications('peter')
+
+        self.assertEquals(
+            [self.activity_4, self.activity_2, self.activity_1],
+            [notification.activity for notification in notifications])
+
+        self.center.mark_notification_as_read(notifications[0].notification_id)
+
+        self.assertEquals(
+            [self.activity_2, self.activity_1, self.activity_4],
+            [notification.activity for notification in notifications])
+
     def test_mark_notification_as_read(self):
         notification = Notification.query.by_user('peter').first()
         self.center.mark_notification_as_read(notification.notification_id)


### PR DESCRIPTION
This ensures that the frontend always displays the first unread notifications and that it always knows if there are unread notifications.

For [CA-5959]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-5959]: https://4teamwork.atlassian.net/browse/CA-5959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ