### PR TITLE
Add method marking unconverted documents as skipped in meeting Zip.

### DIFF
--- a/changes/CA-6285.other
+++ b/changes/CA-6285.other
@@ -1,0 +1,1 @@
+Add method marking unconverted documents as skipped in meeting Zip. [njohner]

--- a/opengever/meeting/browser/meetings/configure.zcml
+++ b/opengever/meeting/browser/meetings/configure.zcml
@@ -144,6 +144,13 @@
 
   <browser:page
       for="opengever.meeting.interfaces.IMeetingWrapper"
+      name="skip_unconverted"
+      class=".zipexport.MeetingSkipUnconverted"
+      permission="zope2.View"
+      />
+
+  <browser:page
+      for="opengever.meeting.interfaces.IMeetingWrapper"
       name="reopen_meeting"
       class=".reopen.ReopenMeetingForm"
       permission="cmf.ManagePortal"

--- a/opengever/meeting/browser/meetings/templates/demand_zip.pt
+++ b/opengever/meeting/browser/meetings/templates/demand_zip.pt
@@ -40,6 +40,9 @@
           </a>
         </div>
       </div>
+      <div tal:condition="view/is_manager" class="button confirm">
+        <a tal:attributes="href view/skip_unconverted_url;" i18n:translate="label_skip_unconverted_files">Skip unconverted files.</a>
+      </div>
     </div>
 
   </div>

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-04-27 16:29+0000\n"
+"POT-Creation-Date: 2023-10-31 07:15+0000\n"
 "PO-Revision-Date: 2017-10-23 18:40+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1368,6 +1368,11 @@ msgstr "Traktandieren"
 #: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_secretary"
 msgstr "Protokollführung"
+
+#. Default: "Skip unconverted files."
+#: ./opengever/meeting/browser/meetings/templates/demand_zip.pt
+msgid "label_skip_unconverted_files"
+msgstr "Nicht konvertierte Dateien überspringen."
 
 #. Default: "Start"
 #: ./opengever/meeting/browser/meetings/meeting.py

--- a/opengever/meeting/locales/en/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/en/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-04-27 16:29+0000\n"
+"POT-Creation-Date: 2023-10-31 07:15+0000\n"
 "PO-Revision-Date: 2017-10-23 18:40+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1639,6 +1639,11 @@ msgstr "Schedule"
 #: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_secretary"
 msgstr "Secretary"
+
+#. Default: "Skip unconverted files."
+#: ./opengever/meeting/browser/meetings/templates/demand_zip.pt
+msgid "label_skip_unconverted_files"
+msgstr "Skip unconverted files."
 
 #. German translation: Start
 #. Default: "Start"

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-04-27 16:29+0000\n"
+"POT-Creation-Date: 2023-10-31 07:15+0000\n"
 "PO-Revision-Date: 2018-05-22 10:15+0000\n"
 "Last-Translator: Niklaus Johner <Niklaus.johner@4teamwork.ch>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-meeting/fr/>\n"
@@ -1370,6 +1370,11 @@ msgstr "Mettre à l'ordre du jour"
 #: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_secretary"
 msgstr "Secrétaire"
+
+#. Default: "Skip unconverted files."
+#: ./opengever/meeting/browser/meetings/templates/demand_zip.pt
+msgid "label_skip_unconverted_files"
+msgstr "Ignorer les fichiers non convertis."
 
 #. Default: "Start"
 #: ./opengever/meeting/browser/meetings/meeting.py

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-04-27 16:29+0000\n"
+"POT-Creation-Date: 2023-10-31 07:15+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1366,6 +1366,11 @@ msgstr ""
 #. Default: "Secretary"
 #: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_secretary"
+msgstr ""
+
+#. Default: "Skip unconverted files."
+#: ./opengever/meeting/browser/meetings/templates/demand_zip.pt
+msgid "label_skip_unconverted_files"
 msgstr ""
 
 #. Default: "Start"

--- a/opengever/meeting/tests/test_zipexport.py
+++ b/opengever/meeting/tests/test_zipexport.py
@@ -55,6 +55,34 @@ class TestZipExporter(IntegrationTestCase):
             {'status': 'converting'},
             doc_job)
 
+    def test_mark_unconverted_docs_as_skipped(self):
+        self.login(self.meeting_user)
+        self.schedule_proposal(self.meeting, self.submitted_proposal)
+        self.schedule_ad_hoc(self.meeting, 'ad-hoc agenda item')
+        reset_queue()
+
+        exporter = MeetingZipExporter(self.meeting.model)
+        job = exporter.demand_pdfs()
+
+        self.assertFalse(exporter.is_finished_converting())
+        self.assertEqual(
+            {'skipped': 0,
+             'finished': 0,
+             'converting': 3,
+             'zipped': 0,
+             'is_finished': False},
+            job.get_progress())
+
+        exporter.mark_unconverted_docs_as_skipped()
+        self.assertTrue(exporter.is_finished_converting())
+        self.assertEqual(
+            {'skipped': 3,
+             'finished': 0,
+             'converting': 0,
+             'zipped': 0,
+             'is_finished': False},
+            job.get_progress())
+
 
 class TestZipJobManager(IntegrationTestCase):
 

--- a/opengever/meeting/zipexport.py
+++ b/opengever/meeting/zipexport.py
@@ -464,3 +464,15 @@ class MeetingZipExporter(object):
 
     def _collect_meeting_documents(self):
         return ZipExportDocumentCollector(self.meeting).get_documents()
+
+    def mark_unconverted_docs_as_skipped(self):
+        """This is a helper method that will fix the Zip export if any documents
+        cannot be converted. It will basically mark the documents that still
+        have status converting as skipped, which will lead to attaching the
+        original document instead of the PDF to the zip file."""
+        if self.is_finished_converting():
+            return
+
+        for docid in self.zip_job.list_document_ids():
+            if self.zip_job.get_doc_status(docid)['status'] == 'converting':
+                self.zip_job.update_doc_status(docid, {'status': 'skipped'})


### PR DESCRIPTION
This will fix the Zip export if any documents cannot be converted. It will basically mark the documents that still have status converting as skipped, which will lead to attaching the original document instead of the PDF to the zip file.

For [CA-6285]

## Checklist
- [ ] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-6285]: https://4teamwork.atlassian.net/browse/CA-6285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ