### PR TITLE
Fix attaching documents from different parents to mails.

### DIFF
--- a/changes/CA-6262.bugfix
+++ b/changes/CA-6262.bugfix
@@ -1,0 +1,1 @@
+Fix attaching documents from different parents to mails. [njohner]

--- a/opengever/officeconnector/service.py
+++ b/opengever/officeconnector/service.py
@@ -214,15 +214,14 @@ class OfficeConnectorAttachPayload(OfficeConnectorPayload):
         self.request.response.setHeader('Content-type', 'application/json')
         payloads = self.get_base_payloads()
         payloads_by_parent = group_payloads_by_parent(payloads, self.request)
-
-        for container_uuid, payloads in payloads_by_parent.items():
+        for container_uuid, container_payloads in payloads_by_parent.items():
 
             if container_uuid and not is_workspace_feature_enabled():
                 dossier = api.content.get(UID=container_uuid)
-                documents = [p['document'] for p in payloads]
+                documents = [p['document'] for p in container_payloads]
                 notify(DossierAttachedToEmailEvent(dossier, documents))
 
-            for payload in payloads:
+            for payload in container_payloads:
                 document = payload['document']
                 payload['title'] = document.title_or_id()
                 payload['content-type'] = document.get_file().contentType

--- a/opengever/officeconnector/tests/test_api_mail_attach.py
+++ b/opengever/officeconnector/tests/test_api_mail_attach.py
@@ -152,6 +152,65 @@ class TestOfficeconnectorMailAPIWithAttach(OCSolrIntegrationTestCase):
         self.assertItemsEqual(expected_payloads, payloads)
 
     @browsing
+    def test_attach_to_email_from_different_parents(self, browser):
+        self.login(self.regular_user, browser)
+
+        dossier_email = self.fetch_dossier_bcc(browser, self.dossier)
+
+        self.assertTrue(dossier_email)
+        self.assertEqual(200, browser.status_code)
+
+        documents = [self.document, self.subdocument]
+
+        with freeze(FREEZE_DATE):
+            oc_url = self.fetch_dossier_multiattach_oc_url(browser, self.dossier, documents, dossier_email)
+
+        self.assertIsNotNone(oc_url)
+        self.assertEqual(200, browser.status_code)
+
+        expected_token = {
+            u"action": u"attach",
+            u"bcc": u"1014013300@example.org",
+            u"documents": [u"createtreatydossiers000000000002", u"createtreatydossiers000000000017"],
+            u"exp": 4121033100,
+            u"sub": u"kathi.barfuss",
+            u"url": u"http://nohost/plone/oc_attach",
+        }
+        raw_token = oc_url.split(":")[-1]
+        token = jwt.decode(raw_token, JWT_SIGNING_SECRET_PLONE, algorithms=('HS256',))
+        payloads = self.fetch_document_attach_payloads(browser, raw_token, token)
+
+        self.assertItemsEqual(token.pop('documents'), expected_token.pop('documents'))
+        self.assertEqual(expected_token, token)
+
+        expected_payloads = [
+            {
+                u'bcc': u'1014173300@example.org',
+                u'content-type': u'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                u'csrf-token': u'86ecf9b4135514f8c94c61ce336a4b98b4aaed8a',
+                u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/dossier-2/document-22',
+                u'download': u'download',
+                u'filename': u'Uebersicht der Vertraege von 2016.xlsx',
+                u'title': u'\xdcbersicht der Vertr\xe4ge von 2016',
+                u'uuid': u'createtreatydossiers000000000017',
+                u'version': None
+            },
+            {
+                u'bcc': u'1014013300@example.org',
+                u'content-type': u'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+                u'csrf-token': u'86ecf9b4135514f8c94c61ce336a4b98b4aaed8a',
+                u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-14',
+                u'download': u'download',
+                u'filename': u'Vertraegsentwurf.docx',
+                u'title': u'Vertr\xe4gsentwurf',
+                u'uuid': u'createtreatydossiers000000000002',
+                u'version': None
+            }
+        ]
+
+        self.assertItemsEqual(expected_payloads, payloads)
+
+    @browsing
     def test_checkout_checkin(self, browser):
         self.login(self.regular_user, browser)
         with browser.expect_http_error(404):


### PR DESCRIPTION
Attaching documents to an Email from different parents was broken with https://github.com/4teamwork/opengever.core/pull/7762. This change is only included in the two last releases 2023.12 and 2023.13, which are releases used only for SaaS, so we do not need to backport this.

For [CA-6262]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-6262]: https://4teamwork.atlassian.net/browse/CA-6262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ