### PR TITLE
Fix dossier end date validation

### DIFF
--- a/changes/CA-6279.bugfix
+++ b/changes/CA-6279.bugfix
@@ -1,0 +1,1 @@
+Only skip enddate validation when it will be set over archive form. [njohner]

--- a/opengever/dossier/interfaces.py
+++ b/opengever/dossier/interfaces.py
@@ -160,9 +160,6 @@ class IDossierResolver(Interface):
         """Check if the end dates of dossiers and subdossiers are valid.
         """
 
-    def is_archive_form_needed():
-        """Check if the archive form must be rendered or not."""
-
     def resolve():
         """Resolve the dossier and recursly also the subdossiers.
         """

--- a/opengever/dossier/resolve.py
+++ b/opengever/dossier/resolve.py
@@ -563,8 +563,10 @@ class ResolveConditions(object):
 
         return self._invalid_dates
 
-    def _recursive_date_validation(self, dossier, main=True):
-        if not main:
+    def _recursive_date_validation(self, dossier):
+        # When the archive form is needed on a dossier, we need not check the
+        # end date as it will be set in the form.
+        if not is_archive_form_needed(dossier):
             # check end_date
             # If a dossier is already resolved, but seems to have an invalid
             # end date, it's because we changed the resolution logic and rules
@@ -578,4 +580,4 @@ class ResolveConditions(object):
         subdossiers = dossier.get_subdossiers(depth=1)
         for sub in subdossiers:
             sub = sub.getObject()
-            self._recursive_date_validation(sub, main=False)
+            self._recursive_date_validation(sub)

--- a/opengever/dossier/tests/test_retention_expiration.py
+++ b/opengever/dossier/tests/test_retention_expiration.py
@@ -53,6 +53,9 @@ class TestRetentionExpirationDate(FunctionalTestCase):
     def test_index_is_updated_when_end_date_is_changed_during_resolving(self, browser):
         self.grant('Reader', 'Contributor', 'Editor', 'Reviewer')
 
+        # End date is invalid and will not be reset automatically
+        IDossier(self.dossier).end = None
+
         create(Builder('document')
                .within(self.dossier)
                .having(document_date=date(2015, 1, 1)))


### PR DESCRIPTION
Current implementation simply did not make sense anymore. It skipped the end date validation on the current context, i.e. if the user tries to resolve a dossier with an invalid end date on a subdossier it would fail. But if he resolved the subdossier it would instead reset the end date of the subdossier. Then he could resolve the dossier.

This was simply due to an error in the implementation, which IMO, meant to skip end date validation on the main dossier when the archival form gets displayed, as it allows to reset the end date of the main dossier (see https://github.com/4teamwork/opengever.core/commit/d37f44adeaee30fa4b65f13bbd86cf7264a22725).

The change implemented here makes the behaviour consistent, simply disallowing invalid end dates except when it might get corrected by the archival form. Drawback is that maybe users got used to end dates getting automatically corrected on the main dossier, but IMO when a user sets the end date, he does so on purpose and therefore should be informed that it is not valid and it should not be changed automatically. I mean he can easily then simply remove the end date on the dossier and it will get calculated automatically.

For [CA-6279]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
