### PR TITLE
Also support usernames for the responsible field in dossier API.

### DIFF
--- a/changes/CA-6237.other
+++ b/changes/CA-6237.other
@@ -1,0 +1,1 @@
+The dossiers responsible field supports now also usernames not just userids. [phgross]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -19,6 +19,8 @@ Other Changes
 
 - The api will now always return the ``uid`` of summary serialized objects.
 
+- The dossiers responsible field support now also usernames not just userids.
+
 
 2023.14.0 (2023-11-09)
 ----------------------

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -120,7 +120,7 @@ DOSSIER_DEFAULTS = {
     'dossier_type': None,
 }
 DOSSIER_FORM_DEFAULTS = {
-    'responsible': 'kathi.barfuss',
+    'responsible': u'kathi.barfuss',
 }
 DOSSIER_MISSING_VALUES = {
     'archival_value_annotation': None,

--- a/opengever/ogds/base/sources.py
+++ b/opengever/ogds/base/sources.py
@@ -511,13 +511,15 @@ class AllUsersSource(AllUsersInboxesAndTeamsSource):
         try:
             user = self.base_query.filter(User.userid == value).one()
         except orm.exc.NoResultFound:
-            raise LookupError(
-                'No row was found with userid: {}'.format(value))
+            try:
+                user = self.base_query.filter(User.username == value).one()
+            except orm.exc.NoResultFound:
+                raise LookupError(
+                    'No row was found with userid or username: {}'.format(value))
 
-        token = value
         title = u'{} ({})'.format(user.fullname(),
                                   user.userid)
-        return SimpleTerm(value, token, title)
+        return SimpleTerm(user.userid, user.userid, title)
 
     def search(self, query_string):
         self.terms = []

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -30,6 +30,7 @@ from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.ogds.base.utils import get_current_org_unit
 from opengever.ogds.models.org_unit import OrgUnit
 from opengever.ogds.models.service import ogds_service
+from opengever.ogds.models.user import User
 from opengever.private import enable_opengever_private
 from opengever.task.interfaces import ISuccessorTaskController
 from opengever.task.task import ITask
@@ -809,6 +810,12 @@ class IntegrationTestCase(TestCase):
     def set_roles(self, obj, principal, roles):
         RoleAssignmentManager(obj).add_or_update_assignment(
             SharingRoleAssignment(principal, roles))
+
+    def change_loginname(self, userid, new_loginname):
+        acl_users = api.portal.get_tool('acl_users')
+        acl_users.source_users.updateUser(userid, new_loginname)
+        user = User.query.get(userid)
+        user.username = new_loginname
 
 
 class SolrIntegrationTestCase(IntegrationTestCase, SolrTestMixin):


### PR DESCRIPTION
With the recently introduced separation between userid and username, certain API endpoints now expect the userid to be specified. Since external applications such as the RIS have no knowledge of the GEVER internal userid, they must be adapted so that they can also handle the username.  This PR introduces this support for the dossier responsible field.

For [CA-6237]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- API change:
  - [x] Documentation is updated _(imho not necessary)_
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))

[CA-6237]: https://4teamwork.atlassian.net/browse/CA-6237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ