### PR TITLE
Fixes for feature giving local roles to dossier responsibles.

### DIFF
--- a/opengever/api/schema/adapters.py
+++ b/opengever/api/schema/adapters.py
@@ -81,7 +81,7 @@ class DossierResponsibleJsonSchemaProvider(GEVERChoiceJsonSchemaProvider):
         result = super(DossierResponsibleJsonSchemaProvider, self).additional()
         if is_grant_role_manager_to_responsible_enabled() and\
            not IAnnotations(self.request).get(TYPE_TO_BE_ADDED_KEY) and\
-           not api.user.has_permission("Sharing page: Delegate roles"):
+           not api.user.has_permission("Sharing page: Delegate roles", obj=self.context):
             result['mode'] = 'display'
         return result
 

--- a/opengever/api/tests/test_schema.py
+++ b/opengever/api/tests/test_schema.py
@@ -159,7 +159,7 @@ class TestSchemaEndpoint(IntegrationTestCase):
 
     @browsing
     def test_edit_schema_sets_display_mode_for_responsible_field_when_necessary(self, browser):
-        self.login(self.regular_user, browser)
+        self.login(self.dossier_responsible, browser)
         response = browser.open(
             self.dossier, view='@schema', method='GET',
             headers=self.api_headers,).json
@@ -170,7 +170,13 @@ class TestSchemaEndpoint(IntegrationTestCase):
             self.dossier, view='@schema', method='GET',
             headers=self.api_headers,).json
         self.assertIn('mode', response['properties']["responsible"])
-        self.assertTrue(response['properties']["responsible"]['mode'])
+        self.assertEqual("display", response['properties']["responsible"]['mode'])
+
+        self.dossier.give_permissions_to_responsible()
+        response = browser.open(
+            self.dossier, view='@schema', method='GET',
+            headers=self.api_headers,).json
+        self.assertNotIn('mode', response['properties']["responsible"])
 
     @browsing
     def test_schema_endpoint_returns_jsonschema_for_propertysheets(self, browser):

--- a/opengever/dossier/handlers.py
+++ b/opengever/dossier/handlers.py
@@ -199,6 +199,10 @@ def set_responsible_role(obj, event):
 
 
 def update_responsible_role(obj, event):
+    if ILocalrolesModifiedEvent.providedBy(event) or \
+       IContainerModifiedEvent.providedBy(event):
+        return
+
     if not is_grant_role_manager_to_responsible_enabled():
         return
 


### PR DESCRIPTION
Two things were broken in the new feature implemented in https://github.com/4teamwork/opengever.core/pull/7789:
- Permission check for editing the responsible field was not correct
- The event handler setting the local roles for the responsible broke the sharing view. I'm not sure why that was not picked up by any tests, as there are tests of the sharing view. Might be an event order issue?

For [CA-6155]

## Checklist
- [ ] Changelog entry -> no CL entry, the feature was not released yet
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-6155]: https://4teamwork.atlassian.net/browse/CA-6155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ