### PR TITLE
Allow copying dossiers containing locked excerpt documents.

### DIFF
--- a/changes/CA-5991.bugfix
+++ b/changes/CA-5991.bugfix
@@ -1,0 +1,1 @@
+Allow copying dossiers containing locked excerpt documents. [njohner]


### PR DESCRIPTION
Proposal excerpts, which get deposited and locked in the dossier from which the proposal originated, prevented copy/pasting the dossier. Copy/pasting of only the excerpt actually already worked, and there is no reason to prevent copying the dossier. We therefore fix this by removing the locked on the copy of the excerpt before renaming happens (which is what was raising an error before this change).

For [CA-5991]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-5991]: https://4teamwork.atlassian.net/browse/CA-5991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ