### PR TITLE
Add disposition sequence number to SIP folder name.

### DIFF
--- a/changes/CA-5857.other
+++ b/changes/CA-5857.other
@@ -1,0 +1,1 @@
+Add disposition sequence number to SIP folder name. [njohner]

--- a/opengever/disposition/ech0160/sippackage.py
+++ b/opengever/disposition/ech0160/sippackage.py
@@ -2,6 +2,7 @@ from Acquisition import aq_inner
 from Acquisition import aq_parent
 from DateTime import DateTime
 from opengever.base.behaviors.translated_title import ITranslatedTitle
+from opengever.base.interfaces import ISequenceNumber
 from opengever.base.utils import file_checksum
 from opengever.disposition.ech0160 import model as ech0160
 from opengever.disposition.ech0160.bindings import arelda
@@ -11,6 +12,7 @@ from opengever.repository.repositoryroot import IRepositoryRoot
 from pkg_resources import resource_filename
 from plone import api
 from pyxb.namespace import XMLSchema_instance as xsi
+from zope.component import getUtility
 import os.path
 
 
@@ -106,9 +108,10 @@ class SIPPackage(object):
         return ITranslatedTitle(parent).translated_title()
 
     def get_folder_name(self):
-        name = u'SIP_{}_{}'.format(
+        seq_number = getUtility(ISequenceNumber).get_number(self.disposition)
+        name = u'SIP_{}_{}_{}'.format(
             DateTime().strftime('%Y%m%d'),
-            api.portal.get().getId().upper())
+            api.portal.get().getId().upper(), seq_number)
         if self.disposition.transfer_number:
             name = u'{}_{}'.format(name, self.disposition.transfer_number)
 

--- a/opengever/disposition/tests/test_ech0160export.py
+++ b/opengever/disposition/tests/test_ech0160export.py
@@ -4,7 +4,6 @@ from ftw.testbrowser.pages.statusmessages import error_messages
 from ftw.testbrowser.pages.statusmessages import info_messages
 from ftw.testing import freeze
 from opengever.testing import IntegrationTestCase
-import os
 
 
 class TesteCH0160Deployment(IntegrationTestCase):
@@ -23,7 +22,7 @@ class TesteCH0160Deployment(IntegrationTestCase):
                 'application/zip',
                 self.request.response.headers.get('content-type'))
             self.assertEquals(
-                'inline; filename="SIP_20160611_PLONE_10xy.zip"',
+                'inline; filename="SIP_20160611_PLONE_1_10xy.zip"',
                 self.request.response.headers.get('content-disposition'))
 
 

--- a/opengever/disposition/tests/test_sippackage.py
+++ b/opengever/disposition/tests/test_sippackage.py
@@ -23,12 +23,12 @@ class TestSIPPackageIntegration(IntegrationTestCase):
 
         with freeze(datetime(2016, 11, 6)):
             self.assertEquals(
-                'SIP_20161106_PLONE', package.get_folder_name())
+                'SIP_20161106_PLONE_1', package.get_folder_name())
 
         self.disposition.transfer_number = u'10\xe434'
         with freeze(datetime(2016, 11, 6)):
             self.assertEquals(
-                u'SIP_20161106_PLONE_10\xe434', package.get_folder_name())
+                u'SIP_20161106_PLONE_1_10\xe434', package.get_folder_name())
 
     def test_ablieferungs_metadata(self):
         rm_user = ogds_service().fetch_user(self.records_manager.getId())
@@ -113,24 +113,23 @@ class TestSIPPackage(FunctionalTestCase):
 
             package = SIPPackage(disposition)
             package.write_to_zipfile(zip_file)
-
             self.assertItemsEqual(
-                ['SIP_20160611_PLONE_10xy/header/xsd/ablieferung.xsd',
-                 'SIP_20160611_PLONE_10xy/header/xsd/archivischeNotiz.xsd',
-                 'SIP_20160611_PLONE_10xy/header/xsd/archivischerVorgang.xsd',
-                 'SIP_20160611_PLONE_10xy/header/xsd/arelda.xsd',
-                 'SIP_20160611_PLONE_10xy/header/xsd/base.xsd',
-                 'SIP_20160611_PLONE_10xy/header/xsd/datei.xsd',
-                 'SIP_20160611_PLONE_10xy/header/xsd/dokument.xsd',
-                 'SIP_20160611_PLONE_10xy/header/xsd/dossier.xsd',
-                 'SIP_20160611_PLONE_10xy/header/xsd/ordner.xsd',
-                 'SIP_20160611_PLONE_10xy/header/xsd/ordnungssystem.xsd',
-                 'SIP_20160611_PLONE_10xy/header/xsd/ordnungssystemposition.xsd',
-                 'SIP_20160611_PLONE_10xy/header/xsd/paket.xsd',
-                 'SIP_20160611_PLONE_10xy/header/xsd/provenienz.xsd',
-                 'SIP_20160611_PLONE_10xy/header/xsd/zusatzDaten.xsd',
-                 'SIP_20160611_PLONE_10xy/content/d000001/p000001.doc',
-                 'SIP_20160611_PLONE_10xy/content/d000002/p000002.pdf',
-                 'SIP_20160611_PLONE_10xy/content/d000002/p000003.doc',
-                 'SIP_20160611_PLONE_10xy/header/metadata.xml'],
+                ['SIP_20160611_PLONE_1_10xy/header/xsd/ablieferung.xsd',
+                 'SIP_20160611_PLONE_1_10xy/header/xsd/archivischeNotiz.xsd',
+                 'SIP_20160611_PLONE_1_10xy/header/xsd/archivischerVorgang.xsd',
+                 'SIP_20160611_PLONE_1_10xy/header/xsd/arelda.xsd',
+                 'SIP_20160611_PLONE_1_10xy/header/xsd/base.xsd',
+                 'SIP_20160611_PLONE_1_10xy/header/xsd/datei.xsd',
+                 'SIP_20160611_PLONE_1_10xy/header/xsd/dokument.xsd',
+                 'SIP_20160611_PLONE_1_10xy/header/xsd/dossier.xsd',
+                 'SIP_20160611_PLONE_1_10xy/header/xsd/ordner.xsd',
+                 'SIP_20160611_PLONE_1_10xy/header/xsd/ordnungssystem.xsd',
+                 'SIP_20160611_PLONE_1_10xy/header/xsd/ordnungssystemposition.xsd',
+                 'SIP_20160611_PLONE_1_10xy/header/xsd/paket.xsd',
+                 'SIP_20160611_PLONE_1_10xy/header/xsd/provenienz.xsd',
+                 'SIP_20160611_PLONE_1_10xy/header/xsd/zusatzDaten.xsd',
+                 'SIP_20160611_PLONE_1_10xy/content/d000001/p000001.doc',
+                 'SIP_20160611_PLONE_1_10xy/content/d000002/p000002.pdf',
+                 'SIP_20160611_PLONE_1_10xy/content/d000002/p000003.doc',
+                 'SIP_20160611_PLONE_1_10xy/header/metadata.xml'],
                 zip_file.namelist())


### PR DESCRIPTION
I gave up using the creation date of the disposition instead of the delivery date of the SIP package, as this folder name format is part of the eCH 160 standard (see https://www.ech.ch/sites/default/files/dosvers/hauptdokument/STAN_d_DEF_2022-05-11_eCH-0160_V1.2.0_ArchivischeAblieferungsschnittstelle.pdf page 30 or excerpt below). Instead I simply added the dispositions sequence number, making the folder names unique and avoiding name conflicts. This change is also in line with the eCH 160 standard as the last part of the folder name can be freely chosen.

![Screenshot 2023-07-05 at 08 53 56](https://github.com/4teamwork/opengever.core/assets/7374243/9a757872-8c95-427f-8e76-b4a1f5dac9a8)


For [CA-5857]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-5857]: https://4teamwork.atlassian.net/browse/CA-5857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ