### PR TITLE
Add is_current_user_responsible flag to task api serialization.

### DIFF
--- a/changes/CA-6021.feature
+++ b/changes/CA-6021.feature
@@ -1,0 +1,1 @@
+Add is_current_user_responsible flag to task api serialization. [phgross]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,6 +11,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- The task api serialization provides a new ``is_current_user_responsible`` flag.
 - ``oc_attach_is_mail_fileable``: New endpoint to check if OC attach mail will be fileable.
 - The ``@schema`` endpoint supports now a display mode.
 

--- a/opengever/api/task.py
+++ b/opengever/api/task.py
@@ -52,6 +52,7 @@ class SerializeTaskToJson(GeverSerializeFolderToJson):
         result[u'has_remote_predecessor'] = model.has_remote_predecessor
         result[u'has_sequential_successor'] = model.has_sequential_successor
         result[u'responsible_admin_unit_url'] = model.get_assigned_org_unit().admin_unit.public_url
+        result[u'is_current_user_responsible'] = self.context.is_current_user_responsible()
         return result
 
     def _get_containing_dossier_summary(self):

--- a/opengever/api/tests/test_task.py
+++ b/opengever/api/tests/test_task.py
@@ -324,6 +324,27 @@ class TestTaskSerialization(SolrIntegrationTestCase):
         browser.open(self.task, method="GET", headers=self.api_headers)
         self.assertFalse(browser.json['has_sequential_successor'])
 
+    @browsing
+    def test_contains_is_current_user_responsible_flag(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(self.task, method="GET", headers=self.api_headers)
+        self.assertTrue(browser.json['is_current_user_responsible'])
+
+        self.task.responsible = self.dossier_responsible.id
+        browser.open(self.task, method="GET", headers=self.api_headers)
+        self.assertFalse(browser.json['is_current_user_responsible'])
+
+        # team: projekt_a
+        self.task.responsible = 'team:1'
+        browser.open(self.task, method="GET", headers=self.api_headers)
+        self.assertTrue(browser.json['is_current_user_responsible'])
+
+        # inbox group
+        self.task.responsible = 'inbox:fa'
+        browser.open(self.task, method="GET", headers=self.api_headers)
+        self.assertFalse(browser.json['is_current_user_responsible'])
+
 
 class TestTaskCommentSync(FunctionalTestCase):
 

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -462,6 +462,13 @@ class Task(Container, TaskReminderSupport):
     def get_responsible_actor(self):
         return Actor.lookup(self.responsible)
 
+    def is_current_user_responsible(self):
+        """Checks if the current user is the responsible itself or it belongs
+        to representive group."""
+        representatives = Actor.lookup(self.responsible).representatives()
+        current_user_id = api.user.get_current().id
+        return current_user_id in [user.userid for user in representatives]
+
     def get_issuer_actor(self):
         return Actor.lookup(self.issuer)
 


### PR DESCRIPTION
This flag is used to decide correctly if the AcceptTaskAlert should be displayed in the UI or not.

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-6021]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- API change:
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))

[CA-6021]: https://4teamwork.atlassian.net/browse/CA-6021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ