### PR TITLE
Add todo responses for created, closed and reopened todos

### DIFF
--- a/changes/CA-5099.feature
+++ b/changes/CA-5099.feature
@@ -1,0 +1,1 @@
+Add a response object for created, closed and reopened todos [elioschmutz]

--- a/opengever/api/tests/test_response.py
+++ b/opengever/api/tests/test_response.py
@@ -1,9 +1,12 @@
 from datetime import datetime
+from ftw.builder import Builder
+from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testing import freeze
 from opengever.base.response import COMMENT_REMOVED_RESPONSE_TYPE
 from opengever.base.response import COMMENT_RESPONSE_TYPE
 from opengever.base.response import IResponseContainer
+from opengever.base.response import OBJECT_CREATED_RESPONSE_TYPE
 from opengever.base.response import Response
 from opengever.testing import IntegrationTestCase
 import json
@@ -17,7 +20,7 @@ class TestResponseGETSerialization(IntegrationTestCase):
 
         # Todo
         browser.open(self.todo, method="GET", headers=self.api_headers)
-        self.assertEqual([], browser.json['responses'])
+        self.assertEqual(1, len(browser.json['responses']))
 
         # Dossier
         browser.open(self.dossier, method="GET", headers=self.api_headers)
@@ -46,7 +49,19 @@ class TestResponseGETSerialization(IntegrationTestCase):
 
         browser.open(self.todo, method="GET", headers=self.api_headers)
         self.assertEquals(
-            [{u'@id': u'http://nohost/plone/workspaces/workspace-1/todo-1/@responses/1481272800000000',
+            [{u'@id': u'http://nohost/plone/workspaces/workspace-1/todo-1/@responses/1472660373000000',
+              u'additional_data': {},
+              u'changes': [],
+              u'created': u'2016-08-31T18:19:33',
+              u'creator': {u'title': u'Fr\xf6hlich G\xfcnther',
+                           u'token': u'gunther.frohlich'},
+              u'modified': None,
+              u'modifier': None,
+              u'response_id': 1472660373000000,
+              u'response_type': u'object_created',
+              u'text': u''
+              },
+             {u'@id': u'http://nohost/plone/workspaces/workspace-1/todo-1/@responses/1481272800000000',
               u'changes': [],
               u'created': u'2016-12-09T09:40:00',
               u'creator': {
@@ -54,7 +69,7 @@ class TestResponseGETSerialization(IntegrationTestCase):
                   u'token': u'beatrice.schrodinger'},
               u'modified': None,
               u'modifier': None,
-              u'additional_data':{},
+              u'additional_data': {},
               u'response_id': 1481272800000000,
               u'response_type': u'default',
               u'text': u'Ich bin hier anderer Meinung!',
@@ -131,7 +146,7 @@ class TestResponsePost(IntegrationTestCase):
     def test_adding_a_response_sucessful(self, browser):
         self.login(self.workspace_member, browser=browser)
 
-        self.assertEquals([], IResponseContainer(self.todo).list())
+        self.assertEquals(1, len(IResponseContainer(self.todo).list()))
 
         with freeze(datetime(2016, 12, 9, 9, 40)):
             url = '{}/@responses'.format(self.todo.absolute_url())
@@ -139,8 +154,8 @@ class TestResponsePost(IntegrationTestCase):
                          data=json.dumps({'text': u'Angebot \xfcberpr\xfcft'}))
 
         responses = IResponseContainer(self.todo).list()
-        self.assertEquals(1, len(responses))
-        self.assertEquals(u'Angebot \xfcberpr\xfcft', responses[0].text)
+        self.assertEquals(2, len(responses))
+        self.assertEquals(u'Angebot \xfcberpr\xfcft', responses[-1].text)
 
         self.assertEquals(201, browser.status_code)
         self.assertEquals(
@@ -231,10 +246,10 @@ class TestResponsePatch(IntegrationTestCase):
                          data=json.dumps({'text': u'Angebot \xfcberpr\xfcft'}))
 
         responses = IResponseContainer(self.todo).list()
-        self.assertEqual(1, len(responses))
-        self.assertEqual(u'Angebot \xfcberpr\xfcft', responses[0].text)
-        self.assertEqual(self.workspace_member.getId(), responses[0].modifier)
-        self.assertEqual(datetime(2018, 10, 10, 9, 15), responses[0].modified)
+        self.assertEqual(2, len(responses))
+        self.assertEqual(u'Angebot \xfcberpr\xfcft', responses[-1].text)
+        self.assertEqual(self.workspace_member.getId(), responses[-1].modifier)
+        self.assertEqual(datetime(2018, 10, 10, 9, 15), responses[-1].modified)
 
         self.assertEquals(204, browser.status_code)
 
@@ -254,7 +269,7 @@ class TestResponsePatch(IntegrationTestCase):
         self.assertEquals(
             {u'message': u"Property 'text' is required", u'type': u'BadRequest'},
             browser.json)
-        self.assertEquals('Test', IResponseContainer(self.todo).list()[0].text)
+        self.assertEquals('Test', IResponseContainer(self.todo).list()[-1].text)
 
     @browsing
     def test_cannot_edit_response_that_is_not_of_type_comment(self, browser):
@@ -292,22 +307,22 @@ class TestResponseDelete(IntegrationTestCase):
     @browsing
     def test_delete_a_response_sucessful(self, browser):
         self.login(self.workspace_member, browser=browser)
-        with freeze(datetime(2016, 12, 9, 9, 40)):
+        with freeze(datetime(2023, 12, 9, 9, 40)):
             response = Response()
             response.text = 'Test'
             response.response_type = COMMENT_RESPONSE_TYPE
             IResponseContainer(self.todo).add(response)
 
         responses = IResponseContainer(self.todo).list()
-        self.assertEqual(1, len(responses))
-        self.assertEqual(COMMENT_RESPONSE_TYPE, responses[0].response_type)
+        self.assertEqual(2, len(responses))
+        self.assertEqual(COMMENT_RESPONSE_TYPE, responses[-1].response_type)
 
-        url = '{}/@responses/1481272800000000'.format(self.todo.absolute_url())
+        url = '{}/@responses/{}'.format(self.todo.absolute_url(), responses[-1].response_id)
         browser.open(url, method="DELETE", headers=self.api_headers)
 
         responses = IResponseContainer(self.todo).list()
-        self.assertEqual(1, len(responses))
-        self.assertEqual(COMMENT_REMOVED_RESPONSE_TYPE, responses[0].response_type)
+        self.assertEqual(2, len(responses))
+        self.assertEqual(COMMENT_REMOVED_RESPONSE_TYPE, responses[-1].response_type)
 
     @browsing
     def test_cannot_delete_response_that_is_not_of_type_comment(self, browser):
@@ -337,22 +352,36 @@ class TestResponseDelete(IntegrationTestCase):
             response.response_type = COMMENT_RESPONSE_TYPE
             IResponseContainer(self.todo).add(response)
 
+        browser.open(self.todo, method="GET", headers=self.api_headers)
+        self.assertEquals(2, len(browser.json['responses']))
         url = '{}/@responses/1481272800000000'.format(self.todo.absolute_url())
         with freeze(datetime(2023, 6, 1, 8, 12)):
             browser.open(url, method="DELETE", headers=self.api_headers)
 
         browser.open(self.todo, method="GET", headers=self.api_headers)
-        self.assertEquals([
-            {
-                u'@id': u'http://nohost/plone/workspaces/workspace-1/todo-1/@responses/1685599920000000',
-                u'changes': [],
-                u'created': u'2023-06-01T08:12:00',
-                u'creator': {u'title': u'Schr\xf6dinger B\xe9atrice',
-                             u'token': u'beatrice.schrodinger'},
-                u'modified': None,
-                u'modifier': None,
-                u'additional_data': {u'deleted_response_creation_date': u'2016-12-09T09:40:00'},
-                u'response_id': 1685599920000000,
-                u'response_type': u'comment_removed',
-                u'text': u''}
-        ], browser.json['responses'])
+        self.assertEquals(2, len(browser.json['responses']))
+        self.assertEquals({
+            u'@id': u'http://nohost/plone/workspaces/workspace-1/todo-1/@responses/1685599920000000',
+            u'changes': [],
+            u'created': u'2023-06-01T08:12:00',
+            u'creator': {u'title': u'Schr\xf6dinger B\xe9atrice',
+                         u'token': u'beatrice.schrodinger'},
+            u'modified': None,
+            u'modifier': None,
+            u'additional_data': {u'deleted_response_creation_date': u'2016-12-09T09:40:00'},
+            u'response_id': 1685599920000000,
+            u'response_type': u'comment_removed',
+            u'text': u''
+        }, browser.json['responses'][-1])
+
+    @browsing
+    def test_add_an_object_creates_a_new_response_about_the_added_object(self, browser):
+        self.login(self.workspace_member, browser=browser)
+
+        todo = create(Builder('todo')
+                      .titled(u'Fix user login')
+                      .within(self.workspace))
+
+        browser.open(todo, method="GET", headers=self.api_headers)
+        self.assertEquals(1, len(browser.json['responses']))
+        self.assertEquals(OBJECT_CREATED_RESPONSE_TYPE, browser.json['responses'][0].get('response_type'))

--- a/opengever/base/response.py
+++ b/opengever/base/response.py
@@ -198,6 +198,7 @@ COMMENT_REMOVED_RESPONSE_TYPE = 'comment_removed'
 SCHEMA_FIELD_CHANGE_RESPONSE_TYPE = 'schema_field'
 MOVE_RESPONSE_TYPE = 'move'
 OBJECT_CREATED_RESPONSE_TYPE = 'object_created'
+TRANSITION_RESPONSE_TYPE = 'transition'
 
 
 class AutoResponseChangesTracker(object):

--- a/opengever/base/response.py
+++ b/opengever/base/response.py
@@ -197,6 +197,7 @@ COMMENT_RESPONSE_TYPE = 'comment'
 COMMENT_REMOVED_RESPONSE_TYPE = 'comment_removed'
 SCHEMA_FIELD_CHANGE_RESPONSE_TYPE = 'schema_field'
 MOVE_RESPONSE_TYPE = 'move'
+OBJECT_CREATED_RESPONSE_TYPE = 'object_created'
 
 
 class AutoResponseChangesTracker(object):

--- a/opengever/workspace/configure.zcml
+++ b/opengever/workspace/configure.zcml
@@ -71,6 +71,12 @@
       />
 
   <subscriber
+      for="opengever.workspace.interfaces.IToDo
+           Products.DCWorkflow.interfaces.IAfterTransitionEvent"
+      handler=".subscribers.todo_handle_transition"
+      />
+
+  <subscriber
       for="opengever.workspace.interfaces.IWorkspaceMeetingAgendaItem
            zope.lifecycleevent.interfaces.IObjectAddedEvent"
       handler=".subscribers.workspace_meeting_agendaitem_added"

--- a/opengever/workspace/subscribers.py
+++ b/opengever/workspace/subscribers.py
@@ -4,6 +4,7 @@ from opengever.base.response import COMMENT_RESPONSE_TYPE
 from opengever.base.response import IResponseContainer
 from opengever.base.response import OBJECT_CREATED_RESPONSE_TYPE
 from opengever.base.response import Response
+from opengever.base.response import TRANSITION_RESPONSE_TYPE
 from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.base.role_assignments import SharingRoleAssignment
 from opengever.workspace.activities import ToDoAssignedActivity
@@ -15,6 +16,7 @@ from opengever.workspace.indexers import INDEXED_IN_MEETING_SEARCHABLE_TEXT
 from opengever.workspace.interfaces import IWorkspace
 from opengever.workspace.todo import COMPLETE_TODO_TRANSITION
 from opengever.workspace.workspace import IWorkspaceSchema
+from persistent.dict import PersistentDict
 from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
 from zope.container.interfaces import IContainerModifiedEvent
 from zope.globalrequest import getRequest
@@ -92,6 +94,19 @@ def todo_review_state_changed(todo, event):
             ToDoReopenedActivity(todo, getRequest()).record()
 
     todo.reindexObject(idxs=['is_completed'])
+
+
+def todo_handle_transition(todo, event):
+    if not event.status.get('action'):
+        return  # Initial transition.
+
+    response = Response(TRANSITION_RESPONSE_TYPE)
+    response.additional_data = PersistentDict({
+        'new_state': event.new_state.id,
+        'old_state': event.old_state.id,
+        'action': event.status.get('action'),
+    })
+    IResponseContainer(todo).add(response)
 
 
 def todo_modified(todo, event):

--- a/opengever/workspace/subscribers.py
+++ b/opengever/workspace/subscribers.py
@@ -1,6 +1,9 @@
 from ftw.upgrade.interfaces import IDuringUpgrade
 from opengever.base.placeful_workflow import assign_placeful_workflow
 from opengever.base.response import COMMENT_RESPONSE_TYPE
+from opengever.base.response import IResponseContainer
+from opengever.base.response import OBJECT_CREATED_RESPONSE_TYPE
+from opengever.base.response import Response
 from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.base.role_assignments import SharingRoleAssignment
 from opengever.workspace.activities import ToDoAssignedActivity
@@ -71,6 +74,8 @@ def todo_added(todo, event):
     WorkspaceWatcherManager(workspace).new_todo_added(todo)
     if todo.responsible is not None:
         ToDoAssignedActivity(todo, getRequest()).record()
+
+    IResponseContainer(todo).add(Response(OBJECT_CREATED_RESPONSE_TYPE))
 
 
 def todo_review_state_changed(todo, event):

--- a/opengever/workspace/tests/test_todo.py
+++ b/opengever/workspace/tests/test_todo.py
@@ -210,14 +210,14 @@ class TestAPISupportForTodo(IntegrationTestCase):
         self.login(self.workspace_member, browser)
 
         responses = IResponseContainer(self.todo).list()
-        self.assertEqual(0, len(responses))
+        self.assertEqual(1, len(responses))
 
         browser.open(self.todo, method='PATCH',
                      headers=self.api_headers,
                      data=json.dumps({'title': u'\xc4 new login'}))
 
         responses = IResponseContainer(self.todo).list()
-        self.assertEqual(1, len(responses))
+        self.assertEqual(2, len(responses))
 
         last_response = responses[-1]
         self.assertEqual('', last_response.text)


### PR DESCRIPTION
This PR adds response objects for created, closed and reopened todos.

For [CA-5099]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-5099]: https://4teamwork.atlassian.net/browse/CA-5099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ