### PR TITLE
Remove role manager from sharing view of other contexts than dossier.

### DIFF
--- a/opengever/sharing/browser/sharing.py
+++ b/opengever/sharing/browser/sharing.py
@@ -177,8 +177,7 @@ class OpengeverSharingView(SharingView):
             available_roles = [u'Reader', u'Contributor', u'Editor', u'Reviewer',
                                u'Publisher', u'DossierManager']
         else:
-            available_roles = [u'Reader', u'Contributor', u'Editor',
-                               u'Role Manager']
+            available_roles = [u'Reader', u'Contributor', u'Editor']
 
         if IDossierMarker.providedBy(self.context) or IInbox.providedBy(self.context):
             available_roles.append(u'TaskResponsible')

--- a/opengever/sharing/tests/test_sharing.py
+++ b/opengever/sharing/tests/test_sharing.py
@@ -51,6 +51,71 @@ class TestOpengeverSharing(IntegrationTestCase):
             [role['id'] for role in browser.json.get('available_roles')])
 
     @browsing
+    def test_available_roles_on_templatefolder(self, browser):
+        self.login(self.manager, browser=browser)
+
+        browser.open(self.templates, view='@sharing',
+                     method='GET', headers={'Accept': 'application/json'})
+
+        self.assertEqual(
+            [u'Reader', u'Contributor', u'Editor'],
+            [role['id'] for role in browser.json.get('available_roles')])
+
+    @browsing
+    def test_available_roles_on_inbox(self, browser):
+        self.login(self.manager, browser=browser)
+
+        browser.open(self.inbox, view='@sharing',
+                     method='GET', headers={'Accept': 'application/json'})
+
+        self.assertEqual(
+            [u'Reader', u'Contributor', u'Editor', u'TaskResponsible'],
+            [role['id'] for role in browser.json.get('available_roles')])
+
+    @browsing
+    def test_available_roles_on_repository_root(self, browser):
+        self.login(self.manager, browser=browser)
+
+        browser.open(self.repository_root, view='@sharing',
+                     method='GET', headers={'Accept': 'application/json'})
+
+        self.assertEqual(
+            [u'Reader',
+             u'Contributor',
+             u'Editor',
+             u'Reviewer',
+             u'Publisher',
+             u'DossierManager'],
+            [role['id'] for role in browser.json.get('available_roles')])
+
+    @browsing
+    def test_available_roles_on_repository_folder(self, browser):
+        self.login(self.manager, browser=browser)
+
+        browser.open(self.leaf_repofolder, view='@sharing',
+                     method='GET', headers={'Accept': 'application/json'})
+
+        self.assertEqual(
+            [u'Reader',
+             u'Contributor',
+             u'Editor',
+             u'Reviewer',
+             u'Publisher',
+             u'DossierManager'],
+            [role['id'] for role in browser.json.get('available_roles')])
+
+    @browsing
+    def test_available_roles_on_task(self, browser):
+        self.login(self.manager, browser=browser)
+
+        browser.open(self.task, view='@sharing',
+                     method='GET', headers={'Accept': 'application/json'})
+
+        self.assertEqual(
+            [u'Reader', u'Contributor', u'Editor'],
+            [role['id'] for role in browser.json.get('available_roles')])
+
+    @browsing
     def test_consider_the_ignore_permissions_flag(self, browser):
         self.login(self.regular_user, browser=browser)
 


### PR DESCRIPTION
with https://github.com/4teamwork/opengever.core/pull/7789/commits/3f0cce71eb3f96f2a4a6fd4f0f97654c87be1ade, `Role Manager` was added to lawgiver, which has as side-effect that it appears in the sharing view of diverse portal types, where it is not desired. This is fixed here, which, at least on the tested object types, recovers the roles displayed before that change in the sharing view.

For [CA-6155]

## Checklist
- [ ] Changelog entry -> no CL entry, it's in the same release as the PR introducing this issue
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-6155]: https://4teamwork.atlassian.net/browse/CA-6155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ