### PR TITLE
Base64 encode a literal occurence of EICAR Test-File:

### DIFF
--- a/changes/CA-5703.other
+++ b/changes/CA-5703.other
@@ -1,0 +1,1 @@
+Base64 encode a literal occurence of EICAR Test-File. [lgraf]

--- a/opengever/virusscan/testing.py
+++ b/opengever/virusscan/testing.py
@@ -19,10 +19,10 @@ Content-Transfer-Encoding: 7bit
 MIME-Version: 1.0
 Content-Disposition: attachment
 
-X5O!P%@AP[4\\PZX54(P^)7CC)7}}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*
+%s
 
 --===============1701826978839754121==--
-"""
+""" % EICAR.replace('}', '}}')
 
 
 class MockAVScanner(object):


### PR DESCRIPTION
Base64 encode a literal occurence of EICAR Test-File:

This is to avoid triggering an HTTPS proxy on an on prem installation that performs virus scans.

For [CA-5703](https://4teamwork.atlassian.net/browse/CA-5703)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-5703]: https://4teamwork.atlassian.net/browse/CA-5703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ