### PR TITLE
Fix extraction of attachments from mails in closed tasks.

### DIFF
--- a/changes/CA-6128.bugfix
+++ b/changes/CA-6128.bugfix
@@ -1,0 +1,1 @@
+Fix extraction of attachments from mails in closed tasks. [njohner]

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -1368,7 +1368,7 @@
       name="@extract-attachments"
       for="opengever.mail.mail.IOGMailMarker"
       factory=".mail.ExtractAttachments"
-      permission="opengever.document.AddDocument"
+      permission="zope2.View"
       />
 
   <plone:service

--- a/opengever/api/mail.py
+++ b/opengever/api/mail.py
@@ -1,7 +1,9 @@
 from ftw.mail.mail import IMail
 from opengever.api.deserializer import GeverDeserializeFromJson
 from opengever.api.document import SerializeDocumentToJson
+from opengever.api.not_reported_exceptions import Forbidden as NotReportedForbidden
 from opengever.base.transforms.msg2mime import Msg2MimeTransform
+from opengever.mail import _ as mail_mf
 from opengever.mail.exceptions import AlreadyExtractedError
 from opengever.mail.exceptions import InvalidAttachmentPosition
 from opengever.mail.mail import initialize_metadata
@@ -73,6 +75,10 @@ class SerializeMailToJson(SerializeDocumentToJson):
 class ExtractAttachments(Service):
 
     def reply(self):
+        if not self.context.can_extract_attachments_to_parent():
+            raise NotReportedForbidden(mail_mf(
+                'attachment_extraction_disallowed',
+                default=u'You are not allowed to extract attachments from this Email'))
 
         # Disable CSRF protection, as POST requests cannot include the needed
         # X-CSRF-TOKEN to pass plone's autoprotect.

--- a/opengever/mail/browser/extract_attachments.py
+++ b/opengever/mail/browser/extract_attachments.py
@@ -122,6 +122,12 @@ class ExtractAttachments(BrowserView):
     def __call__(self):
         disable_edit_bar()
 
+        if not self.context.can_extract_attachments_to_parent():
+            msg = _('attachment_extraction_disallowed',
+                    default=u'You are not allowed to extract attachments from this Email')
+            api.portal.show_message(msg, request=self.request, type='warning')
+            return self.request.RESPONSE.redirect(self.context.absolute_url())
+
         if not self.context.has_attachments():
             msg = _(u'error_no_attachments_to_extract',
                     default=u'This mail has no attachments to extract.')

--- a/opengever/mail/locales/de/LC_MESSAGES/opengever.mail.po
+++ b/opengever/mail/locales/de/LC_MESSAGES/opengever.mail.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-08 11:40+0000\n"
+"POT-Creation-Date: 2023-08-25 06:41+0000\n"
 "PO-Revision-Date: 2016-07-22 16:52+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-mail/de/>\n"
@@ -39,6 +39,11 @@ msgstr "Die Grösse der ausgewählten Dateien überschreitet die erlaubte Maxima
 #: ./opengever/mail/browser/send_document.py
 msgid "You have to select a intern                             or enter a extern mail-addres"
 msgstr "Wählen Sie mindestens eine interne oder eine externe E-Mail Adresse."
+
+#. Default: "You are not allowed to extract attachments from this Email"
+#: ./opengever/mail/browser/extract_attachments.py
+msgid "attachment_extraction_disallowed"
+msgstr "Sie dürfen die Anhänge aus diesem E-mail nicht extrahieren."
 
 #. Default: "Send"
 #: ./opengever/mail/browser/send_document.py

--- a/opengever/mail/locales/en/LC_MESSAGES/opengever.mail.po
+++ b/opengever/mail/locales/en/LC_MESSAGES/opengever.mail.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-18 12:35+0000\n"
+"POT-Creation-Date: 2023-08-25 06:41+0000\n"
 "PO-Revision-Date: 2016-07-22 16:52+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-mail/de/>\n"
@@ -45,6 +45,11 @@ msgstr "The files you selected exceed the maximum allowed size."
 #: ./opengever/mail/browser/send_document.py
 msgid "You have to select a intern                             or enter a extern mail-addres"
 msgstr "Select at least one internal or external email address."
+
+#. Default: "You are not allowed to extract attachments from this Email"
+#: ./opengever/mail/browser/extract_attachments.py
+msgid "attachment_extraction_disallowed"
+msgstr "You are not allowed to extract attachments from this Email"
 
 #. German translation: Senden
 #. Default: "Send"

--- a/opengever/mail/locales/fr/LC_MESSAGES/opengever.mail.po
+++ b/opengever/mail/locales/fr/LC_MESSAGES/opengever.mail.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-08 11:40+0000\n"
+"POT-Creation-Date: 2023-08-25 06:41+0000\n"
 "PO-Revision-Date: 2017-09-04 06:15+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-mail/fr/>\n"
@@ -39,6 +39,11 @@ msgstr "La taille des fichiers séléctionnés dépasse la taille maximum permis
 #: ./opengever/mail/browser/send_document.py
 msgid "You have to select a intern                             or enter a extern mail-addres"
 msgstr "Sélectionner au minimum une adresse e-mail interne ou externe."
+
+#. Default: "You are not allowed to extract attachments from this Email"
+#: ./opengever/mail/browser/extract_attachments.py
+msgid "attachment_extraction_disallowed"
+msgstr "Vous n'avez pas le droit d'extraire les pièces jointes de cet E-mail."
 
 #. Default: "Send"
 #: ./opengever/mail/browser/send_document.py

--- a/opengever/mail/locales/opengever.mail.pot
+++ b/opengever/mail/locales/opengever.mail.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-08 11:40+0000\n"
+"POT-Creation-Date: 2023-08-25 06:41+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -39,6 +39,11 @@ msgstr ""
 
 #: ./opengever/mail/browser/send_document.py
 msgid "You have to select a intern                             or enter a extern mail-addres"
+msgstr ""
+
+#. Default: "You are not allowed to extract attachments from this Email"
+#: ./opengever/mail/browser/extract_attachments.py
+msgid "attachment_extraction_disallowed"
 msgstr ""
 
 #. Default: "Send"

--- a/opengever/mail/mail.py
+++ b/opengever/mail/mail.py
@@ -176,6 +176,10 @@ class OGMail(Mail, BaseDocumentMixin):
             return tuple(info for info in self.attachment_infos if not info.get('extracted'))
         return self.attachment_infos
 
+    def can_extract_attachments_to_parent(self):
+        parent = self.get_extraction_parent()
+        return api.user.has_permission('opengever.document: Add document', obj=parent)
+
     def has_attachments(self):
         """Return whether this mail has attachments."""
         return len(self.get_attachments()) > 0

--- a/opengever/mail/tests/test_extract_attachments.py
+++ b/opengever/mail/tests/test_extract_attachments.py
@@ -160,6 +160,23 @@ class TestExtractAttachments(IntegrationTestCase):
         doc = children["added"].pop()
         self.assertEquals('word_document', doc.Title())
 
+    @browsing
+    def test_returns_error_when_extraction_parent_is_not_open(self, browser):
+        self.login(self.regular_user, browser)
+        mail = create(Builder('mail')
+                      .within(self.inactive_dossier)
+                      .with_asset_message(
+                          'mail_with_multiple_attachments.eml'))
+
+        with self.observe_children(self.inactive_dossier) as children:
+            browser.login().open(mail, view='extract_attachments')
+
+        self.assertEquals(
+            ['You are not allowed to extract attachments from this Email'],
+            statusmessages.warning_messages())
+
+        self.assertEqual(0, len(children['added']))
+
 
 class TestExtractAttachmentsSolr(SolrIntegrationTestCase):
 


### PR DESCRIPTION
Extraction worked in the classic UI but not over the API because we checked the permission to add documents on the context instead of on the extraction target.

Test failures seem unrelated, probably due to the new solr  container that was pushed to the `latest` tag.

For [CA-6128]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-6128]: https://4teamwork.atlassian.net/browse/CA-6128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ