### PR TITLE
Prepare testing for using a username different from userid

### DIFF
--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -2269,10 +2269,10 @@ class OpengeverContentFixture(object):
 
         try:
             try:
-                login(getSite(), user.getId())
+                login(getSite(), user.getUserName())
             # XXX - Allow (early) lookups from the Zope acl_users as well
             except ValueError:
-                login(getSite().getPhysicalRoot(), user.getId())
+                login(getSite().getPhysicalRoot(), user.getUserName())
             yield
 
         finally:

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -43,8 +43,10 @@ from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
 from plone.app.textfield.value import RichTextValue
+from plone.i18n.normalizer.interfaces import IIDNormalizer
 from time import time
 from zope.annotation.interfaces import IAnnotations
+from zope.component import getUtility
 from zope.component.hooks import getSite
 from zope.globalrequest import getRequest
 import json
@@ -2018,18 +2020,32 @@ class OpengeverContentFixture(object):
         from within tests.
         """
         globalroles = ['Member'] + list(globalroles)
+
+        def make_username(firstname, lastname):
+            normalizer = getUtility(IIDNormalizer)
+            first = normalizer.normalize(firstname)
+            last = normalizer.normalize(lastname)
+            username = '.'.join((first, last))
+            return username
+
+        userid = kwargs.pop('userid', None)
+        if not userid:
+            # For now, we create a userid in the style of first.last,
+            # same as the username. This will be changed later.
+            userid = make_username(firstname, lastname)
+
         builder = (
             Builder('user')
+            .with_userid(userid)
             .named(firstname, lastname)
             .with_roles(*globalroles)
             .in_groups(self.org_unit_fa.users_group_id)
         )
 
-        builder.update_properties()  # updates builder.userid
         if 'email' in kwargs:
             email = kwargs['email']
         else:
-            email = '{}@gever.local'.format(builder.userid)
+            email = '{}@gever.local'.format(userid)
 
         plone_user = create(builder.with_email(email))
 

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -2037,20 +2037,16 @@ class OpengeverContentFixture(object):
         # For now, username is exactly the same as userid
         username = userid
 
-        builder = (
+        email = kwargs.pop('email', '{}@gever.local'.format(username))
+
+        plone_user = create(
             Builder('user')
             .with_userid(userid)
             .named(firstname, lastname)
             .with_roles(*globalroles)
             .in_groups(self.org_unit_fa.users_group_id)
+            .with_email(email)
         )
-
-        if 'email' in kwargs:
-            email = kwargs['email']
-        else:
-            email = '{}@gever.local'.format(userid)
-
-        plone_user = create(builder.with_email(email))
 
         # Update username for the Plone user.
         # Because ftw.builder uses the registration tool to create users,

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -2034,6 +2034,9 @@ class OpengeverContentFixture(object):
             # same as the username. This will be changed later.
             userid = make_username(firstname, lastname)
 
+        # For now, username is exactly the same as userid
+        username = userid
+
         builder = (
             Builder('user')
             .with_userid(userid)
@@ -2049,12 +2052,19 @@ class OpengeverContentFixture(object):
 
         plone_user = create(builder.with_email(email))
 
+        # Update username for the Plone user.
+        # Because ftw.builder uses the registration tool to create users,
+        # it doesn't allow to set a username that is different from the userid
+        acl_users = api.portal.get_tool('acl_users')
+        acl_users.source_users.updateUser(userid, username)
+        plone_user = api.user.get(userid)
+
         display_name = u"{} {}".format(lastname.title(), firstname.title())
         create(
             Builder('ogds_user')
             .id(plone_user.getId())
             .having(firstname=firstname, lastname=lastname, email=email,
-                    display_name=display_name)
+                    username=plone_user.getUserName(), display_name=display_name)
             .assign_to_org_units([self.org_unit_fa])
             .in_group(group)
             .having(**kwargs)

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -211,22 +211,22 @@ class IntegrationTestCase(TestCase):
         The method may also be used used as context manager, ensuring that
         after leaving the same user is logged in as before.
         """
-        if hasattr(user, 'getId'):
-            userid = user.getId()
+        if hasattr(user, 'getUserName'):
+            username = user.getUserName()
         else:
-            userid = user
+            username = user
 
         security_manager = getSecurityManager()
-        if userid == SITE_OWNER_NAME:
-            login(self.layer['app'], userid)
+        if username == SITE_OWNER_NAME:
+            login(self.layer['app'], username)
         else:
-            login(self.portal, userid)
+            login(self.portal, username)
 
         if browser is not None:
             browser_auth_headers = filter(
                 lambda item: item[0] == 'Authorization',
                 browser.session_headers)
-            browser.login(userid)
+            browser.login(username)
 
         @contextmanager
         def login_context_manager():


### PR DESCRIPTION
Prepare testing for using a username different from userid.

- Use `username` for logging in during test, instead of `userid`
- Make sure username gets set correctly for Plone users
- Base email on username


For [CA-6237](https://4teamwork.atlassian.net/browse/CA-6237)

## Checklist

- [ ] Changelog entry (testing changes only)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-6237]: https://4teamwork.atlassian.net/browse/CA-6237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ