### PR TITLE
Policyless deployments: Fix link to bundle import view.

### DIFF
--- a/changes/CA-6039-1.bugfix
+++ b/changes/CA-6039-1.bugfix
@@ -1,0 +1,1 @@
+Policyless deployments: Fix link to bundle import view. [lgraf]

--- a/opengever/setup/browser/adddeployment.pt
+++ b/opengever/setup/browser/adddeployment.pt
@@ -156,7 +156,7 @@
         Setup successful!
         <a class="open-deployment" href="#">open deployment ...</a><br/>
         For policyless setup style, continue with
-        <a href="http://localhost:8080/ogsite/@@import-bundle">OGGBundle Import</a>
+        <a tal:attributes="href string:${context/absolute_url}/ogsite/@@import-bundle">OGGBundle Import</a>
     </div>
 
   </body>


### PR DESCRIPTION
Policyless deployments: Fix link to bundle import view.

For [CA-6039](https://4teamwork.atlassian.net/browse/CA-6039)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-6039]: https://4teamwork.atlassian.net/browse/CA-6039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ