### PR TITLE
Respect local dossier depth when uploading a dossier structure.

### DIFF
--- a/changes/CA-6197.bugfix
+++ b/changes/CA-6197.bugfix
@@ -1,0 +1,1 @@
+Respect local dossier depth when uploading a dossier structure. [elioschmutz]

--- a/opengever/api/upload_structure.py
+++ b/opengever/api/upload_structure.py
@@ -6,7 +6,6 @@ from opengever.api.not_reported_exceptions import BadRequest as NotReportedBadRe
 from opengever.api.not_reported_exceptions import Forbidden as NotReportedForbidden
 from opengever.document.document import is_email_upload
 from opengever.dossier.behaviors.dossier import IDossierMarker
-from opengever.dossier.interfaces import IDossierContainerTypes
 from opengever.dossier.templatefolder import get_template_folder
 from opengever.dossier.templatefolder.interfaces import ITemplateFolder
 from opengever.dossier.utils import get_main_dossier
@@ -188,11 +187,8 @@ class DossierDepthCheckMixin(object):
         if self.structure["max_container_depth"] == 0:
             return
 
-        max_depth = api.portal.get_registry_record(
-            name='maximum_dossier_depth',
-            interface=IDossierContainerTypes
-        )
-        if self.current_depth + self.structure["max_container_depth"] > max_depth + 1:
+        if not self.context.is_dossier_structure_addable(
+                self.structure["max_container_depth"]):
             raise MaximalDepthExceeded(
                 _(u'msg_max_dossier_depth_exceeded',
                   default=u'Maximum dossier depth exceeded'))


### PR DESCRIPTION
We can set a global allowed dossier depth in the registry. Adding a subdossier deeper than the configured limit is not possible. Beside of this global limit, we also have a local limit which can be higher than the actual global limit. Usually, this will happen if the user creates a dossier from a template. dossier templates can be deeper nested than the global limit. 

Such dossiers will automatically expand the allowed limit to the existing subdossier-depth. Means, the user can always create siblings, even if the depth is higher than the global limit.

Currently, we do not respect this local depth when uploading a folder structure. The `@upload-structure` endpoint only checks for the global limit.

This PR fixes this issue and uses the same mechanism for checking the allowed depth in the `@upload-structure` endpoint as we do it when manually adding a new dossier.

For [CA-6215]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-6197]: https://4teamwork.atlassian.net/browse/CA-6197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CA-6215]: https://4teamwork.atlassian.net/browse/CA-6215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ