### PR TITLE
Fix Unicode error in `@accessible-workspaces` endpoint.

### DIFF
--- a/changes/CA-6464.bugfix
+++ b/changes/CA-6464.bugfix
@@ -1,0 +1,1 @@
+Fix Unicode error in `@accessible-workspaces` endpoint. [lgraf]

--- a/opengever/api/accessible_workspaces.py
+++ b/opengever/api/accessible_workspaces.py
@@ -36,7 +36,8 @@ class AccessibleWorkspacesGet(SolrQueryBaseService):
 
         user = api.user.get(userid)
         if user:
-            allowed_roles_and_users.extend([u'user:{}'.format(group) for group in user.getGroups()])
+            allowed_roles_and_users.extend(
+                [u'user:{}'.format(group.decode('utf-8')) for group in user.getGroups()])
             allowed_roles_and_users.extend(user.getRoles())
 
         field = self.fields.get('allowedRolesAndUsers')


### PR DESCRIPTION
Fix Unicode error in `@accessible-workspaces` endpoint.

For [CA-6464](https://4teamwork.atlassian.net/browse/CA-6464)

Follow-Up story: https://4teamwork.atlassian.net/browse/CA-6473

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- Further improvements needed:
  - [x] Create follow-up stories and link them in the PR and Jira issue


[CA-6464]: https://4teamwork.atlassian.net/browse/CA-6464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ