### PR TITLE
Remove EICAR Test file entirely from tests

### DIFF
--- a/opengever/virusscan/testing.py
+++ b/opengever/virusscan/testing.py
@@ -4,9 +4,7 @@ from zope.component import getSiteManager
 from zope.interface import implements
 
 
-EICAR = """
-    WDVPIVAlQEFQWzRcUFpYNTQoUF4pN0NDKTd9JEVJQ0FSLVNUQU5E
-    QVJELUFOVElWSVJVUy1URVNU\nLUZJTEUhJEgrSCo=\n""".decode('base64')
+EICAR = "Test-Virus-Marker"
 
 EICAR_MAIL_TEMPLATE = """Subject: test mail
 From: {from_address}


### PR DESCRIPTION
Remove EICAR Test file entirely from tests:
This is to avoid triggering an HTTPS proxy on an on prem installation that performs virus scans.

For [CA-5703](https://4teamwork.atlassian.net/browse/CA-5703)

## Checklist

- [ ] Changelog entry (not needed)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

