### PR TITLE
Enable GEVER UI registry feature by default.

### DIFF
--- a/changes/CA-6039.other
+++ b/changes/CA-6039.other
@@ -1,0 +1,1 @@
+Enable GEVER UI registry feature by default. [lgraf]

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -71,7 +71,7 @@ class TestConfig(IntegrationTestCase):
                 u'ech0147_import': False,
                 u'favorites': True,
                 u'filing_number': False,
-                u'gever_ui_enabled': False,
+                u'gever_ui_enabled': True,
                 u'hubspot': False,
                 u'journal_pdf': False,
                 u'meetings': False,

--- a/opengever/base/interfaces.py
+++ b/opengever/base/interfaces.py
@@ -430,7 +430,7 @@ class IGeverUI(Interface):
     is_feature_enabled = schema.Bool(
         title=u'Enable new GEVER UI',
         description=u'Whether new GEVER UI is enabled',
-        default=False)
+        default=True)
 
     custom_dashboard_cards = schema.Text(
         title=u'custom dashboard cards',

--- a/opengever/base/tests/test_configuration_adapter.py
+++ b/opengever/base/tests/test_configuration_adapter.py
@@ -78,7 +78,7 @@ class TestConfigurationAdapter(IntegrationTestCase):
                 ('ech0147_import', False),
                 ('favorites', True),
                 ('filing_number', False),
-                ('gever_ui_enabled', False),
+                ('gever_ui_enabled', True),
                 ('hubspot', False),
                 ('journal_pdf', False),
                 ('tasks_pdf', False),

--- a/opengever/base/tests/test_gever_ui_action.py
+++ b/opengever/base/tests/test_gever_ui_action.py
@@ -5,24 +5,24 @@ from opengever.testing import IntegrationTestCase
 
 class TestGeverUIAction(IntegrationTestCase):
 
-    def test_feature_disabled_by_default(self):
+    def test_feature_enabled_by_default(self):
         self.login(self.regular_user)
         settings = IGeverSettings(self.portal).get_features()
         self.assertIn("gever_ui_enabled", settings)
-        self.assertFalse(settings.get("gever_ui_enabled"))
+        self.assertTrue(settings.get("gever_ui_enabled"))
 
     @browsing
-    def test_action_is_visible_when_feature_enabled(self, browser):
+    def test_action_is_invisible_when_feature_disabled(self, browser):
         self.login(self.regular_user, browser)
         browser.open(self.repository_root)
 
         self.assertEqual(
-            [],
+            ['Switch to new UI'],
             browser.css('#portal-personaltools #personaltools-switch_ui').text)
 
-        self.activate_feature("gever_ui")
+        self.deactivate_feature("gever_ui")
         browser.open(self.repository_root)
 
         self.assertEqual(
-            ['Switch to new UI'],
+            [],
             browser.css('#portal-personaltools #personaltools-switch_ui').text)

--- a/opengever/policytemplates/hooks.py
+++ b/opengever/policytemplates/hooks.py
@@ -65,7 +65,6 @@ IGNORED_FILES = {
 
 VARIABLE_VALUES = {
     'teamraum': {
-        'setup.geverui': True,
         'setup.bumblebee_auto_refresh': True,
         'setup.enable_activity_feature': True,
         'setup.maximum_mail_size': DEFAULT_MAIL_MAX_SIZE,

--- a/opengever/policytemplates/policy_template/.mrbob.ini
+++ b/opengever/policytemplates/policy_template/.mrbob.ini
@@ -206,12 +206,6 @@ deployment.workspace_users_group.required = False
 setup.invitation_group_dn.question = Invitation Group DN
 setup.invitation_group_dn.help = If not set, the OrgUnit's users_group_id is used.
 
-
-setup.geverui.question = Enable new GEVER UI
-setup.geverui.required = True
-setup.geverui.default = true
-setup.geverui.post_ask_question = mrbob.hooks:to_boolean
-
 setup.hubspot.question = Enable HubSpot feature
 setup.hubspot.required = True
 setup.hubspot.default = false

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/profiles/default/registry.xml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/profiles/default/registry.xml.bob
@@ -41,12 +41,6 @@
   </records>
 
 {{% endif %}}
-{{% if setup.geverui %}}
-  <records interface="opengever.base.interfaces.IGeverUI">
-    <value key="is_feature_enabled">True</value>
-  </records>
-
-{{% endif %}}
 {{% if setup.hubspot %}}
   <records interface="opengever.base.interfaces.IHubSpotSettings">
     <value key="is_feature_enabled">True</value>


### PR DESCRIPTION
Enable GEVER UI registry feature by default.

Even though the classic UI still has many fans 😜 , there won't be any deployments any more where we don't also deploy the GEVER UI. Any this feature flag only controls the switcher action anyway. We therefore make it true by default, and we can kill the feature flag soon with https://4teamwork.atlassian.net/browse/CA-6036

I also removed the question from the policytemplate:
Since the flag is now enabled by default, we don't need the explicit registry entry any more. Disabling it is still possible, but should be so rare that it's not supported by the policytemplate any more.

For [CA-6039](https://4teamwork.atlassian.net/browse/CA-6039)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-6039]: https://4teamwork.atlassian.net/browse/CA-6039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ