### PR TITLE
Bundle import: Map principal names to ids in local roles

### DIFF
--- a/changes/CA-6039.feature
+++ b/changes/CA-6039.feature
@@ -1,0 +1,1 @@
+Bundle import: Map principal names to ids in local roles. [lgraf]

--- a/opengever/bundle/cfgs/oggbundle.cfg
+++ b/opengever/bundle/cfgs/oggbundle.cfg
@@ -21,6 +21,7 @@ pipeline =
     propertiesupdater
     map-local-roles
     map-principals
+    map-principal-names-to-ids
     local_roles
     blocklocalroles
     constraintypes
@@ -73,6 +74,9 @@ blueprint = opengever.bundle.map_local_roles
 
 [map-principals]
 blueprint = opengever.bundle.map_principals
+
+[map-principal-names-to-ids]
+blueprint = opengever.bundle.map_principal_names_to_ids
 
 [blocklocalroles]
 blueprint = opengever.setup.blocklocalroles

--- a/opengever/bundle/console.py
+++ b/opengever/bundle/console.py
@@ -30,6 +30,8 @@ def parse_args(argv):
                         help='Path to the .oggbundle directory')
     parser.add_argument('--no-intermediate-commits', action='store_true',
                         help="Don't to intermediate commits")
+    parser.add_argument('--no-check-unique-principals', action='store_true',
+                        help="Don't to check for OGDS principal name uniqueness")
 
     args = parser.parse_args(argv)
     return args
@@ -62,6 +64,7 @@ def import_oggbundle(app, args):
         no_intermediate_commits=args.no_intermediate_commits,
         possibly_unpatch_collective_indexing=True,
         no_separate_connection_for_sequence_numbers=True,
+        no_check_unique_principals=args.no_check_unique_principals,
     )
     importer.run()
 

--- a/opengever/bundle/importer.py
+++ b/opengever/bundle/importer.py
@@ -8,6 +8,7 @@ from opengever.bundle.sections.bundlesource import BUNDLE_INJECT_INITIAL_CONTENT
 from opengever.bundle.sections.bundlesource import BUNDLE_KEY
 from opengever.bundle.sections.bundlesource import BUNDLE_PATH_KEY
 from opengever.bundle.sections.commit import INTERMEDIATE_COMMITS_KEY
+from opengever.bundle.sections.map_principal_names_to_ids import CHECK_UNIQUE_PRINCIPALS_KEY
 from opengever.bundle.sections.report import SKIP_REPORT_KEY
 from plone import api
 from zope.annotation import IAnnotations
@@ -26,7 +27,8 @@ class BundleImporter(object):
                  create_guid_index=True, no_intermediate_commits=False,
                  possibly_unpatch_collective_indexing=True,
                  no_separate_connection_for_sequence_numbers=True,
-                 skip_report=False, create_initial_content=False):
+                 skip_report=False, create_initial_content=False,
+                 no_check_unique_principals=False):
         self.site = site
         self.bundle_path = bundle_path
 
@@ -37,6 +39,7 @@ class BundleImporter(object):
         self.no_separate_connection_for_sequence_numbers = no_separate_connection_for_sequence_numbers
         self.skip_report = skip_report
         self.create_initial_content = create_initial_content
+        self.no_check_unique_principals = no_check_unique_principals
 
     def run(self):
         log.info("Importing OGGBundle %s" % self.bundle_path)
@@ -57,6 +60,7 @@ class BundleImporter(object):
         ann[INTERMEDIATE_COMMITS_KEY] = not self.no_intermediate_commits
         ann[SKIP_REPORT_KEY] = self.skip_report
         ann[BUNDLE_INJECT_INITIAL_CONTENT_KEY] = self.create_initial_content
+        ann[CHECK_UNIQUE_PRINCIPALS_KEY] = not self.no_check_unique_principals
 
         solr_enabled = api.portal.get_registry_record(
             'opengever.base.interfaces.ISearchSettings.use_solr',

--- a/opengever/bundle/sections/map_principal_names_to_ids.py
+++ b/opengever/bundle/sections/map_principal_names_to_ids.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from collective.transmogrifier.interfaces import ISection
 from collective.transmogrifier.interfaces import ISectionBlueprint
 from opengever.base.model import create_session
@@ -13,6 +14,13 @@ from zope.interface import implements
 import logging
 
 
+CHECK_UNIQUE_PRINCIPALS_KEY = 'check_unique_principals'
+
+
+class AmbiguousPrincipalNames(Exception):
+    pass
+
+
 class MapPrincipalNamesToIDsSection(object):
     """Map local role principal names to IDs based on OGDS.
 
@@ -26,12 +34,15 @@ class MapPrincipalNamesToIDsSection(object):
         self.previous = previous
         self.logger = logging.getLogger(options['blueprint'])
         self.bundle = IAnnotations(transmogrifier)[BUNDLE_KEY]
+        self.check_unique_principals = IAnnotations(transmogrifier).get(
+            CHECK_UNIQUE_PRINCIPALS_KEY, True)
         self.principal_ids_by_name = self.get_principal_mapping_from_ogds()
 
     def get_principal_mapping_from_ogds(self):
         session = create_session()
 
         principal_ids_by_name = {}
+        ambig_names_by_type = {}
 
         # Groups take precedence over users
         columns_to_fetch = [
@@ -46,14 +57,60 @@ class MapPrincipalNamesToIDsSection(object):
                 .order_by(id_col)
             )
 
-            # Make sure lookups by name are case-insensitive
             matches = [
-                (row[name_col.name].lower(), row[id_col.name])
+                (row[name_col.name], row[id_col.name])
                 for row in session.execute(query)
             ]
-            principal_ids_by_name.update(dict(matches))
+
+            ids_by_name = dict(matches)
+
+            # Check that principal names are unambiguous in regard to casing
+            if self.check_unique_principals:
+                principal_type = name_col.name
+                ambig_names_by_type[principal_type] = self.find_non_unique(ids_by_name)
+
+            # Make sure lookups by name are case-insensitive
+            for name, id_ in ids_by_name.items():
+                principal_ids_by_name[name.lower()] = id_
+
+        if self.check_unique_principals and any(ambig_names_by_type.values()):
+            self.report_non_unique(ambig_names_by_type)
+            raise AmbiguousPrincipalNames(
+                'Ambiguous principal names in OGDS found. See above.')
 
         return principal_ids_by_name
+
+    def find_non_unique(self, ids_by_name):
+        """Find OGDS user / group names that are ambiguous regarding case.
+        """
+        ambig_names = defaultdict(list)
+
+        for name, id_ in ids_by_name.items():
+            ambig_names[name.lower()].append((name, id_))
+
+        for lower_name, matching_names in ambig_names.items():
+            if len(matching_names) == 1:
+                ambig_names.pop(lower_name)
+
+        return ambig_names
+
+    def report_non_unique(self, ambig_names_by_type):
+        log = self.logger.error
+        log('Found ambiguous principal names in OGDS.')
+        log('The following users/groups are not case-insensitively unique:')
+        log('')
+
+        for principal_type, dupes_by_lower in ambig_names_by_type.items():
+            for lower_name, duplicates in dupes_by_lower.items():
+                log(
+                    '%s "%s" matches multiple records:' % (principal_type, lower_name))
+
+                for name, id_ in duplicates:
+                    log('  %s: %s (id: %s)' % (principal_type, name, id_))
+
+                log('')
+        log('Skip this check by running import with '
+            '--no-check-unique-principals flag')
 
     def __iter__(self):
         for item in self.previous:

--- a/opengever/bundle/sections/map_principal_names_to_ids.py
+++ b/opengever/bundle/sections/map_principal_names_to_ids.py
@@ -1,0 +1,80 @@
+from collective.transmogrifier.interfaces import ISection
+from collective.transmogrifier.interfaces import ISectionBlueprint
+from opengever.base.model import create_session
+from opengever.bundle.sections.bundlesource import BUNDLE_KEY
+from opengever.bundle.sections.map_local_roles import ROLEMAP_KEY
+from opengever.ogds.models.group import Group
+from opengever.ogds.models.user import User
+from sqlalchemy.sql import select
+from sqlalchemy.sql.expression import true
+from zope.annotation import IAnnotations
+from zope.interface import classProvides
+from zope.interface import implements
+import logging
+
+
+class MapPrincipalNamesToIDsSection(object):
+    """Map local role principal names to IDs based on OGDS.
+
+    Must be applied after the map-principals section.
+    """
+
+    classProvides(ISectionBlueprint)
+    implements(ISection)
+
+    def __init__(self, transmogrifier, name, options, previous):
+        self.previous = previous
+        self.logger = logging.getLogger(options['blueprint'])
+        self.bundle = IAnnotations(transmogrifier)[BUNDLE_KEY]
+        self.principal_ids_by_name = self.get_principal_mapping_from_ogds()
+
+    def get_principal_mapping_from_ogds(self):
+        session = create_session()
+
+        principal_ids_by_name = {}
+
+        # Groups take precedence over users
+        columns_to_fetch = [
+            (User.active, User.username, User.userid),
+            (Group.active, Group.groupname, Group.groupid),
+        ]
+
+        for (active_col, name_col, id_col) in columns_to_fetch:
+            query = (
+                select((name_col, id_col))
+                .where(active_col == true())
+                .order_by(id_col)
+            )
+
+            # Make sure lookups by name are case-insensitive
+            matches = [
+                (row[name_col.name].lower(), row[id_col.name])
+                for row in session.execute(query)
+            ]
+            principal_ids_by_name.update(dict(matches))
+
+        return principal_ids_by_name
+
+    def __iter__(self):
+        for item in self.previous:
+            if not self.principal_ids_by_name:
+                yield item
+                continue
+
+            # What we operate on is a mapping of
+            # <list of principal names> by <short role name>:
+            # {
+            #     'add': ['john.doe'],
+            #     'edit': ['james.bond', 'administrators'],
+            #     ...
+            # }
+            principals_by_role = item.get(ROLEMAP_KEY, {})
+
+            for role_name, principal_names in principals_by_role.items():
+                principal_ids = [
+                    self.principal_ids_by_name.get(pn.lower(), pn)
+                    for pn in principal_names
+                ]
+                principals_by_role[role_name] = principal_ids
+
+            yield item

--- a/opengever/bundle/tests/test_section_map_principal_names_to_ids.py
+++ b/opengever/bundle/tests/test_section_map_principal_names_to_ids.py
@@ -1,0 +1,324 @@
+from collective.transmogrifier.interfaces import ISection
+from collective.transmogrifier.interfaces import ISectionBlueprint
+from opengever.base.model import create_session
+from opengever.bundle.sections.bundlesource import BUNDLE_KEY
+from opengever.bundle.sections.map_principal_names_to_ids import MapPrincipalNamesToIDsSection
+from opengever.bundle.tests import MockBundle
+from opengever.bundle.tests import MockTransmogrifier
+from opengever.ogds.models.group import Group
+from opengever.ogds.models.user import User
+from opengever.testing import IntegrationTestCase
+from uuid import uuid4
+from zope.annotation import IAnnotations
+from zope.interface.verify import verifyClass
+from zope.interface.verify import verifyObject
+
+
+class TestMapPrincipalNamesToIDs(IntegrationTestCase):
+
+    def setUp(self):
+        super(TestMapPrincipalNamesToIDs, self).setUp()
+        self.session = create_session()
+
+    def setup_section(self, previous=None):
+        previous = previous or []
+        transmogrifier = MockTransmogrifier()
+        self.bundle = MockBundle()
+        IAnnotations(transmogrifier)[BUNDLE_KEY] = self.bundle
+
+        options = {'blueprint': 'opengever.bundle.map_principal_names_to_ids'}
+
+        return MapPrincipalNamesToIDsSection(transmogrifier, '', options, previous)
+
+    def test_implements_interface(self):
+        self.assertTrue(ISection.implementedBy(MapPrincipalNamesToIDsSection))
+        verifyClass(ISection, MapPrincipalNamesToIDsSection)
+
+        self.assertTrue(ISectionBlueprint.providedBy(MapPrincipalNamesToIDsSection))
+        verifyObject(ISectionBlueprint, MapPrincipalNamesToIDsSection)
+
+    def test_maps_usernames_to_userids(self):
+        user1 = User(
+            userid='11111',
+            username='user1',
+            external_id=uuid4().hex,
+        )
+        user2 = User(
+            userid='22222',
+            username='user2',
+            external_id=uuid4().hex,
+        )
+        user3 = User(
+            userid='33333',
+            username='user3',
+            external_id=uuid4().hex,
+        )
+        user4 = User(
+            userid='44444',
+            username='user4',
+            external_id=uuid4().hex,
+        )
+        user5 = User(
+            userid='55555',
+            username='user5',
+            external_id=uuid4().hex,
+        )
+
+        for user in (user1, user2, user3, user4, user5):
+            self.session.add(user)
+        self.session.flush()
+
+        items = [
+            {
+                'guid': 'mapped-users',
+                '_type': 'opengever.dossier.businesscasedossier',
+                '_permissions': {
+                    'read': ['user1'],
+                    'add': ['user2'],
+                    'edit': ['user3'],
+                    'close': ['user4'],
+                    'reactivate': ['user5'],
+                },
+            },
+
+        ]
+        section = self.setup_section(previous=items)
+        transformed_items = list(section)
+
+        expected = [
+            {
+                'guid': 'mapped-users',
+                '_type': 'opengever.dossier.businesscasedossier',
+                '_permissions': {
+                    'read': [user1.userid],
+                    'add': [user2.userid],
+                    'edit': [user3.userid],
+                    'close': [user4.userid],
+                    'reactivate': [user5.userid],
+                },
+            },
+
+        ]
+
+        self.assertEquals(expected, transformed_items)
+
+    def test_maps_groupnames_to_groupids(self):
+        group1 = Group(
+            groupid='11111',
+            groupname='group1',
+            external_id=uuid4().hex,
+        )
+        group2 = Group(
+            groupid='22222',
+            groupname='group2',
+            external_id=uuid4().hex,
+        )
+        group3 = Group(
+            groupid='33333',
+            groupname='group3',
+            external_id=uuid4().hex,
+        )
+        group4 = Group(
+            groupid='44444',
+            groupname='group4',
+            external_id=uuid4().hex,
+        )
+        group5 = Group(
+            groupid='55555',
+            groupname='group5',
+            external_id=uuid4().hex,
+        )
+
+        for group in (group1, group2, group3, group4, group5):
+            self.session.add(group)
+        self.session.flush()
+
+        items = [
+            {
+                'guid': 'mapped-groups',
+                '_type': 'opengever.dossier.businesscasedossier',
+                '_permissions': {
+                    'read': ['group1'],
+                    'add': ['group2'],
+                    'edit': ['group3'],
+                    'close': ['group4'],
+                    'reactivate': ['group5'],
+                },
+            },
+
+        ]
+        section = self.setup_section(previous=items)
+        transformed_items = list(section)
+
+        expected = [
+            {
+                'guid': 'mapped-groups',
+                '_type': 'opengever.dossier.businesscasedossier',
+                '_permissions': {
+                    'read': [group1.groupid],
+                    'add': [group2.groupid],
+                    'edit': [group3.groupid],
+                    'close': [group4.groupid],
+                    'reactivate': [group5.groupid],
+                },
+            },
+
+        ]
+
+        self.assertEquals(expected, transformed_items)
+
+    def test_leaves_unapped_principal_names_unchanged(self):
+        items = [
+            {
+                'guid': 'unmapped-principals',
+                '_type': 'opengever.dossier.businesscasedossier',
+                '_permissions': {
+                    'read': ['john.doe'],
+                    'add': ['admin_users'],
+                    'edit': ['admin_users', 'afi_users'],
+                    'close': ['admin_users'],
+                    'reactivate': ['admin_users'],
+                },
+            },
+
+        ]
+        section = self.setup_section(previous=items)
+        transformed_items = list(section)
+
+        self.assertEquals(items, transformed_items)
+
+    def test_groups_take_precedence_over_users(self):
+        group1 = Group(
+            groupid='11111',
+            groupname='one',
+            external_id=uuid4().hex,
+        )
+        user1 = User(
+            userid='22222',
+            username='one',
+            external_id=uuid4().hex,
+        )
+
+        for obj in (group1, user1):
+            self.session.add(obj)
+        self.session.flush()
+
+        items = [
+            {
+                'guid': 'mapped-groups',
+                '_type': 'opengever.dossier.businesscasedossier',
+                '_permissions': {
+                    'read': ['one'],
+                },
+            },
+
+        ]
+        section = self.setup_section(previous=items)
+        transformed_items = list(section)
+
+        expected = [
+            {
+                'guid': 'mapped-groups',
+                '_type': 'opengever.dossier.businesscasedossier',
+                '_permissions': {
+                    'read': [group1.groupid],
+                },
+            },
+
+        ]
+
+        self.assertEquals(expected, transformed_items)
+
+    def test_mapping_is_case_insensitive(self):
+        group1 = Group(
+            groupid='11111',
+            groupname='GROUP1',
+            external_id=uuid4().hex,
+        )
+        group2 = Group(
+            groupid='22222',
+            groupname='group2',
+            external_id=uuid4().hex,
+        )
+
+        for group in (group1, group2):
+            self.session.add(group)
+        self.session.flush()
+
+        items = [
+            {
+                'guid': 'mapped-groups',
+                '_type': 'opengever.dossier.businesscasedossier',
+                '_permissions': {
+                    'read': ['group1'],
+                    'add': ['GROUP1'],
+                    'edit': ['group2'],
+                    'close': ['GROUP2'],
+                },
+            },
+
+        ]
+        section = self.setup_section(previous=items)
+        transformed_items = list(section)
+
+        expected = [
+            {
+                'guid': 'mapped-groups',
+                '_type': 'opengever.dossier.businesscasedossier',
+                '_permissions': {
+                    'read': [group1.groupid],
+                    'add': [group1.groupid],
+                    'edit': [group2.groupid],
+                    'close': [group2.groupid],
+                },
+            },
+
+        ]
+
+        self.assertEquals(expected, transformed_items)
+
+    def test_only_active_ogds_principals_are_considered(self):
+        inactive_group = Group(
+            groupid='inactive-11111',
+            groupname='group1',
+            external_id=uuid4().hex,
+            active=False,
+        )
+        inactive_user = User(
+            userid='inactive-22222',
+            username='user1',
+            external_id=uuid4().hex,
+            active=False,
+        )
+
+        for principal in (inactive_group, inactive_user):
+            self.session.add(principal)
+        self.session.flush()
+
+        items = [
+            {
+                'guid': 'mapped-groups',
+                '_type': 'opengever.dossier.businesscasedossier',
+                '_permissions': {
+                    'read': ['group1'],
+                    'add': ['user1'],
+                },
+            },
+
+        ]
+        section = self.setup_section(previous=items)
+        transformed_items = list(section)
+
+        expected = [
+            {
+                'guid': 'mapped-groups',
+                '_type': 'opengever.dossier.businesscasedossier',
+                '_permissions': {
+                    'read': ['group1'],
+                    'add': ['user1'],
+                },
+            },
+
+        ]
+
+        self.assertEquals(expected, transformed_items)

--- a/opengever/bundle/transmogrifier.zcml
+++ b/opengever/bundle/transmogrifier.zcml
@@ -64,6 +64,11 @@
       />
 
   <utility
+      component=".sections.map_principal_names_to_ids.MapPrincipalNamesToIDsSection"
+      name="opengever.bundle.map_principal_names_to_ids"
+      />
+
+  <utility
       component=".sections.progress.ProgressSection"
       name="opengever.bundle.progress"
       />


### PR DESCRIPTION
For principal names that appear in local roles (the `_permissions` property in bundle items), **map their names to ids** based on OGDS users / groups.

This is required to support new-style deployments with OGDS auth plugin and user/group names and ids that are distinct from each other (as opposed to legacy style deployments where they are identical).

**Notes:**
- This mapping will be applied during every bundle import, regardless of whether the deployment is new-style or legacy. On legacy deployments it will just not have any effects, since `name == id`
- Lookups by username/groupname are case-insensitive
- If a princpal name in local roles matches both a user and a group, the group is preferred
- Since we are doing case insensitive lookups, we require that usernames / groupnames in OGDS are case-insensitively unique. A check is therefore performed early to ensure all names in OGDS are  case-insensitively unique.

The check for case-insensitively unique names in OGDS can be skipped using the `--no-check-unique-principals` flag. If not skipped,  it will raise an exception if it fails, and report errors as follows:

```
Found ambiguous principal names in OGDS.
The following users/groups are not case-insensitively unique:

username "user1" matches multiple records:
  username: user1 (id: 33333)
  username: USER1 (id: 44444)

groupname "group1" matches multiple records:
  groupname: GROUP1 (id: 22222)
  groupname: group1 (id: 11111)

Skip this check by running import with --no-check-unique-principals flag
```


For [CA-6039](https://4teamwork.atlassian.net/browse/CA-6039)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)



[CA-6039]: https://4teamwork.atlassian.net/browse/CA-6039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ