### PR TITLE
Also support usernames for the responsible and issuer field in tasks API.

### DIFF
--- a/changes/CA-6237-2.other
+++ b/changes/CA-6237-2.other
@@ -1,0 +1,1 @@
+Task responsible and issuer field supports now also usernames not just userids. [phgross]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -23,6 +23,8 @@ Other Changes
 
 - The ``@ogds-users`` endpoint supports now also username as parameter not just the userid.
 
+- The task issuer and responsible field support now also usernames not just userids.
+
 
 2023.14.0 (2023-11-09)
 ----------------------

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -209,7 +209,7 @@ MAIL_MISSING_VALUES = {
 
 TASK_REQUIREDS = {
     'changed': FROZEN_DATETIME_NOW,
-    'issuer': 'regular_user',
+    'issuer': u'regular_user',
     'responsible': u'regular_user',
     'responsible_client': DEFAULT_CLIENT,
     'task_type': 'information',


### PR DESCRIPTION
Same as I already did for dossiers (#7831), we need also for task creation and modification.

With the recently introduced separation between userid and username, certain API endpoints now expect the userid to be specified. Since external applications such as the RIS have no knowledge of the GEVER internal userid, they must be adapted so that they can also handle the username.

For [CA-6237]

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- API change:
  - [ ] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))


[CA-6237]: https://4teamwork.atlassian.net/browse/CA-6237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ