### PR TITLE
Make max dossier depth restriction less strict.

### DIFF
--- a/changes/CA-6440.bugfix
+++ b/changes/CA-6440.bugfix
@@ -1,0 +1,1 @@
+Make max dossier depth restriction less strict. [phgross]

--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -184,16 +184,19 @@ class DossierContainer(Container):
 
         # Max depth would technically be exceeded.
         # However, if a dossier structure that exceeds the max depth already
-        # exists at the same level, we'll allow new structures with the same
-        # additional depth (or lower).
-        path = '/'.join(self.getPhysicalPath())
-        subdossiers = self.get_subdossiers(unrestricted=True)
+        # exists, we'll allow new structures with the same additional
+        # depth (or lower).
+        main_dossier = self.get_main_dossier()
+        subdossiers = main_dossier.get_subdossiers(unrestricted=True)
+        main_dossier_path = '/'.join(self.get_main_dossier().getPhysicalPath())
+
         if subdossiers:
-            max_existing_additional_depth = max((
-                sub.getPath()[len(path):].count('/') for sub in subdossiers
+            max_existing_depth = max((
+                sub.getPath()[len(main_dossier_path):].count('/') for sub in subdossiers
             ))
 
-            if additional_depth <= max_existing_additional_depth:
+            current_depth = '/'.join(self.getPhysicalPath())[len(main_dossier_path):].count('/')
+            if (current_depth + additional_depth) <= max_existing_depth:
                 return True
 
         return False

--- a/opengever/dossier/tests/test_base.py
+++ b/opengever/dossier/tests/test_base.py
@@ -79,10 +79,10 @@ class TestDossierContainer(IntegrationTestCase):
     def test_max_subdossier_depth_is_1_by_default(self):
         self.login(self.dossier_responsible)
         self.assertIn('opengever.dossier.businesscasedossier',
-                      [fti.id for fti in self.meeting_dossier.allowedContentTypes()])
+                      [fti.id for fti in self.resolvable_dossier.allowedContentTypes()])
 
         self.assertNotIn('opengever.dossier.businesscasedossier',
-                         [fti.id for fti in self.subdossier2.allowedContentTypes()])
+                         [fti.id for fti in self.resolvable_subdossier.allowedContentTypes()])
 
     def test_max_subdossier_depth_is_configurable(self):
         self.login(self.dossier_responsible)
@@ -93,6 +93,21 @@ class TestDossierContainer(IntegrationTestCase):
         proxy.maximum_dossier_depth = 3
         self.assertIn('opengever.dossier.businesscasedossier',
                       [fti.id for fti in self.subsubdossier.allowedContentTypes()])
+
+    def test_max_subdossier_depth_is_allowed_if_already_violated_by_other_subdossiers(self):
+        self.login(self.dossier_responsible)
+
+        self.assertNotIn('opengever.dossier.businesscasedossier',
+                         [fti.id for fti in self.subsubdossier.allowedContentTypes()])
+
+        sub2 = create(Builder('dossier').within(self.dossier))
+        subsub2 = create(Builder('dossier').within(sub2))
+        subsubsub2 = create(Builder('dossier').within(subsub2))
+
+        self.assertIn('opengever.dossier.businesscasedossier',
+                      [fti.id for fti in self.subsubdossier.allowedContentTypes()])
+        self.assertNotIn('opengever.dossier.businesscasedossier',
+                         [fti.id for fti in subsubsub2.allowedContentTypes()])
 
     def test_get_subdossiers_is_recursive_by_default(self):
         self.login(self.dossier_responsible)

--- a/opengever/dossier/tests/test_dossier.py
+++ b/opengever/dossier/tests/test_dossier.py
@@ -117,7 +117,7 @@ class TestDossier(IntegrationTestCase):
     def test_nested_subdossiers_is_not_possible_by_default(self):
         self.login(self.dossier_responsible)
 
-        sub = create(Builder('dossier').within(self.dossier))
+        sub = create(Builder('dossier').within(self.empty_dossier))
 
         self.assertNotIn('opengever.dossier.businesscasedossier',
                          [fti.id for fti in sub.allowedContentTypes()])

--- a/opengever/dossier/tests/test_move_items.py
+++ b/opengever/dossier/tests/test_move_items.py
@@ -62,12 +62,12 @@ class TestMoveItems(IntegrationTestCase, MoveItemsHelper):
         self.login(self.manager)
         empty_dossier_title = self.empty_dossier.title.encode("utf-8")
         self.assert_contains(self.leaf_repofolder, [empty_dossier_title])
-        self.assert_does_not_contain(self.subdossier2, [empty_dossier_title])
+        self.assert_does_not_contain(self.resolvable_subdossier, [empty_dossier_title])
         self.move_items([self.empty_dossier],
                         source=self.leaf_repofolder,
-                        target=self.subdossier2)
+                        target=self.resolvable_subdossier)
         self.assert_contains(self.leaf_repofolder, [empty_dossier_title])
-        self.assert_does_not_contain(self.subdossier2, [empty_dossier_title])
+        self.assert_does_not_contain(self.resolvable_subdossier, [empty_dossier_title])
 
     @browsing
     def test_moving_dossier_containing_subdossier_respects_maximum_dossier_depth(self, browser):
@@ -1825,8 +1825,8 @@ class TestDossierMovabilityChecker(IntegrationTestCase):
 
         # a dossier containing a subdossier can even be moved to a place
         # where it would exceed the max nesting depth by 2, if another
-        # subdossier with a subsubdossier already exists on that level and
-        # already violates the max nesting depth by 2.
+        # subdossier in this main dossier already violates the max nesting
+        # depth by 2.
         DossierMovabiliyChecker(self.resolvable_dossier).validate_movement(
             self.dossier)
 


### PR DESCRIPTION
Allow max depth violations, if the main dossier already contains subdossiers which exceed the max dossier depth.  Regardless of whether it is the current sub-branch or not.

For [CA-6440]

Backport to 2023.14 necessary. 

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)




[CA-6440]: https://4teamwork.atlassian.net/browse/CA-6440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ