### PR TITLE
Tests: Use different userid for fixture user member_admin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -637,7 +637,7 @@ Users
 - ``self.limited_admin``: ``limited_admin``
 - ``self.manager``: ``admin``
 - ``self.meeting_user``: ``herbert.jager``
-- ``self.member_admin``: ``david.meier``
+- ``self.member_admin``: ``member_admin``
 - ``self.propertysheets_manager``: ``propertysheets_manager``
 - ``self.reader_user``: ``lucklicher.laser``
 - ``self.records_manager``: ``ramon.flucht``

--- a/opengever/api/tests/test_external_activities.py
+++ b/opengever/api/tests/test_external_activities.py
@@ -326,7 +326,7 @@ class TestExternalActivitiesPost(IntegrationTestCase):
         )
 
         def fail_for_david(notification):
-            if notification.userid == 'david.meier':
+            if notification.userid == self.member_admin.getId():
                 raise Exception('Boom')
 
         patched_dispatch.side_effect = fail_for_david
@@ -356,9 +356,9 @@ class TestExternalActivitiesPost(IntegrationTestCase):
 
         self.assertEqual([{
             'type': 'dispatch_failed',
-            'msg': u"Failed to dispatch notification for user u'david.meier'",
-            'userid': 'david.meier',
-            }], browser.json['errors'])
+            'msg': u"Failed to dispatch notification for user u'%s'" % self.member_admin.getId(),
+            'userid': self.member_admin.getId(),
+        }], browser.json['errors'])
 
         activity = Activity.query.all()[-1]
 

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -2041,6 +2041,7 @@ class OpengeverContentFixture(object):
         users_with_different_userid = (
             'propertysheets_manager',
             'limited_admin',
+            'member_admin',
         )
 
         if attrname in users_with_different_userid:


### PR DESCRIPTION
Tests: Use different userid for fixture user `member_admin`

For [CA-6237](https://4teamwork.atlassian.net/browse/CA-6237)

## Checklist

- [ ] Changelog entry _(testing changes only)_
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-6237]: https://4teamwork.atlassian.net/browse/CA-6237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ