### PR TITLE
Fix dossier details for dossier with custom property with a list as value

### DIFF
--- a/changes/CA-6217.bugfix
+++ b/changes/CA-6217.bugfix
@@ -1,0 +1,1 @@
+Fix dossier details for dossier with custom property with a list as value. [njohner]

--- a/opengever/latex/dossierdetails.py
+++ b/opengever/latex/dossierdetails.py
@@ -200,7 +200,7 @@ class DossierDetailsLaTeXView(MakoLaTeXView):
                         else translate(_('label_no', default=u"No"), context=self.request))
                 elif isinstance(custom_field_value, date):
                     custom_field_value = helper.readable_date(self.context, custom_field_value)
-                elif isinstance(custom_field_value, set):
+                elif isinstance(custom_field_value, set) or isinstance(custom_field_value, list):
                     if not custom_field_value:
                         continue
                     custom_field_value = u', '.join(custom_field_value)

--- a/opengever/latex/tests/test_dossierdetails.py
+++ b/opengever/latex/tests/test_dossierdetails.py
@@ -10,6 +10,7 @@ from opengever.kub.testing import KuBIntegrationTestCase
 from opengever.latex.dossierdetails import IDossierDetailsLayer
 from opengever.latex.layouts.default import DefaultLayout
 from opengever.propertysheets.storage import PropertySheetSchemaStorage
+from opengever.propertysheets.utils import set_custom_property
 from opengever.testing import IntegrationTestCase
 from zope.component import getMultiAdapter
 import json
@@ -93,6 +94,17 @@ class TestDossierDetails(TestDossierDetailsBase):
         dossierdetails = self.get_dossierdetails_view(dossier)
         self.assertEqual('\\bf Choose & zw\xc3\xb6i \\\\%%\n'
                          '\\bf Choose Multi & three, one \\\\%%\n'
+                         '\\bf A line of text & bl\xc3\xa4 \\\\%%\n'
+                         '\\bf Birthday & 30.01.2022 \\\\%%\n'
+                         '\\bf Number & 12 \\\\%%\n'
+                         '\\bf Some lines of text & Irgend \xc3\xa4 Texscht \\\\%%\n'
+                         '\\bf Yes or no & Yes \\\\%%', dossierdetails.get_custom_fields_data())
+
+        # handle lists correctly
+        set_custom_property(dossier, 'choosemulti', value=["two", "three"])
+        dossierdetails = self.get_dossierdetails_view(dossier)
+        self.assertEqual('\\bf Choose & zw\xc3\xb6i \\\\%%\n'
+                         '\\bf Choose Multi & two, three \\\\%%\n'
                          '\\bf A line of text & bl\xc3\xa4 \\\\%%\n'
                          '\\bf Birthday & 30.01.2022 \\\\%%\n'
                          '\\bf Number & 12 \\\\%%\n'


### PR DESCRIPTION
It seems that in some cases custom properties with multiple values return a list and not a set. [A similar issue was already fixed for docproperties](https://github.com/4teamwork/opengever.core/pull/7710).

This might need to be backported for Zug.

This fixes https://sentry.4teamwork.ch/organizations/sentry/issues/98136

For [CA-6217]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- Bug fixed:
  - [x] Resolved any Sentry issues caused by this bug

[CA-6217]: https://4teamwork.atlassian.net/browse/CA-6217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ