### PR TITLE
Add support for viewing documents with Office Connector

### DIFF
--- a/changes/CA-5815.feature
+++ b/changes/CA-5815.feature
@@ -1,0 +1,1 @@
+Add support for viewing documents with Office Connector. [buchi]

--- a/opengever/api/tests/test_actions.py
+++ b/opengever/api/tests/test_actions.py
@@ -151,6 +151,7 @@ class TestFileActionsGetForWorkspaceDocument(FileActionsTestBase):
     def test_available_file_actions_for_workspace_document(self, browser):
         self.login(self.workspace_member, browser)
         expected_file_actions = [
+            {u'icon': u'', u'id': u'oc_view', u'title': u'View'},
             {u'icon': u'', u'id': u'oc_direct_checkout', u'title': u'Checkout and edit'},
             {u'icon': u'', u'id': u'download_copy', u'title': u'Download copy'},
             {u'icon': u'', u'id': u'attach_to_email', u'title': u'Attach to email'},
@@ -167,6 +168,7 @@ class TestFileActionsGetForWorkspaceDocument(FileActionsTestBase):
         self.login(self.workspace_member, browser)
         ITrasher(self.workspace_document).trash()
         expected_file_actions = [
+            {u'icon': u'', u'id': u'oc_view', u'title': u'View'},
             {u'icon': u'', u'id': u'download_copy', u'title': u'Download copy'},
             {u'icon': u'', u'id': u'attach_to_email', u'title': u'Attach to email'},
             {u'icon': u'', u'id': u'open_as_pdf', u'title': u'Open as PDF'},
@@ -185,6 +187,9 @@ class TestFileActionsGetForMails(FileActionsTestBase):
     def test_available_file_actions(self, browser):
         self.login(self.regular_user, browser)
         expected_file_actions = [
+            {u'id': u'oc_view',
+             u'title': u'View',
+             u'icon': u''},
             {u'id': u'download_copy',
              u'title': u'Download copy',
              u'icon': u''},
@@ -212,6 +217,9 @@ class TestFileActionsGetForDocuments(FileActionsTestBase):
     def test_available_file_actions(self, browser):
         self.login(self.regular_user, browser)
         expected_file_actions = [
+            {u'id': u'oc_view',
+             u'icon': u'',
+             u'title': u'View'},
             {u'id': u'oc_direct_checkout',
              u'title': u'Checkout and edit',
              u'icon': u''},
@@ -276,6 +284,9 @@ class TestFileActionsGetForDocuments(FileActionsTestBase):
         self.login(self.regular_user, browser)
 
         expected_file_actions = [
+            {u'id': u'oc_view',
+             u'title': u'View',
+             u'icon': u''},
             {u'id': u'open_as_pdf',
              u'title': u'Open as PDF',
              u'icon': u''},
@@ -298,6 +309,9 @@ class TestFileActionsGetForDocuments(FileActionsTestBase):
         self.login(self.regular_user, browser)
 
         expected_file_actions = [
+            {u'id': u'oc_view',
+             u'icon': u'',
+             u'title': u'View'},
             {u'id': u'download_copy',
              u'title': u'Download copy',
              u'icon': u''},
@@ -323,6 +337,9 @@ class TestFileActionsGetForDocuments(FileActionsTestBase):
         self.login(self.regular_user, browser)
 
         expected_file_actions = [
+            {u'id': u'oc_view',
+             u'icon': u'',
+             u'title': u'View'},
             {u'id': u'download_copy',
              u'title': u'Download copy',
              u'icon': u''},
@@ -343,52 +360,27 @@ class TestFileActionsGetForDocuments(FileActionsTestBase):
     def test_oc_zem_checkout_available_if_oc_checkout_deactivated(self, browser):
         self.deactivate_feature('officeconnector-checkout')
         self.login(self.regular_user, browser)
-        expected_file_actions = [
-            {u'id': u'oc_zem_checkout',
-             u'title': u'Checkout and edit',
-             u'icon': u''},
-            {u'id': u'download_copy',
-             u'title': u'Download copy',
-             u'icon': u''},
-            {u'id': u'attach_to_email',
-             u'title': u'Attach to email',
-             u'icon': u''},
-            {u'id': u'open_as_pdf',
-             u'title': u'Open as PDF',
-             u'icon': u''},
-            {u'id': u'trash_context',
-             u'title': u'Trash',
-             u'icon': u''},
-            {u'id': u'new_task_from_document',
-             u'title': u'New task from document',
-             u'icon': u''},
-            ]
-        self.assertEqual(expected_file_actions,
-                         self.get_file_actions(browser, self.document))
+        self.assertIn(
+            {
+                u'id': u'oc_zem_checkout',
+                u'title': u'Checkout and edit',
+                u'icon': u'',
+            },
+            self.get_file_actions(browser, self.document),
+        )
 
     @browsing
     def test_oc_unsupported_file_checkout_available_if_file_not_oc_editable(self, browser):
         self.login(self.regular_user, browser)
         self.document.file.contentType = u'foo/bar'
-        expected_file_actions = [
-            {u'id': u'oc_unsupported_file_checkout',
-             u'title': u'Checkout',
-             u'icon': u''},
-            {u'id': u'download_copy',
-             u'title': u'Download copy',
-             u'icon': u''},
-            {u'id': u'attach_to_email',
-             u'title': u'Attach to email',
-             u'icon': u''},
-            {u'id': u'trash_context',
-             u'title': u'Trash',
-             u'icon': u''},
-            {u'id': u'new_task_from_document',
-             u'title': u'New task from document',
-             u'icon': u''},
-            ]
-        self.assertEqual(expected_file_actions,
-                         self.get_file_actions(browser, self.document))
+        self.assertIn(
+            {
+                u'id': u'oc_unsupported_file_checkout',
+                u'title': u'Checkout',
+                u'icon': u'',
+            },
+            self.get_file_actions(browser, self.document),
+        )
 
     @browsing
     def test_checkin_available_if_checked_out_by_current_user(self, browser):
@@ -466,61 +458,65 @@ class TestFileActionsGetForDocuments(FileActionsTestBase):
         self.checkout_document(self.document)
 
         self.login(self.manager, browser)
-        expected_manager_file_actions = [
-            {u'id': u'checkin_without_comment',
-             u'title': u'Check in without comment',
-             u'icon': u''},
-            {u'id': u'checkin_with_comment',
-             u'title': u'Check in with comment',
-             u'icon': u''},
-            {u'id': u'cancel_checkout',
-             u'title': u'Cancel checkout',
-             u'icon': u''},
-            {u'id': u'open_as_pdf',
-             u'title': u'Open as PDF',
-             u'icon': u''},
-            {u'id': u'new_task_from_document',
-             u'title': u'New task from document',
-             u'icon': u''},
-            ]
-        self.assertEqual(expected_manager_file_actions,
-                         self.get_file_actions(browser, self.document))
+        self.assertIn(
+            {
+                u'id': u'checkin_without_comment',
+                u'title': u'Check in without comment',
+                u'icon': u'',
+            },
+            self.get_file_actions(browser, self.document),
+        )
+        self.assertIn(
+            {
+                u'id': u'checkin_with_comment',
+                u'title': u'Check in with comment',
+                u'icon': u'',
+            },
+            self.get_file_actions(browser, self.document),
+        )
+        self.assertIn(
+            {
+                u'id': u'cancel_checkout',
+                u'title': u'Cancel checkout',
+                u'icon': u'',
+            },
+            self.get_file_actions(browser, self.document),
+        )
 
         self.login(self.dossier_manager, browser)
-        expected_dossier_manager_file_actions = [
-            {u'id': u'open_as_pdf',
-             u'title': u'Open as PDF',
-             u'icon': u''},
-            {u'id': u'new_task_from_document',
-             u'title': u'New task from document',
-             u'icon': u''},
-            ]
-        self.assertEqual(expected_dossier_manager_file_actions,
-                         self.get_file_actions(browser, self.document))
+        self.assertNotIn(
+            {
+                u'id': u'checkin_without_comment',
+                u'title': u'Check in without comment',
+                u'icon': u'',
+            },
+            self.get_file_actions(browser, self.document),
+        )
+        self.assertNotIn(
+            {
+                u'id': u'checkin_with_comment',
+                u'title': u'Check in with comment',
+                u'icon': u'',
+            },
+            self.get_file_actions(browser, self.document),
+        )
+        self.assertNotIn(
+            {
+                u'id': u'cancel_checkout',
+                u'title': u'Cancel checkout',
+                u'icon': u'',
+            },
+            self.get_file_actions(browser, self.document),
+        )
 
     @browsing
     def test_attach_not_available_if_feature_disabled(self, browser):
         self.deactivate_feature('officeconnector-attach')
         self.login(self.regular_user, browser)
-        expected_file_actions = [
-            {u'id': u'oc_direct_checkout',
-             u'title': u'Checkout and edit',
-             u'icon': u''},
-            {u'id': u'download_copy',
-             u'title': u'Download copy',
-             u'icon': u''},
-            {u'id': u'open_as_pdf',
-             u'title': u'Open as PDF',
-             u'icon': u''},
-            {u'id': u'trash_context',
-             u'title': u'Trash',
-             u'icon': u''},
-            {u'id': u'new_task_from_document',
-             u'title': u'New task from document',
-             u'icon': u''},
-            ]
-        self.assertEqual(expected_file_actions,
-                         self.get_file_actions(browser, self.document))
+        self.assertNotIn(
+            {u'icon': u'', u'id': u'attach_to_email', u'title': u'Attach to email'},
+            self.get_file_actions(browser, self.document)
+        )
 
     @browsing
     def test_oneoffixx_retry_available_for_shadow_documents(self, browser):
@@ -544,25 +540,10 @@ class TestFileActionsGetForDocuments(FileActionsTestBase):
     def test_open_as_pdf_not_available_if_bumblebee_disabled(self, browser):
         self.deactivate_feature('bumblebee')
         self.login(self.regular_user, browser)
-        expected_file_actions = [
-            {u'id': u'oc_direct_checkout',
-             u'title': u'Checkout and edit',
-             u'icon': u''},
-            {u'id': u'download_copy',
-             u'title': u'Download copy',
-             u'icon': u''},
-            {u'id': u'attach_to_email',
-             u'title': u'Attach to email',
-             u'icon': u''},
-            {u'id': u'trash_context',
-             u'title': u'Trash',
-             u'icon': u''},
-            {u'id': u'new_task_from_document',
-             u'title': u'New task from document',
-             u'icon': u''},
-            ]
-        self.assertEqual(expected_file_actions,
-                         self.get_file_actions(browser, self.document))
+        self.assertNotIn(
+            {u'id': u'open_as_pdf', u'title': u'Open as PDF', u'icon': u''},
+            self.get_file_actions(browser, self.document)
+        )
 
     @browsing
     def test_oc_view_available_if_document_has_file(self, browser):
@@ -595,28 +576,14 @@ class TestTrashingActionsForDocuments(FileActionsTestBase):
     @browsing
     def test_trashing_available_for_document(self, browser):
         self.login(self.regular_user, browser)
-        expected_file_actions = [
-            {u'id': u'oc_direct_checkout',
-             u'title': u'Checkout and edit',
-             u'icon': u''},
-            {u'id': u'download_copy',
-             u'title': u'Download copy',
-             u'icon': u''},
-            {u'id': u'attach_to_email',
-             u'title': u'Attach to email',
-             u'icon': u''},
-            {u'id': u'open_as_pdf',
-             u'title': u'Open as PDF',
-             u'icon': u''},
-            {u'id': u'trash_context',
-             u'title': u'Trash',
-             u'icon': u''},
-            {u'id': u'new_task_from_document',
-             u'title': u'New task from document',
-             u'icon': u''},
-            ]
-        self.assertEqual(expected_file_actions,
-                         self.get_file_actions(browser, self.document))
+        self.assertIn(
+            {
+                u'id': u'trash_context',
+                u'title': u'Trash',
+                u'icon': u'',
+            },
+            self.get_file_actions(browser, self.document),
+        )
 
     @browsing
     def test_untrashing_available_for_trashed_document(self, browser):
@@ -625,25 +592,14 @@ class TestTrashingActionsForDocuments(FileActionsTestBase):
         trasher = ITrasher(self.document)
         trasher.trash()
 
-        expected_file_actions = [
-            {u'id': u'download_copy',
-             u'title': u'Download copy',
-             u'icon': u''},
-            {u'id': u'attach_to_email',
-             u'title': u'Attach to email',
-             u'icon': u''},
-            {u'id': u'open_as_pdf',
-             u'title': u'Open as PDF',
-             u'icon': u''},
-            {u'id': u'untrash_context',
-             u'title': u'Untrash',
-             u'icon': u''},
-            {u'id': u'new_task_from_document',
-             u'title': u'New task from document',
-             u'icon': u''},
-            ]
-        self.assertEqual(expected_file_actions,
-                         self.get_file_actions(browser, self.document))
+        self.assertIn(
+            {
+                u'id': u'untrash_context',
+                u'title': u'Untrash',
+                u'icon': u'',
+            },
+            self.get_file_actions(browser, self.document),
+        )
 
 
 class TestFileActionsGetForTemplates(FileActionsTestBase):
@@ -653,6 +609,7 @@ class TestFileActionsGetForTemplates(FileActionsTestBase):
         self.login(self.dossier_responsible, browser)
 
         expected_file_actions = [
+            {u'icon': u'', u'id': u'oc_view', u'title': u'View'},
             {u'icon': u'', u'id': u'oc_direct_checkout', u'title': u'Checkout and edit'},
             {u'icon': u'', u'id': u'download_copy', u'title': u'Download copy'},
             {u'icon': u'', u'id': u'open_as_pdf', u'title': u'Open as PDF'}
@@ -673,6 +630,7 @@ class TestFileActionsGetForDossierTemplateDocuments(FileActionsTestBase):
                           .with_dummy_content())
 
         expected_file_actions = [
+            {u'icon': u'', u'id': u'oc_view', u'title': u'View'},
             {u'icon': u'', u'id': u'oc_direct_checkout', u'title': u'Checkout and edit'},
             {u'icon': u'', u'id': u'download_copy', u'title': u'Download copy'},
             {u'icon': u'', u'id': u'open_as_pdf', u'title': u'Open as PDF'}
@@ -690,6 +648,7 @@ class TestFileActionsGetForDossierTemplateDocuments(FileActionsTestBase):
                           .with_dummy_content())
 
         expected_file_actions = [
+            {u'icon': u'', u'id': u'oc_view', u'title': u'View'},
             {u'icon': u'', u'id': u'oc_direct_checkout', u'title': u'Checkout and edit'},
             {u'icon': u'', u'id': u'download_copy', u'title': u'Download copy'},
             {u'icon': u'', u'id': u'open_as_pdf', u'title': u'Open as PDF'},
@@ -707,6 +666,7 @@ class TestFileActionsGetForProposalTemplates(FileActionsTestBase):
     def test_available_file_actions_for_proposal_template(self, browser):
         self.login(self.dossier_responsible, browser)
         expected_file_actions = [
+            {u'icon': u'', u'id': u'oc_view', u'title': u'View'},
             {u'icon': u'', u'id': u'oc_direct_checkout', u'title': u'Checkout and edit'},
             {u'icon': u'', u'id': u'download_copy', u'title': u'Download copy'},
             {u'icon': u'', u'id': u'open_as_pdf', u'title': u'Open as PDF'},
@@ -727,108 +687,62 @@ class TestNewTaskFromDocumentAction(FileActionsTestBase):
         browser.open(self.resolvable_dossier,
                      view='transition-resolve',
                      data={'_authenticator': createToken()})
-        expected_file_actions = [
-            {u'id': u'download_copy',
-             u'title': u'Download copy',
-             u'icon': u''},
-            {u'id': u'attach_to_email',
-             u'title': u'Attach to email',
-             u'icon': u''},
-            {u'id': u'open_as_pdf',
-             u'title': u'Open as PDF',
-             u'icon': u''},
-            ]
-        self.assertEqual(expected_file_actions,
-                         self.get_file_actions(browser, self.resolvable_document))
+        self.assertNotIn(
+            {
+                u'id': u'new_task_from_document',
+                u'title': u'New task from document',
+                u'icon': u'',
+            },
+            self.get_file_actions(browser, self.resolvable_document),
+        )
 
     @browsing
     def test_task_from_doc_available_for_doc_in_task(self, browser):
         self.login(self.regular_user, browser)
-        expected_file_actions = [
-            {u'id': u'oc_direct_checkout',
-             u'title': u'Checkout and edit',
-             u'icon': u''},
-            {u'id': u'download_copy',
-             u'title': u'Download copy',
-             u'icon': u''},
-            {u'id': u'attach_to_email',
-             u'title': u'Attach to email',
-             u'icon': u''},
-            {u'id': u'open_as_pdf',
-             u'title': u'Open as PDF',
-             u'icon': u''},
-            {u'id': u'trash_context',
-             u'title': u'Trash',
-             u'icon': u''},
-            {u'id': u'new_task_from_document',
-             u'title': u'New task from document',
-             u'icon': u''},
-            ]
-        self.assertEqual(expected_file_actions,
-                         self.get_file_actions(browser, self.taskdocument))
+        self.assertIn(
+            {
+                u'id': u'new_task_from_document',
+                u'title': u'New task from document',
+                u'icon': u'',
+            },
+            self.get_file_actions(browser, self.taskdocument),
+        )
 
     @browsing
     def test_task_from_doc_not_available_for_doc_in_inbox(self, browser):
         self.login(self.secretariat_user, browser)
-        expected_file_actions = [
-            {u'id': u'oc_direct_checkout',
-             u'title': u'Checkout and edit',
-             u'icon': u''},
-            {u'id': u'download_copy',
-             u'title': u'Download copy',
-             u'icon': u''},
-            {u'id': u'attach_to_email',
-             u'title': u'Attach to email',
-             u'icon': u''},
-            {u'id': u'open_as_pdf',
-             u'title': u'Open as PDF',
-             u'icon': u''},
-            {u'id': u'trash_context',
-             u'title': u'Trash',
-             u'icon': u''},
-            ]
-        self.assertEqual(expected_file_actions,
-                         self.get_file_actions(browser, self.inbox_document))
+        self.assertNotIn(
+            {
+                u'id': u'new_task_from_document',
+                u'title': u'New task from document',
+                u'icon': u'',
+            },
+            self.get_file_actions(browser, self.inbox_document),
+        )
 
     @browsing
     def test_task_from_doc_not_available_for_doc_in_private_dossier(self, browser):
         self.login(self.regular_user, browser)
-        expected_file_actions = [
-            {u'id': u'oc_direct_checkout',
-             u'title': u'Checkout and edit',
-             u'icon': u''},
-            {u'id': u'download_copy',
-             u'title': u'Download copy',
-             u'icon': u''},
-            {u'id': u'attach_to_email',
-             u'title': u'Attach to email',
-             u'icon': u''},
-            {u'id': u'open_as_pdf',
-             u'title': u'Open as PDF',
-             u'icon': u''},
-            {u'id': u'trash_context',
-             u'title': u'Trash',
-             u'icon': u''},
-            ]
-        self.assertEqual(expected_file_actions,
-                         self.get_file_actions(browser, self.private_document))
+        self.assertNotIn(
+            {
+                u'id': u'new_task_from_document',
+                u'title': u'New task from document',
+                u'icon': u'',
+            },
+            self.get_file_actions(browser, self.private_document),
+        )
 
     @browsing
     def test_task_from_doc_not_available_for_doc_in_inactive_dossier(self, browser):
         self.login(self.regular_user, browser)
-        expected_file_actions = [
-            {u'id': u'download_copy',
-             u'title': u'Download copy',
-             u'icon': u''},
-            {u'id': u'attach_to_email',
-             u'title': u'Attach to email',
-             u'icon': u''},
-            {u'id': u'open_as_pdf',
-             u'title': u'Open as PDF',
-             u'icon': u''},
-            ]
-        self.assertEqual(expected_file_actions,
-                         self.get_file_actions(browser, self.inactive_document))
+        self.assertNotIn(
+            {
+                u'id': u'new_task_from_document',
+                u'title': u'New task from document',
+                u'icon': u'',
+            },
+            self.get_file_actions(browser, self.inactive_document),
+        )
 
 
 class TestUnlockAction(FileActionsTestBase):
@@ -838,97 +752,59 @@ class TestUnlockAction(FileActionsTestBase):
         self.login(self.regular_user, browser)
         ILockable(self.document).lock()
 
-        expected_file_actions = [
-            {u'id': u'download_copy',
-             u'title': u'Download copy',
-             u'icon': u''},
-            {u'id': u'attach_to_email',
-             u'title': u'Attach to email',
-             u'icon': u''},
-            {u'id': u'open_as_pdf',
-             u'title': u'Open as PDF',
-             u'icon': u''},
-            {u'id': u'new_task_from_document',
-             u'title': u'New task from document',
-             u'icon': u''},
-            {u'id': u'unlock',
-             u'title': u'Unlock',
-             u'icon': u''},
-            ]
-        self.assertEqual(expected_file_actions,
-                         self.get_file_actions(browser, self.document))
+        self.assertIn(
+            {
+                u'id': u'unlock',
+                u'title': u'Unlock',
+                u'icon': u'',
+            },
+            self.get_file_actions(browser, self.document),
+        )
 
     @browsing
     def test_unlock_not_available_if_document_is_locked_by_another_user(self, browser):
         self.login(self.regular_user, browser)
         ILockable(self.document).lock()
         self.login(self.dossier_responsible, browser)
-        expected_file_actions = [
-            {u'id': u'download_copy',
-             u'title': u'Download copy',
-             u'icon': u''},
-            {u'id': u'attach_to_email',
-             u'title': u'Attach to email',
-             u'icon': u''},
-            {u'id': u'open_as_pdf',
-             u'title': u'Open as PDF',
-             u'icon': u''},
-            {u'id': u'new_task_from_document',
-             u'title': u'New task from document',
-             u'icon': u''},
-            ]
-        self.assertEqual(expected_file_actions,
-                         self.get_file_actions(browser, self.document))
+
+        self.assertNotIn(
+            {
+                u'id': u'unlock',
+                u'title': u'Unlock',
+                u'icon': u'',
+            },
+            self.get_file_actions(browser, self.document),
+        )
 
     @browsing
     def test_unlock_available_for_manager(self, browser):
         self.login(self.regular_user, browser)
         ILockable(self.document).lock()
         self.login(self.manager, browser)
-        expected_file_actions = [
-            {u'id': u'download_copy',
-             u'title': u'Download copy',
-             u'icon': u''},
-            {u'id': u'attach_to_email',
-             u'title': u'Attach to email',
-             u'icon': u''},
-            {u'id': u'open_as_pdf',
-             u'title': u'Open as PDF',
-             u'icon': u''},
-            {u'id': u'new_task_from_document',
-             u'title': u'New task from document',
-             u'icon': u''},
-            {u'id': u'unlock',
-             u'title': u'Unlock',
-             u'icon': u''},
-            ]
-        self.assertEqual(expected_file_actions,
-                         self.get_file_actions(browser, self.document))
+
+        self.assertIn(
+            {
+                u'id': u'unlock',
+                u'title': u'Unlock',
+                u'icon': u'',
+            },
+            self.get_file_actions(browser, self.document),
+        )
 
     @browsing
     def test_unlock_available_if_document_is_locked_by_workspace_lock(self, browser):
         self.login(self.regular_user, browser)
         ILockable(self.document).lock(COPIED_TO_WORKSPACE_LOCK)
         self.login(self.dossier_responsible, browser)
-        expected_file_actions = [
-            {u'id': u'download_copy',
-             u'title': u'Download copy',
-             u'icon': u''},
-            {u'id': u'attach_to_email',
-             u'title': u'Attach to email',
-             u'icon': u''},
-            {u'id': u'open_as_pdf',
-             u'title': u'Open as PDF',
-             u'icon': u''},
-            {u'id': u'new_task_from_document',
-             u'title': u'New task from document',
-             u'icon': u''},
-            {u'id': u'unlock',
-             u'title': u'Unlock',
-             u'icon': u''},
-            ]
-        self.assertEqual(expected_file_actions,
-                         self.get_file_actions(browser, self.document))
+
+        self.assertIn(
+            {
+                u'id': u'unlock',
+                u'title': u'Unlock',
+                u'icon': u'',
+            },
+            self.get_file_actions(browser, self.document),
+        )
 
 
 class TestFolderButtons(FolderActionsTestBase):

--- a/opengever/api/tests/test_actions.py
+++ b/opengever/api/tests/test_actions.py
@@ -564,6 +564,31 @@ class TestFileActionsGetForDocuments(FileActionsTestBase):
         self.assertEqual(expected_file_actions,
                          self.get_file_actions(browser, self.document))
 
+    @browsing
+    def test_oc_view_available_if_document_has_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.assertIn(
+            {u'id': u'oc_view', u'title': u'View', u'icon': u''},
+            self.get_file_actions(browser, self.document)
+        )
+
+    @browsing
+    def test_oc_view_not_available_if_document_has_no_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.assertNotIn(
+            {u'id': u'oc_view', u'title': u'View', u'icon': u''},
+            self.get_file_actions(browser, self.empty_document)
+        )
+
+    @browsing
+    def test_oc_view_not_available_if_document_is_checked_out_by_current_user(self, browser):
+        self.login(self.regular_user, browser)
+        self.checkout_document(self.document)
+        self.assertNotIn(
+            {u'id': u'oc_view', u'title': u'View', u'icon': u''},
+            self.get_file_actions(browser, self.document)
+        )
+
 
 class TestTrashingActionsForDocuments(FileActionsTestBase):
 

--- a/opengever/base/context_actions.py
+++ b/opengever/base/context_actions.py
@@ -51,6 +51,7 @@ class BaseContextActions(object):
         self.maybe_add_new_task_from_document()
         self.maybe_add_oc_direct_checkout()
         self.maybe_add_oc_direct_edit()
+        self.maybe_add_oc_view()
         self.maybe_add_office_online_edit()
         self.maybe_add_oneoffixx_retry()
         self.maybe_add_open_as_pdf()
@@ -187,6 +188,9 @@ class BaseContextActions(object):
         return False
 
     def is_oc_direct_edit_available(self):
+        return False
+
+    def is_oc_view_available(self):
         return False
 
     def is_office_online_edit_available(self):
@@ -388,6 +392,10 @@ class BaseContextActions(object):
     def maybe_add_oc_direct_edit(self):
         if self.is_oc_direct_edit_available():
             self.add_action(u'oc_direct_edit')
+
+    def maybe_add_oc_view(self):
+        if self.is_oc_view_available():
+            self.add_action(u'oc_view')
 
     def maybe_add_office_online_edit(self):
         if self.is_office_online_edit_available():

--- a/opengever/bumblebee/tests/test_overlay_view.py
+++ b/opengever/bumblebee/tests/test_overlay_view.py
@@ -172,6 +172,7 @@ class TestBumblebeeOverlayListing(IntegrationTestCase):
 
         self.assertEqual(
             [
+                'View (read-only)',
                 'Edit metadata',
                 'Check out and edit',
                 'Download copy',
@@ -233,6 +234,7 @@ class TestBumblebeeOverlayListing(IntegrationTestCase):
 
         self.assertEqual(
             [
+                'View (read-only)',
                 'Open as PDF',
                 'Open detail view',
                 ],
@@ -247,6 +249,7 @@ class TestBumblebeeOverlayListing(IntegrationTestCase):
 
         self.assertEqual(
             [
+                'View (read-only)',
                 'Edit metadata',
                 'Download copy',
                 'Attach to email',
@@ -268,6 +271,7 @@ class TestBumblebeeOverlayListing(IntegrationTestCase):
 
         self.assertEqual(
             [
+                'View (read-only)',
                 'Download copy',
                 'Attach to email',
                 'Restore this version',
@@ -342,6 +346,7 @@ class TestBumblebeeOverlayDocument(IntegrationTestCase):
 
         self.assertEqual(
             [
+                'View (read-only)',
                 'Edit metadata',
                 'Check out and edit',
                 'Download copy',
@@ -400,6 +405,7 @@ class TestBumblebeeOverlayDocument(IntegrationTestCase):
 
         self.assertEqual(
             [
+                'View (read-only)',
                 'Open as PDF',
                 ],
             browser.css('.file-action-buttons a').text,
@@ -413,6 +419,7 @@ class TestBumblebeeOverlayDocument(IntegrationTestCase):
 
         self.assertEqual(
             [
+                'View (read-only)',
                 'Edit metadata',
                 'Download copy',
                 'Attach to email',
@@ -433,6 +440,7 @@ class TestBumblebeeOverlayDocument(IntegrationTestCase):
 
         self.assertEqual(
             [
+                'View (read-only)',
                 'Download copy',
                 'Attach to email',
                 'Restore this version',

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -18,6 +18,15 @@
   <!-- FILE ACTIONS used to list available actions through the actions endpoint-->
   <object name="file_actions" meta_type="CMF Action Category">
 
+    <object name="oc_view" meta_type="CMF Action" i18n:domain="opengever.document">
+      <property name="title" i18n:translate="label_view">View</property>
+      <property name="available_expr">object/@@file_actions_availability/is_oc_view_action_available</property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
     <object name="oc_direct_checkout" meta_type="CMF Action" i18n:domain="opengever.document">
       <property name="title" i18n:translate="label_checkout_and_edit">Checkout and edit</property>
       <property name="available_expr">object/@@file_actions_availability/is_oc_direct_checkout_action_available</property>

--- a/opengever/core/upgrades/20231006164401_add_view_document_action/actions.xml
+++ b/opengever/core/upgrades/20231006164401_add_view_document_action/actions.xml
@@ -1,0 +1,15 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="portal_actions" meta_type="Plone Actions Tool">
+
+  <object name="file_actions" meta_type="CMF Action Category">
+
+    <object name="oc_view" meta_type="CMF Action" i18n:domain="opengever.document" insert-before="oc_direct_checkout">
+      <property name="title" i18n:translate="label_view">View</property>
+      <property name="available_expr">object/@@file_actions_availability/is_oc_view_action_available</property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
+  </object>
+</object>

--- a/opengever/core/upgrades/20231006164401_add_view_document_action/upgrade.py
+++ b/opengever/core/upgrades/20231006164401_add_view_document_action/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddViewDocumentAction(UpgradeStep):
+    """Add view document action.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/document/actions.py
+++ b/opengever/document/actions.py
@@ -261,6 +261,9 @@ class DocumentSchemaContextActions(BaseDocumentContextActions):
     def is_oc_direct_edit_available(self):
         return self.file_actions.is_oc_direct_edit_action_available()
 
+    def is_oc_view_available(self):
+        return self.file_actions.is_oc_view_action_available()
+
     def is_office_online_edit_available(self):
         return self.file_actions.is_office_online_edit_action_available()
 

--- a/opengever/document/browser/actionbuttons.py
+++ b/opengever/document/browser/actionbuttons.py
@@ -75,6 +75,12 @@ class VisibleActionButtonRendererMixin(FileActionAvailabilityMixin):
     def is_open_as_pdf_action_visible(self):
         return False
 
+    def get_oc_view_url(self):
+        return (
+            u"javascript:officeConnectorCheckout("
+            "'{}/officeconnector_view_url'"
+            ");".format(self.context.absolute_url()))
+
     def get_oc_direct_checkout_url(self):
         return (
             u"javascript:officeConnectorCheckout("

--- a/opengever/document/browser/templates/macros.pt
+++ b/opengever/document/browser/templates/macros.pt
@@ -2,6 +2,15 @@
 
     <div class="file-action-buttons">
 
+        <tal:oc_view tal:condition="view/is_oc_view_action_available">
+            <a tal:attributes="href view/get_oc_view_url;
+                               data-document-url context/absolute_url"
+                class="function-view-details oc-view"
+                i18n:translate="label_view">
+                View
+            </a>
+        </tal:oc_view>
+
         <tal:edit_metadata tal:condition="view/is_edit_metadata_action_visible">
             <a class="function-edit-metadata"
                 tal:attributes="href view/get_edit_metadata_url"

--- a/opengever/document/fileactions.py
+++ b/opengever/document/fileactions.py
@@ -51,6 +51,9 @@ class BaseDocumentFileActions(object):
     def is_office_online_edit_action_available(self):
         return False
 
+    def is_oc_view_action_available(self):
+        return self.context.has_file()
+
     def is_oc_direct_checkout_action_available(self):
         return False
 
@@ -176,6 +179,15 @@ class DocumentFileActions(BaseDocumentFileActions):
                 and self.context.is_checkout_permitted()
                 and self.context.is_office_online_editable()
                 and self._can_edit_with_office_online())
+
+    def is_oc_view_action_available(self):
+        manager = getMultiAdapter(
+            (self.context, self.request), ICheckinCheckoutManager)
+
+        return (
+            self.context.has_file()
+            and not manager.is_checked_out_by_current_user()
+        )
 
     def is_oc_direct_checkout_action_available(self):
         return (self.is_any_checkout_or_edit_available()

--- a/opengever/document/interfaces.py
+++ b/opengever/document/interfaces.py
@@ -162,6 +162,10 @@ class IFileActions(Interface):
     def is_office_online_edit_action_available():
         """Return whether the edit with Office Online action is available."""
 
+    def is_oc_view_action_available():
+        """Return whether OfficeConnector view document action is available.
+        """
+
     def is_oc_direct_checkout_action_available():
         """Return whether OfficeConnector direct checkout action is available.
         """

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2023-06-23 10:57+0000\n"
+"POT-Creation-Date: 2023-10-06 14:48+0000\n"
 "PO-Revision-Date: 2017-10-13 14:27+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -690,6 +690,11 @@ msgstr "Titel"
 #: ./opengever/document/browser/versions_tab.py
 msgid "label_version"
 msgstr "Version"
+
+#. Default: "View"
+#: ./opengever/document/browser/templates/macros.pt
+msgid "label_view"
+msgstr "Anzeigen (schreibgeschützt)"
 
 #. Default: "This document is currently being worked on. When you check it in manually you will lose the changes. Please allow for the process to be finished first."
 #: ./opengever/document/checkout/checkin.py

--- a/opengever/document/locales/en/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/en/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2023-06-23 10:57+0000\n"
+"POT-Creation-Date: 2023-10-06 14:48+0000\n"
 "PO-Revision-Date: 2017-10-13 14:27+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -818,6 +818,11 @@ msgstr "Title"
 #: ./opengever/document/browser/versions_tab.py
 msgid "label_version"
 msgstr "Version"
+
+#. Default: "View"
+#: ./opengever/document/browser/templates/macros.pt
+msgid "label_view"
+msgstr "View (read-only)"
 
 #. German translation: Dieses Dokument wird gerade bearbeitet. Wenn Sie es manuell einchecken, so gehen die Änderungen verloren. Bitte veranlassen Sie, dass die Bearbeitung des Dokuments zuerst abgeschlossen wird.
 #. Default: "This document is currently being worked on. When you check it in manually you will lose the changes. Please allow for the process to be finished first."

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-06-23 10:57+0000\n"
+"POT-Creation-Date: 2023-10-06 14:48+0000\n"
 "PO-Revision-Date: 2017-09-03 08:50+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-document/fr/>\n"
@@ -687,6 +687,11 @@ msgstr "Titre"
 #: ./opengever/document/browser/versions_tab.py
 msgid "label_version"
 msgstr "Version"
+
+#. Default: "View"
+#: ./opengever/document/browser/templates/macros.pt
+msgid "label_view"
+msgstr "Voir (en lecture seule)"
 
 #. Default: "This document is currently being worked on. When you check it in manually you will lose the changes. Please allow for the process to be finished first."
 #: ./opengever/document/checkout/checkin.py

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-06-23 10:57+0000\n"
+"POT-Creation-Date: 2023-10-06 14:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -683,6 +683,11 @@ msgstr ""
 #. Default: "Version"
 #: ./opengever/document/browser/versions_tab.py
 msgid "label_version"
+msgstr ""
+
+#. Default: "View"
+#: ./opengever/document/browser/templates/macros.pt
+msgid "label_view"
 msgstr ""
 
 #. Default: "This document is currently being worked on. When you check it in manually you will lose the changes. Please allow for the process to be finished first."

--- a/opengever/document/tests/test_actions.py
+++ b/opengever/document/tests/test_actions.py
@@ -121,56 +121,117 @@ class TestDocumentContextActions(IntegrationTestCase):
 
     def test_context_actions_for_document_in_dossier(self):
         self.login(self.regular_user)
-        expected_actions = [u'attach_to_email', u'checkout_document', u'copy_item',
-                            u'download_copy', u'edit', u'move_item', u'new_task_from_document',
-                            u'oc_direct_checkout', u'open_as_pdf', u'revive_bumblebee_preview',
-                            u'save_document_as_pdf', u'trash_context']
+        expected_actions = [
+            u'attach_to_email',
+            u'checkout_document',
+            u'copy_item',
+            u'download_copy',
+            u'edit',
+            u'move_item',
+            u'new_task_from_document',
+            u'oc_direct_checkout',
+            u'oc_view',
+            u'open_as_pdf',
+            u'revive_bumblebee_preview',
+            u'save_document_as_pdf',
+            u'trash_context',
+        ]
         self.assertEqual(expected_actions, self.get_actions(self.document))
 
     def test_context_actions_for_trashed_document_in_dossier(self):
         self.login(self.regular_user)
         ITrasher(self.document).trash()
-        expected_actions = [u'revive_bumblebee_preview', u'untrash_context']
+        expected_actions = [
+            u'oc_view',
+            u'revive_bumblebee_preview',
+            u'untrash_context',
+        ]
         self.assertEqual(expected_actions, self.get_actions(self.document))
 
     def test_context_actions_for_checked_out_document(self):
         self.login(self.regular_user)
         self.assertIn(u'copy_item', self.get_actions(self.document))
         queryMultiAdapter((self.document, self.request), ICheckinCheckoutManager).checkout()
-        expected_actions = [u'attach_to_email', u'cancel_checkout', u'checkin_with_comment',
-                            u'checkin_without_comment', u'download_copy', u'edit',
-                            u'new_task_from_document', u'oc_direct_edit', u'open_as_pdf',
-                            u'revive_bumblebee_preview']
+        expected_actions = [
+            u'attach_to_email',
+            u'cancel_checkout',
+            u'checkin_with_comment',
+            u'checkin_without_comment',
+            u'download_copy',
+            u'edit',
+            u'new_task_from_document',
+            u'oc_direct_edit',
+            u'open_as_pdf',
+            u'revive_bumblebee_preview',
+        ]
         self.assertEqual(expected_actions, self.get_actions(self.document))
 
     def test_context_actions_for_document_in_inbox(self):
         self.login(self.secretariat_user)
-        expected_actions = [u'attach_to_email', u'checkout_document', u'copy_item',
-                            u'create_forwarding', u'download_copy', u'edit', u'move_item',
-                            u'oc_direct_checkout', u'open_as_pdf', u'revive_bumblebee_preview',
-                            u'save_document_as_pdf', u'trash_context']
+        expected_actions = [
+            u'attach_to_email',
+            u'checkout_document',
+            u'copy_item',
+            u'create_forwarding',
+            u'download_copy',
+            u'edit',
+            u'move_item',
+            u'oc_direct_checkout',
+            u'oc_view',
+            u'open_as_pdf',
+            u'revive_bumblebee_preview',
+            u'save_document_as_pdf',
+            u'trash_context',
+        ]
         self.assertEqual(expected_actions, self.get_actions(self.inbox_document))
 
     def test_context_actions_for_proposal_document(self):
         self.login(self.regular_user)
-        expected_actions = [u'attach_to_email', u'copy_item', u'download_copy',
-                            u'new_task_from_document', u'open_as_pdf',
-                            u'revive_bumblebee_preview', u'save_document_as_pdf']
+        expected_actions = [
+            u'attach_to_email',
+            u'copy_item',
+            u'download_copy',
+            u'new_task_from_document',
+            u'oc_view',
+            u'open_as_pdf',
+            u'revive_bumblebee_preview',
+            u'save_document_as_pdf',
+        ]
         self.assertEqual(expected_actions, self.get_actions(self.proposaldocument))
 
     def test_context_actions_for_task_document(self):
         self.login(self.regular_user)
-        expected_actions = [u'attach_to_email', u'checkout_document', u'copy_item',
-                            u'download_copy', u'edit', u'new_task_from_document',
-                            u'oc_direct_checkout', u'open_as_pdf', u'revive_bumblebee_preview',
-                            u'save_document_as_pdf', u'trash_context']
+        expected_actions = [
+            u'attach_to_email',
+            u'checkout_document',
+            u'copy_item',
+            u'download_copy',
+            u'edit',
+            u'new_task_from_document',
+            u'oc_direct_checkout',
+            u'oc_view',
+            u'open_as_pdf',
+            u'revive_bumblebee_preview',
+            u'save_document_as_pdf',
+            u'trash_context',
+        ]
         self.assertEqual(expected_actions, self.get_actions(self.taskdocument))
 
     def test_context_actions_for_template_document(self):
         self.login(self.administrator)
-        expected_actions = [u'checkout_document', u'copy_item', u'delete', u'download_copy',
-                            u'edit', u'move_item', u'oc_direct_checkout', u'open_as_pdf',
-                            u'revive_bumblebee_preview', u'save_document_as_pdf']
+        expected_actions = [
+            u'checkout_document',
+            u'copy_item',
+            u'delete',
+            u'download_copy',
+            u'edit',
+            u'move_item',
+            u'oc_direct_checkout',
+            u'oc_view',
+            u'open_as_pdf',
+            u'revive_bumblebee_preview',
+            u'save_document_as_pdf',
+        ]
         self.assertEqual(expected_actions, self.get_actions(self.normal_template))
 
     def test_context_actions_for_document_in_dossier_template(self):
@@ -179,7 +240,17 @@ class TestDocumentContextActions(IntegrationTestCase):
                           .within(self.dossiertemplate)
                           .titled(u'Werkst\xe4tte')
                           .with_dummy_content())
-        expected_actions = [u'checkout_document', u'copy_item', u'delete', u'download_copy',
-                            u'edit', u'move_item', u'oc_direct_checkout', u'open_as_pdf',
-                            u'revive_bumblebee_preview', u'save_document_as_pdf']
+        expected_actions = [
+            u'checkout_document',
+            u'copy_item',
+            u'delete',
+            u'download_copy',
+            u'edit',
+            u'move_item',
+            u'oc_direct_checkout',
+            u'oc_view',
+            u'open_as_pdf',
+            u'revive_bumblebee_preview',
+            u'save_document_as_pdf',
+        ]
         self.assertEqual(expected_actions, self.get_actions(template))

--- a/opengever/document/tests/test_document_tooltip.py
+++ b/opengever/document/tests/test_document_tooltip.py
@@ -33,8 +33,16 @@ class TestDocumentTooltip(IntegrationTestCase):
         self.login(self.regular_user, browser)
 
         browser.open(self.document, view='tooltip')
-        metadata, checkout, download, details = browser.css(
+        view, metadata, checkout, download, details = browser.css(
             '.file-action-buttons a')
+
+        # View
+        self.assertEquals('View (read-only)', view.text)
+        self.assertEquals(
+            "javascript:officeConnectorCheckout('http://nohost/plone/"
+            "ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/"
+            "document-14/officeconnector_view_url');",
+            view.get('href'))
 
         # metadata
         self.assertEquals('Edit metadata', metadata.text)
@@ -73,9 +81,10 @@ class TestDocumentTooltip(IntegrationTestCase):
         mock_wopi_discovery()
 
         browser.open(self.document, view='tooltip')
-        metadata, checkout, edit_in_office_online, download, details = browser.css(
+        view, metadata, checkout, edit_in_office_online, download, details = browser.css(
             '.file-action-buttons a')
 
+        self.assertEquals('View (read-only)', view.text)
         self.assertEquals('Edit metadata', metadata.text)
         self.assertEquals('Check out and edit', checkout.text)
 
@@ -114,9 +123,8 @@ class TestDocumentTooltip(IntegrationTestCase):
                      data={'_authenticator': createToken()})
 
         browser.open(self.resolvable_document, view='tooltip')
-        self.assertEquals(['Download copy',
-                           'Open detail view'],
-                          browser.css('.file-action-buttons a').text)
+        self.assertNotIn('Check out and edit',
+                         browser.css('.file-action-buttons a').text)
 
     @browsing
     def test_download_link_is_available_for_documents_and_mails_when_file_exists(self, browser):  # noqa

--- a/opengever/document/tests/test_overview.py
+++ b/opengever/document/tests/test_overview.py
@@ -715,16 +715,10 @@ class TestDocumentOverviewVanilla(IntegrationTestCase):
         # Tabbedview gets in the way of the redirect so we'll have to revisit
         browser.open(self.document, view='tabbedview_view-overview')
 
-        file_actions = [
-            'Edit again',
-            'Check in with comment',
-            'Download copy',
-            ]
-
-        self.assertEquals(
-            file_actions,
+        self.assertNotIn(
+            'Check in without comment',
             browser.css('.file-action-buttons a').text,
-            )
+        )
 
     @browsing
     def test_checkin_without_comment_portal_action_not_rendered_for_locked_documents(self, browser):
@@ -967,6 +961,7 @@ class TestDocumentOverviewWithOfficeOnline(IntegrationTestCase):
         file_actions = browser.css('.file-action-buttons a').text
 
         # Collaborative checkout by someone else:
+        # - "View" action is available
         # - "Edit in Office Online" action is available
         # But not:
         # - Cancel checkout (because it's locked)
@@ -974,7 +969,7 @@ class TestDocumentOverviewWithOfficeOnline(IntegrationTestCase):
         # - Edit (checked out by someone else)
         # - Download copy (checked out by someone else)
         self.assertEquals(
-            ['Edit in Office Online'],
+            ['View (read-only)', 'Edit in Office Online'],
             file_actions)
 
     @browsing
@@ -997,13 +992,7 @@ class TestDocumentOverviewWithOfficeOnline(IntegrationTestCase):
         file_actions = browser.css('.file-action-buttons a').text
 
         # "Edit in Office Online" action not shown (regular checkout by self)
-        self.assertEquals(
-            ['Edit again',
-             'Check in without comment',
-             'Check in with comment',
-             'Cancel checkout',
-             'Download copy'],
-            file_actions)
+        self.assertNotIn('Edit in Office Online', file_actions)
 
     @browsing
     def test_not_office_online_editable_if_regularly_checked_out_by_other(self, browser):
@@ -1026,7 +1015,7 @@ class TestDocumentOverviewWithOfficeOnline(IntegrationTestCase):
         file_actions = browser.css('.file-action-buttons a').text
 
         # "Edit in Office Online" action not shown (regular checkout by other)
-        self.assertEquals([], file_actions)
+        self.assertNotIn('Edit in Office Online', file_actions)
 
     @browsing
     def test_not_office_online_editable_if_in_resolved_dossier(self, browser):
@@ -1044,9 +1033,7 @@ class TestDocumentOverviewWithOfficeOnline(IntegrationTestCase):
         file_actions = browser.css('.file-action-buttons a').text
 
         # "Edit in Office Online" action not shown (resolved dossier)
-        self.assertEquals(
-            ['Download copy'],
-            file_actions)
+        self.assertNotIn('Edit in Office Online', file_actions)
 
     @browsing
     def test_not_office_online_editable_if_in_inactive_dossier(self, browser):
@@ -1064,6 +1051,4 @@ class TestDocumentOverviewWithOfficeOnline(IntegrationTestCase):
         file_actions = browser.css('.file-action-buttons a').text
 
         # "Edit in Office Online" action not shown (inactive dossier)
-        self.assertEquals(
-            ['Download copy'],
-            file_actions)
+        self.assertNotIn('Edit in Office Online', file_actions)

--- a/opengever/locking/tests/test_locks.py
+++ b/opengever/locking/tests/test_locks.py
@@ -172,6 +172,7 @@ class TestDocumentsLockedWithMeetingSubmittedLock(SolrIntegrationTestCase, MoveI
                      method='GET', headers=self.api_headers)
 
         expected_file_actions = [
+            u'oc_view',
             u'oc_direct_checkout',
             u'download_copy',
             u'attach_to_email',
@@ -187,6 +188,7 @@ class TestDocumentsLockedWithMeetingSubmittedLock(SolrIntegrationTestCase, MoveI
                      method='GET', headers=self.api_headers)
 
         expected_file_actions = [
+            u'oc_view',
             u'download_copy',
             u'attach_to_email',
             u'new_task_from_document',

--- a/opengever/mail/actions.py
+++ b/opengever/mail/actions.py
@@ -18,3 +18,6 @@ class MailContextActions(BaseDocumentContextActions):
 
     def is_extract_attachments_available(self):
         return self.context.can_extract_attachments_to_parent()
+
+    def is_oc_view_available(self):
+        return True

--- a/opengever/mail/tests/test_actions.py
+++ b/opengever/mail/tests/test_actions.py
@@ -16,18 +16,31 @@ class TestMailContextActions(IntegrationTestCase):
 
     def test_context_actions_for_mail_in_dossier(self):
         self.login(self.regular_user)
-        expected_actions = [u'attach_to_email', u'copy_item', u'download_copy', u'edit',
-                            u'move_item', u'new_task_from_document', u'open_as_pdf',
-                            u'revive_bumblebee_preview', u'trash_context',
-                            u'extract_attachments']
+        expected_actions = [
+            u'attach_to_email',
+            u'copy_item',
+            u'download_copy',
+            u'edit',
+            u'move_item',
+            u'new_task_from_document',
+            u'oc_view',
+            u'open_as_pdf',
+            u'revive_bumblebee_preview',
+            u'trash_context',
+            u'extract_attachments',
+        ]
 
         self.assertEqual(expected_actions, self.get_actions(self.mail_eml))
 
     def test_context_actions_for_trashed_mail_in_dossier(self):
         self.login(self.regular_user)
         ITrasher(self.mail_eml).trash()
-        expected_actions = [u'revive_bumblebee_preview', u'untrash_context',
-                            u'extract_attachments']
+        expected_actions = [
+            u'oc_view',
+            u'revive_bumblebee_preview',
+            u'untrash_context',
+            u'extract_attachments',
+        ]
         self.assertEqual(expected_actions, self.get_actions(self.mail_eml))
 
     def test_context_actions_for_mail_in_resolved_task(self):
@@ -37,10 +50,18 @@ class TestMailContextActions(IntegrationTestCase):
                       .with_asset_message(
                           'mail_with_multiple_attachments.eml'))
 
-        expected_actions = [u'attach_to_email', u'copy_item', u'download_copy', u'edit',
-                            u'new_task_from_document', u'open_as_pdf',
-                            u'revive_bumblebee_preview', u'trash_context',
-                            u'extract_attachments']
+        expected_actions = [
+            u'attach_to_email',
+            u'copy_item',
+            u'download_copy',
+            u'edit',
+            u'new_task_from_document',
+            u'oc_view',
+            u'open_as_pdf',
+            u'revive_bumblebee_preview',
+            u'trash_context',
+            u'extract_attachments',
+        ]
         self.assertEqual(expected_actions, self.get_actions(mail))
 
     def test_returns_error_when_extraction_parent_is_not_open(self):
@@ -50,6 +71,12 @@ class TestMailContextActions(IntegrationTestCase):
                       .with_asset_message(
                           'mail_with_multiple_attachments.eml'))
 
-        expected_actions = [u'attach_to_email', u'copy_item', u'download_copy',
-                            u'open_as_pdf', u'revive_bumblebee_preview']
+        expected_actions = [
+            u'attach_to_email',
+            u'copy_item',
+            u'download_copy',
+            u'oc_view',
+            u'open_as_pdf',
+            u'revive_bumblebee_preview',
+        ]
         self.assertEqual(expected_actions, self.get_actions(mail))

--- a/opengever/mail/tests/test_mail_overviewtab.py
+++ b/opengever/mail/tests/test_mail_overviewtab.py
@@ -35,6 +35,7 @@ class TestOverview(FunctionalTestCase):
                   ['Foreign reference', ''],
                   ['Message',
                    u'Mehrere Anhaenge.eml \u2014 32 KB '
+                   u'View (read-only) '
                    u'Check out and edit Download copy Attach to email'],
                   ['Attachments',
                    u'Inneres Testma\u0308il ohne Attachments.eml 1 KB '

--- a/opengever/officeconnector/configure.zcml
+++ b/opengever/officeconnector/configure.zcml
@@ -44,6 +44,15 @@
       method="GET"
       for="opengever.document.document.IDocumentSchema"
       accept="application/json"
+      factory=".service.OfficeConnectorViewURL"
+      name="officeconnector_view_url"
+      permission="zope2.View"
+      />
+
+  <plone:service
+      method="GET"
+      for="opengever.document.document.IDocumentSchema"
+      accept="application/json"
       factory=".service.OfficeConnectorCheckoutURL"
       name="officeconnector_checkout_url"
       permission="cmf.ModifyPortalContent"
@@ -82,6 +91,15 @@
       accept="application/json"
       factory=".service.OfficeConnectorCheckoutPayload"
       name="oc_checkout"
+      permission="zope2.View"
+      />
+
+  <plone:service
+      method="POST"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      accept="application/json"
+      factory=".service.OfficeConnectorViewPayload"
+      name="oc_view"
       permission="zope2.View"
       />
 

--- a/opengever/officeconnector/configure.zcml
+++ b/opengever/officeconnector/configure.zcml
@@ -51,6 +51,15 @@
 
   <plone:service
       method="GET"
+      for="opengever.mail.mail.IOGMailMarker"
+      accept="application/json"
+      factory=".service.OfficeConnectorViewURL"
+      name="officeconnector_view_url"
+      permission="zope2.View"
+      />
+
+  <plone:service
+      method="GET"
       for="opengever.document.document.IDocumentSchema"
       accept="application/json"
       factory=".service.OfficeConnectorCheckoutURL"

--- a/opengever/officeconnector/service.py
+++ b/opengever/officeconnector/service.py
@@ -94,6 +94,18 @@ class OfficeConnectorCheckoutURL(OfficeConnectorURL):
         raise NotFound
 
 
+class OfficeConnectorViewURL(OfficeConnectorURL):
+    """Create oc:<JWT> URLs for javascript to fetch and pass to the OS.
+
+    Instruct where to fetch an OfficeConnector 'view' action payload for this
+    document.
+    """
+
+    def render(self):
+        payload = {'action': 'view'}
+        return self.create_officeconnector_url_json(payload)
+
+
 class OfficeConnectorOneOffixxURL(OfficeConnectorURL):
     """Create oc:<JWT> URLs for javascript to fetch and pass to the OS.
 
@@ -287,6 +299,24 @@ class OfficeConnectorCheckoutPayload(OfficeConnectorPayload):
                 raise Forbidden
 
         self.request.response.setHeader('Content-type', 'application/json')
+
+        return json.dumps(payloads)
+
+
+class OfficeConnectorViewPayload(OfficeConnectorPayload):
+    """Issue JSON instruction payloads for OfficeConnector.
+
+    Consists of the minimal instruction set with which to perform a view
+    document action.
+    """
+    def render(self):
+        self.request.response.setHeader('Content-type', 'application/json')
+        payloads = self.get_base_payloads()
+        for payload in payloads:
+            document = payload.pop('document')
+            payload['content-type'] = document.get_file().contentType
+            payload['filename'] = document.get_filename()
+            payload['download'] = document.get_download_view_name()
 
         return json.dumps(payloads)
 


### PR DESCRIPTION
Provides a new action `oc_view` for opening documents in read-only mode with Office Connector and the associated application.

The action is always displayed if the document has a file representation unless the document is checked-out by the user himself.

Office Connector > 1.18.1 (https://github.com/4teamwork/OfficeConnector/pull/403) is required for the action to work. With older versions the action is ignored.

For [CA-5815](https://4teamwork.atlassian.net/browse/CA-5815)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-5815]: https://4teamwork.atlassian.net/browse/CA-5815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ