### PR TITLE
Introduce display mode in the @schema endpoint.

### DIFF
--- a/changes/CA-6037.bugfix
+++ b/changes/CA-6037.bugfix
@@ -1,0 +1,1 @@
+Show lifecycle fields in schema display mode. [phgross]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,6 +11,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- The ``@schema`` endpoint supports now a display mode.
 
 2023.11.0 (2023-06-29)
 ----------------------

--- a/opengever/api/tests/test_schema.py
+++ b/opengever/api/tests/test_schema.py
@@ -91,6 +91,29 @@ class TestSchemaEndpoint(IntegrationTestCase):
         self.assertNotIn('privacy_layer', fieldset['fields'])
 
     @browsing
+    def test_add_schema_does_contain_protected_fields_if_display_mode(self, browser):
+        self.login(self.regular_user, browser)
+        response = browser.open(
+            self.leaf_repofolder, view='@schema/opengever.dossier.businesscasedossier',
+            method='GET',
+            headers=self.api_headers,
+        ).json
+        fieldset = self._get_schema_fieldset(response, "classification")
+        self.assertIn('classification', fieldset['fields'])
+        self.assertIn('privacy_layer', fieldset['fields'])
+
+        self.leaf_repofolder.manage_permission("Edit lifecycle and classification", roles=[])
+        response = browser.open(
+            self.leaf_repofolder,
+            view='@schema/opengever.dossier.businesscasedossier?mode=display',
+            method='GET',
+            headers=self.api_headers,
+        ).json
+        fieldset = self._get_schema_fieldset(response, "classification")
+        self.assertIn('classification', fieldset['fields'])
+        self.assertIn('privacy_layer', fieldset['fields'])
+
+    @browsing
     def test_edit_schema_only_contains_translated_title_fields_for_active_languages(self, browser):
         self.login(self.regular_user, browser)
 

--- a/opengever/base/monkey/patches/__init__.py
+++ b/opengever/base/monkey/patches/__init__.py
@@ -31,6 +31,7 @@ from .readonly import PatchPloneUserAllowed
 from .readonly import PatchPloneUserGetRolesInContext
 from .relation_fields import PatchRelationFieldEventHandlers
 from .resource_registries_url_regex import PatchResourceRegistriesURLRegex
+from .restapi_utils import PatchRestAPICreateForm
 from .rolemanager import PatchOFSRoleManager
 from .scrub_bobo_exceptions import ScrubBoboExceptions
 from .session import PatchSessionCookie
@@ -72,6 +73,7 @@ PatchOFSRoleManager()()
 PatchPlone43RC1Upgrade()()
 PatchPloneProtectOnUserLogsIn()()
 PatchRelationFieldEventHandlers()()
+PatchRestAPICreateForm()()
 PatchResourceRegistriesURLRegex()()
 PatchSessionCookie()()
 PatchTransmogrifyDXSchemaUpdater()()

--- a/opengever/base/monkey/patches/restapi_utils.py
+++ b/opengever/base/monkey/patches/restapi_utils.py
@@ -1,0 +1,35 @@
+from opengever.base.monkey.patching import MonkeyPatch
+
+
+class PatchRestAPICreateForm(MonkeyPatch):
+    """Monkey patch plone.restapi's create_form so that it supports
+    also a display mode.
+    """
+
+    def __call__(self):
+        from plone.autoform.form import AutoExtensibleForm
+        from z3c.form import form as z3c_form
+        from z3c.form.interfaces import DISPLAY_MODE
+
+        def create_form(context, request, base_schema, additional_schemata=None):
+            """Create a minimal, standalone z3c form and run the field processing
+            logic of plone.autoform on it.
+            """
+            if additional_schemata is None:
+                additional_schemata = ()
+
+            class SchemaForm(AutoExtensibleForm, z3c_form.AddForm):
+                schema = base_schema
+                additionalSchemata = additional_schemata
+                ignoreContext = True
+
+            form = SchemaForm(context, request)
+            if request.get('mode') == 'display':
+                form.mode = DISPLAY_MODE
+
+            form.updateFieldsFromSchemata()
+            return form
+
+        from plone.restapi.types import utils
+        self.patch_refs(
+            utils, 'create_form', create_form)


### PR DESCRIPTION
Currently the @schema endpoint only returns information for the add or the edit form. This leads to the problem, that the lifecycle informations (ILifeCycle) are not visible for users, which does not have the `EditLifecycleAndClassification` permission. 

To fix this issue I introduced a display mode, similar than plone.dexterity already those for the DefaultView, that mode can be used by the gever-ui for the MetaDataPanel.


Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-6037]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- API change:
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))


[CA-6037]: https://4teamwork.atlassian.net/browse/CA-6037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ