### PR TITLE
Fix title updating of sub repositoryfolder when prefix changes.

### DIFF
--- a/changes/CA-5949.bugfix
+++ b/changes/CA-5949.bugfix
@@ -1,0 +1,1 @@
+Fix title updating of sub repositoryfolder when prefix changes. [phgross]

--- a/opengever/repository/subscribers.py
+++ b/opengever/repository/subscribers.py
@@ -1,6 +1,7 @@
 from opengever.base.security import elevated_privileges
 from opengever.document.behaviors import IBaseDocument
 from opengever.repository.interfaces import IDuringRepositoryDeletion
+from opengever.repository.interfaces import IRepositoryFolder
 from plone import api
 from plone.app.workflow.interfaces import ILocalrolesModifiedEvent
 from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
@@ -41,6 +42,13 @@ def update_reference_prefixes(obj, event):
                     idxs.append('metadata')
                 else:
                     idxs.append('SearchableText')
+
+                if IRepositoryFolder.providedBy(obj):
+                    idxs += ['Title',
+                             'sortable_title',
+                             'title_de',
+                             'title_fr',
+                             'title_en']
 
                 obj.reindexObject(idxs=idxs)
 

--- a/opengever/repository/tests/test_subscribers.py
+++ b/opengever/repository/tests/test_subscribers.py
@@ -77,3 +77,45 @@ class TestReferencePrefixUpdating(SolrIntegrationTestCase):
         self.login(self.manager, browser)
         self.assertEquals('Client1 1.7 / 1.1 / 24',
                           solr_data_for(self.empty_document, 'reference'))
+
+    @browsing
+    def test_reference_number_in_repositoryfolder_titles_gets_updated(self, browser):
+        self.login(self.administrator, browser)
+
+        self.assertEquals(
+            u'1.1. Vertr\xe4ge und Vereinbarungen',
+            solr_data_for(self.leaf_repofolder, 'Title'))
+        self.assertEquals(
+            u'0001.0001. vertrage und vereinbarungen',
+            solr_data_for(self.leaf_repofolder, 'sortable_title'))
+        self.assertEquals(
+            u'1.1. Vertr\xe4ge und Vereinbarungen',
+            solr_data_for(self.leaf_repofolder, 'title_de'))
+        self.assertEquals(
+            u'1.1. Contrats et accords',
+            solr_data_for(self.leaf_repofolder, 'title_fr'))
+        self.assertEquals(
+            u'1.1. Vertr\xe4ge und Vereinbarungen',
+            solr_data_for(self.leaf_repofolder, 'title_en'))
+
+        browser.open(self.branch_repofolder, view='edit')
+        browser.fill({'Repository number': u'8'}).save()
+        self.commit_solr()
+
+        self.login(self.manager, browser)
+
+        self.assertEquals(
+            u'8.1. Vertr\xe4ge und Vereinbarungen',
+            solr_data_for(self.leaf_repofolder, 'Title'))
+        self.assertEquals(
+            u'0008.0001. vertrage und vereinbarungen',
+            solr_data_for(self.leaf_repofolder, 'sortable_title'))
+        self.assertEquals(
+            u'8.1. Vertr\xe4ge und Vereinbarungen',
+            solr_data_for(self.leaf_repofolder, 'title_de'))
+        self.assertEquals(
+            u'8.1. Contrats et accords',
+            solr_data_for(self.leaf_repofolder, 'title_fr'))
+        self.assertEquals(
+            u'8.1. Vertr\xe4ge und Vereinbarungen',
+            solr_data_for(self.leaf_repofolder, 'title_en'))


### PR DESCRIPTION
Repositoryfolder contains the complete prefix number, so we need to reindex all title indexes for sub-repositoryfolders.

IMHO no need for an upgradestep, the users reindex the object, by manually edit each sub position.

For [CA-5949]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)




[CA-5949]: https://4teamwork.atlassian.net/browse/CA-5949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ