### PR TITLE
Fix deletion of dossiers containing attachments extracted from mails.

### DIFF
--- a/opengever/mail/exceptions.py
+++ b/opengever/mail/exceptions.py
@@ -23,12 +23,6 @@ class InvalidAttachmentPosition(Exception):
             position))
 
 
-class SourceMailNotFound(Exception):
-    """Raised when a document extracted from a Mail is modified and its
-    info cannot be updated in the Mail from which it was extracted because
-    it could not be found"""
-
-
 class MessageContainsVirus(MailInboundException):
 
     def __init__(self, message):

--- a/opengever/mail/subscribers.py
+++ b/opengever/mail/subscribers.py
@@ -1,7 +1,6 @@
 from opengever.base.utils import unrestrictedUuidToObject
 from opengever.document.behaviors.related_docs import IRelatedDocuments
 from opengever.document.subscribers import resolve_document_author
-from opengever.mail.exceptions import SourceMailNotFound
 from opengever.mail.interfaces import IExtractedFromMail
 from opengever.mail.mail import IOGMailMarker
 from plone.uuid.interfaces import IUUID
@@ -44,7 +43,6 @@ def extracted_attachment_deleted(doc, event):
                     extracted=False,
                     extracted_document_uid=None)
                 return
-    raise SourceMailNotFound("Source Mail not found when Extracted attachment moved.")
 
 
 def mail_deleted(doc, event):
@@ -62,4 +60,7 @@ def mail_deleted(doc, event):
         if not info.get('extracted'):
             continue
         extracted_doc = unrestrictedUuidToObject(info.get('extracted_document_uid'))
-        noLongerProvides(extracted_doc, IExtractedFromMail)
+        # When deleting the dossier, it can happen that the extracted doc
+        # was already deleted
+        if extracted_doc:
+            noLongerProvides(extracted_doc, IExtractedFromMail)


### PR DESCRIPTION
There are two event handlers that can fail when deleting a dossier containing documents extracted from an E-mail: depending on the order of the object deletion, either the source E-mail will not be found, or the extracted document is not found.

For [CA-6195]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-6195]: https://4teamwork.atlassian.net/browse/CA-6195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ