### PR TITLE
Extend dispositon SIP package with csv exports.

### DIFF
--- a/changes/CA-6302.feature
+++ b/changes/CA-6302.feature
@@ -1,0 +1,1 @@
+Extend dispositon SIP package with csv exports. [phgross]

--- a/opengever/core/upgrades/20231120152734_add_disposition_setting_attach_csv_reports/registry.xml
+++ b/opengever/core/upgrades/20231120152734_add_disposition_setting_attach_csv_reports/registry.xml
@@ -1,0 +1,6 @@
+<registry>
+
+  <record interface="opengever.disposition.interfaces.IDispositionSettings"
+          field="attach_csv_reports" />
+
+</registry>

--- a/opengever/core/upgrades/20231120152734_add_disposition_setting_attach_csv_reports/upgrade.py
+++ b/opengever/core/upgrades/20231120152734_add_disposition_setting_attach_csv_reports/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddDispositionSettingAttachCsvReports(UpgradeStep):
+    """Add disposition setting attach_csv_reports.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/disposition/ech0160/model/document.py
+++ b/opengever/disposition/ech0160/model/document.py
@@ -12,6 +12,7 @@ class Document(object):
     def __init__(self, obj):
         self.obj = obj
         self.file_refs = []
+        self.files = []
 
     def binding(self):
         dokument = arelda.dokumentGeverSIP(id=u'_{}'.format(self.obj.UID()))

--- a/opengever/disposition/ech0160/model/dossier.py
+++ b/opengever/disposition/ech0160/model/dossier.py
@@ -24,6 +24,7 @@ class Dossier(object):
         self.obj = obj
         self.dossiers = {}
         self.documents = {}
+        self.folder = None
 
         self._add_descendants()
 

--- a/opengever/disposition/ech0160/model/file.py
+++ b/opengever/disposition/ech0160/model/file.py
@@ -11,6 +11,7 @@ class File(object):
         self.file = file
         self.id = u'_{}'.format(binascii.hexlify(self.file._p_oid))
         document.file_refs.append(self.id)
+        document.files.append(self)
         self.document = document
         self.filename = self.file.filename
         self.filepath = self.file._blob.committed()

--- a/opengever/disposition/ech0160/model/folder.py
+++ b/opengever/disposition/ech0160/model/folder.py
@@ -31,6 +31,8 @@ class Folder(object):
 
                 self.files.append(File(toc, doc, doc.obj.get_file()))
 
+        dossier.folder = self
+
     def binding(self):
         ordner = arelda.ordnerSIP(self.name)
 

--- a/opengever/disposition/ech0160/sippackage.py
+++ b/opengever/disposition/ech0160/sippackage.py
@@ -6,6 +6,7 @@ from opengever.base.interfaces import ISequenceNumber
 from opengever.base.utils import file_checksum
 from opengever.disposition.ech0160 import model as ech0160
 from opengever.disposition.ech0160.bindings import arelda
+from opengever.disposition.interfaces import IDispositionSettings
 from opengever.disposition.reports import DispositionDossierCSVReporter
 from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.ogds.models.service import ogds_service
@@ -161,6 +162,12 @@ class SIPPackage(object):
         zipfile.writestr(arcname, dom.toprettyxml(encoding='UTF-8'))
 
     def add_csv_files(self, zipfile):
+        attach_csv_reports_enabled = api.portal.get_registry_record(
+            name='attach_csv_reports', interface=IDispositionSettings)
+
+        if not attach_csv_reports_enabled:
+            return
+
         self.add_dossier_csv(zipfile)
 
     def add_dossier_csv(self, zipfile):

--- a/opengever/disposition/ech0160/sippackage.py
+++ b/opengever/disposition/ech0160/sippackage.py
@@ -173,10 +173,12 @@ class SIPPackage(object):
         self.add_documents_csv(zipfile)
 
     def add_dossier_csv(self, zipfile):
-        data = DispositionDossierCSVReporter(self.dossiers)()
+        reporter = DispositionDossierCSVReporter(self.dossiers)
         stream = StringIO()
-        csvout = csv.writer(stream, delimiter=';', doublequote=False, escapechar='\\')
-        csvout.writerows(map(utf8ize, data))
+        writer = csv.DictWriter(stream, fieldnames=reporter.fieldnames, delimiter=';',
+                                doublequote=False, escapechar='\\')
+        writer.writeheader()
+        writer.writerows(reporter())
         dossier_csv = os.path.join(self.get_folder_name(), 'dossiers.csv')
         zipfile.writestr(dossier_csv, stream.getvalue())
 

--- a/opengever/disposition/interfaces.py
+++ b/opengever/disposition/interfaces.py
@@ -67,6 +67,12 @@ class IDispositionSettings(Interface):
         'attached in the SIP package if no conversion file exists.',
         default=False)
 
+    attach_csv_reports = schema.Bool(
+        title=u'Attach csv reports',
+        description=u'Whether some additional csv reports should be '
+        'attached in the SIP package.',
+        default=False)
+
 
 class IFilesystemTransportSettings(Interface):
 

--- a/opengever/disposition/reports.py
+++ b/opengever/disposition/reports.py
@@ -13,150 +13,66 @@ def format_date(value):
 
 class DispositionDossierCSVReporter(object):
 
+    fieldnames = [
+        'dossier_id',
+        'Mandant',
+        'Ordnungsystem_Version',
+        'Ordnungssystem_Pfad',
+        'Dossier_Titel',
+        'entstehungszeitraum_von',
+        'entstehungszeitraum_bis',
+        'klassifizierungskategorie',
+        'datenschutz',
+        'oeffentlichkeitsstatus',
+        'aktenzeichen',
+        'eroeffnungsdatum',
+        'abschlussdatum',
+        'schutzfrist',
+        'Ablage_Pr\xe4fix',
+        'Ablage_Nr',
+        'Beschreibung',
+    ]
+
     def __init__(self, dossiers):
         self.dossiers = dossiers
 
     def __call__(self):
         lines = []
-        lines.append([attr.get('label') for attr in self.attributes()])
-
         for dossier in self.dossiers:
-            values = []
-            for attribute in self.attributes():
-                if attribute.get('binding_id'):
-                    value = getattr(dossier.binding(), attribute.get('binding_id'))
-                else:
-                    value = attribute.get('value')(dossier)
-
-                value = value if value else u''
-                values.append(value)
-
-            lines.append(values)
+            binding = dossier.binding()
+            lines.append(
+                {
+                    'dossier_id': binding.id,
+                    'Mandant': get_current_admin_unit().label(),
+                    'Ordnungsystem_Version': dossier.parents()[0].version,
+                    'Ordnungssystem_Pfad': self.repository_path(dossier),
+                    'Dossier_Titel': dossier.obj.title,
+                    'entstehungszeitraum_von': format_date(
+                        binding.entstehungszeitraum.von.datum),
+                    'entstehungszeitraum_bis': format_date(
+                        binding.entstehungszeitraum.bis.datum),
+                    'klassifizierungskategorie': binding.klassifizierungskategorie,
+                    'datenschutz': binding.datenschutz,
+                    'oeffentlichkeitsstatus': binding.oeffentlichkeitsstatus,
+                    'aktenzeichen': binding.aktenzeichen,
+                    'eroeffnungsdatum': format_date(dossier.binding().eroeffnungsdatum.datum),
+                    'abschlussdatum': format_date(dossier.binding().abschlussdatum.datum),
+                    'schutzfrist': binding.schutzfrist,
+                    'Ablage_Pr\xe4fix': dossier.obj.filing_prefix,
+                    'Ablage_Nr': self.filing_number(dossier),
+                    'Beschreibung': dossier.obj.description,
+                })
 
         return lines
-
-    def attributes(self):
-        return [
-            {
-                'label': u'id',
-                'binding_id': 'id'
-            },
-            {
-                'label': u'Mandant',
-                'value': self.admin_unit_label
-            },
-            {
-                'label': u'Ordnungsystem_Version',
-                'value': self.repository_version
-            },
-            {
-                'label': u'Ordnungssystem_Pfad',
-                'value': self.repository_path
-            },
-            {
-                'label': u'Dossier_Titel',
-                'value': self.dossier_title
-            },
-            {
-                'label': u'entstehungszeitraum_von',
-                'value': self.entstehtungszeitraum_von
-            },
-            {
-                'label': u'entstehungszeitraum_bis',
-                'value': self.entstehtungszeitraum_bis
-            },
-            {
-                'label': u'klassifizierungskategorie',
-                'binding_id': 'klassifizierungskategorie'
-            },
-            {
-                'label': u'datenschutz',
-                'binding_id': 'datenschutz'
-            },
-            {
-                'label': u'oeffentlichkeitsstatus',
-                'binding_id': 'oeffentlichkeitsstatus'
-            },
-            {
-                'label': u'aktenzeichen',
-                'binding_id': 'aktenzeichen'
-            },
-            {
-                'label': u'eroeffnungsdatum',
-                'value': self.start_date
-            },
-            {
-                'label': u'abschlussdatum',
-                'value': self.end_date
-            },
-            {
-                'label': u'schutzfrist',
-                'binding_id': 'schutzfrist'
-            },
-            {
-                'label': u'Ablage_Pr\xe4fix',
-                'value': self.filing_prefix
-            },
-            {
-                'label': u'Ablage_Nr',
-                'value': self.filing_number
-            },
-            {
-                'label': u'Beschreibung',
-                'value': self.description
-            }
-        ]
-
-    def binding_id(self, dossier):
-        return dossier.binding().id
-
-    def admin_unit_label(self, dossier):
-        return get_current_admin_unit().label()
-
-    def repository_version(self, dossier):
-        return dossier.parents()[0].version
 
     def repository_path(self, dossier):
         # skip dossier itself
         return u'/'.join(
             [parent.Title().decode('utf-8') for parent in dossier.parents()[:-1]])
 
-    def dossier_title(self, dossier):
-        return dossier.obj.title
-
-    def start_date(self, dossier):
-        value = dossier.binding().eroeffnungsdatum.datum
-        if isinstance(value, date):
-            return value.strftime("%Y-%M-%d")
-        return None
-
-    def end_date(self, dossier):
-        value = dossier.binding().abschlussdatum.datum
-        if isinstance(value, date):
-            return value.strftime("%Y-%M-%d")
-        return None
-
-    def entstehtungszeitraum_von(self, dossier):
-        value = dossier.binding().entstehungszeitraum.von.datum
-        if isinstance(value, date):
-            return value.strftime("%Y-%M-%d")
-        return None
-
-    def entstehtungszeitraum_bis(self, dossier):
-        value = dossier.binding().entstehungszeitraum.bis.datum
-        if isinstance(value, date):
-            return value.strftime("%Y-%M-%d")
-        return None
-
-    def filing_prefix(self, dossier):
-        return dossier.obj.filing_prefix
-
     def filing_number(self, dossier):
         if IFilingNumberMarker.providedBy(dossier.obj):
             return IFilingNumber(dossier.obj).filing_no
-
-    def description(self, dossier):
-        return dossier.obj.description
 
 
 class DispositionDocumentCSVReporter(object):

--- a/opengever/disposition/reports.py
+++ b/opengever/disposition/reports.py
@@ -1,0 +1,152 @@
+from datetime import date
+from opengever.dossier.behaviors.filing import IFilingNumber
+from opengever.dossier.behaviors.filing import IFilingNumberMarker
+from opengever.ogds.base.utils import get_current_admin_unit
+
+
+class DispositionDossierCSVReporter(object):
+
+    def __init__(self, dossiers):
+        self.dossiers = dossiers
+
+    def __call__(self):
+        lines = []
+        lines.append([attr.get('label') for attr in self.attributes()])
+
+        for dossier in self.dossiers:
+            values = []
+            for attribute in self.attributes():
+                if attribute.get('binding_id'):
+                    value = getattr(dossier.binding(), attribute.get('binding_id'))
+                else:
+                    value = attribute.get('value')(dossier)
+
+                value = value if value else u''
+                values.append(value)
+
+            lines.append(values)
+
+        return lines
+
+    def attributes(self):
+        return [
+            {
+                'label': u'id',
+                'binding_id': 'id'
+            },
+            {
+                'label': u'Mandant',
+                'value': self.admin_unit_label
+            },
+            {
+                'label': u'Ordnungsystem_Version',
+                'value': self.repository_version
+            },
+            {
+                'label': u'Ordnungssystem_Pfad',
+                'value': self.repository_path
+            },
+            {
+                'label': u'Dossier_Titel',
+                'value': self.dossier_title
+            },
+            {
+                'label': u'entstehungszeitraum_von',
+                'value': self.entstehtungszeitraum_von
+            },
+            {
+                'label': u'entstehungszeitraum_bis',
+                'value': self.entstehtungszeitraum_bis
+            },
+            {
+                'label': u'klassifizierungskategorie',
+                'binding_id': 'klassifizierungskategorie'
+            },
+            {
+                'label': u'datenschutz',
+                'binding_id': 'datenschutz'
+            },
+            {
+                'label': u'oeffentlichkeitsstatus',
+                'binding_id': 'oeffentlichkeitsstatus'
+            },
+            {
+                'label': u'aktenzeichen',
+                'binding_id': 'aktenzeichen'
+            },
+            {
+                'label': u'eroeffnungsdatum',
+                'value': self.start_date
+            },
+            {
+                'label': u'abschlussdatum',
+                'value': self.end_date
+            },
+            {
+                'label': u'schutzfrist',
+                'binding_id': 'schutzfrist'
+            },
+            {
+                'label': u'Ablage_Pr\xe4fix',
+                'value': self.filing_prefix
+            },
+            {
+                'label': u'Ablage_Nr',
+                'value': self.filing_number
+            },
+            {
+                'label': u'Beschreibung',
+                'value': self.description
+            }
+        ]
+
+    def binding_id(self, dossier):
+        return dossier.binding().id
+
+    def admin_unit_label(self, dossier):
+        return get_current_admin_unit().label()
+
+    def repository_version(self, dossier):
+        return dossier.parents()[0].version
+
+    def repository_path(self, dossier):
+        # skip dossier itself
+        return u'/'.join(
+            [parent.Title().decode('utf-8') for parent in dossier.parents()[:-1]])
+
+    def dossier_title(self, dossier):
+        return dossier.obj.title
+
+    def start_date(self, dossier):
+        value = dossier.binding().eroeffnungsdatum.datum
+        if isinstance(value, date):
+            return value.strftime("%Y-%M-%d")
+        return None
+
+    def end_date(self, dossier):
+        value = dossier.binding().abschlussdatum.datum
+        if isinstance(value, date):
+            return value.strftime("%Y-%M-%d")
+        return None
+
+    def entstehtungszeitraum_von(self, dossier):
+        value = dossier.binding().entstehungszeitraum.von.datum
+        if isinstance(value, date):
+            return value.strftime("%Y-%M-%d")
+        return None
+
+    def entstehtungszeitraum_bis(self, dossier):
+        value = dossier.binding().entstehungszeitraum.bis.datum
+        if isinstance(value, date):
+            return value.strftime("%Y-%M-%d")
+        return None
+
+    def filing_prefix(self, dossier):
+        return dossier.obj.filing_prefix
+
+    def filing_number(self, dossier):
+        if IFilingNumberMarker.providedBy(dossier.obj):
+            return IFilingNumber(dossier.obj).filing_no
+
+    def description(self, dossier):
+        return dossier.obj.description

--- a/opengever/disposition/reports.py
+++ b/opengever/disposition/reports.py
@@ -1,5 +1,6 @@
 from datetime import date
 from opengever.base.interfaces import IReferenceNumber
+from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.behaviors.filing import IFilingNumber
 from opengever.dossier.behaviors.filing import IFilingNumberMarker
 from opengever.ogds.base.utils import get_current_admin_unit
@@ -138,3 +139,31 @@ class DispositionDocumentCSVReporter(object):
                     })
 
         return lines
+
+
+class DispositionDossierPerTypeCSVReporter(object):
+
+    def __init__(self, dossiers):
+        self.dossiers = dossiers
+
+    def __call__(self):
+        values_per_type = {}
+        for dossier in self.dossiers:
+            dossier_type = IDossier(dossier.obj).dossier_type
+            if not dossier_type:
+                continue
+
+            if not dossier.binding().zusatzDaten:
+                continue
+
+            value = {'dossier_id': dossier.binding().id}
+            value.update(
+                {item.name: item.value()
+                 for item in dossier.binding().zusatzDaten.merkmal})
+
+            if dossier_type not in values_per_type:
+                values_per_type[dossier_type] = []
+
+            values_per_type[dossier_type].append(value)
+
+        return values_per_type

--- a/opengever/disposition/tests/test_sippackage.py
+++ b/opengever/disposition/tests/test_sippackage.py
@@ -5,10 +5,12 @@ from ftw.testing import freeze
 from opengever.base.behaviors.lifecycle import ARCHIVAL_VALUE_WORTHY
 from opengever.disposition.ech0160.sippackage import SIPPackage
 from opengever.disposition.interfaces import IAppraisal
+from opengever.disposition.interfaces import IDispositionSettings
 from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.ogds.models.service import ogds_service
 from opengever.testing import FunctionalTestCase
 from opengever.testing import IntegrationTestCase
+from plone import api
 from tempfile import TemporaryFile
 from zipfile import ZipFile
 import csv
@@ -191,8 +193,7 @@ class TestSIPPackage(FunctionalTestCase):
                  'SIP_20160611_PLONE_1_10xy/content/d000001/p000001.doc',
                  'SIP_20160611_PLONE_1_10xy/content/d000002/p000002.pdf',
                  'SIP_20160611_PLONE_1_10xy/content/d000002/p000003.doc',
-                 'SIP_20160611_PLONE_1_10xy/header/metadata.xml',
-                 'SIP_20160611_PLONE_1_10xy/dossiers.csv'],
+                 'SIP_20160611_PLONE_1_10xy/header/metadata.xml'],
                 zip_file.namelist())
 
     def test_adds_dossiers_csv(self):

--- a/opengever/disposition/tests/test_sippackage.py
+++ b/opengever/disposition/tests/test_sippackage.py
@@ -227,7 +227,7 @@ class TestSIPPackage(FunctionalTestCase):
 
             self.assertDictContainsSubset(
                 {'Ablage_Nr': '',
-                 'Ablage_Pr\xc3\xa4fix': '',
+                 'Ablage_Pr\xe4fix': '',
                  'Beschreibung': 'Lorem ipsum',
                  'Dossier_Titel': '',
                  'Mandant': 'Admin Unit 1',
@@ -235,7 +235,7 @@ class TestSIPPackage(FunctionalTestCase):
                  'Ordnungsystem_Version': '',
                  'abschlussdatum': '2000-00-11',
                  'aktenzeichen': 'Client1 1 / 1',
-                 'datenschutz': '',
+                 'datenschutz': 'false',
                  'entstehungszeitraum_bis': '',
                  'entstehungszeitraum_von': '',
                  'eroeffnungsdatum': '2016-00-11',
@@ -247,7 +247,7 @@ class TestSIPPackage(FunctionalTestCase):
 
             self.assertDictContainsSubset(
                 {'Ablage_Nr': '',
-                 'Ablage_Pr\xc3\xa4fix': '',
+                 'Ablage_Pr\xe4fix': '',
                  'Beschreibung': '',
                  'Dossier_Titel': '',
                  'Mandant': 'Admin Unit 1',
@@ -255,7 +255,7 @@ class TestSIPPackage(FunctionalTestCase):
                  'Ordnungsystem_Version': '',
                  'abschlussdatum': '2000-00-11',
                  'aktenzeichen': 'Client1 1 / 2',
-                 'datenschutz': '',
+                 'datenschutz': 'false',
                  'entstehungszeitraum_bis': '',
                  'entstehungszeitraum_von': '',
                  'eroeffnungsdatum': '2016-00-11',


### PR DESCRIPTION
LTAs from certain customers cannot automatically process the metadata.xml of the SIP package. In this case, we therefore extend the SIP package with additional csv exports. A list of all dossiers (`dossiers.csv`), a list of all files (`items.csv`) and a list with the custom fields for each dossier type.

This feature is disabled per default. The column names are based on the ech0160 spec and are therefore in german.

For [CA-6302]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- Upgrade-Steps:
  - [x] Make it deferrable if possible
  - [x] Execute as much as possible conditionally
- New functionality:
  - [x] for `document` also works for `mail`


[CA-6302]: https://4teamwork.atlassian.net/browse/CA-6302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ