### PR TITLE
Respect local dossier depth when uploading a dossier structure.

### DIFF
--- a/changes/CA-6215.bugfix
+++ b/changes/CA-6215.bugfix
@@ -1,0 +1,1 @@
+Respect local dossier depth when uploading a dossier structure. [elioschmutz]

--- a/opengever/api/tests/test_upload_structure.py
+++ b/opengever/api/tests/test_upload_structure.py
@@ -3,7 +3,9 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from opengever.api.upload_structure import IUploadStructureAnalyser
 from opengever.contact.tests import create_contacts
+from opengever.dossier.interfaces import IDossierContainerTypes
 from opengever.testing import SolrIntegrationTestCase
+from plone import api
 import json
 
 
@@ -156,9 +158,14 @@ class TestUploadStructure(SolrIntegrationTestCase):
             self.dossier,
             ['/folder/file.txt'])
 
-        self.assert_upload_structure_raises_bad_request(
+        self.assert_upload_structure_returns_ok(
             browser,
             self.subdossier,
+            ['/folder/file.txt'])
+
+        self.assert_upload_structure_raises_bad_request(
+            browser,
+            self.subsubdossier,
             ['/folder/file.txt'],
             u'Maximum dossier depth exceeded')
 
@@ -178,6 +185,43 @@ class TestUploadStructure(SolrIntegrationTestCase):
             browser,
             subsubdossier,
             ['file.txt'])
+
+    @browsing
+    def test_upload_structure_respects_local_dossier_depth(self, browser):
+        self.login(self.regular_user, browser)
+
+        # validate the max_dossier_depth
+        self.assertEqual(1, api.portal.get_registry_record(
+            name='maximum_dossier_depth', interface=IDossierContainerTypes))
+
+        # Uploading a structure to this brand new dossier will not be possible
+        # because the global max_depth will will be exceeded.
+        dossier = create(Builder('dossier').within(self.leaf_repofolder))
+        self.assert_upload_structure_raises_bad_request(
+            browser,
+            dossier,
+            ['/folder1/folder2/file.txt'],
+            u'Maximum dossier depth exceeded')
+
+        # We now create some subdossier up to a depth of three which is more
+        # than the allowed global depth. So the local allowed depth will be 3
+        # for this dossier-tree.
+        #
+        # Uploading a structure up to a depth of three to the dossier should be
+        # possible now.
+        subdossier = create(Builder('dossier').within(dossier))
+        create(Builder('dossier').within(subdossier))
+        self.assert_upload_structure_returns_ok(
+            browser,
+            dossier,
+            ['/folder1/folder2/file.txt'])
+
+        # but will still raise if the upload structure exceeds the local limit
+        self.assert_upload_structure_raises_bad_request(
+            browser,
+            dossier,
+            ['/folder1/folder2/folder3/file.txt'],
+            u'Maximum dossier depth exceeded')
 
     @browsing
     def test_upload_structure_ignores_maximal_depth_in_workspace_area(self, browser):

--- a/opengever/api/upload_structure.py
+++ b/opengever/api/upload_structure.py
@@ -6,7 +6,6 @@ from opengever.api.not_reported_exceptions import BadRequest as NotReportedBadRe
 from opengever.api.not_reported_exceptions import Forbidden as NotReportedForbidden
 from opengever.document.document import is_email_upload
 from opengever.dossier.behaviors.dossier import IDossierMarker
-from opengever.dossier.interfaces import IDossierContainerTypes
 from opengever.dossier.templatefolder import get_template_folder
 from opengever.dossier.templatefolder.interfaces import ITemplateFolder
 from opengever.dossier.utils import get_main_dossier
@@ -179,20 +178,13 @@ class DossierDepthCheckMixin(object):
         self.check_dossier_depth()
         super(DossierDepthCheckMixin, self).check_structure()
 
-    @property
-    def current_depth(self):
-        return 0
-
     def check_dossier_depth(self):
         # It is only a file upload
         if self.structure["max_container_depth"] == 0:
             return
 
-        max_depth = api.portal.get_registry_record(
-            name='maximum_dossier_depth',
-            interface=IDossierContainerTypes
-        )
-        if self.current_depth + self.structure["max_container_depth"] > max_depth + 1:
+        if not self.context.is_dossier_structure_addable(
+                self.structure["max_container_depth"]):
             raise MaximalDepthExceeded(
                 _(u'msg_max_dossier_depth_exceeded',
                   default=u'Maximum dossier depth exceeded'))
@@ -202,10 +194,6 @@ class DossierDepthCheckMixin(object):
 class DossierUploadStructureAnalyser(DossierDepthCheckMixin, DefaultUploadStructureAnalyser):
 
     container_type = 'opengever.dossier.businesscasedossier'
-
-    @property
-    def current_depth(self):
-        return self.context._get_dossier_depth()
 
 
 @adapter(IRepositoryFolder)
@@ -232,10 +220,6 @@ class PrivateFolderUploadStructureAnalyser(DossierDepthCheckMixin, DefaultUpload
 class PrivateDossierUploadStructureAnalyser(DossierDepthCheckMixin, DefaultUploadStructureAnalyser):
 
     container_type = 'opengever.private.dossier'
-
-    @property
-    def current_depth(self):
-        return self.context._get_dossier_depth()
 
 
 @adapter(IWorkspace)

--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -19,6 +19,7 @@ from opengever.dossier.behaviors.participation import IParticipationAwareMarker
 from opengever.dossier.interfaces import IConstrainTypeDecider
 from opengever.dossier.interfaces import IDossierContainerTypes
 from opengever.dossier.interfaces import IDossierResolveProperties
+from opengever.dossier.utils import check_subdossier_depth_allowed
 from opengever.meeting import is_meeting_feature_enabled
 from opengever.meeting import OPEN_PROPOSAL_STATES
 from opengever.ogds.base.actor import Actor
@@ -172,13 +173,8 @@ class DossierContainer(Container):
         """Checks if the maximum dossier depth allows additional_depth levels
         of subdossiers but not for permissions.
         """
-        max_depth = api.portal.get_registry_record(
-            name='maximum_dossier_depth',
-            interface=IDossierContainerTypes,
-            default=100,
-        )
-        max_depth_respected = (
-            self._get_dossier_depth() + additional_depth <= max_depth + 1)
+        max_depth_respected = check_subdossier_depth_allowed(
+            self._get_dossier_depth() - 1 + additional_depth)
 
         if max_depth_respected:
             return True

--- a/opengever/dossier/utils.py
+++ b/opengever/dossier/utils.py
@@ -3,8 +3,10 @@ from Acquisition import aq_parent
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.dossiertemplate.behaviors import IDossierTemplateMarker
 from opengever.dossier.dossiertemplate.behaviors import IDossierTemplateSchema
+from opengever.dossier.interfaces import IDossierContainerTypes
 from opengever.inbox.inbox import IInbox
 from opengever.workspace.interfaces import IWorkspace
+from plone import api
 from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
 import unicodedata
 
@@ -78,3 +80,16 @@ def supports_is_subdossier(obj):
     the is_subdossier index / method.
     """
     return IDossierMarker.providedBy(obj) or IDossierTemplateMarker.providedBy(obj)
+
+
+def check_subdossier_depth_allowed(subdossier_depth=1):
+    """Checks if the maximum dossier depth will be exceeded for a specific
+    target depth.
+    """
+    max_subdossier_depth = api.portal.get_registry_record(
+        name='maximum_dossier_depth',
+        interface=IDossierContainerTypes,
+        default=100,
+    )
+
+    return subdossier_depth <= max_subdossier_depth

--- a/opengever/private/folder.py
+++ b/opengever/private/folder.py
@@ -1,4 +1,5 @@
 from opengever.base.default_values import set_default_values
+from opengever.dossier.utils import check_subdossier_depth_allowed
 from opengever.ogds.base.actor import Actor
 from opengever.private.interfaces import IPrivateContainer
 from opengever.repository.repositoryfolder import IRepositoryFolderSchema
@@ -39,3 +40,6 @@ class PrivateFolder(Container):
         # creation, that doesn't properly set default values. We therefore
         # apply them here after creation.
         set_default_values(self, self.aq_parent, {})
+
+    def is_dossier_structure_addable(self, depth=1):
+        return check_subdossier_depth_allowed(depth - 1)

--- a/opengever/repository/repositoryfolder.py
+++ b/opengever/repository/repositoryfolder.py
@@ -1,6 +1,7 @@
 from opengever.base.behaviors.lifecycle import ILifeCycle
 from opengever.base.behaviors.translated_title import ITranslatedTitle
 from opengever.base.interfaces import IReferenceNumber
+from opengever.dossier.utils import check_subdossier_depth_allowed
 from opengever.repository import _
 from opengever.repository.interfaces import IRepositoryFolder
 from plone.app.content.interfaces import INameFromTitle
@@ -148,6 +149,9 @@ class RepositoryFolder(content.Container):
             else:
                 return True
         return True
+
+    def is_dossier_structure_addable(self, depth=1):
+        return check_subdossier_depth_allowed(depth - 1)
 
 
 @implementer(INameFromTitle)


### PR DESCRIPTION
We can set a global allowed dossier depth in the registry. Adding a subdossier deeper than the configured limit is not possible. Beside of this global limit, we also have a local limit which can be higher than the actual global limit. Usually, this will happen if the user creates a dossier from a template. dossier templates can be deeper nested than the global limit. 

Such dossiers will automatically expand the allowed limit to the existing subdossier-depth. Means, the user can always create siblings, even if the depth is higher than the global limit.

Currently, we do not respect this local depth when uploading a folder structure. The `@upload-structure` endpoint only checks for the global limit.

This PR fixes this issue and uses the same mechanism for checking the allowed depth in the `@upload-structure` endpoint as we do it when manually adding a new dossier.

For [CA-6215]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-6215]: https://4teamwork.atlassian.net/browse/CA-6215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ