### PR TITLE
Include only dossiers with positive appraisal in the SIP package.

### DIFF
--- a/changes/CA-6168.bugfix
+++ b/changes/CA-6168.bugfix
@@ -1,0 +1,1 @@
+Include only dossiers with posotive appraisal in the SIP package. [phgross]

--- a/opengever/disposition/disposition.py
+++ b/opengever/disposition/disposition.py
@@ -253,6 +253,10 @@ class Disposition(Container):
     def get_dossiers(self):
         return [relation.to_object for relation in self.dossiers]
 
+    def get_dossiers_with_positive_appraisal(self):
+        appraisal = IAppraisal(self)
+        return [dossier for dossier in self.get_dossiers() if appraisal.get(dossier)]
+
     def get_history(self):
         history = [DispositionHistory.get(response)
                    for response in IResponseContainer(self)]

--- a/opengever/disposition/ech0160/sippackage.py
+++ b/opengever/disposition/ech0160/sippackage.py
@@ -32,7 +32,8 @@ class SIPPackage(object):
     def __init__(self, disposition):
         self.xsd = self.create_xsd()
         self.disposition = disposition
-        self.dossiers = self.create_dossiers(self.disposition.get_dossiers())
+        self.dossiers = self.create_dossiers(
+            self.disposition.get_dossiers_with_positive_appraisal())
         self.repo = self.create_repository()
         self.content_folder = self.create_content_folder()
         self.ablieferung = self.create_ablieferung()


### PR DESCRIPTION
Currently the SIP package include also dossiers with a negative appraisal, which should not be exported and imported in to a DLZA. This PR fixes this issue.

For [CA-6168]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-6168]: https://4teamwork.atlassian.net/browse/CA-6168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ