### PR TITLE
Read OGDS sync timestamp from OGDS instead of ZODB

### DIFF
--- a/changes/CA-5766.other
+++ b/changes/CA-5766.other
@@ -1,0 +1,1 @@
+Read OGDS sync timestamp from OGDS instead of ZODB, as the new OGDS sync service only sets it in OGDS. [buchi]

--- a/opengever/ogds/base/sync/import_stamp.py
+++ b/opengever/ogds/base/sync/import_stamp.py
@@ -30,7 +30,7 @@ def get_ogds_sync_stamp():
     This function is used by the @@health-check view in og.maintenance.
     Don't change it without testing that the health check still works!
     """
-    sync_stamp = getUtility(ISyncStamp).get_sync_stamp()
+    sync_stamp = dictstorage.get(DICTSTORAGE_SYNC_KEY)
 
     if sync_stamp:
         return dateutil.parser.parse(sync_stamp)


### PR DESCRIPTION
The new OGDS sync service only sets it in OGDS.
This is used for the extended healthcheck.

Should fix extended health check for test.onegovgever.ch and lab.onegovgever.ch

For [CA-5766](https://4teamwork.atlassian.net/browse/CA-5766)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)




[CA-5766]: https://4teamwork.atlassian.net/browse/CA-5766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ