### PR TITLE
Fix deeply nested task templates

### DIFF
--- a/changes/CA-6355-2.bugfix
+++ b/changes/CA-6355-2.bugfix
@@ -1,0 +1,1 @@
+Properly open deeply nested tasks. [elioschmutz]

--- a/changes/CA-6355.bugfix
+++ b/changes/CA-6355.bugfix
@@ -1,0 +1,1 @@
+Properly set state of deeply nested task template folders. [elioschmutz]

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -729,14 +729,19 @@ class Task(Container, TaskReminderSupport):
         self.sync()
 
     def start_subprocess(self):
-        if IContainParallelProcess.providedBy(self):
-            for child in self.objectValues():
+        self._start_subprocess(self)
+
+    def _start_subprocess(self, obj):
+        if IContainParallelProcess.providedBy(obj):
+            for child in obj.objectValues():
                 if ITask.providedBy(child):
                     child._open_planned_task()
-        elif IContainSequentialProcess.providedBy(self):
-            for child in self.objectValues():
+                    self._start_subprocess(child)
+        elif IContainSequentialProcess.providedBy(obj):
+            for child in obj.objectValues():
                 if ITask.providedBy(child):
                     child._open_planned_task()
+                    self._start_subprocess(child)
                     # start only the first task if sequential
                     return
 

--- a/opengever/task/tests/test_task_from_template.py
+++ b/opengever/task/tests/test_task_from_template.py
@@ -368,7 +368,14 @@ class TestSequentialTaskProcess(IntegrationTestCase):
                                           issuer=self.dossier_responsible.getId(),
                                           task_type='correction')
                                   .in_state('task-state-planned'))
-
+        alsoProvides(subprocess_task2, IContainParallelProcess)
+        subprocess_task2_task1 = create(Builder('task')
+                                        .within(subprocess_task2)
+                                        .having(responsible_client='fa',
+                                                responsible=self.regular_user.getId(),
+                                                issuer=self.dossier_responsible.getId(),
+                                                task_type='correction')
+                                        .in_state('task-state-planned'))
         api.content.transition(
             obj=self.seq_subtask_1,
             transition='task-transition-open-tested-and-closed')
@@ -377,6 +384,8 @@ class TestSequentialTaskProcess(IntegrationTestCase):
             'task-state-open', api.content.get_state(subprocess_task1))
         self.assertEquals(
             'task-state-open', api.content.get_state(subprocess_task2))
+        self.assertEquals(
+            'task-state-open', api.content.get_state(subprocess_task2_task1))
 
     def test_starts_sequential_subprocess(self):
         self.login(self.secretariat_user)
@@ -390,6 +399,16 @@ class TestSequentialTaskProcess(IntegrationTestCase):
                                           issuer=self.dossier_responsible.getId(),
                                           task_type='correction')
                                   .in_state('task-state-planned'))
+
+        alsoProvides(subprocess_task1, IContainSequentialProcess)
+        subprocess_task1_task1 = create(Builder('task')
+                                        .within(subprocess_task1)
+                                        .having(responsible_client='fa',
+                                                responsible=self.regular_user.getId(),
+                                                issuer=self.dossier_responsible.getId(),
+                                                task_type='correction')
+                                        .in_state('task-state-planned'))
+
         subprocess_task2 = create(Builder('task')
                                   .within(self.seq_subtask_2)
                                   .having(responsible_client='fa',
@@ -406,6 +425,8 @@ class TestSequentialTaskProcess(IntegrationTestCase):
 
         self.assertEquals(
             'task-state-open', api.content.get_state(subprocess_task1))
+        self.assertEquals(
+            'task-state-open', api.content.get_state(subprocess_task1_task1))
         self.assertEquals(
             'task-state-planned', api.content.get_state(subprocess_task2))
 


### PR DESCRIPTION
This PR fixes two issues with deeply nested tasks from tasktemplates.

# Properly set the state of deeply nested tasks created from a tasktemplate:

Having a deeply nested tasktemplate with sequential and parallel tasks, task states have not been set properly in deeper nesting levels:

## Before
<img width="375" alt="Bildschirmfoto 2023-11-03 um 13 29 48" src="https://github.com/4teamwork/opengever.core/assets/557005/cdd929aa-e14e-4c60-9712-13a5f071e4e0">

## After
<img width="381" alt="Bildschirmfoto 2023-11-03 um 13 27 53" src="https://github.com/4teamwork/opengever.core/assets/557005/55a1932f-5dd5-406e-b0a8-cbf6e2a5a4f2">

# Properly open the next tasks of deeply nested tasks created from a tasktemplate

When closing a task in a task sequence, the next task should open. If the next task is a parallel task container, the subtasks have not been properly opened.

## Before
https://github.com/4teamwork/opengever.core/assets/557005/ab798bbd-db79-4294-9eb7-a4a66da0d3cc

## After
https://github.com/4teamwork/opengever.core/assets/557005/0496d208-e668-49aa-bebd-3b2e8738f5ee

For [CA-6355]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-6355]: https://4teamwork.atlassian.net/browse/CA-6355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ