### PR TITLE
Tests: Use different userid for fixture user limited_admin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -634,7 +634,7 @@ Users
 - ``self.dossier_manager``: ``faivel.fruhling``
 - ``self.dossier_responsible``: ``robert.ziegler``
 - ``self.foreign_contributor``: ``james.bond``
-- ``self.limited_admin``: ``maja.harzig``
+- ``self.limited_admin``: ``limited_admin``
 - ``self.manager``: ``admin``
 - ``self.meeting_user``: ``herbert.jager``
 - ``self.member_admin``: ``david.meier``

--- a/opengever/api/tests/test_ogdsuserlisting.py
+++ b/opengever/api/tests/test_ogdsuserlisting.py
@@ -72,11 +72,11 @@ class TestOGDSUserListingGet(IntegrationTestCase):
         self.assertEqual(200, browser.status_code)
 
         self.assertEqual(4, len(browser.json['items']))
-        self.assertEqual(
-            [u'fridolin.hugentobler',
-             u'maja.harzig',
-             u'herbert.jager',
-             u'nicole.kohler'],
+        self.assertItemsEqual(
+            [self.workspace_admin.getId(),
+             self.limited_admin.getId(),
+             self.meeting_user.getId(),
+             self.administrator.getId(),],
             [each['userid'] for each in browser.json['items']])
         self.assertEqual(23, browser.json['items_total'])
 

--- a/opengever/ogds/auth/tests/test_plugin.py
+++ b/opengever/ogds/auth/tests/test_plugin.py
@@ -96,30 +96,30 @@ class TestOGDSAuthPluginIUserEnumeration(TestOGDSAuthPluginBase):
     def test_enum_users_without_search_critera_returns_all_users(self):
         results = self.plugin.enumerateUsers()
         expected = (
-            self.workspace_member.getId(),
             api.user.get('committee.secretary').getId(),
-            self.member_admin.getId(),
-            self.dossier_manager.getId(),
-            self.committee_responsible.getId(),
-            self.workspace_admin.getId(),
-            self.workspace_owner.getId(),
-            self.workspace_guest.getId(),
-            self.meeting_user.getId(),
             api.user.get('james.bond').getId(),
-            self.archivist.getId(),
-            self.secretariat_user.getId(),
-            self.regular_user.getId(),
             api.user.get('lucklicher.laser').getId(),
-            self.limited_admin.getId(),
             api.user.get('nicole.kohler').getId(),
+            api.user.get('test_user_1_').getId(),
+            self.archivist.getId(),
+            self.committee_responsible.getId(),
+            self.dossier_manager.getId(),
+            self.dossier_responsible.getId(),
+            self.limited_admin.getId(),
+            self.meeting_user.getId(),
+            self.member_admin.getId(),
             self.propertysheets_manager.getId(),
             self.records_manager.getId(),
-            self.dossier_responsible.getId(),
+            self.regular_user.getId(),
+            self.secretariat_user.getId(),
             self.service_user.getId(),
-            api.user.get('test_user_1_').getId(),
             self.webaction_manager.getId(),
+            self.workspace_admin.getId(),
+            self.workspace_guest.getId(),
+            self.workspace_member.getId(),
+            self.workspace_owner.getId(),
         )
-        self.assertEqual(expected, self.ids(results))
+        self.assertItemsEqual(expected, self.ids(results))
 
     def test_enum_users_with_unknown_search_criteria_returns_empty_tuple(self):
         results = self.plugin.enumerateUsers(unkown_attr='foo')
@@ -467,26 +467,26 @@ class TestOGDSAuthPluginIGroupIntrospection(TestOGDSAuthPluginBase):
 
     def test_get_group_members_returns_list_of_user_ids(self):
         user_ids = self.plugin.getGroupMembers('fa_users')
-        self.assertEqual(user_ids, [
-            self.workspace_member.getId(),
+        self.assertItemsEqual(user_ids, [
             api.user.get('committee.secretary').getId(),
-            self.member_admin.getId(),
-            self.dossier_manager.getId(),
-            self.committee_responsible.getId(),
-            self.workspace_admin.getId(),
-            self.workspace_owner.getId(),
-            self.workspace_guest.getId(),
-            self.meeting_user.getId(),
-            self.archivist.getId(),
-            self.secretariat_user.getId(),
-            self.regular_user.getId(),
-            self.limited_admin.getId(),
             api.user.get('nicole.kohler').getId(),
+            self.archivist.getId(),
+            self.committee_responsible.getId(),
+            self.dossier_manager.getId(),
+            self.dossier_responsible.getId(),
+            self.limited_admin.getId(),
+            self.meeting_user.getId(),
+            self.member_admin.getId(),
             self.propertysheets_manager.getId(),
             self.records_manager.getId(),
-            self.dossier_responsible.getId(),
+            self.regular_user.getId(),
+            self.secretariat_user.getId(),
             self.service_user.getId(),
             self.webaction_manager.getId(),
+            self.workspace_admin.getId(),
+            self.workspace_guest.getId(),
+            self.workspace_member.getId(),
+            self.workspace_owner.getId(),
         ])
 
     def test_get_group_members_for_unknown_id_returns_empty_list(self):

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -2040,6 +2040,7 @@ class OpengeverContentFixture(object):
         # Except for these users
         users_with_different_userid = (
             'propertysheets_manager',
+            'limited_admin',
         )
 
         if attrname in users_with_different_userid:


### PR DESCRIPTION
Tests: Use different userid for fixture user `limited_admin`

For [CA-6237](https://4teamwork.atlassian.net/browse/CA-6237)

## Checklist

- [ ] Changelog entry _(testing changes only)_
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-6237]: https://4teamwork.atlassian.net/browse/CA-6237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ