### PR TITLE
Massively speed up download of file version.

### DIFF
--- a/changes/CA-6272.other
+++ b/changes/CA-6272.other
@@ -1,0 +1,1 @@
+Massively speed up download of file version. [njohner]

--- a/opengever/base/viewlets/download.py
+++ b/opengever/base/viewlets/download.py
@@ -2,6 +2,7 @@ from opengever.base import _
 from opengever.base.behaviors.utils import set_attachment_content_disposition
 from opengever.document.versioner import Versioner
 from plone.dexterity.primary import PrimaryFieldInfo
+from plone.namedfile.utils import stream_data
 from Products.CMFEditions.interfaces.IArchivist import ArchivistRetrieveError
 from Products.Five import BrowserView
 from Products.statusmessages.interfaces import IStatusMessage
@@ -48,4 +49,4 @@ class DownloadFileVersion(BrowserView):
         set_attachment_content_disposition(
             self.request, self.version_file.filename.encode('utf-8'))
 
-        return self.version_file.data
+        return stream_data(self.version_file)


### PR DESCRIPTION
Speedup is hard to measure, locally for an 84MB file it decreased from ~12 seconds to something like 200ms. On Kapo there is a 600MB file that takes 2 hours when downloading a version and a few seconds when downloading the document itself.

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-6272]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-6272]: https://4teamwork.atlassian.net/browse/CA-6272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ