### PR TITLE
Grant view permissions to archivists on offered dossiers

### DIFF
--- a/changes/CA-6167.feature
+++ b/changes/CA-6167.feature
@@ -1,0 +1,1 @@
+Archivists are granted view permissions on offered dossiers. [njohner]

--- a/opengever/api/disposition.py
+++ b/opengever/api/disposition.py
@@ -70,6 +70,7 @@ class SerializeDispositionToJson(GeverSerializeFolderToJson):
         result[u'sip_filename'] = self.context.get_sip_filename()
         result[u'sip_delivery_status'] = self.context.get_delivery_status_infos()
         result[u'dossier_details'] = self.get_dossier_details()
+        result[u'has_dossiers_with_pending_permissions_changes'] = self.context.has_dossiers_with_pending_permissions_changes
         return result
 
     def get_dossier_details(self):

--- a/opengever/api/tests/test_disposition.py
+++ b/opengever/api/tests/test_disposition.py
@@ -125,6 +125,13 @@ class TestDispositionSerialization(IntegrationTestCase):
             browser.json['sip_delivery_status'])
 
     @browsing
+    def test_includes_has_dossiers_with_pending_permissions_changes(self, browser):
+        self.login(self.records_manager, browser)
+
+        browser.open(self.disposition, method='GET', headers=self.api_headers)
+        self.assertTrue(browser.json['has_dossiers_with_pending_permissions_changes'])
+
+    @browsing
     def test_provides_dossier_details(self, browser):
         self.login(self.records_manager, browser)
         browser.open(self.disposition, method='GET', headers=self.api_headers)

--- a/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-01-10 12:25+0000\n"
+"POT-Creation-Date: 2023-09-21 13:00+0000\n"
 "PO-Revision-Date: 2014-09-04 01:03+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -233,6 +233,11 @@ msgstr "Kommentar zur Archivwürdigkeit"
 #: ./opengever/base/role_assignments.py
 msgid "label_assignment_via_committee_group"
 msgstr "Durch Mitgliedschaft in Gremiumsgruppe"
+
+#. Default: "Via disposition"
+#: ./opengever/base/role_assignments.py
+msgid "label_assignment_via_disposition"
+msgstr "Durch Angebot"
 
 #. Default: "By protect dossier"
 #: ./opengever/base/role_assignments.py

--- a/opengever/base/locales/en/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/en/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-01-10 12:25+0000\n"
+"POT-Creation-Date: 2023-09-21 13:00+0000\n"
 "PO-Revision-Date: 2014-09-04 01:03+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -279,6 +279,11 @@ msgstr "Comment about archival value assessment"
 #: ./opengever/base/role_assignments.py
 msgid "label_assignment_via_committee_group"
 msgstr "Via committee group"
+
+#. Default: "Via disposition"
+#: ./opengever/base/role_assignments.py
+msgid "label_assignment_via_disposition"
+msgstr "Via disposition"
 
 #. German translation: Durch «Dossier schützen»
 #. Default: "By protect dossier"

--- a/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-01-10 12:25+0000\n"
+"POT-Creation-Date: 2023-09-21 13:00+0000\n"
 "PO-Revision-Date: 2017-11-29 10:53+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-base/fr/>\n"
@@ -232,6 +232,11 @@ msgstr "Commentaire concernant la valeur archivistique"
 #: ./opengever/base/role_assignments.py
 msgid "label_assignment_via_committee_group"
 msgstr "Par l'appartenance au groupe de la commission"
+
+#. Default: "Via disposition"
+#: ./opengever/base/role_assignments.py
+msgid "label_assignment_via_disposition"
+msgstr "Par offre"
 
 #. Default: "By protect dossier"
 #: ./opengever/base/role_assignments.py

--- a/opengever/base/locales/opengever.base.pot
+++ b/opengever/base/locales/opengever.base.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-01-10 12:25+0000\n"
+"POT-Creation-Date: 2023-09-21 13:00+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -229,6 +229,11 @@ msgstr ""
 #. Default: "By committee group"
 #: ./opengever/base/role_assignments.py
 msgid "label_assignment_via_committee_group"
+msgstr ""
+
+#. Default: "Via disposition"
+#: ./opengever/base/role_assignments.py
+msgid "label_assignment_via_disposition"
 msgstr ""
 
 #. Default: "By protect dossier"

--- a/opengever/base/role_assignments.py
+++ b/opengever/base/role_assignments.py
@@ -15,6 +15,7 @@ ASSIGNMENT_VIA_SHARING = 3
 ASSIGNMENT_VIA_PROTECT_DOSSIER = 4
 ASSIGNMENT_VIA_INVITATION = 5
 ASSIGNMENT_VIA_COMMITTEE_GROUP = 6
+ASSIGNMENT_VIA_DISPOSITION = 7
 
 # When copying a dossier, we keep or drop local roles depending on
 # their assignment cause.
@@ -116,6 +117,23 @@ class TaskAgencyRoleAssignment(RoleAssignment):
 
 
 RoleAssignment.register(TaskAgencyRoleAssignment)
+
+
+class ArchivistRoleAssignment(RoleAssignment):
+
+    cause = ASSIGNMENT_VIA_DISPOSITION
+
+    def __init__(self, principal, roles, reference):
+        self.principal = principal
+        self.roles = roles
+        self.reference = reference
+
+    def cause_title(self):
+        return _(u'label_assignment_via_disposition',
+                 default=u'Via disposition')
+
+
+RoleAssignment.register(ArchivistRoleAssignment)
 
 
 class ProtectDossierRoleAssignment(RoleAssignment):

--- a/opengever/base/role_assignments.py
+++ b/opengever/base/role_assignments.py
@@ -332,6 +332,10 @@ class RoleAssignmentManager(object):
         return [RoleAssignment.get(**data) for data
                 in self.storage.get_by_principal(principal_id)]
 
+    def get_assignments_by_reference(self, reference):
+        return [RoleAssignment.get(**data) for data
+                in self.storage.get_by_reference(Oguid.for_object(reference).id)]
+
     def get_roles_by_principal_id(self, principal_id):
         roles = set()
         for assignment_data in self.storage.get_by_principal(principal_id):

--- a/opengever/base/tests/test_copy_paste.py
+++ b/opengever/base/tests/test_copy_paste.py
@@ -6,6 +6,7 @@ from ftw.testbrowser.pages.statusmessages import info_messages
 from opengever.base.interfaces import ISequenceNumber
 from opengever.base.oguid import Oguid
 from opengever.base.role_assignments import ASSIGNMENT_VIA_COMMITTEE_GROUP
+from opengever.base.role_assignments import ASSIGNMENT_VIA_DISPOSITION
 from opengever.base.role_assignments import ASSIGNMENT_VIA_INVITATION
 from opengever.base.role_assignments import ASSIGNMENT_VIA_PROTECT_DOSSIER
 from opengever.base.role_assignments import ASSIGNMENT_VIA_SHARING
@@ -589,7 +590,8 @@ class TestCopyPastePermissionHandling(IntegrationTestCase):
     def test_all_assignment_types_are_handled(self):
         assignments_dropped_when_copying = [ASSIGNMENT_VIA_TASK,
                                             ASSIGNMENT_VIA_TASK_AGENCY,
-                                            ASSIGNMENT_VIA_COMMITTEE_GROUP]
+                                            ASSIGNMENT_VIA_COMMITTEE_GROUP,
+                                            ASSIGNMENT_VIA_DISPOSITION]
 
         for assignment in assignments_kept_when_copying:
             assignment_class = RoleAssignment.registry[assignment]
@@ -601,7 +603,7 @@ class TestCopyPastePermissionHandling(IntegrationTestCase):
         handled_assignments = assignments_dropped_when_copying + list(assignments_kept_when_copying)
 
         for key in RoleAssignment.registry:
-            assignment_class = RoleAssignment.registry[assignment]
+            assignment_class = RoleAssignment.registry[key]
             self.assertIn(key, handled_assignments,
                           "local roles for {} are dropped during copy/paste. If this"
                           " is on purpose, please adapt this test.".format(assignment_class))

--- a/opengever/base/tests/test_role_assignments.py
+++ b/opengever/base/tests/test_role_assignments.py
@@ -195,6 +195,19 @@ class TestRoleAssignmentManager(IntegrationTestCase):
             set(['TaskResponsible']),
             manager.get_roles_by_principal_id(self.regular_user.id))
 
+    def test_get_assignments_by_reference(self):
+        self.login(self.regular_user)
+
+        manager = RoleAssignmentManager(self.dossier)
+        assignments = manager.get_assignments_by_reference(self.task)
+
+        self.assertItemsEqual(
+            [('kathi.barfuss', 1, ['TaskResponsible']),
+             ('fa_inbox_users', 2, ['TaskResponsible'])],
+            [(assignment.principal, assignment.cause, assignment.roles)
+             for assignment in assignments]
+        )
+
 
 class TestManageRoleAssignmentsView(IntegrationTestCase):
 

--- a/opengever/core/upgrades/20230922085455_add_new_attributes_to_dispositions/upgrade.py
+++ b/opengever/core/upgrades/20230922085455_add_new_attributes_to_dispositions/upgrade.py
@@ -1,0 +1,17 @@
+from ftw.upgrade import UpgradeStep
+from opengever.disposition.interfaces import IDisposition
+from persistent.list import PersistentList
+from Products.CMFPlone.utils import safe_hasattr
+
+
+class AddNewAttributesToDispositions(UpgradeStep):
+    """Add new attributes to dispositions.
+    """
+
+    def __call__(self):
+        query = {'object_provides': IDisposition.__identifier__}
+        for disposition in self.objects(query, "Add storage for new attributes on dispositions."):
+            if not safe_hasattr(disposition, "_dossiers_with_missing_permissions"):
+                disposition._dossiers_with_missing_permissions = PersistentList()
+            if not safe_hasattr(disposition, "_dossiers_with_extra_permissions"):
+                disposition._dossiers_with_extra_permissions = PersistentList()

--- a/opengever/disposition/__init__.py
+++ b/opengever/disposition/__init__.py
@@ -13,3 +13,9 @@ def only_attach_original_enabled():
     return api.portal.get_registry_record(
         'only_attach_original_if_conversion_is_missing',
         interface=IDispositionSettings)
+
+
+DISPOSITION_ACTIVE_STATES = ["disposition-state-in-progress",
+                             "disposition-state-appraised",
+                             "disposition-state-archived",
+                             "disposition-state-disposed"]

--- a/opengever/disposition/activities.py
+++ b/opengever/disposition/activities.py
@@ -35,6 +35,10 @@ class DispositionAddedActivity(BaseActivity):
     def before_recording(self):
         self.context.register_watchers()
 
+    @property
+    def actor_id(self):
+        return self.context.Creator()
+
 
 class DispositionStateChangedActivity(BaseActivity):
 

--- a/opengever/disposition/configure.zcml
+++ b/opengever/disposition/configure.zcml
@@ -36,6 +36,11 @@
       name="create-dossier-journal-pdf"
       />
 
+  <adapter
+      factory=".nightly_jobs.NightlyDossierPermissionSetter"
+      name="update-disposition-permissions"
+      />
+
   <genericsetup:registerProfile
       name="default"
       title="opengever.disposition"

--- a/opengever/disposition/disposition.py
+++ b/opengever/disposition/disposition.py
@@ -232,6 +232,7 @@ class Disposition(Container):
     implements(IDisposition, IResponseSupported)
 
     destroyed_key = 'destroyed_dossiers'
+    creation_activity_recorded_key = 'creation_activity_recorded'
 
     def __init__(self, *args, **kwargs):
         super(Disposition, self).__init__(*args, **kwargs)
@@ -497,3 +498,11 @@ class Disposition(Container):
 
     def revoke_view_permissions_from_archivists_on_dossier(self, dossier):
         RoleAssignmentManager(dossier).clear_by_reference(self)
+
+    @property
+    def creation_activity_recorded(self):
+        return IAnnotations(self).get(self.creation_activity_recorded_key, False)
+
+    @creation_activity_recorded.setter
+    def creation_activity_recorded(self, value):
+        IAnnotations(self)[self.creation_activity_recorded_key] = value

--- a/opengever/disposition/disposition.py
+++ b/opengever/disposition/disposition.py
@@ -10,6 +10,8 @@ from opengever.base.behaviors.classification import IClassification
 from opengever.base.behaviors.lifecycle import ILifeCycle
 from opengever.base.response import IResponseContainer
 from opengever.base.response import IResponseSupported
+from opengever.base.role_assignments import ArchivistRoleAssignment
+from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.base.security import elevated_privileges
 from opengever.base.source import SolrObjPathSourceBinder
 from opengever.disposition import _
@@ -487,3 +489,11 @@ class Disposition(Container):
             {'name': n, 'status': translate(DELIVERY_STATUS_LABELS[s], context=getRequest())}
             for n, s in statuses.items()]
         return status_infos
+
+    def give_view_permissions_to_archivists_on_dossier(self, dossier):
+        assignments = [ArchivistRoleAssignment(principal, ["Reader"], self)
+                       for principal, info in self.get_archivists_infos()]
+        RoleAssignmentManager(dossier).add_or_update_assignments(assignments)
+
+    def revoke_view_permissions_from_archivists_on_dossier(self, dossier):
+        RoleAssignmentManager(dossier).clear_by_reference(self)

--- a/opengever/disposition/disposition.py
+++ b/opengever/disposition/disposition.py
@@ -358,7 +358,8 @@ class Disposition(Container):
             center.add_watcher_to_resource(
                 self, archivist, DISPOSITION_ARCHIVIST_ROLE)
 
-    def get_all_archivists(self):
+    @staticmethod
+    def get_archivists_infos():
         archivists = []
         acl_users = api.portal.get_tool('acl_users')
         role_manager = acl_users.get('portal_role_manager')
@@ -369,7 +370,14 @@ class Disposition(Container):
             # skip not existing or duplicated groups or users
             if len(info) != 1:
                 continue
+            archivists.append((principal, info))
 
+        return archivists
+
+    def get_all_archivists(self):
+        archivists_infos = self.get_archivists_infos()
+        archivists = []
+        for principal, info in archivists_infos:
             if info[0].get('principal_type') == 'group':
                 archivists += [user.userid for user in
                                ogds_service().fetch_group(principal).users]

--- a/opengever/disposition/handlers.py
+++ b/opengever/disposition/handlers.py
@@ -1,5 +1,4 @@
 from opengever.base.response import IResponseContainer
-from opengever.disposition.activities import DispositionAddedActivity
 from opengever.disposition.activities import DispositionStateChangedActivity
 from opengever.disposition.interfaces import IDuringDossierDestruction
 from opengever.disposition.response import DispositionResponse
@@ -46,7 +45,6 @@ def disposition_added(context, event):
                          in context.get_dossier_representations()]
 
     IResponseContainer(context).add(response)
-    DispositionAddedActivity(context, getRequest()).record()
 
 
 def disposition_modified(context, event):

--- a/opengever/disposition/nightly_jobs.py
+++ b/opengever/disposition/nightly_jobs.py
@@ -1,5 +1,6 @@
 from BTrees.IIBTree import IITreeSet
 from opengever.disposition import DISPOSITION_ACTIVE_STATES
+from opengever.disposition.activities import DispositionAddedActivity
 from opengever.disposition.delivery import DeliveryScheduler
 from opengever.disposition.interfaces import IDisposition
 from opengever.nightlyjobs.provider import NightlyJobProviderBase
@@ -156,4 +157,8 @@ class NightlyDossierPermissionSetter(NightlyJobProviderBase):
             transaction.commit()
             self.logger.info("Added permissions on %r" % dossier)
 
+        if not disposition.creation_activity_recorded:
+            DispositionAddedActivity(disposition, self.request).record()
+            disposition.creation_activity_recorded = True
+            transaction.commit()
         self.logger.info("Finished setting permissions for %r" % disposition)

--- a/opengever/disposition/tests/test_activities.py
+++ b/opengever/disposition/tests/test_activities.py
@@ -27,7 +27,7 @@ class TestDispositionNotifications(IntegrationTestCase):
         jobs = list(nightly_job_provider)
         self.assertEqual(expected, len(jobs))
         for job in jobs:
-            nightly_job_provider.run_job(job, None)
+            nightly_job_provider.run_job(job, lambda: False)
 
     def test_creator_and_all_archivist_are_registered_as_watchers(self):
         self.login(self.manager)

--- a/opengever/nightlyjobs/tests/test_nightly_job_runner.py
+++ b/opengever/nightlyjobs/tests/test_nightly_job_runner.py
@@ -382,6 +382,7 @@ class TestNightlyJobRunner(IntegrationTestCase):
             u'document-title': 1,
             u'execute-after-resolve-jobs': 0,
             u'maintenance-jobs': 0,
+            u'update-disposition-permissions': 2
         }
 
         self.assertEqual(expected, get_job_counts())

--- a/opengever/nightlyjobs/tests/test_nightly_jobs_stats.py
+++ b/opengever/nightlyjobs/tests/test_nightly_jobs_stats.py
@@ -20,10 +20,11 @@ class TestNightlyJobsStats(IntegrationTestCase):
                          'Last nightly run: never\n\n'
                          'Nightly job counts:\n'
                          'maintenance-jobs: 4\n'
-                         'deliver-sip-packages: 0\n'
                          'create-dossier-journal-pdf: 0\n'
-                         'complete-role-assignment-reports: 1\n'
-                         'execute-after-resolve-jobs: 0', browser.contents)
+                         'deliver-sip-packages: 0\n'
+                         'update-disposition-permissions: 2\n'
+                         'execute-after-resolve-jobs: 0\n'
+                         'complete-role-assignment-reports: 1', browser.contents)
 
         with freeze(datetime(2019, 12, 31, 17, 45)) as clock:
             runner = NightlyJobRunner(force_execution=True)
@@ -35,7 +36,8 @@ class TestNightlyJobsStats(IntegrationTestCase):
                          'Last nightly run: 2019-12-31T17:45:00\n\n'
                          'Nightly job counts:\n'
                          'maintenance-jobs: 0\n'
-                         'deliver-sip-packages: 0\n'
                          'create-dossier-journal-pdf: 0\n'
-                         'complete-role-assignment-reports: 0\n'
-                         'execute-after-resolve-jobs: 0', browser.contents)
+                         'deliver-sip-packages: 0\n'
+                         'update-disposition-permissions: 0\n'
+                         'execute-after-resolve-jobs: 0\n'
+                         'complete-role-assignment-reports: 0', browser.contents)


### PR DESCRIPTION
With this PR we make sure that archivists have the needed permissions to inspect the dossiers of an offer.

- Because this requires reindexing of all the objects inside the offer, we set the permissions in a nightly job. 
- We also provide `has_dossiers_with_pending_permissions_changes` in the serialisation of the disposition so that a warning can be shown when permissions are not up to date yet. 
- To avoid that the archivists receive an E-mail for a newly created disposition that they can't evaluate yet because they don't have the permissions on the dossier, we delay creation of the activity to after updating the permissions on all offered dossiers.

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-6167]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- New translations
  - [x] All msg-strings are unicode

[CA-6167]: https://4teamwork.atlassian.net/browse/CA-6167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ