### PR TITLE
Fix docproperty writing when creating a doc from template.

### DIFF
--- a/changes/CA-6253.bugfix
+++ b/changes/CA-6253.bugfix
@@ -1,0 +1,1 @@
+Make sure docproperty values are written to the initial version when creating a document from template. [phgross]

--- a/opengever/dossier/command.py
+++ b/opengever/dossier/command.py
@@ -4,6 +4,7 @@ from opengever.base.role_assignments import RoleAssignment
 from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.document.docprops import DocPropertyWriter
 from opengever.document.handlers import DISABLE_DOCPROPERTY_UPDATE_FLAG
+from opengever.document.versioner import AvoidInitialVersion
 from opengever.dossier.dossiertemplate.dossiertemplate import BEHAVIOR_INTERFACE_MAPPING
 from plone.dexterity.utils import iterSchemataForType
 from zope.globalrequest import getRequest
@@ -44,9 +45,11 @@ class CreateDocumentFromTemplateCommand(CreateDocumentCommand):
         obj = super(CreateDocumentFromTemplateCommand, self).execute()
 
         getRequest().set(DISABLE_DOCPROPERTY_UPDATE_FLAG, False)
-        DocPropertyWriter(obj, recipient_data=self.recipient_data,
-                          sender_data=self.sender_data,
-                          participation_data=self.participation_data).initialize()
+        with AvoidInitialVersion():
+            DocPropertyWriter(
+                obj, recipient_data=self.recipient_data,
+                sender_data=self.sender_data,
+                participation_data=self.participation_data).initialize()
 
         # Set blocking of role inheritance based on the template object
         if self.block_role_inheritance is not None:


### PR DESCRIPTION
By avoiding the creation of the initial version before writing the docproperty values, we fix an issue when creating a document from template. Currently when a document gets created from template, the docproperty values are not written to the initial version of a document, but only in the working copy. This leads to a wrong document, when closing the document without doing any change after generation. Because with the recently changed office connector behavior, this cancels the checkout and drops the changes in the working copy.

For [CA-6253]


## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)



[CA-6317]: https://4teamwork.atlassian.net/browse/CA-6317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CA-6253]: https://4teamwork.atlassian.net/browse/CA-6253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ