### PR TITLE
Remove unnecessary term splitting solr livesearch preprocessing.

### DIFF
--- a/changes/CA-6264.other
+++ b/changes/CA-6264.other
@@ -1,0 +1,1 @@
+Remove unnecessary term splitting solr livesearch preprocessing. [njohner]

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -175,8 +175,6 @@ class SolrQueryBaseService(Service, RequestPayloadMixin):
 
 OPERATORS = ["and", "or", "&&", "||", "not", "!"]
 IGNORED_TOKENS = ["/"]
-TERM_SPLIT_TOKENS = [",", ";", r"\?", "!", "-", r"\+", "/", "\\\\", r"\|", "<", ">", "=", "%", "#", "@"]
-term_split_pattern = re.compile("|".join(TERM_SPLIT_TOKENS))
 part_split_pattern = re.compile(r'; |, |\. |\s')
 
 
@@ -188,26 +186,12 @@ class LiveSearchQueryPreprocessingMixin(object):
             return term
         if term in IGNORED_TOKENS:
             return None
-        prefix = ""
         term = term.rstrip(";,.")
-        if term.startswith("-"):
-            prefix = "-"
-            term = term.lstrip("-")
-        elif term.startswith("+"):
-            prefix = "+"
-            term = term.lstrip("+")
-        tokens = ["{}{}".format(prefix, token)
-                  for token in term_split_pattern.split(term)]
 
         # Handle bracket and add wildcard to last token
-        last_token = tokens[-1]
-        n_brackets = len(last_token) - len(last_token.rstrip(")"))
-        last_token = last_token.rstrip(")").rstrip("*") + "*" + n_brackets * ")"
-        tokens[-1] = last_token
-
-        if len(tokens) > 1:
-            return "({})".format(" ".join(tokens))
-        return tokens[0]
+        n_brackets = len(term) - len(term.rstrip(")"))
+        term = term.rstrip(")").rstrip("*") + "*" + n_brackets * ")"
+        return term
 
     @staticmethod
     def _preprocess_phrase(phrase, phrase_prefix):

--- a/opengever/api/tests/test_solrsearch.py
+++ b/opengever/api/tests/test_solrsearch.py
@@ -1375,7 +1375,6 @@ class TestSolrLiveSearchGet(SolrIntegrationTestCase):
              u'Antrag f\xfcr Kreiselbau'],
             [item["title"] for item in livesearch["items"]])
 
-
         query = {"q": "Kreiselbau"}
         search = self.solr_search(browser, query)
         livesearch = self.solr_livesearch(browser, query)
@@ -1842,6 +1841,29 @@ class TestSolrLiveSearchGet(SolrIntegrationTestCase):
         self.assertItemsEqual(
             [u'Client1 11-1.1.1-23'],
             [item["reference_number"] for item in search["items"]])
+
+    @browsing
+    def test_livesearch_handles_alphanumeric_tokens(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        self.document.title = "4A.BE.2301-11B/C32"
+        self.document.reindexObject(idxs=["Title"])
+        self.commit_solr()
+
+        queries = [{"q": "4A.BE.2301-11B/C32"},
+                   {"q": "4A.BE.2301-11"},
+                   {"q": "4A.BE"}]
+        for query in queries:
+            search = self.solr_search(browser, query)
+            livesearch = self.solr_livesearch(browser, query)
+            self.assertEqual(1, search["items_total"])
+            self.assertEqual(1, livesearch["items_total"])
+            self.assertItemsEqual(
+                [self.document.absolute_url()],
+                [item["@id"] for item in livesearch[u'items']])
+            self.assertItemsEqual(
+                [self.document.absolute_url()],
+                [item["@id"] for item in search[u'items']])
 
     @browsing
     def test_querying_filenames(self, browser):


### PR DESCRIPTION
Splitting terms in solr livesearch query preprocessing is not necessary anymore since we are not using the `StandardTokenizer` anymore.

This change is not necessary to fix the specific case described in the Story, but it still improves results and simplifies the preprocessing.

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-6264]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-6264]: https://4teamwork.atlassian.net/browse/CA-6264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ