### PR TITLE
OGDS user and group labels display name instead of ID.

### DIFF
--- a/changes/CA-6237.other
+++ b/changes/CA-6237.other
@@ -1,0 +1,1 @@
+OGDS user and group labels display name instead of ID. [njohner]

--- a/opengever/ogds/models/group.py
+++ b/opengever/ogds/models/group.py
@@ -104,7 +104,7 @@ class Group(Base):
         return self.groupid
 
     def label(self):
-        return self.title or self.groupid
+        return self.title or self.groupname
 
 
 def create_additional_group_indexes(table, connection, *args, **kw):

--- a/opengever/ogds/models/tests/test_group.py
+++ b/opengever/ogds/models/tests/test_group.py
@@ -43,3 +43,9 @@ class TestGroupModel(OGDSTestCase):
 
         self.members_b.users.remove(self.john)
         self.assertNotIn(self.john, self.members_b.users)
+
+    def test_label_displays_title_or_groupanem(self):
+        group = Group(groupid='group1', groupname='One')
+        self.assertEqual('One', group.label())
+        group.title = "Group One"
+        self.assertEqual('Group One', group.label())

--- a/opengever/ogds/models/tests/test_user.py
+++ b/opengever/ogds/models/tests/test_user.py
@@ -33,9 +33,9 @@ class TestUserModel(OGDSTestCase):
     def test_fullname_is_userid_if_no_name_given(self):
         self.assertEqual('admin', self.admin.fullname())
 
-    def test_label_is_the_fullname_with_userid_in_braces(self):
-        sammy = User('sammy', firstname='Samuel', lastname='Jackson')
-        self.assertEqual('Jackson Samuel (sammy)', sammy.label())
+    def test_label_is_the_fullname_with_username_in_braces(self):
+        sammy = User('sammy', firstname='Samuel', lastname='Jackson', username="sjackson")
+        self.assertEqual('Jackson Samuel (sjackson)', sammy.label())
 
     def test_create_sets_attrs(self):
         attrs = {
@@ -76,5 +76,8 @@ class TestUserModel(OGDSTestCase):
 
     def test_supports_non_ascii_userid(self):
         self.john.userid = u'J\xf6hn'
-        self.assertEqual(u'Smith John (J\xf6hn)', self.john.label())
         self.assertEqual("<User u'J\\xf6hn'>", str(self.john))
+
+    def test_supports_non_ascii_username(self):
+        self.john.username = u'J\xf6hn'
+        self.assertEqual(u'Smith John (J\xf6hn)', self.john.label())

--- a/opengever/ogds/models/user.py
+++ b/opengever/ogds/models/user.py
@@ -131,7 +131,7 @@ class User(Base):
         if not with_principal:
             return self.fullname()
 
-        return u"%s (%s)" % (self.fullname(), self.userid)
+        return u"%s (%s)" % (self.fullname(), self.username)
 
     def fullname(self):
         """Return a visual representation of the user's full name.


### PR DESCRIPTION
OGDSUser and OGDSGroup labels now use the name instead of the id. The `__repr__` still uses the ids, but I think that is correct.

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-6237]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)