### PR TITLE
Tests: Use different userid for fixture user service_user

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -643,7 +643,7 @@ Users
 - ``self.records_manager``: ``records_manager``
 - ``self.regular_user``: ``kathi.barfuss``
 - ``self.secretariat_user``: ``jurgen.konig``
-- ``self.service_user``: ``service.user``
+- ``self.service_user``: ``service_user``
 - ``self.test_user``: ``test_user_1_``
 - ``self.webaction_manager``: ``webaction.manager``
 - ``self.workspace_admin``: ``fridolin.hugentobler``

--- a/opengever/api/tests/test_serializer.py
+++ b/opengever/api/tests/test_serializer.py
@@ -376,10 +376,10 @@ class TestGroupSerializer(IntegrationTestCase):
              u'roles': [u'Authenticated'],
              u'title': u'fa Users Group',
              u'users': {u'@id': u'http://nohost/plone/@groups/fa_users',
-                        u'items': [{u'@id': u'http://nohost/plone/@users/service.user',
+                        u'items': [{u'@id': u'http://nohost/plone/@users/%s' % self.propertysheets_manager.getId(),
                                     u'@type': u'virtual.plone.user',
-                                    u'title': u'User Service (service.user)',
-                                    u'token': u'service.user'}],
+                                    u'title': u'Manager PropertySheets (propertysheets.manager)',
+                                    u'token': self.propertysheets_manager.getId()}],
                         u'items_total': 20}},
             response)
 

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -2043,6 +2043,7 @@ class OpengeverContentFixture(object):
             'limited_admin',
             'member_admin',
             'records_manager',
+            'service_user',
         )
 
         if attrname in users_with_different_userid:


### PR DESCRIPTION
Tests: Use different userid for fixture user `service_user`

For [CA-6237](https://4teamwork.atlassian.net/browse/CA-6237)

## Checklist

- [ ] Changelog entry _(testing changes only)_
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-6237]: https://4teamwork.atlassian.net/browse/CA-6237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ