### PR TITLE
Add transferring office field to dispositions to overwrite the AktenbildnerName.

### DIFF
--- a/changes/CA-6281.feature
+++ b/changes/CA-6281.feature
@@ -1,0 +1,1 @@
+Add transferring office field to dispositions to overwrite the AktenbildnerName. [njohner]

--- a/opengever/disposition/disposition.py
+++ b/opengever/disposition/disposition.py
@@ -185,12 +185,16 @@ def title_default():
         api.portal.get_localized_time(date.today(), long_format=False))
 
 
+def transferring_office_default():
+    return get_current_admin_unit().label()
+
+
 class IDispositionSchema(model.Schema):
 
     model.fieldset(
         u'common',
         label=_(u'fieldset_common', default=u'Common'),
-        fields=[u'title', u'dossiers', u'transfer_number'],
+        fields=[u'title', u'dossiers', u'transfer_number', u'transferring_office'],
     )
 
     dexteritytextindexer.searchable('title')
@@ -225,6 +229,12 @@ class IDispositionSchema(model.Schema):
     transfer_number = schema.TextLine(
         title=_(u"label_transfer_number", default=u"Transfer number"),
         required=False,
+    )
+
+    transferring_office = schema.TextLine(
+        title=_(u"label_transferring_office", default=u"Transferring office"),
+        required=False,
+        defaultFactory=transferring_office_default
     )
 
 

--- a/opengever/disposition/ech0160/sippackage.py
+++ b/opengever/disposition/ech0160/sippackage.py
@@ -70,7 +70,7 @@ class SIPPackage(object):
         ablieferung.ablieferungstyp = ABLIEFERUNGSTYP
         ablieferung.ablieferndeStelle = self.get_transferring_office()
         ablieferung.provenienz = arelda.provenienzGeverSIP()
-        ablieferung.provenienz.aktenbildnerName = get_current_admin_unit().label()
+        ablieferung.provenienz.aktenbildnerName = self.disposition.transferring_office
         ablieferung.provenienz.registratur = self.get_repository_title()
 
         ablieferung.ordnungssystem = self.repo.binding()

--- a/opengever/disposition/locales/de/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/de/LC_MESSAGES/opengever.disposition.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-12-22 20:31+0000\n"
+"POT-Creation-Date: 2023-10-31 14:16+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -253,6 +253,11 @@ msgstr "Titel"
 #: ./opengever/disposition/disposition.py
 msgid "label_transfer_number"
 msgstr "Ablieferungsnummer"
+
+#. Default: "Transferring office"
+#: ./opengever/disposition/disposition.py
+msgid "label_transferring_office"
+msgstr "Aktenbildner Name"
 
 #. Default: "Yes"
 #: ./opengever/disposition/browser/removal_protocol.py

--- a/opengever/disposition/locales/en/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/en/LC_MESSAGES/opengever.disposition.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-12-22 20:31+0000\n"
+"POT-Creation-Date: 2023-10-31 14:16+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -299,6 +299,11 @@ msgstr "Title"
 #: ./opengever/disposition/disposition.py
 msgid "label_transfer_number"
 msgstr "Transfer number"
+
+#. Default: "Transferring office"
+#: ./opengever/disposition/disposition.py
+msgid "label_transferring_office"
+msgstr "Transferring office (AktenbildnerName)"
 
 #. German translation: Ja
 #. Default: "Yes"

--- a/opengever/disposition/locales/fr/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/fr/LC_MESSAGES/opengever.disposition.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-12-22 20:31+0000\n"
+"POT-Creation-Date: 2023-10-31 14:16+0000\n"
 "PO-Revision-Date: 2018-05-22 10:09+0000\n"
 "Last-Translator: Niklaus Johner <Niklaus.johner@4teamwork.ch>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-disposition/fr/>\n"
@@ -255,6 +255,11 @@ msgstr "Titre"
 #: ./opengever/disposition/disposition.py
 msgid "label_transfer_number"
 msgstr "Numéro de livraison"
+
+#. Default: "Transferring office"
+#: ./opengever/disposition/disposition.py
+msgid "label_transferring_office"
+msgstr "Service versant (AktenbildnerName)"
 
 #. Default: "Yes"
 #: ./opengever/disposition/browser/removal_protocol.py

--- a/opengever/disposition/locales/opengever.disposition.pot
+++ b/opengever/disposition/locales/opengever.disposition.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-12-22 20:31+0000\n"
+"POT-Creation-Date: 2023-10-31 14:16+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -255,6 +255,11 @@ msgstr ""
 #: ./opengever/disposition/browser/templates/overview.pt
 #: ./opengever/disposition/disposition.py
 msgid "label_transfer_number"
+msgstr ""
+
+#. Default: "Transferring office"
+#: ./opengever/disposition/disposition.py
+msgid "label_transferring_office"
 msgstr ""
 
 #. Default: "Yes"

--- a/opengever/disposition/tests/test_disposition.py
+++ b/opengever/disposition/tests/test_disposition.py
@@ -349,6 +349,16 @@ class TestDispositionEditForm(IntegrationTestCase):
         self.assertEquals(['Item state changed.'], info_messages())
         self.assertFalse(self.disposition.has_sip_package())
 
+    @browsing
+    def test_can_overwrite_transferring_office(self, browser):
+        self.login(self.records_manager, browser)
+        self.assertEqual(u'Hauptmandant', self.disposition.transferring_office)
+
+        browser.open(self.disposition, view='edit')
+        browser.fill({'Transferring office (AktenbildnerName)': "Foo"})
+        browser.find('Save').click()
+        self.assertEqual(u'Foo', self.disposition.transferring_office)
+
 
 class TestDispositionDelivery(IntegrationTestCase):
 

--- a/opengever/disposition/tests/test_sippackage.py
+++ b/opengever/disposition/tests/test_sippackage.py
@@ -46,9 +46,17 @@ class TestSIPPackageIntegration(IntegrationTestCase):
             u'Hauptmand\xe4nt, Flucht R\xe4mon',
             package.ablieferung.ablieferndeStelle)
         self.assertEquals(
-            u'Hauptmand\xe4nt', package.ablieferung.provenienz.aktenbildnerName)
-        self.assertEquals(
             u'Ordnungssystem', package.ablieferung.provenienz.registratur)
+        # aktenbildnerName default is admin unit label, but it was set
+        # before the change done above
+        self.assertEquals(
+            u'Hauptmandant', package.ablieferung.provenienz.aktenbildnerName)
+
+        # Can overwrite aktenbildnerName
+        self.disposition.transferring_office = "my custom transferring office"
+        package = SIPPackage(self.disposition)
+        self.assertEquals(
+            u'my custom transferring office', package.ablieferung.provenienz.aktenbildnerName)
 
 
 class TestSIPPackage(FunctionalTestCase):


### PR DESCRIPTION
Our default for the `AktebnbildnerName` in the SIP package only makes sense for deployments where we have one AdminUnit per Service, but not for deployments like Fribourg. That Metadata should indeed contain the name of the service which was responsible for the set of documents and therefore needs to be overwritable.

For [CA-6281]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-6281]: https://4teamwork.atlassian.net/browse/CA-6281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ