### PR TITLE
Use lenient dossier resolver by default for newly created policies.

### DIFF
--- a/changes/CA-6219.other
+++ b/changes/CA-6219.other
@@ -1,0 +1,1 @@
+Use lenient dossier resolver by default for newly created policies. [njohner]

--- a/opengever/policytemplates/policy_template/.mrbob.ini
+++ b/opengever/policytemplates/policy_template/.mrbob.ini
@@ -103,6 +103,11 @@ deployment.records_manager_group.required = True
 deployment.archivist_group.question = Archivist group
 deployment.archivist_group.required = True
 
+setup.use_lenient_dossier_resolver.question = Use lenient dossier resolver
+setup.use_lenient_dossier_resolver.required = True
+setup.use_lenient_dossier_resolver.default = true
+setup.use_lenient_dossier_resolver.post_ask_question = mrbob.hooks:to_boolean
+
 setup.enable_activity_feature.question = Enable activity feature
 setup.enable_activity_feature.required = True
 setup.enable_activity_feature.default = true

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/profiles/default/registry.xml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/profiles/default/registry.xml.bob
@@ -120,6 +120,12 @@
   </records>
 
 {{% endif %}}
+{{% if setup.use_lenient_dossier_resolver %}}
+  <records interface="opengever.dossier.interfaces.IDossierResolveProperties">
+    <value key="resolver_name">lenient</value>
+  </records>
+
+{{% endif %}}
 {{% if not setup.preserved_as_paper %}}
   <records interface="opengever.document.interfaces.IDocumentSettings">
       <value key="preserved_as_paper_default">False</value>


### PR DESCRIPTION
I did not change the default on the `IDossierResolveProperties` interface, as this might affect existing deployments. Instead we simply set the lenient resolver in the policy templates by default.
 
For [CA-6219]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-6219]: https://4teamwork.atlassian.net/browse/CA-6219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ