### PR TITLE
Disposition: Fix UnicodeError in removal protocol download.

### DIFF
--- a/changes/CA-6141.bugfix
+++ b/changes/CA-6141.bugfix
@@ -1,0 +1,1 @@
+Disposition: Fix UnicodeError in removal protocol download. [lgraf]

--- a/opengever/disposition/browser/removal_protocol.py
+++ b/opengever/disposition/browser/removal_protocol.py
@@ -6,6 +6,7 @@ from opengever.disposition import _
 from opengever.latex.listing import Column
 from opengever.latex.listing import ILaTexListing
 from opengever.latex.listing import LaTexListing
+from Products.CMFPlone.utils import safe_unicode
 from zope.component import adapter
 from zope.component import getMultiAdapter
 from zope.i18n import translate
@@ -133,7 +134,8 @@ class RemovalProtocolLaTeXView(MakoLaTeXView):
 
         for row in config:
             label = translate(row.get('label'), context=self.request)
-            rows.append(u'\\bf {} & {} \\\\%%'.format(
-                self.convert_plain(label), row.get('value')))
+            row_label = safe_unicode(self.convert_plain(label))
+            value = safe_unicode(row.get('value'))
+            rows.append(u'\\bf {} & {} \\\\%%'.format(row_label, value))
 
-        return '\n'.join(rows)
+        return u'\n'.join(rows)

--- a/opengever/disposition/tests/test_removal_protocol.py
+++ b/opengever/disposition/tests/test_removal_protocol.py
@@ -5,6 +5,7 @@ from ftw.testbrowser import browsing
 from opengever.disposition.browser.removal_protocol import IRemovalProtocolLayer
 from opengever.latex.layouts.default import DefaultLayout
 from opengever.testing import IntegrationTestCase
+from plone import api
 from zope.component import getMultiAdapter
 
 
@@ -32,4 +33,23 @@ class TestRemovalProtocolLaTeXView(IntegrationTestCase):
 
         self.assertEquals(
             'attachment; filename="Removal protocol for {}.pdf"'.format(self.disposition.title),
+            browser.headers.get('content-disposition'))
+
+
+class TestRemovalProtocolLaTeXViewInFrench(TestRemovalProtocolLaTeXView):
+
+    def setUp(self):
+        super(TestRemovalProtocolLaTeXViewInFrench, self).setUp()
+
+        lang_tool = api.portal.get_tool('portal_languages')
+        lang_tool.setDefaultLanguage('fr-ch')
+
+    @browsing
+    def test_pdf_title_is_removal_protocol_for_disposition_title(self, browser):
+        self.login(self.records_manager, browser)
+        browser.open(self.disposition, view='removal_protocol')
+
+        self.assertEquals(
+            'attachment; filename="Protocole de suppression pour {}.pdf"'.format(
+                self.disposition.title),
             browser.headers.get('content-disposition'))


### PR DESCRIPTION
Fix UnicodeError in removal protocol download.

`View.convert_plain()` from ftw.pdfgenerator always returns a bytestring, even when passed unicode.

Sentry: https://sentry.4teamwork.ch/organizations/sentry/issues/105603/

For [CA-6141](https://4teamwork.atlassian.net/browse/CA-6141)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)



[CA-6141]: https://4teamwork.atlassian.net/browse/CA-6141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ