### PR TITLE
Fixes the sharing tab for subdossiers created by a dossier from template

### DIFF
--- a/changes/CA-6493.bugfix
+++ b/changes/CA-6493.bugfix
@@ -1,0 +1,1 @@
+Fixes the sharing tab for subdossiers created by a dossier from template. [elioschmutz]

--- a/opengever/dossier/command.py
+++ b/opengever/dossier/command.py
@@ -68,9 +68,10 @@ class CreateDossierFromTemplateCommand(BaseObjectCreatorCommand):
     """
     portal_type = 'opengever.dossier.businesscasedossier'
 
-    def __init__(self, context, template):
+    def __init__(self, context, template, **kwargs):
         kw = self._get_additional_attributes(template)
-        self.fields = kw["IOpenGeverBase"]
+        self.fields = kwargs
+        self.fields.update(kw["IOpenGeverBase"])
         del kw["IOpenGeverBase"]
         self.additional_fields = kw
 

--- a/opengever/dossier/dossiertemplate/form.py
+++ b/opengever/dossier/dossiertemplate/form.py
@@ -212,9 +212,8 @@ class CreateDossierContentFromTemplateMixin(object):
         for child_obj in template_obj.listFolderContents():
             if IDossierTemplateSchema.providedBy(child_obj):
                 dossier = CreateDossierFromTemplateCommand(
-                    target_container, child_obj).execute()
-
-                IDossier(dossier).responsible = responsible
+                    target_container, child_obj,
+                    responsible=responsible).execute()
 
                 self.recursive_content_creation(child_obj, dossier)
             else:

--- a/opengever/dossier/tests/test_command.py
+++ b/opengever/dossier/tests/test_command.py
@@ -4,6 +4,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from opengever.document.docprops import TemporaryDocFile
 from opengever.document.versioner import Versioner
+from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.command import CreateDocumentFromTemplateCommand
 from opengever.dossier.command import CreateDossierFromTemplateCommand
@@ -89,7 +90,10 @@ class TestCreateDossierFromTemplateCommand(IntegrationTestCase):
 
     def test_create_dossier_from_template(self):
         self.login(self.regular_user)
-        command = CreateDossierFromTemplateCommand(self.dossier, self.dossiertemplate)
+        command = CreateDossierFromTemplateCommand(self.dossier,
+                                                   self.dossiertemplate,
+                                                   responsible=self.regular_user.id)
         dossier = command.execute()
         self.assertEqual(self.dossiertemplate.title, dossier.title)
         self.assertTrue(IDossierMarker.providedBy(dossier))
+        self.assertEqual(self.regular_user.id, IDossier(dossier).responsible)


### PR DESCRIPTION
🚧  Upgradestep is missing

For [CA-6493]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-6493]: https://4teamwork.atlassian.net/browse/CA-6493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ