### PR TITLE
Allow to configure an upload mimetype blacklist

### DIFF
--- a/changes/CA-4999.feature
+++ b/changes/CA-4999.feature
@@ -1,0 +1,1 @@
+Allow to configure an upload mimetype blacklist. [elioschmutz]

--- a/opengever/api/tests/test_document.py
+++ b/opengever/api/tests/test_document.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from ftw.testbrowser import browsing
 from opengever.document.approvals import IApprovalList
 from opengever.document.interfaces import ICheckinCheckoutManager
+from opengever.document.interfaces import IDocumentSettings
 from opengever.document.interfaces import ITemplateDocumentMarker
 from opengever.document.versioner import Versioner
 from opengever.private.interfaces import IPrivateFolderQuotaSettings
@@ -355,6 +356,33 @@ class TestDocumentPost(IntegrationTestCase):
         self.assertEqual(1, len(children["added"]))
         doc = children["added"].pop()
         self.assertFalse(ITemplateDocumentMarker.providedBy(doc))
+
+    @browsing
+    def test_does_not_allow_blacklisted_file_mime_types(self, browser):
+        self.login(self.regular_user, browser)
+
+        api.portal.set_registry_record(
+            'upload_mimetype_blacklist', ['application/zip'], IDocumentSettings)
+
+        # Do not allow to upload zip-files
+        with browser.expect_http_error(code=400, reason='Bad Request'):
+            data = {'@type': 'opengever.document.document',
+                    'file': {'data': 'foo bar', 'filename': 'test.zip'}}
+            browser.open(self.dossier, data=json.dumps(data), method='POST',
+                         headers=self.api_headers)
+
+        self.assertEqual(u'BadRequest', browser.json[u'type'])
+        self.assertEqual(u'It is not allowed to upload this file format',
+                         browser.json[u'translated_message'])
+
+        # But allow all other mime types
+        with self.observe_children(self.dossier) as children:
+            data = {'@type': 'opengever.document.document',
+                    'file': {'data': 'foo bar', 'filename': 'test.docx'}}
+            browser.open(self.dossier, data=json.dumps(data), method='POST',
+                         headers=self.api_headers)
+
+        self.assertEqual(1, len(children["added"]))
 
 
 class TestDocumentDelete(IntegrationTestCase):

--- a/opengever/core/upgrades/20230623124442_add_upload_mimetype_blacklist/registry.xml
+++ b/opengever/core/upgrades/20230623124442_add_upload_mimetype_blacklist/registry.xml
@@ -1,0 +1,3 @@
+<registry purge="False">
+  <records interface="opengever.document.interfaces.IDocumentSettings" />
+</registry>

--- a/opengever/core/upgrades/20230623124442_add_upload_mimetype_blacklist/upgrade.py
+++ b/opengever/core/upgrades/20230623124442_add_upload_mimetype_blacklist/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddUploadMimetypeBlacklist(UpgradeStep):
+    """Add upload mimetype blacklist.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -16,6 +16,7 @@ from opengever.document.behaviors import IBaseDocument
 from opengever.document.behaviors.related_docs import IRelatedDocuments
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.document.interfaces import IDocumentSavedAsPDFMarker
+from opengever.document.interfaces import IDocumentSettings
 from opengever.document.versioner import Versioner
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.meeting.proposal import ISubmittedProposal
@@ -132,6 +133,19 @@ class IDocumentSchema(model.Schema):
         if data.file:
             validateUploadForFieldIfNecessary(
                 "file", data.file.filename, data.file.open(), getRequest())
+
+    @invariant
+    def disallow_blacklisted_mimetypes(data):
+        if not data.file:
+            return
+
+        blacklisted_mimetypes = api.portal.get_registry_record(
+            name='upload_mimetype_blacklist', interface=IDocumentSettings)
+
+        if data.file.contentType in blacklisted_mimetypes:
+            raise Invalid(
+                _('error_blocked_mimetype_by_blacklist',
+                  default="It is not allowed to upload this file format"))
 
 
 class UploadValidator(Z3CFormClamavValidator):

--- a/opengever/document/interfaces.py
+++ b/opengever/document/interfaces.py
@@ -82,6 +82,13 @@ class IDocumentSettings(Interface):
         default=PRESERVED_AS_PAPER_DEFAULT,
     )
 
+    upload_mimetype_blacklist = schema.List(
+        title=u'MIME types upload blacklist',
+        description=u'A list of blacklisted MIME types.'
+        u'An error will be raised if a user tries to upload a file of one of'
+        u'the listed MIME types',
+        default=list())
+
 
 class ICheckinCheckoutManager(Interface):
     """Interface for the checkin / checkout manager.

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2023-02-06 17:59+0000\n"
+"POT-Creation-Date: 2023-06-23 10:57+0000\n"
 "PO-Revision-Date: 2017-10-13 14:27+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -208,6 +208,11 @@ msgstr "Dokument-ID"
 #: ./opengever/document/forms.py
 msgid "error_NotInContentTypes"
 msgstr "Sie dürfen kein Dokument in diesem Zielort erstellen."
+
+#. Default: "It is not allowed to upload this file format"
+#: ./opengever/document/document.py
+msgid "error_blocked_mimetype_by_blacklist"
+msgstr "Die Ablage von Dateien in diesem Format ist nicht erlaubt."
 
 #. Default: "It's not possible to add E-mails here, please send it to ${mailaddress} or drag it to the dossier (Dragn'n'Drop)."
 #: ./opengever/document/document.py

--- a/opengever/document/locales/en/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/en/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2023-02-06 17:59+0000\n"
+"POT-Creation-Date: 2023-06-23 10:57+0000\n"
 "PO-Revision-Date: 2017-10-13 14:27+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -243,6 +243,11 @@ msgstr "Document-ID"
 #: ./opengever/document/forms.py
 msgid "error_NotInContentTypes"
 msgstr "You're not allowed to add documents in the target container."
+
+#. Default: "It is not allowed to upload this file format"
+#: ./opengever/document/document.py
+msgid "error_blocked_mimetype_by_blacklist"
+msgstr ""
 
 #. German translation: Es ist nicht erlaubt hier E-Mails anzufügen. Bitte senden Sie das E-Mail an die Addresse ${mailaddress} oder ziehen Sie es in das Dossier (Drag'n'Drop).
 #. Default: "It's not possible to add E-mails here, please send it to ${mailaddress} or drag it to the dossier (Dragn'n'Drop)."

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-02-06 17:59+0000\n"
+"POT-Creation-Date: 2023-06-23 10:57+0000\n"
 "PO-Revision-Date: 2017-09-03 08:50+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-document/fr/>\n"
@@ -210,6 +210,11 @@ msgstr "Document-ID"
 #: ./opengever/document/forms.py
 msgid "error_NotInContentTypes"
 msgstr "Vous ne pouvez pas créer de document à cette position."
+
+#. Default: "It is not allowed to upload this file format"
+#: ./opengever/document/document.py
+msgid "error_blocked_mimetype_by_blacklist"
+msgstr ""
 
 #. Default: "It's not possible to add E-mails here, please send it to ${mailaddress} or drag it to the dossier (Dragn'n'Drop)."
 #: ./opengever/document/document.py

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-02-06 17:59+0000\n"
+"POT-Creation-Date: 2023-06-23 10:57+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -209,6 +209,11 @@ msgstr ""
 #. Default: "User is not allowed to add a document there."
 #: ./opengever/document/forms.py
 msgid "error_NotInContentTypes"
+msgstr ""
+
+#. Default: "It is not allowed to upload this file format"
+#: ./opengever/document/document.py
+msgid "error_blocked_mimetype_by_blacklist"
 msgstr ""
 
 #. Default: "It's not possible to add E-mails here, please send it to ${mailaddress} or drag it to the dossier (Dragn'n'Drop)."


### PR DESCRIPTION
This PR adds an upload mimetype blacklist.

## Possible ui implementation
https://github.com/4teamwork/opengever.core/assets/557005/735759fa-3aaa-4f45-aea6-e0d725454694

For [CA-4999]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-4999]: https://4teamwork.atlassian.net/browse/CA-4999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ