### PR TITLE
Add WordDelimiterGraphFilterFactory to all text indexers.

### DIFF
--- a/changes/CA-6136.bugfix
+++ b/changes/CA-6136.bugfix
@@ -1,0 +1,1 @@
+Improve solr-indexing for words combined with underscores. [phgross]

--- a/opengever/api/tests/test_solrsearch.py
+++ b/opengever/api/tests/test_solrsearch.py
@@ -1515,6 +1515,39 @@ class TestSolrLiveSearchGet(SolrIntegrationTestCase):
             [item["title"] for item in livesearch[u'items']])
 
     @browsing
+    def test_splits_on_underscores(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        self.document.title = "vorbereitung_103"
+        self.document.reindexObject(idxs=["Title"])
+        self.subdocument.title = "vorbereitung_104"
+        self.subdocument.reindexObject(idxs=["Title"])
+        self.subsubdocument.title = "nachbearbeitung_104"
+        self.subsubdocument.reindexObject(idxs=["Title"])
+        self.commit_solr()
+
+        query = {"q": "104"}
+        livesearch = self.solr_livesearch(browser, query)
+        self.assertEqual(2, livesearch["items_total"])
+        self.assertItemsEqual(
+            [u'vorbereitung_104', u'nachbearbeitung_104'],
+            [item["title"] for item in livesearch[u'items']])
+
+        query = {"q": "vorbereitung"}
+        livesearch = self.solr_livesearch(browser, query)
+        self.assertEqual(2, livesearch["items_total"])
+        self.assertItemsEqual(
+            [u'vorbereitung_103', u'vorbereitung_104'],
+            [item["title"] for item in livesearch[u'items']])
+
+        query = {"q": '"vorbereitung_104"'}
+        livesearch = self.solr_livesearch(browser, query)
+        self.assertEqual(1, livesearch["items_total"])
+        self.assertItemsEqual(
+            [u'vorbereitung_104'],
+            [item["title"] for item in livesearch[u'items']])
+
+    @browsing
     def test_livesearch_handles_brackets(self, browser):
         self.login(self.regular_user, browser=browser)
 

--- a/opengever/api/tests/test_solrsearch.py
+++ b/opengever/api/tests/test_solrsearch.py
@@ -1364,37 +1364,27 @@ class TestSolrLiveSearchGet(SolrIntegrationTestCase):
     def test_livesearch_adds_wildcard(self, browser):
         self.login(self.regular_user, browser=browser)
 
-        query = {"q": "Title:an"}
+        query = {"q": "Kreis"}
         search = self.solr_search(browser, query)
+        self.solr_search(browser, query)
         livesearch = self.solr_livesearch(browser, query)
-        self.assertEqual(1, search["items_total"])
-        self.assertItemsEqual(
-            [u'An empty dossier'],
-            [item["title"] for item in search["items"]])
-
-        self.assertEqual(5, livesearch["items_total"])
-        self.assertItemsEqual(
-            [u'Vorstellungsrunde bei anderen Mitarbeitern',
-             u'An empty dossier',
-             u'Antrag f\xfcr Kreiselbau',
-             u'Antrag f\xfcr Kreiselbau',
-             u'Anfragen'],
-            [item["title"] for item in livesearch["items"]])
-
-        query = {"q": "Title:antrag"}
-        search = self.solr_search(browser, query)
-        livesearch = self.solr_livesearch(browser, query)
-        self.assertEqual(2, search["items_total"])
-        self.assertItemsEqual(
-            [u'Antrag f\xfcr Kreiselbau',
-             u'Antrag f\xfcr Kreiselbau'],
-            [item["title"] for item in search["items"]])
-
+        self.assertEqual(0, search["items_total"])
         self.assertEqual(2, livesearch["items_total"])
         self.assertItemsEqual(
             [u'Antrag f\xfcr Kreiselbau',
              u'Antrag f\xfcr Kreiselbau'],
             [item["title"] for item in livesearch["items"]])
+
+
+        query = {"q": "Kreiselbau"}
+        search = self.solr_search(browser, query)
+        livesearch = self.solr_livesearch(browser, query)
+        self.assertEqual(2, search["items_total"])
+        self.assertEqual(2, livesearch["items_total"])
+        self.assertItemsEqual(
+            [u'Antrag f\xfcr Kreiselbau',
+             u'Antrag f\xfcr Kreiselbau'],
+            [item["title"] for item in search["items"]])
 
     @browsing
     def test_livesearch_adds_wildcard_to_each_term(self, browser):
@@ -1427,20 +1417,11 @@ class TestSolrLiveSearchGet(SolrIntegrationTestCase):
     def test_livesearch_preserves_negative_queries(self, browser):
         self.login(self.regular_user, browser=browser)
 
-        query = {"q": "Title:an -kr"}
+        query = {"q": "Title:Antrag -kreiselbau"}
         search = self.solr_search(browser, query)
         livesearch = self.solr_livesearch(browser, query)
-        self.assertEqual(1, search["items_total"])
-        self.assertItemsEqual(
-            [u'An empty dossier'],
-            [item["title"] for item in search["items"]])
-
-        self.assertEqual(3, livesearch["items_total"])
-        self.assertItemsEqual(
-            [u'Vorstellungsrunde bei anderen Mitarbeitern',
-             u'An empty dossier',
-             u'Anfragen'],
-            [item["title"] for item in livesearch["items"]])
+        self.assertEqual(0, search["items_total"])
+        self.assertEqual(0, livesearch["items_total"])
 
     @browsing
     def test_livesearch_handles_operators(self, browser):
@@ -1679,7 +1660,7 @@ class TestSolrLiveSearchGet(SolrIntegrationTestCase):
         query = {"q": "Title:taktische-banane*"}
         search = self.solr_search(browser, query)
         livesearch = self.solr_livesearch(browser, query)
-        self.assertEqual(0, search["items_total"])
+        self.assertEqual(1, search["items_total"])
         self.assertEqual(1, livesearch["items_total"])
         self.assertItemsEqual(
             [u'Taktische-Banane'],
@@ -1722,7 +1703,7 @@ class TestSolrLiveSearchGet(SolrIntegrationTestCase):
         self.commit_solr()
 
         query = {"q": "dotted.title."}
-        self.assertEqual(0, self.solr_search(browser, query)["items_total"])
+        self.assertEqual(1, self.solr_search(browser, query)["items_total"])
         self.assertEqual(1, self.solr_livesearch(browser, query)["items_total"])
 
         self.document.title = "dotted. title. with. spaces"
@@ -1862,18 +1843,6 @@ class TestSolrLiveSearchGet(SolrIntegrationTestCase):
             [u'Client1 11-1.1.1-23'],
             [item["reference_number"] for item in search["items"]])
 
-        query = {"q": "Client1 11-1.1.1", "fl": "@id,reference_number"}
-        search = self.solr_search(browser, query)
-        livesearch = self.solr_livesearch(browser, query)
-        self.assertEqual(2, livesearch["items_total"])
-        self.assertItemsEqual(
-            [u'Client1 11-1.1.1', u'Client1 11-1.1.1-23'],
-            [item["reference_number"] for item in livesearch["items"]])
-        self.assertEqual(2, search["items_total"])
-        self.assertItemsEqual(
-            [u'Client1 11-1.1.1', u'Client1 11-1.1.1-23'],
-            [item["reference_number"] for item in search["items"]])
-
     @browsing
     def test_querying_filenames(self, browser):
         self.login(self.regular_user, browser=browser)
@@ -1882,7 +1851,7 @@ class TestSolrLiveSearchGet(SolrIntegrationTestCase):
         self.commit_solr()
 
         # partial filename is only found with livesearch
-        query = {"q": "20221121"}
+        query = {"q": "202211"}
         search = self.solr_search(browser, query)
         livesearch = self.solr_livesearch(browser, query)
         self.assertEqual(0, search["items_total"])
@@ -1891,7 +1860,7 @@ class TestSolrLiveSearchGet(SolrIntegrationTestCase):
         query = {"q": "20221121_some"}
         search = self.solr_search(browser, query)
         livesearch = self.solr_livesearch(browser, query)
-        self.assertEqual(0, search["items_total"])
+        self.assertEqual(1, search["items_total"])
         self.assertEqual(1, livesearch["items_total"])
 
         # full filename without extension is found by both

--- a/solr-conf/managed-schema
+++ b/solr-conf/managed-schema
@@ -323,6 +323,17 @@
         <charFilter class="solr.ICUNormalizer2CharFilterFactory"/>
         <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-FoldToASCII.txt"/>
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <filter class="solr.WordDelimiterGraphFilterFactory"
+                splitOnCaseChange="1"
+                splitOnNumerics="1"
+                stemEnglishPossessive="1"
+                generateWordParts="1"
+                generateNumberParts="1"
+                catenateWords="1"
+                catenateNumbers="1"
+                catenateAll="0"
+                preserveOriginal="1"/>
+        <filter class="solr.FlattenGraphFilterFactory" />
         <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
         <filter class="solr.LowerCaseFilterFactory"/>
@@ -337,17 +348,39 @@
     <fieldType name="text_general" class="solr.TextField" positionIncrementGap="100">
       <analyzer type="index">
         <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-FoldToASCII.txt"/>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <filter class="solr.KeywordRepeatFilterFactory" />
+        <filter class="solr.WordDelimiterGraphFilterFactory"
+                splitOnCaseChange="1"
+                splitOnNumerics="1"
+                stemEnglishPossessive="1"
+                generateWordParts="1"
+                generateNumberParts="1"
+                catenateWords="1"
+                catenateNumbers="1"
+                catenateAll="0"
+                preserveOriginal="1"/>
+        <filter class="solr.FlattenGraphFilterFactory" />
         <!-- <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" /> -->
         <!-- in this example, we will only use synonyms at query time
         <filter class="solr.SynonymGraphFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
-        <filter class="solr.FlattenGraphFilterFactory"/>
         -->
         <filter class="solr.LowerCaseFilterFactory"/>
       </analyzer>
       <analyzer type="query">
         <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-FoldToASCII.txt"/>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <filter class="solr.WordDelimiterGraphFilterFactory"
+                splitOnCaseChange="1"
+                splitOnNumerics="1"
+                stemEnglishPossessive="1"
+                generateWordParts="1"
+                generateNumberParts="1"
+                catenateWords="1"
+                catenateNumbers="1"
+                catenateAll="0"
+                preserveOriginal="1"/>
+        <filter class="solr.FlattenGraphFilterFactory" />
         <!-- <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" /> -->
         <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
         <filter class="solr.LowerCaseFilterFactory"/>
@@ -361,7 +394,8 @@
          also applies synonyms from synonyms.txt. -->
     <fieldType name="text_en" class="solr.TextField" positionIncrementGap="100">
       <analyzer type="index">
-        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <filter class="solr.KeywordRepeatFilterFactory" />
         <!-- in this example, we will only use synonyms at query time
         <filter class="solr.SynonymGraphFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
         <filter class="solr.FlattenGraphFilterFactory"/>
@@ -372,10 +406,20 @@
                 ignoreCase="true"
                 words="lang/stopwords_en.txt"
                 /> -->
+        <filter class="solr.WordDelimiterGraphFilterFactory"
+                splitOnCaseChange="1"
+                splitOnNumerics="1"
+                stemEnglishPossessive="1"
+                generateWordParts="1"
+                generateNumberParts="1"
+                catenateWords="1"
+                catenateNumbers="1"
+                catenateAll="0"
+                preserveOriginal="1"/>
+        <filter class="solr.FlattenGraphFilterFactory" />
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="true" />
         <filter class="solr.EnglishPossessiveFilterFactory"/>
-        <filter class="solr.KeywordRepeatFilterFactory" />
         <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
         <!-- Optionally you may want to use this less aggressive stemmer instead of PorterStemFilterFactory:
               <filter class="solr.EnglishMinimalStemFilterFactory"/>
@@ -384,7 +428,18 @@
         <filter class="solr.RemoveDuplicatesTokenFilterFactory" />
       </analyzer>
       <analyzer type="query">
-        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <filter class="solr.WordDelimiterGraphFilterFactory"
+                splitOnCaseChange="1"
+                splitOnNumerics="1"
+                stemEnglishPossessive="1"
+                generateWordParts="1"
+                generateNumberParts="1"
+                catenateWords="1"
+                catenateNumbers="1"
+                catenateAll="0"
+                preserveOriginal="1"/>
+        <filter class="solr.FlattenGraphFilterFactory" />
         <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
 <!--         <filter class="solr.StopFilterFactory"
                 ignoreCase="true"
@@ -405,9 +460,20 @@
     <!-- German -->
     <fieldType name="text_de" class="solr.TextField" positionIncrementGap="100">
       <analyzer type="index">
-        <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.LowerCaseFilterFactory"/>
+        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
         <filter class="solr.KeywordRepeatFilterFactory" />
+        <filter class="solr.WordDelimiterGraphFilterFactory"
+                splitOnCaseChange="1"
+                splitOnNumerics="1"
+                stemEnglishPossessive="1"
+                generateWordParts="1"
+                generateNumberParts="1"
+                catenateWords="1"
+                catenateNumbers="1"
+                catenateAll="0"
+                preserveOriginal="1"/>
+        <filter class="solr.FlattenGraphFilterFactory" />
+        <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.HyphenationCompoundWordTokenFilterFactory" hyphenator="lang/hyph_de.xml" dictionary="lang/compound_stems_de.txt"/>
         <!-- <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_de.txt" format="snowball" /> -->
         <filter class="solr.GermanNormalizationFilterFactory"/>
@@ -418,7 +484,18 @@
         <filter class="solr.RemoveDuplicatesTokenFilterFactory" />
       </analyzer>
       <analyzer type="query">
-        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <filter class="solr.WordDelimiterGraphFilterFactory"
+                splitOnCaseChange="1"
+                splitOnNumerics="1"
+                stemEnglishPossessive="1"
+                generateWordParts="1"
+                generateNumberParts="1"
+                catenateWords="1"
+                catenateNumbers="1"
+                catenateAll="0"
+                preserveOriginal="1"/>
+        <filter class="solr.FlattenGraphFilterFactory" />
         <filter class="solr.LowerCaseFilterFactory"/>
         <!-- <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_de.txt" format="snowball" /> -->
         <filter class="solr.KeywordRepeatFilterFactory" />
@@ -432,12 +509,23 @@
 
     <!-- French -->
     <fieldType name="text_fr" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/>
+      <analyzer>
+        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <filter class="solr.KeywordRepeatFilterFactory" />
+        <filter class="solr.WordDelimiterGraphFilterFactory"
+                splitOnCaseChange="1"
+                splitOnNumerics="1"
+                stemEnglishPossessive="1"
+                generateWordParts="1"
+                generateNumberParts="1"
+                catenateWords="1"
+                catenateNumbers="1"
+                catenateAll="0"
+                preserveOriginal="1"/>
+        <filter class="solr.FlattenGraphFilterFactory" />
         <!-- removes l', etc -->
         <filter class="solr.ElisionFilterFactory" ignoreCase="true" articles="lang/contractions_fr.txt"/>
         <filter class="solr.LowerCaseFilterFactory"/>
-        <filter class="solr.KeywordRepeatFilterFactory" />
         <!-- <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_fr.txt" format="snowball" /> -->
         <filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="true" />
         <filter class="solr.FrenchLightStemFilterFactory"/>

--- a/solr-conf/solrconfig.xml
+++ b/solr-conf/solrconfig.xml
@@ -765,14 +765,14 @@
           Title_de^10 Title_en^10 Title_fr^10 Title_general^10
           Description_de^5 Description_en^5 Description_fr^5 Description_general^5
           SearchableText_de SearchableText_en SearchableText_fr SearchableText_general
-          sequence_number_string^1000 metadata^5
+          sequence_number_string^1000 metadata^5 reference^1500
      </str>
      <!-- Phrase fields -->
       <str name="pf">
           Title_de^100 Title_en^100 Title_fr^100 Title_general^100
           Description_de^50 Description_en^50 Description_fr^50 Description_general^50
           SearchableText_de^20 SearchableText_en^20 SearchableText_fr^20 SearchableText_general^20
-          metadata^50
+          metadata^50 reference^1500
      </str>
       <!-- Field aliases -->
       <str name="f.title.qf">Title_de Title_en Title_fr Title_general</str>


### PR DESCRIPTION
Currently two strings combined with an underscore are not indexed separately as it was in former versions of GEVER.
I also added the reference field  to the searched fields, this improves the search results, when searching with a specific
reference-number.

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-6136]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-6136]: https://4teamwork.atlassian.net/browse/CA-6136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ