### PR TITLE
Do not display create_disposition action on subdossier listings.

### DIFF
--- a/changes/CA-6061.bugfix
+++ b/changes/CA-6061.bugfix
@@ -1,0 +1,1 @@
+Do not display create_disposition action on subdossier listings. [njohner]

--- a/opengever/dossier/actions.py
+++ b/opengever/dossier/actions.py
@@ -67,6 +67,9 @@ class SubDossierListingActions(DossierListingActions):
         linked_workspaces_manager = ILinkedWorkspaces(self.context.get_main_dossier())
         return linked_workspaces_manager.has_linked_workspaces()
 
+    def is_create_disposition_available(self):
+        return False
+
 
 @adapter(IDossierMarker, IOpengeverBaseLayer)
 class DossierContextActions(BaseContextActions):

--- a/opengever/dossier/tests/test_actions.py
+++ b/opengever/dossier/tests/test_actions.py
@@ -42,13 +42,13 @@ class TestDossierListingActions(IntegrationTestCase):
         self.login(self.archivist)
         self.assertIn(u'create_disposition', self.get_actions(self.repository_root))
         self.assertIn(u'create_disposition', self.get_actions(self.branch_repofolder))
-        self.assertIn(u'create_disposition', self.get_actions(self.dossier))
+        self.assertNotIn(u'create_disposition', self.get_actions(self.dossier))
 
     def test_create_disposition_available_for_records_manager(self):
         self.login(self.records_manager)
         self.assertIn(u'create_disposition', self.get_actions(self.repository_root))
         self.assertIn(u'create_disposition', self.get_actions(self.branch_repofolder))
-        self.assertIn(u'create_disposition', self.get_actions(self.dossier))
+        self.assertNotIn(u'create_disposition', self.get_actions(self.dossier))
 
     def test_dossier_actions_for_private_dossier_and_private_folder(self):
         self.login(self.regular_user)


### PR DESCRIPTION
Dispositions cannot be created in dossiers, so the action should not be available on subdossier listings.

For [CA-6061]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-6061]: https://4teamwork.atlassian.net/browse/CA-6061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ