### PR TITLE
Getting @linked-workspaces on subdossier returns workspaces linked to main dossier

### DIFF
--- a/changes/CA-6104.feature
+++ b/changes/CA-6104.feature
@@ -1,0 +1,1 @@
+Getting @linked-workspaces on subdossier returns workspaces linked to main dossier. [njohner]


### PR DESCRIPTION
We need to cover the case where a user has permissions on a subdossier but not on the main dossier. The gever-ui would until now call the `@linked-workspaces` on the main dossier, leading to an error. Instead we now allow calling that endpoint on subdossiers, but it will return the workspaces linked to the main dossier. As workspaces can only be linked to main dossiers, this is fine.

For [CA-6104]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-6104]: https://4teamwork.atlassian.net/browse/CA-6104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ