### PR TITLE
Introduce configuration options for workspace meeting minutes PDF 

### DIFF
--- a/changes/CA-1971.feature
+++ b/changes/CA-1971.feature
@@ -1,0 +1,1 @@
+Introduce header and footer configuration for meeting minutes. [phgross]

--- a/docs/schema-dumps/opengever.workspace.workspace.schema.json
+++ b/docs/schema-dumps/opengever.workspace.workspace.schema.json
@@ -36,6 +36,18 @@
             "description": "",
             "_zope_schema_type": "Bool"
         },
+        "meeting_template_header": {
+            "type": "object",
+            "title": "Kopfzeile von Meeting-Protokollen",
+            "description": "Definieren sie die Fusszeile von Meeting-Protokollen",
+            "_zope_schema_type": "JSONField"
+        },
+        "meeting_template_footer": {
+            "type": "object",
+            "title": "Fusszeile von Meeting-Protokollen",
+            "description": "Definieren sie die Kopfzeile von Meeting-Protokollen",
+            "_zope_schema_type": "JSONField"
+        },
         "changed": {
             "type": "string",
             "title": "Zuletzt ver\u00e4ndert",
@@ -72,6 +84,8 @@
         "external_reference",
         "gever_url",
         "hide_members_for_guests",
+        "meeting_template_header",
+        "meeting_template_footer",
         "changed",
         "title",
         "description",

--- a/docs/schema-dumps/opengever.workspace.workspace.schema.json
+++ b/docs/schema-dumps/opengever.workspace.workspace.schema.json
@@ -39,14 +39,25 @@
         "meeting_template_header": {
             "type": "object",
             "title": "Kopfzeile von Meeting-Protokollen",
-            "description": "Definieren sie die Fusszeile von Meeting-Protokollen",
+            "description": "Dynamische Textinhalte sind {page_number}, {number_of_pages} und {print_date}, sowie die Bild-Platzhalter {customer_logo} und {workspace_logo}",
             "_zope_schema_type": "JSONField"
         },
         "meeting_template_footer": {
             "type": "object",
             "title": "Fusszeile von Meeting-Protokollen",
-            "description": "Definieren sie die Kopfzeile von Meeting-Protokollen",
-            "_zope_schema_type": "JSONField"
+            "description": "Dynamische Textinhalte sind {page_number}, {number_of_pages} und {print_date}, sowie die Bild-Platzhalter {customer_logo} und {workspace_logo}",
+            "_zope_schema_type": "JSONField",
+            "default": {
+                "right": "{page_number}/{number_of_pages}",
+                "center": "",
+                "left": "{print_date}"
+            }
+        },
+        "workspace_logo": {
+            "type": "string",
+            "title": "Teamraum logo",
+            "description": "Kann in Kopf- und Fusszeilen von Protokollen verwendet werden.",
+            "_zope_schema_type": "NamedImage"
         },
         "changed": {
             "type": "string",
@@ -86,6 +97,7 @@
         "hide_members_for_guests",
         "meeting_template_header",
         "meeting_template_footer",
+        "workspace_logo",
         "changed",
         "title",
         "description",

--- a/opengever/bundle/schemas/workspaces.schema.json
+++ b/opengever/bundle/schemas/workspaces.schema.json
@@ -63,7 +63,7 @@
                         "object"
                     ],
                     "title": "Kopfzeile von Meeting-Protokollen",
-                    "description": "Definieren sie die Fusszeile von Meeting-Protokollen",
+                    "description": "Dynamische Textinhalte sind {page_number}, {number_of_pages} und {print_date}, sowie die Bild-Platzhalter {customer_logo} und {workspace_logo}",
                     "_zope_schema_type": "JSONField"
                 },
                 "meeting_template_footer": {
@@ -72,8 +72,22 @@
                         "object"
                     ],
                     "title": "Fusszeile von Meeting-Protokollen",
-                    "description": "Definieren sie die Kopfzeile von Meeting-Protokollen",
-                    "_zope_schema_type": "JSONField"
+                    "description": "Dynamische Textinhalte sind {page_number}, {number_of_pages} und {print_date}, sowie die Bild-Platzhalter {customer_logo} und {workspace_logo}",
+                    "_zope_schema_type": "JSONField",
+                    "default": {
+                        "right": "{page_number}/{number_of_pages}",
+                        "center": "",
+                        "left": "{print_date}"
+                    }
+                },
+                "workspace_logo": {
+                    "type": [
+                        "null",
+                        "string"
+                    ],
+                    "title": "Teamraum logo",
+                    "description": "Kann in Kopf- und Fusszeilen von Protokollen verwendet werden.",
+                    "_zope_schema_type": "NamedImage"
                 },
                 "changed": {
                     "type": [
@@ -167,6 +181,7 @@
                 "hide_members_for_guests",
                 "meeting_template_header",
                 "meeting_template_footer",
+                "workspace_logo",
                 "changed",
                 "title",
                 "description",

--- a/opengever/bundle/schemas/workspaces.schema.json
+++ b/opengever/bundle/schemas/workspaces.schema.json
@@ -57,6 +57,24 @@
                     "description": "",
                     "_zope_schema_type": "Bool"
                 },
+                "meeting_template_header": {
+                    "type": [
+                        "null",
+                        "object"
+                    ],
+                    "title": "Kopfzeile von Meeting-Protokollen",
+                    "description": "Definieren sie die Fusszeile von Meeting-Protokollen",
+                    "_zope_schema_type": "JSONField"
+                },
+                "meeting_template_footer": {
+                    "type": [
+                        "null",
+                        "object"
+                    ],
+                    "title": "Fusszeile von Meeting-Protokollen",
+                    "description": "Definieren sie die Kopfzeile von Meeting-Protokollen",
+                    "_zope_schema_type": "JSONField"
+                },
                 "changed": {
                     "type": [
                         "null",
@@ -147,6 +165,8 @@
                 "external_reference",
                 "gever_url",
                 "hide_members_for_guests",
+                "meeting_template_header",
+                "meeting_template_footer",
                 "changed",
                 "title",
                 "description",

--- a/opengever/core/upgrades/20230622101030_initialize_footer_meeting_template_settings/upgrade.py
+++ b/opengever/core/upgrades/20230622101030_initialize_footer_meeting_template_settings/upgrade.py
@@ -1,0 +1,15 @@
+from ftw.upgrade import UpgradeStep
+from opengever.workspace.workspace import FOOTER_DEFAULT_FORMAT
+
+
+class InitializeFooterMeetingTemplateSettings(UpgradeStep):
+    """Initialize footer meeting template settings.
+    """
+
+    deferrable = True
+
+    def __call__(self):
+        query = {'portal_type': 'opengever.workspace.workspace'}
+        for workspace in self.objects(query, "Initalize footer meeting template settings"):
+            if not workspace.meeting_template_footer:
+                workspace.meeting_template_footer = FOOTER_DEFAULT_FORMAT

--- a/opengever/workspace/browser/meeting_pdf.py
+++ b/opengever/workspace/browser/meeting_pdf.py
@@ -1,5 +1,3 @@
-from Acquisition import aq_inner
-from Acquisition import aq_parent
 from datetime import datetime
 from logging import getLogger
 from opengever.base.helpers import display_name
@@ -18,6 +16,19 @@ import requests
 
 
 logger = getLogger('opengever.workspace')
+
+DYNAMIC_CONTENT_PLACEHOLDERS = [
+    'page_number', 'number_of_pages', 'print_date',
+    'customer_logo', 'workspace_logo']
+
+
+def validate_header_footer(configuration):
+    if not configuration:
+        return
+
+    for allignment in ['left', 'center', 'right']:
+        value = configuration.get(allignment, '')
+        value.format(**{k: '' for k in DYNAMIC_CONTENT_PLACEHOLDERS})
 
 
 class MeetingMinutesPDFView(BrowserView):

--- a/opengever/workspace/browser/templates/meeting_minutes.pt
+++ b/opengever/workspace/browser/templates/meeting_minutes.pt
@@ -77,28 +77,22 @@ a {
   font-size: 10pt;
 
   @top-left {
-    content: ${python:options['header']['left']};
-    white-space: pre;
+    ${python:options['header']['left']}
   }
   @top-center {
-    content: ${python:options['header']['center']};
-    white-space: pre;
+    ${python:options['header']['center']}
   }
   @top-right {
-    content: ${python:options['header']['right']};
-    white-space: pre;
+    ${python:options['header']['right']}
   }
   @bottom-left {
-    content: ${python:options['footer']['left']};
-    white-space: pre;
+    ${python:options['footer']['left']}
   }
   @bottom-center {
-    content: ${python:options['footer']['center']};
-    white-space: pre;
+    ${python:options['footer']['center']}
   }
   @bottom-right {
-    content: ${python:options['footer']['right']};
-    white-space: pre;
+    ${python:options['footer']['right']}
   }
 }
 </style>

--- a/opengever/workspace/browser/templates/meeting_minutes.pt
+++ b/opengever/workspace/browser/templates/meeting_minutes.pt
@@ -75,11 +75,30 @@ a {
   margin-right: 2.5cm;
   font-family: Helvetica, Arial, Sans-serif;
   font-size: 10pt;
-  @bottom-right {
-    content: counter(page) "/" counter(pages);
+
+  @top-left {
+    content: ${python:options['header']['left']};
+    white-space: pre;
+  }
+  @top-center {
+    content: ${python:options['header']['center']};
+    white-space: pre;
+  }
+  @top-right {
+    content: ${python:options['header']['right']};
+    white-space: pre;
   }
   @bottom-left {
-    content: "${python:toLocalizedTime(options['print_date'], long_format=True)}";
+    content: ${python:options['footer']['left']};
+    white-space: pre;
+  }
+  @bottom-center {
+    content: ${python:options['footer']['center']};
+    white-space: pre;
+  }
+  @bottom-right {
+    content: ${python:options['footer']['right']};
+    white-space: pre;
   }
 }
 </style>

--- a/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-05-12 05:59+0000\n"
+"POT-Creation-Date: 2023-06-22 07:37+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -133,10 +133,15 @@ msgstr "Protokoll: ${title}"
 msgid "help_videoconferencing_url"
 msgstr "Verwendete URL um eine Videokonferenz für diesen Teamraum zu starten."
 
-#. Default: "Dynamic content placeholders are {page_number}, {number_of_pages} and {print_date}"
+#. Default: "Dynamic content placeholders are {page_number}, {number_of_pages} and {print_date}, as well as the image placeholders {customer_logo} and {workspace_logo}"
 #: ./opengever/workspace/workspace.py
 msgid "help_workspace_header_and_footer"
-msgstr "Dynamische Textinhalte sind {page_number}, {number_of_pages} und {print_date}"
+msgstr "Dynamische Textinhalte sind {page_number}, {number_of_pages} und {print_date}, sowie die Bild-Platzhalter {customer_logo} und {workspace_logo}"
+
+#. Default: "Can be used in headers and footers of meeting minutes"
+#: ./opengever/workspace/workspace.py
+msgid "help_workspace_logo"
+msgstr "Kann in Kopf- und Fusszeilen von Protokollen verwendet werden."
 
 #. Default: "Invitation"
 #: ./opengever/workspace/participation/__init__.py
@@ -338,6 +343,11 @@ msgstr "Video-Call Link"
 #: ./opengever/workspace/workspace.py
 msgid "label_videoconferencing_url"
 msgstr "Videokonferenz URL"
+
+#. Default: "Workspace logo"
+#: ./opengever/workspace/workspace.py
+msgid "label_workspace_logo"
+msgstr "Teamraum logo"
 
 #. Default: "Meeting minutes footer"
 #: ./opengever/workspace/workspace.py

--- a/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-06-22 07:37+0000\n"
+"POT-Creation-Date: 2023-06-27 10:13+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -368,6 +368,11 @@ msgstr "Zum Teamraum hinzugefügt worden"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_workspaces"
 msgstr "Teamräume"
+
+#. Default: "Invalid meeting minutes configuration, not supported placeholders \"${placeholder}\" are used."
+#: ./opengever/workspace/workspace.py
+msgid "msg_invalid_placholders_in_meeting_settings"
+msgstr "Ungültige Protokoll Einstellungen, der nicht unterstützte Platzhalter \"${placeholder}\" wird verwendet."
 
 #. Default: "At least one principal must remain admin."
 #: ./opengever/workspace/participation/browser/manage_participants.py

--- a/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-02-21 18:23+0000\n"
+"POT-Creation-Date: 2023-05-12 05:59+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -132,6 +132,11 @@ msgstr "Protokoll: ${title}"
 #: ./opengever/workspace/workspace.py
 msgid "help_videoconferencing_url"
 msgstr "Verwendete URL um eine Videokonferenz für diesen Teamraum zu starten."
+
+#. Default: "Dynamic content placeholders are {page_number}, {number_of_pages} and {print_date}"
+#: ./opengever/workspace/workspace.py
+msgid "help_workspace_header_and_footer"
+msgstr "Dynamische Textinhalte sind {page_number}, {number_of_pages} und {print_date}"
 
 #. Default: "Invitation"
 #: ./opengever/workspace/participation/__init__.py
@@ -333,6 +338,16 @@ msgstr "Video-Call Link"
 #: ./opengever/workspace/workspace.py
 msgid "label_videoconferencing_url"
 msgstr "Videokonferenz URL"
+
+#. Default: "Meeting minutes footer"
+#: ./opengever/workspace/workspace.py
+msgid "label_workspace_meeting_template_footer"
+msgstr "Fusszeile von Meeting-Protokollen"
+
+#. Default: "Meeting minutes header"
+#: ./opengever/workspace/workspace.py
+msgid "label_workspace_meeting_template_header"
+msgstr "Kopfzeile von Meeting-Protokollen"
 
 #. Default: "Added to the workspace"
 #: ./opengever/workspace/activities.py

--- a/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-02-21 18:23+0000\n"
+"POT-Creation-Date: 2023-05-12 05:59+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -153,6 +153,11 @@ msgstr "Meeting Minutes: ${title}"
 #: ./opengever/workspace/workspace.py
 msgid "help_videoconferencing_url"
 msgstr "URL to launch a video conference for this workspace"
+
+#. Default: "Dynamic content placeholders are {page_number}, {number_of_pages} and {print_date}"
+#: ./opengever/workspace/workspace.py
+msgid "help_workspace_header_and_footer"
+msgstr ""
 
 #. German translation: Einladung
 #. Default: "Invitation"
@@ -379,6 +384,16 @@ msgstr "Video call link"
 #: ./opengever/workspace/workspace.py
 msgid "label_videoconferencing_url"
 msgstr "Video conferencing URL"
+
+#. Default: "Meeting minutes footer"
+#: ./opengever/workspace/workspace.py
+msgid "label_workspace_meeting_template_footer"
+msgstr "Meeting minutes footer"
+
+#. Default: "Meeting minutes header"
+#: ./opengever/workspace/workspace.py
+msgid "label_workspace_meeting_template_header"
+msgstr "Meeting minutes header"
 
 #. Default: "Added to the workspace"
 #: ./opengever/workspace/activities.py

--- a/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-05-12 05:59+0000\n"
+"POT-Creation-Date: 2023-06-22 07:37+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -154,10 +154,15 @@ msgstr "Meeting Minutes: ${title}"
 msgid "help_videoconferencing_url"
 msgstr "URL to launch a video conference for this workspace"
 
-#. Default: "Dynamic content placeholders are {page_number}, {number_of_pages} and {print_date}"
+#. Default: "Dynamic content placeholders are {page_number}, {number_of_pages} and {print_date}, as well as the image placeholders {customer_logo} and {workspace_logo}"
 #: ./opengever/workspace/workspace.py
 msgid "help_workspace_header_and_footer"
-msgstr ""
+msgstr "Dynamic content placeholders are {page_number}, {number_of_pages} and {print_date}, as well as the image placeholders {customer_logo} and {workspace_logo}"
+
+#. Default: "Can be used in headers and footers of meeting minutes"
+#: ./opengever/workspace/workspace.py
+msgid "help_workspace_logo"
+msgstr "Can be used in headers and footers of meeting minutes"
 
 #. German translation: Einladung
 #. Default: "Invitation"
@@ -384,6 +389,11 @@ msgstr "Video call link"
 #: ./opengever/workspace/workspace.py
 msgid "label_videoconferencing_url"
 msgstr "Video conferencing URL"
+
+#. Default: "Workspace logo"
+#: ./opengever/workspace/workspace.py
+msgid "label_workspace_logo"
+msgstr "Workspace logo"
 
 #. Default: "Meeting minutes footer"
 #: ./opengever/workspace/workspace.py

--- a/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-06-22 07:37+0000\n"
+"POT-Creation-Date: 2023-06-27 10:13+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -415,6 +415,11 @@ msgstr "Added to the workspace"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_workspaces"
 msgstr "Workspaces"
+
+#. Default: "Invalid meeting minutes configuration, not supported placeholders \"${placeholder}\" are used."
+#: ./opengever/workspace/workspace.py
+msgid "msg_invalid_placholders_in_meeting_settings"
+msgstr "Invalid meeting minutes configuration, not supported placeholders \"${placeholder}\" are used."
 
 #. Default: "At least one principal must remain admin."
 #: ./opengever/workspace/participation/browser/manage_participants.py

--- a/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-02-21 18:23+0000\n"
+"POT-Creation-Date: 2023-05-12 05:59+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -132,6 +132,11 @@ msgstr "Procès-verbal de réunion: ${title}"
 #: ./opengever/workspace/workspace.py
 msgid "help_videoconferencing_url"
 msgstr "URL utilisée pour lancer une vidéoconférence pour cet espace partagé."
+
+#. Default: "Dynamic content placeholders are {page_number}, {number_of_pages} and {print_date}"
+#: ./opengever/workspace/workspace.py
+msgid "help_workspace_header_and_footer"
+msgstr ""
 
 #. Default: "Invitation"
 #: ./opengever/workspace/participation/__init__.py
@@ -333,6 +338,16 @@ msgstr "Lien pour la vidéoconférence"
 #: ./opengever/workspace/workspace.py
 msgid "label_videoconferencing_url"
 msgstr "URL de vidéoconférence"
+
+#. Default: "Meeting minutes footer"
+#: ./opengever/workspace/workspace.py
+msgid "label_workspace_meeting_template_footer"
+msgstr ""
+
+#. Default: "Meeting minutes header"
+#: ./opengever/workspace/workspace.py
+msgid "label_workspace_meeting_template_header"
+msgstr ""
 
 #. Default: "Added to the workspace"
 #: ./opengever/workspace/activities.py

--- a/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-06-22 07:37+0000\n"
+"POT-Creation-Date: 2023-06-27 10:13+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -368,6 +368,11 @@ msgstr "Ajouté à l'espace de travail partagé"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_workspaces"
 msgstr "Teamraüme"
+
+#. Default: "Invalid meeting minutes configuration, not supported placeholders \"${placeholder}\" are used."
+#: ./opengever/workspace/workspace.py
+msgid "msg_invalid_placholders_in_meeting_settings"
+msgstr ""
 
 #. Default: "At least one principal must remain admin."
 #: ./opengever/workspace/participation/browser/manage_participants.py

--- a/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-05-12 05:59+0000\n"
+"POT-Creation-Date: 2023-06-22 07:37+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -133,9 +133,14 @@ msgstr "Procès-verbal de réunion: ${title}"
 msgid "help_videoconferencing_url"
 msgstr "URL utilisée pour lancer une vidéoconférence pour cet espace partagé."
 
-#. Default: "Dynamic content placeholders are {page_number}, {number_of_pages} and {print_date}"
+#. Default: "Dynamic content placeholders are {page_number}, {number_of_pages} and {print_date}, as well as the image placeholders {customer_logo} and {workspace_logo}"
 #: ./opengever/workspace/workspace.py
 msgid "help_workspace_header_and_footer"
+msgstr ""
+
+#. Default: "Can be used in headers and footers of meeting minutes"
+#: ./opengever/workspace/workspace.py
+msgid "help_workspace_logo"
 msgstr ""
 
 #. Default: "Invitation"
@@ -338,6 +343,11 @@ msgstr "Lien pour la vidéoconférence"
 #: ./opengever/workspace/workspace.py
 msgid "label_videoconferencing_url"
 msgstr "URL de vidéoconférence"
+
+#. Default: "Workspace logo"
+#: ./opengever/workspace/workspace.py
+msgid "label_workspace_logo"
+msgstr ""
 
 #. Default: "Meeting minutes footer"
 #: ./opengever/workspace/workspace.py

--- a/opengever/workspace/locales/opengever.workspace.pot
+++ b/opengever/workspace/locales/opengever.workspace.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-05-12 05:59+0000\n"
+"POT-Creation-Date: 2023-06-22 07:37+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -136,9 +136,14 @@ msgstr ""
 msgid "help_videoconferencing_url"
 msgstr ""
 
-#. Default: "Dynamic content placeholders are {page_number}, {number_of_pages} and {print_date}"
+#. Default: "Dynamic content placeholders are {page_number}, {number_of_pages} and {print_date}, as well as the image placeholders {customer_logo} and {workspace_logo}"
 #: ./opengever/workspace/workspace.py
 msgid "help_workspace_header_and_footer"
+msgstr ""
+
+#. Default: "Can be used in headers and footers of meeting minutes"
+#: ./opengever/workspace/workspace.py
+msgid "help_workspace_logo"
 msgstr ""
 
 #. Default: "Invitation"
@@ -340,6 +345,11 @@ msgstr ""
 #. Default: "Videoconferencing URL"
 #: ./opengever/workspace/workspace.py
 msgid "label_videoconferencing_url"
+msgstr ""
+
+#. Default: "Workspace logo"
+#: ./opengever/workspace/workspace.py
+msgid "label_workspace_logo"
 msgstr ""
 
 #. Default: "Meeting minutes footer"

--- a/opengever/workspace/locales/opengever.workspace.pot
+++ b/opengever/workspace/locales/opengever.workspace.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-06-22 07:37+0000\n"
+"POT-Creation-Date: 2023-06-27 10:13+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -370,6 +370,11 @@ msgstr ""
 #. Default: "Workspaces"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_workspaces"
+msgstr ""
+
+#. Default: "Invalid meeting minutes configuration, not supported placeholders \"${placeholder}\" are used."
+#: ./opengever/workspace/workspace.py
+msgid "msg_invalid_placholders_in_meeting_settings"
 msgstr ""
 
 #. Default: "At least one principal must remain admin."

--- a/opengever/workspace/locales/opengever.workspace.pot
+++ b/opengever/workspace/locales/opengever.workspace.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-02-21 18:23+0000\n"
+"POT-Creation-Date: 2023-05-12 05:59+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -134,6 +134,11 @@ msgstr ""
 #. Default: "URL for videoconferencing link"
 #: ./opengever/workspace/workspace.py
 msgid "help_videoconferencing_url"
+msgstr ""
+
+#. Default: "Dynamic content placeholders are {page_number}, {number_of_pages} and {print_date}"
+#: ./opengever/workspace/workspace.py
+msgid "help_workspace_header_and_footer"
 msgstr ""
 
 #. Default: "Invitation"
@@ -335,6 +340,16 @@ msgstr ""
 #. Default: "Videoconferencing URL"
 #: ./opengever/workspace/workspace.py
 msgid "label_videoconferencing_url"
+msgstr ""
+
+#. Default: "Meeting minutes footer"
+#: ./opengever/workspace/workspace.py
+msgid "label_workspace_meeting_template_footer"
+msgstr ""
+
+#. Default: "Meeting minutes header"
+#: ./opengever/workspace/workspace.py
+msgid "label_workspace_meeting_template_header"
 msgstr ""
 
 #. Default: "Added to the workspace"

--- a/opengever/workspace/tests/test_meeting_minutes.py
+++ b/opengever/workspace/tests/test_meeting_minutes.py
@@ -1,4 +1,6 @@
+from datetime import datetime
 from ftw.testbrowser import browsing
+from ftw.testing import freeze
 from opengever.base.interfaces import IDeleter
 from opengever.core.testing import WEASYPRINT_SERVICE_INTEGRATION_TESTING
 from opengever.testing import IntegrationTestCase
@@ -113,7 +115,7 @@ class TestMeetingMinutes(IntegrationTestCase):
 
         self.workspace.meeting_template_header = {
             'left': '{print_date}',
-            'center': '',
+            'center': '{customer_logo}',
             'right': '{page_number} / {number_of_pages}',
         }
 
@@ -127,7 +129,7 @@ class TestMeetingMinutes(IntegrationTestCase):
     white-space: pre;
   }
   @top-center {
-    content: "";
+    content: ""url("asset.customer_logo.png")"";
     white-space: pre;
   }
   @top-right {

--- a/opengever/workspace/tests/test_meeting_minutes.py
+++ b/opengever/workspace/tests/test_meeting_minutes.py
@@ -110,13 +110,19 @@ class TestMeetingMinutes(IntegrationTestCase):
         self.assertIn(expected_header, html)
 
     @browsing
-    def test_meeting_minutes_header_dynamic_content(self, browser):
+    def test_meeting_minutes_header_and_footer_dynamic_content(self, browser):
         self.login(self.workspace_member, browser)
 
         self.workspace.meeting_template_header = {
             'left': '{print_date}',
             'center': '{customer_logo}',
             'right': '{page_number} / {number_of_pages}',
+        }
+
+        self.workspace.meeting_template_footer = {
+            'left': '{workspace_logo}',
+            'center': '',
+            'right': '',
         }
 
         with freeze(datetime(2023, 5, 10)):
@@ -129,11 +135,15 @@ class TestMeetingMinutes(IntegrationTestCase):
     white-space: pre;
   }
   @top-center {
-    content: ""url("asset.customer_logo.png")"";
+    content: ""url("asset.customer_logo")"";
     white-space: pre;
   }
   @top-right {
     content: ""counter(page)" / "counter(pages)"";
+    white-space: pre;
+  }
+  @bottom-left {
+    content: ""url("asset.workspace_logo")"";
     white-space: pre;
   }
 """

--- a/opengever/workspace/tests/test_meeting_minutes.py
+++ b/opengever/workspace/tests/test_meeting_minutes.py
@@ -135,16 +135,26 @@ class TestMeetingMinutes(IntegrationTestCase):
     white-space: pre;
   }
   @top-center {
-    content: ""url("asset.customer_logo")"";
-    white-space: pre;
+    content: "";
+    width: 100px;
+    height: 100%;
+    background-image: url("asset.customer_logo");
+    background-position: center;
+    background-size: contain;
+    background-repeat: no-repeat;
   }
   @top-right {
     content: ""counter(page)" / "counter(pages)"";
     white-space: pre;
   }
   @bottom-left {
-    content: ""url("asset.workspace_logo")"";
-    white-space: pre;
+    content: "";
+    width: 100px;
+    height: 100%;
+    background-image: url("asset.workspace_logo");
+    background-position: center;
+    background-size: contain;
+    background-repeat: no-repeat;
   }
 """
 

--- a/opengever/workspace/workspace.py
+++ b/opengever/workspace/workspace.py
@@ -30,6 +30,12 @@ HEADER_FOOTER_FORMAT = json.dumps({
     'right': '',
 })
 
+FOOTER_DEFAULT_FORMAT = {
+    'left': '{print_date}',
+    'center': '',
+    'right': '{page_number}/{number_of_pages}',
+}
+
 
 def videoconferencing_url_default():
     """Concatenate base_url with a random UUID.
@@ -94,6 +100,7 @@ class IWorkspaceSchema(model.Schema):
         description=_(u'help_workspace_header_and_footer',
                       default=u'Dynamic content placeholders are {page_number}, {number_of_pages} and {print_date}'),
         schema=HEADER_FOOTER_FORMAT,
+        default=dict(FOOTER_DEFAULT_FORMAT),
         required=False,
     )
     workspace_logo = NamedImage(

--- a/opengever/workspace/workspace.py
+++ b/opengever/workspace/workspace.py
@@ -90,7 +90,9 @@ class IWorkspaceSchema(model.Schema):
         title=_(u'label_workspace_meeting_template_header',
                 default=u'Meeting minutes header'),
         description=_(u'help_workspace_header_and_footer',
-                      default=u'Dynamic content placeholders are {page_number}, {number_of_pages} and {print_date}'),
+                      default=u'Dynamic content placeholders are {page_number}, '
+                      u'{number_of_pages} and {print_date}, as well as the image '
+                      u'placeholders {customer_logo} and {workspace_logo}'),
         schema=HEADER_FOOTER_FORMAT,
         required=False,
     )
@@ -98,13 +100,18 @@ class IWorkspaceSchema(model.Schema):
         title=_(u'label_workspace_meeting_template_footer',
                 default=u'Meeting minutes footer'),
         description=_(u'help_workspace_header_and_footer',
-                      default=u'Dynamic content placeholders are {page_number}, {number_of_pages} and {print_date}'),
+                      default=u'Dynamic content placeholders are {page_number}, '
+                      u'{number_of_pages} and {print_date}, as well as the image '
+                      u'placeholders {customer_logo} and {workspace_logo}'),
         schema=HEADER_FOOTER_FORMAT,
         default=dict(FOOTER_DEFAULT_FORMAT),
         required=False,
     )
     workspace_logo = NamedImage(
         title=_(u'label_workspace_logo', default='Workspace logo'),
+        description=_(u'help_workspace_logo',
+                      default=u'Can be used in headers and footers of meeting '
+                      u'minutes'),
         required=False,
     )
 

--- a/opengever/workspace/workspace.py
+++ b/opengever/workspace/workspace.py
@@ -82,16 +82,16 @@ class IWorkspaceSchema(model.Schema):
     meeting_template_header = JSONField(
         title=_(u'label_workspace_meeting_template_header',
                 default=u'Meeting minutes header'),
-        description=_(u'help_workspace_meeting_template_header',
-                      default=u'Define the header of meeting minutes'),
+        description=_(u'help_workspace_header_and_footer',
+                      default=u'Dynamic content placeholders are {page_number}, {number_of_pages} and {print_date}'),
         schema=HEADER_FOOTER_FORMAT,
         required=False,
     )
     meeting_template_footer = JSONField(
         title=_(u'label_workspace_meeting_template_footer',
                 default=u'Meeting minutes footer'),
-        description=_(u'help_workspace_meeting_template_footer',
-                      default=u'Define the footer of meeting minutes'),
+        description=_(u'help_workspace_header_and_footer',
+                      default=u'Dynamic content placeholders are {page_number}, {number_of_pages} and {print_date}'),
         schema=HEADER_FOOTER_FORMAT,
         required=False,
     )

--- a/opengever/workspace/workspace.py
+++ b/opengever/workspace/workspace.py
@@ -10,6 +10,7 @@ from opengever.workspace.interfaces import IWorkspaceSettings
 from plone import api
 from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
+from plone.namedfile.field import NamedImage
 from plone.restapi.deserializer import json_body
 from plone.restapi.services.content.update import ContentPatch
 from plone.schema import JSONField
@@ -19,8 +20,8 @@ from zExceptions import Unauthorized
 from zope import schema
 from zope.interface import implements
 from zope.interface import provider
-import uuid
 import json
+import uuid
 
 
 HEADER_FOOTER_FORMAT = json.dumps({
@@ -93,6 +94,10 @@ class IWorkspaceSchema(model.Schema):
         description=_(u'help_workspace_header_and_footer',
                       default=u'Dynamic content placeholders are {page_number}, {number_of_pages} and {print_date}'),
         schema=HEADER_FOOTER_FORMAT,
+        required=False,
+    )
+    workspace_logo = NamedImage(
+        title=_(u'label_workspace_logo', default='Workspace logo'),
         required=False,
     )
 

--- a/opengever/workspace/workspace.py
+++ b/opengever/workspace/workspace.py
@@ -5,6 +5,7 @@ from opengever.workspace import _
 from opengever.workspace import is_todo_feature_enabled
 from opengever.workspace import is_workspace_meeting_feature_enabled
 from opengever.workspace.base import WorkspaceBase
+from opengever.workspace.browser.meeting_pdf import validate_header_footer
 from opengever.workspace.interfaces import IWorkspace
 from opengever.workspace.interfaces import IWorkspaceSettings
 from plone import api
@@ -19,6 +20,8 @@ from zExceptions import Forbidden
 from zExceptions import Unauthorized
 from zope import schema
 from zope.interface import implements
+from zope.interface import Invalid
+from zope.interface import invariant
 from zope.interface import provider
 import json
 import uuid
@@ -114,6 +117,19 @@ class IWorkspaceSchema(model.Schema):
                       u'minutes'),
         required=False,
     )
+
+    @invariant
+    def validate_meeting_minutes_header_and_footer(data):
+        try:
+            validate_header_footer(data.meeting_template_header)
+            validate_header_footer(data.meeting_template_footer)
+
+        except KeyError as e:
+            raise Invalid(
+                _(u'msg_invalid_placholders_in_meeting_settings',
+                  default=u'Invalid meeting minutes configuration, not '
+                  u'supported placeholders "${placeholder}" are used.',
+                  mapping={'placeholder': e.message}))
 
 
 class Workspace(WorkspaceBase):

--- a/opengever/workspace/workspace.py
+++ b/opengever/workspace/workspace.py
@@ -12,6 +12,7 @@ from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.restapi.deserializer import json_body
 from plone.restapi.services.content.update import ContentPatch
+from plone.schema import JSONField
 from plone.supermodel import model
 from zExceptions import Forbidden
 from zExceptions import Unauthorized
@@ -19,6 +20,14 @@ from zope import schema
 from zope.interface import implements
 from zope.interface import provider
 import uuid
+import json
+
+
+HEADER_FOOTER_FORMAT = json.dumps({
+    'left': '',
+    'center': '',
+    'right': '',
+})
 
 
 def videoconferencing_url_default():
@@ -68,6 +77,22 @@ class IWorkspaceSchema(model.Schema):
     hide_members_for_guests = schema.Bool(
         title=_(u'label_hide_members_for_guests',
                 default=u'Hide workspace members for workspace guests'),
+        required=False,
+    )
+    meeting_template_header = JSONField(
+        title=_(u'label_workspace_meeting_template_header',
+                default=u'Meeting minutes header'),
+        description=_(u'help_workspace_meeting_template_header',
+                      default=u'Define the header of meeting minutes'),
+        schema=HEADER_FOOTER_FORMAT,
+        required=False,
+    )
+    meeting_template_footer = JSONField(
+        title=_(u'label_workspace_meeting_template_footer',
+                default=u'Meeting minutes footer'),
+        description=_(u'help_workspace_meeting_template_footer',
+                      default=u'Define the footer of meeting minutes'),
+        schema=HEADER_FOOTER_FORMAT,
         required=False,
     )
 


### PR DESCRIPTION
This PR introduces the possibility to configure the header and footer of the meeting minutes PDF for a workspace. The configuration provides a left, center and right block for the header and footer area, where the user can add text, use dynamic content like page_number, number_of_pages, print_date or even include the customers logo or a specific workspace logo.

The configuration is stored in two separate JSON fields. Those fields are initialized with the current configuration, so nothing changes for existing workspaces. 

The UI Implementation will look like this:

<img width="1241" alt="Bildschirmfoto 2023-06-22 um 10 37 35" src="https://github.com/4teamwork/opengever.core/assets/485755/037b44b3-9d87-4e08-92f0-3a91285a8adf">


Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-1971]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- Upgrade-Steps:
  - [x] Make it deferrable if possible
  - [x] Execute as much as possible conditionally
- New translations
  - [x] All msg-strings are unicode

[CA-1971]: https://4teamwork.atlassian.net/browse/CA-1971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ