### PR TITLE
Add extract_attachments context action for mails.

### DIFF
--- a/changes/CA-6128.other
+++ b/changes/CA-6128.other
@@ -1,0 +1,1 @@
+Add extract_attachments context action for mails. [njohner]

--- a/opengever/document/configure.zcml
+++ b/opengever/document/configure.zcml
@@ -450,7 +450,6 @@
            opengever.base.interfaces.IOpengeverBaseLayer"
       />
 
-  <adapter factory=".actions.BaseDocumentContextActions" />
   <adapter factory=".actions.DocumentSchemaContextActions" />
 
   <!-- transitions -->

--- a/opengever/document/tests/test_actions.py
+++ b/opengever/document/tests/test_actions.py
@@ -127,24 +127,11 @@ class TestDocumentContextActions(IntegrationTestCase):
                             u'save_document_as_pdf', u'trash_context']
         self.assertEqual(expected_actions, self.get_actions(self.document))
 
-    def test_context_actions_for_mail_in_dossier(self):
-        self.login(self.regular_user)
-        expected_actions = [u'attach_to_email', u'copy_item', u'download_copy', u'edit',
-                            u'move_item', u'new_task_from_document', u'open_as_pdf',
-                            u'revive_bumblebee_preview', u'trash_context']
-        self.assertEqual(expected_actions, self.get_actions(self.mail_eml))
-
     def test_context_actions_for_trashed_document_in_dossier(self):
         self.login(self.regular_user)
         ITrasher(self.document).trash()
         expected_actions = [u'revive_bumblebee_preview', u'untrash_context']
         self.assertEqual(expected_actions, self.get_actions(self.document))
-
-    def test_context_actions_for_trashed_mail_in_dossier(self):
-        self.login(self.regular_user)
-        ITrasher(self.mail_eml).trash()
-        expected_actions = [u'revive_bumblebee_preview', u'untrash_context']
-        self.assertEqual(expected_actions, self.get_actions(self.mail_eml))
 
     def test_context_actions_for_checked_out_document(self):
         self.login(self.regular_user)

--- a/opengever/mail/actions.py
+++ b/opengever/mail/actions.py
@@ -1,0 +1,20 @@
+from opengever.base.interfaces import IOpengeverBaseLayer
+from opengever.document.actions import BaseDocumentContextActions
+from opengever.mail.mail import IOGMailMarker
+from zope.component import adapter
+
+
+@adapter(IOGMailMarker, IOpengeverBaseLayer)
+class MailContextActions(BaseDocumentContextActions):
+
+    def get_actions(self):
+        super(MailContextActions, self).get_actions()
+        self.maybe_add_extract_attachments()
+        return self.actions
+
+    def maybe_add_extract_attachments(self):
+        if self.is_extract_attachments_available():
+            self.add_action(u'extract_attachments')
+
+    def is_extract_attachments_available(self):
+        return self.context.can_extract_attachments_to_parent()

--- a/opengever/mail/configure.zcml
+++ b/opengever/mail/configure.zcml
@@ -29,6 +29,8 @@
 
   <adapter factory=".zipexport.OGMailZipExport" />
 
+  <adapter factory=".actions.MailContextActions" />
+
   <adapter
       factory=".indexer.checked_out"
       name="checked_out"

--- a/opengever/mail/tests/test_actions.py
+++ b/opengever/mail/tests/test_actions.py
@@ -1,0 +1,55 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.base.interfaces import IContextActions
+from opengever.testing import IntegrationTestCase
+from opengever.trash.trash import ITrasher
+from zope.component import queryMultiAdapter
+
+
+class TestMailContextActions(IntegrationTestCase):
+
+    features = ('bumblebee', )
+
+    def get_actions(self, context):
+        adapter = queryMultiAdapter((context, self.request), interface=IContextActions)
+        return adapter.get_actions() if adapter else []
+
+    def test_context_actions_for_mail_in_dossier(self):
+        self.login(self.regular_user)
+        expected_actions = [u'attach_to_email', u'copy_item', u'download_copy', u'edit',
+                            u'move_item', u'new_task_from_document', u'open_as_pdf',
+                            u'revive_bumblebee_preview', u'trash_context',
+                            u'extract_attachments']
+
+        self.assertEqual(expected_actions, self.get_actions(self.mail_eml))
+
+    def test_context_actions_for_trashed_mail_in_dossier(self):
+        self.login(self.regular_user)
+        ITrasher(self.mail_eml).trash()
+        expected_actions = [u'revive_bumblebee_preview', u'untrash_context',
+                            u'extract_attachments']
+        self.assertEqual(expected_actions, self.get_actions(self.mail_eml))
+
+    def test_context_actions_for_mail_in_resolved_task(self):
+        self.login(self.regular_user)
+        mail = create(Builder('mail')
+                      .within(self.subtask)
+                      .with_asset_message(
+                          'mail_with_multiple_attachments.eml'))
+
+        expected_actions = [u'attach_to_email', u'copy_item', u'download_copy', u'edit',
+                            u'new_task_from_document', u'open_as_pdf',
+                            u'revive_bumblebee_preview', u'trash_context',
+                            u'extract_attachments']
+        self.assertEqual(expected_actions, self.get_actions(mail))
+
+    def test_returns_error_when_extraction_parent_is_not_open(self):
+        self.login(self.regular_user)
+        mail = create(Builder('mail')
+                      .within(self.inactive_dossier)
+                      .with_asset_message(
+                          'mail_with_multiple_attachments.eml'))
+
+        expected_actions = [u'attach_to_email', u'copy_item', u'download_copy',
+                            u'open_as_pdf', u'revive_bumblebee_preview']
+        self.assertEqual(expected_actions, self.get_actions(mail))


### PR DESCRIPTION
Currently the action to extract attachments from an E-mail always appears, whether it's possible to do so or not. We therefore introduce a context action that the frontend can use to only display the action when necessary.

For [CA-6128]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-6128]: https://4teamwork.atlassian.net/browse/CA-6128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ