### PR TITLE
Add ODS to document types editable with OfficeConnector.

### DIFF
--- a/changes/CA-6292.other
+++ b/changes/CA-6292.other
@@ -1,0 +1,1 @@
+Add Open Document types (.odt, .ods, .odp) to document types editable with OfficeConnector. [njohner]

--- a/opengever/officeconnector/mimetypes.py
+++ b/opengever/officeconnector/mimetypes.py
@@ -42,6 +42,7 @@ EDITABLE_TYPES = [
     'application/vnd.ms-excel',
     'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
     'application/vnd.openxmlformats-officedocument.spreadsheetml.template',
+    'application/vnd.oasis.opendocument.spreadsheet',
     # MS OneNote
     'application/onenote',
     'application/msonenote',
@@ -54,6 +55,7 @@ EDITABLE_TYPES = [
     'application/vnd.openxmlformats-officedocument.presentationml.presentation',
     'application/vnd.openxmlformats-officedocument.presentationml.slideshow',
     'application/vnd.openxmlformats-officedocument.presentationml.template',
+    'application/vnd.oasis.opendocument.presentation',
     # MS Project
     'application/vnd.ms-project',
     'application/x-project',
@@ -73,6 +75,7 @@ EDITABLE_TYPES = [
     'application/vnd.ms-word.template.macroEnabled.12',
     'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
     'application/vnd.openxmlformats-officedocument.wordprocessingml.template',
+    'application/vnd.oasis.opendocument.text',
     # PDF editors - Adobe Acrobat or Nitro PDF
     'application/pdf',
     'application/postscript',


### PR DESCRIPTION
ODS documents can be opened with OpenOffice, which is supported by OfficeConnector.

For [CA-6292]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-6292]: https://4teamwork.atlassian.net/browse/CA-6292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ