### PR TITLE
Add new solr index `is_locked_by_copy_to_workspace` and provide it in serializations. 

### DIFF
--- a/changes/CA-5563.feature
+++ b/changes/CA-5563.feature
@@ -1,0 +1,1 @@
+Add new solr index `is_locked_by_copy_to_workspace` and provide it in all necessary api endpoints [elioschmutz]

--- a/docker/core/etc/site.zcml
+++ b/docker/core/etc/site.zcml
@@ -175,6 +175,7 @@
   <includeOverrides package="opengever.mail" file="overrides.zcml" />
   <includeOverrides package="opengever.readonly" file="overrides.zcml" />
   <includeOverrides package="opengever.setup" file="overrides.zcml" />
+  <includeOverrides package="opengever.locking" file="overrides.zcml" />
   <includeOverrides package="plone.app.dexterity" file="overrides.zcml" />
   <includeOverrides package="ftw.lawgiver" file="overrides.zcml" />
 

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,6 +11,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- Exposes the ``is_locked_by_copy_to_workspace`` attribute for document serializers if the ``workspace_client`` feature is activated.
 - ``@solrsearch`` and ``@listing``: ``is_locked_by_copy_to_workspace`` is provided for documents if the ``workspace_client`` feature is activated.
 
 2023.12.0 (2023-09-08)

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,6 +11,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- @favorites: return ``is_locked_by_copy_to_workspace`` for resolved documents if the ``workspace_client`` feature is activated.
 - Exposes the ``is_locked_by_copy_to_workspace`` attribute for document serializers if the ``workspace_client`` feature is activated.
 - ``@solrsearch`` and ``@listing``: ``is_locked_by_copy_to_workspace`` is provided for documents if the ``workspace_client`` feature is activated.
 

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,6 +11,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- ``@solrsearch`` and ``@listing``: ``is_locked_by_copy_to_workspace`` is provided for documents if the ``workspace_client`` feature is activated.
 
 2023.12.0 (2023-09-08)
 ----------------------

--- a/opengever/api/document.py
+++ b/opengever/api/document.py
@@ -13,6 +13,7 @@ from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.document.versioner import Versioner
 from opengever.meeting import is_meeting_feature_enabled
 from opengever.meeting.model import SubmittedDocument
+from opengever.workspaceclient import is_workspace_client_feature_enabled
 from opengever.workspaceclient.interfaces import ILinkedDocuments
 from plone.restapi.deserializer import json_body
 from plone.restapi.interfaces import IExpandableElement
@@ -61,6 +62,9 @@ class SerializeDocumentToJson(GeverSerializeToJson):
 
         if is_meeting_feature_enabled():
             self.extend_with_meeting_metadata(result)
+
+        if is_workspace_client_feature_enabled():
+            result['is_locked_by_copy_to_workspace'] = obj.is_locked_by_copy_to_workspace()
 
         additional_metadata = {
             'checked_out': checked_out_by,

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -32,6 +32,7 @@ OTHER_ALLOWED_FIELDS = set([
     'UID',
     'watchers',
     'related_items',
+    'is_locked_by_copy_to_workspace',
 ])
 
 ALLOWED_ORDER_GROUP_FIELDS = set([

--- a/opengever/api/serializer.py
+++ b/opengever/api/serializer.py
@@ -26,6 +26,7 @@ from opengever.ogds.models.team import Team
 from opengever.ogds.models.user import User
 from opengever.private.folder import IPrivateFolder
 from opengever.repository.interfaces import IRepositoryFolder
+from opengever.workspaceclient import is_workspace_client_feature_enabled
 from plone import api
 from plone.dexterity.interfaces import IDexterityContainer
 from plone.dexterity.interfaces import IDexterityContent
@@ -96,6 +97,12 @@ def extend_with_is_subdossier(result, context, request):
 def extend_with_dossier_type(result, context, request):
     if IDossierMarker.providedBy(context):
         result['dossier_type'] = IDossier(context).dossier_type
+
+
+def extend_with_is_locked_by_copy_to_workspace(result, context, request):
+    if is_workspace_client_feature_enabled():
+        result['is_locked_by_copy_to_workspace'] = \
+            context.is_locked_by_copy_to_workspace()
 
 
 def extend_with_groupurl(result, context, request):
@@ -462,6 +469,7 @@ class GeverSerializeToJsonSummary(DefaultJSONSummarySerializer):
         if IBaseDocument.providedBy(self.context):
             summary['checked_out'] = self.context.checked_out_by()
             summary['file_extension'] = self.context.get_file_extension()
+            extend_with_is_locked_by_copy_to_workspace(summary, self.context, self.request)
 
         return summary
 

--- a/opengever/api/tests/test_summary_serializer.py
+++ b/opengever/api/tests/test_summary_serializer.py
@@ -1,8 +1,10 @@
 from ftw.testbrowser import browsing
 from opengever.base.oguid import Oguid
 from opengever.dossier.behaviors.dossier import IDossier
+from opengever.locking.lock import COPIED_TO_WORKSPACE_LOCK
 from opengever.testing import IntegrationTestCase
 from opengever.testing.helpers import MockDossierTypes
+from plone.locking.interfaces import ILockable
 from plone.restapi.interfaces import ISerializeToJsonSummary
 from zope.component import getMultiAdapter
 
@@ -52,6 +54,18 @@ class TestGeverSummarySerializer(IntegrationTestCase):
             serilized_doc)
 
     @browsing
+    def test_document_summary_includes_is_locked_by_copy_to_workspace_as_metadata_fields(self, browser):
+        self.activate_feature('workspace_client')
+        self.login(self.regular_user, browser)
+        ILockable(self.document).lock(COPIED_TO_WORKSPACE_LOCK)
+
+        serializer = getMultiAdapter(
+            (self.document, self.request),
+            ISerializeToJsonSummary)
+        serialized_doc = serializer()
+        self.assertTrue(serialized_doc.get('is_locked_by_copy_to_workspace'))
+
+    @browsing
     def test_mail_summary_supports_filename_filesize_and_mimetype_as_metadata_fields(self, browser):
         self.login(self.regular_user, browser)
 
@@ -92,6 +106,18 @@ class TestGeverSummarySerializer(IntegrationTestCase):
              'review_state': u'mail-state-active',
              'title': u'Die B\xfcrgschaft'},
             serilized_doc)
+
+    @browsing
+    def test_mail_summary_includes_is_locked_by_copy_to_workspace_as_metadata_fields(self, browser):
+        self.activate_feature('workspace_client')
+        self.login(self.regular_user, browser)
+        ILockable(self.mail_eml).lock(COPIED_TO_WORKSPACE_LOCK)
+
+        serializer = getMultiAdapter(
+            (self.mail_eml, self.request),
+            ISerializeToJsonSummary)
+        serialized_doc = serializer()
+        self.assertTrue(serialized_doc.get('is_locked_by_copy_to_workspace'))
 
     @browsing
     def test_dossier_summary_includes_dossier_type(self, browser):

--- a/opengever/base/handlers.py
+++ b/opengever/base/handlers.py
@@ -36,7 +36,7 @@ from zope.lifecycleevent.interfaces import IObjectMovedEvent
 from zope.sqlalchemy.datamanager import mark_changed
 
 
-reindex_after_copy = ['created']
+reindex_after_copy = ['created', 'is_locked_by_copy_to_workspace']
 
 CONTAINERS_SUPPORTING_OBJ_POSITION_IN_PARENT = (IWorkspace,
                                                 IToDoList,

--- a/opengever/base/model/favorite.py
+++ b/opengever/base/model/favorite.py
@@ -21,6 +21,7 @@ from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.utils import supports_is_subdossier
 from opengever.ogds.models.admin_unit import AdminUnit
 from opengever.repository.interfaces import IRepositoryFolder
+from opengever.workspaceclient import is_workspace_client_feature_enabled
 from plone import api
 from plone.uuid.interfaces import IUUID
 from Products.CMFCore.WorkflowCore import WorkflowException
@@ -158,6 +159,9 @@ class Favorite(Base):
 
         if resolved_obj and IDossierMarker.providedBy(resolved_obj):
             result['dossier_type'] = IDossier(resolved_obj).dossier_type
+
+        if is_workspace_client_feature_enabled() and IBaseDocument.providedBy(resolved_obj):
+            result['is_locked_by_copy_to_workspace'] = resolved_obj.is_locked_by_copy_to_workspace()
 
         return result
 

--- a/opengever/core/upgrades/20230911131841_reindex_is_locked_by_copy_to_workspace/upgrade.py
+++ b/opengever/core/upgrades/20230911131841_reindex_is_locked_by_copy_to_workspace/upgrade.py
@@ -1,0 +1,35 @@
+from ftw.upgrade import UpgradeStep
+from opengever.core.upgrade import NightlyIndexer
+from opengever.document.document import IDocumentSchema
+from opengever.dossier.interfaces import IDossierMarker
+from opengever.workspaceclient import is_workspace_client_feature_enabled
+from opengever.workspaceclient.interfaces import ILinkedWorkspaces
+
+
+class ReindexIsLockedByCopyToWorkspace(UpgradeStep):
+    """Reindex is locked by copy to workspace.
+    """
+
+    deferrable = True
+
+    def __call__(self):
+        self.install_upgrade_profile()
+        if not is_workspace_client_feature_enabled():
+            return
+        self.reindex()
+
+    def reindex(self):
+        query = {'object_provides': IDossierMarker.__identifier__, 'is_subdossier': False}
+        linked_dossier_paths = []
+
+        # To improve performance, we'll only reindex documents within dossiers linked to a
+        # workspace.
+        for dossier in self.objects(query, "Search for dossiers linked to a workspace"):
+            if ILinkedWorkspaces(dossier).number_of_linked_workspaces():
+                linked_dossier_paths.append('/'.join(dossier.getPhysicalPath()))
+
+        query = {'object_provides': IDocumentSchema.__identifier__, 'path': {'query': linked_dossier_paths}}
+        with NightlyIndexer(idxs=["is_locked_by_copy_to_workspace"],
+                            index_in_solr_only=True) as indexer:
+            for brain in self.brains(query, 'Index is_locked_by_copy_to_workspace in Solr'):
+                indexer.add_by_brain(brain)

--- a/opengever/document/base.py
+++ b/opengever/document/base.py
@@ -10,6 +10,7 @@ from opengever.dossier.interfaces import IDossierResolveProperties
 from opengever.dossier.templatefolder.interfaces import ITemplateFolder
 from opengever.dossier.utils import get_main_dossier
 from opengever.inbox.inbox import IInbox
+from opengever.locking.lock import LOCK_TYPE_COPIED_TO_WORKSPACE_LOCK
 from opengever.meeting.model.generateddocument import GeneratedExcerpt
 from opengever.meeting.proposal import IBaseProposal
 from opengever.meeting.proposal import ISubmittedProposal
@@ -20,6 +21,7 @@ from opengever.workspace.interfaces import IWorkspaceFolder
 from plone import api
 from plone.dexterity.content import Item
 from plone.locking.interfaces import ILockable
+from plone.restapi.services.locking.locking import lock_info
 from Products.CMFCore.utils import getToolByName
 from Products.MimetypesRegistry.common import MimeTypeException
 from Products.MimetypesRegistry.interfaces import IMimetype
@@ -278,6 +280,10 @@ class BaseDocumentMixin(object):
 
     def is_locked(self):
         return False
+
+    def is_locked_by_copy_to_workspace(self):
+        info = lock_info(self)
+        return info and info.get('name') == LOCK_TYPE_COPIED_TO_WORKSPACE_LOCK
 
     def is_archival_file_conversion_skipped(self):
         """The archival file conversion can be skipped for some mimetypes

--- a/opengever/document/configure.zcml
+++ b/opengever/document/configure.zcml
@@ -379,6 +379,11 @@
       name="related_items"
       />
 
+  <adapter
+      factory=".indexers.is_locked_by_copy_to_workspace"
+      name="is_locked_by_copy_to_workspace"
+      />
+
   <adapter factory=".document.UploadValidator" />
 
   <adapter factory=".fileactions.BaseDocumentFileActions" />

--- a/opengever/document/indexers.py
+++ b/opengever/document/indexers.py
@@ -17,6 +17,7 @@ from opengever.document.document import IDocumentSchema
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.document.interfaces import IDocumentIndexer
 from opengever.document.interfaces import ITemplateDocumentMarker
+from opengever.workspaceclient import is_workspace_client_feature_enabled
 from plone import api
 from plone.indexer import indexer
 from Products.CMFDiffTool.utils import safe_utf8
@@ -271,3 +272,11 @@ def related_items(obj):
     brains = [unrestrictedPathToCatalogBrain(rel.to_path)
               for rel in IRelatedDocuments(obj).relatedItems if not rel.isBroken()]
     return [brain.UID for brain in brains if brain]
+
+
+@indexer(IDocumentSchema)
+def is_locked_by_copy_to_workspace(obj):
+    if not is_workspace_client_feature_enabled():
+        return False
+
+    return obj.is_locked_by_copy_to_workspace()

--- a/opengever/dossier/tests/test_move_items.py
+++ b/opengever/dossier/tests/test_move_items.py
@@ -443,6 +443,7 @@ class TestMoveItemsUpdatesIndexAndMetadata(SolrIntegrationTestCase, MoveItemsHel
             u'filesize',
             u'related_items',
             u'Subject',
+            u'is_locked_by_copy_to_workspace',
         ]
 
         unchanged_solrdata += self.common_unchanged_solrdata
@@ -672,6 +673,7 @@ class TestMoveItemsUpdatesIndexAndMetadata(SolrIntegrationTestCase, MoveItemsHel
             u'filename',
             u'filesize',
             u'receipt_date',
+            u'is_locked_by_copy_to_workspace',
         ]
 
         unchanged_solrdata += self.common_unchanged_solrdata

--- a/opengever/locking/overrides.zcml
+++ b/opengever/locking/overrides.zcml
@@ -1,0 +1,24 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser"
+    xmlns:i18n="http://namespaces.zope.org/i18n"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
+    i18n_domain="opengever.locking">
+
+  <include package="z3c.unconfigure" file="meta.zcml" />
+
+  <unconfigure>
+
+    <adapter
+        for="plone.locking.interfaces.ITTWLockable"
+        factory="plone.locking.lockable.TTWLockable"
+        />
+
+  </unconfigure>
+
+  <adapter
+      factory=".lockable.GeverLockable"
+      for="plone.locking.interfaces.ITTWLockable"
+      />
+
+</configure>

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -88,7 +88,7 @@ FEATURE_FLAGS = {
     'repositoryfolder-tasks-tab': 'opengever.repository.interfaces.IRepositoryFolderRecords.show_tasks_tab',
     'tasktemplatefolder_nesting': 'opengever.tasktemplates.interfaces.ITaskTemplateSettings.is_tasktemplatefolder_nesting_enabled',  # noqa
     'workspace': 'opengever.workspace.interfaces.IWorkspaceSettings.is_feature_enabled',
-    'workspace_client': 'opengever.workspace.interfaces.IWorkspaceClientSettings.is_feature_enabled',
+    'workspace_client': 'opengever.workspaceclient.interfaces.IWorkspaceClientSettings.is_feature_enabled',
     'workspace-meeting': 'opengever.workspace.interfaces.IWorkspaceMeetingSettings.is_feature_enabled',
     'workspace-todo': 'opengever.workspace.interfaces.IToDoSettings.is_feature_enabled',
     'favorites': 'opengever.base.interfaces.IFavoritesSettings.is_feature_enabled',

--- a/solr-conf/managed-schema
+++ b/solr-conf/managed-schema
@@ -132,6 +132,7 @@
     <field name="bumblebee_checksum" type="string" indexed="false" stored="false" />
     <field name="changed" type="pdate" indexed="true" stored="false" />
     <field name="checked_out" type="string" indexed="true" stored="false" />
+    <field name="is_locked_by_copy_to_workspace" type="boolean" indexed="true" stored="false" />
     <field name="is_completed" type="boolean" indexed="true" stored="false" />
     <field name="containing_dossier" type="string" indexed="false" stored="false" />
     <field name="containing_subdossier" type="string" indexed="false" stored="false" />


### PR DESCRIPTION
This PR adds a new solr index `is_locked_by_copy_to_workspace` and provides it in listings.

This allows us to mark such contents in listings in the UI as locked.

We can't just reindex the object in the `@lock`/`@unlock` endpoints because it is also possible to unlock the content through the old ui. In addition, there is a function in the `ILocking` behavior which unlocks all locks. So we have to override the `TTWLockable` object to implement the reindex in the source of locking.

For [CA-5563]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-5563]: https://4teamwork.atlassian.net/browse/CA-5563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ