### PR TITLE
Tests: Use different userid for fixture user records_manager

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -640,7 +640,7 @@ Users
 - ``self.member_admin``: ``member_admin``
 - ``self.propertysheets_manager``: ``propertysheets_manager``
 - ``self.reader_user``: ``lucklicher.laser``
-- ``self.records_manager``: ``ramon.flucht``
+- ``self.records_manager``: ``records_manager``
 - ``self.regular_user``: ``kathi.barfuss``
 - ``self.secretariat_user``: ``jurgen.konig``
 - ``self.service_user``: ``service.user``

--- a/opengever/api/tests/test_disposition.py
+++ b/opengever/api/tests/test_disposition.py
@@ -242,7 +242,7 @@ class TestDispositionSerialization(IntegrationTestCase):
 
         self.assertEqual(
             [
-                {u'creator': {u'token': u'ramon.flucht', u'title': u'Flucht Ramon'},
+                {u'creator': {u'token': self.records_manager.getId(), u'title': u'Flucht Ramon'},
                  u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/disposition-2/@responses/1472663373000000',
                  u'created': u'2016-08-31T19:09:33',
                  u'modified': None,
@@ -259,7 +259,7 @@ class TestDispositionSerialization(IntegrationTestCase):
                       u'appraisal': True}],
                  u'text': u'',
                  u'changes': []},
-                {u'creator': {u'token': u'ramon.flucht', u'title': u'Flucht Ramon'},
+                {u'creator': {u'token': self.records_manager.getId(), u'title': u'Flucht Ramon'},
                  u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/disposition-2/@responses/1472663493000000',
                  u'created': u'2016-08-31T19:11:33',
                  u'modified': None,

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -2042,6 +2042,7 @@ class OpengeverContentFixture(object):
             'propertysheets_manager',
             'limited_admin',
             'member_admin',
+            'records_manager',
         )
 
         if attrname in users_with_different_userid:


### PR DESCRIPTION
Tests: Use different userid for fixture user `records_manager`

For [CA-6237](https://4teamwork.atlassian.net/browse/CA-6237)

## Checklist

- [ ] Changelog entry _(testing changes only)_
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-6237]: https://4teamwork.atlassian.net/browse/CA-6237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ