### PR TITLE
Properly set predefined dossier template local roles on dossiers creating by templates

### DIFF
--- a/changes/CA-6493.bugfix
+++ b/changes/CA-6493.bugfix
@@ -1,0 +1,1 @@
+Properly set predefined dossier template local roles on dossiers creating by templates. [elioschmutz]

--- a/opengever/api/templatefolder.py
+++ b/opengever/api/templatefolder.py
@@ -1,6 +1,7 @@
 from opengever.api.add import FolderPost
 from opengever.api.task import deserialize_responsible
 from opengever.api.validation import get_validation_errors
+from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.base.source import DossierPathSourceBinder
 from opengever.base.source import SolrObjPathSourceBinder
 from opengever.contact.ogdsuser import OgdsUserToContactAdapter
@@ -137,6 +138,9 @@ class DossierFromTemplatePost(FolderPost, CreateDossierContentFromTemplateMixin)
 
         serialized_dossier = super(DossierFromTemplatePost, self).reply()
         self.validate_keywords(self.dossier_template, self.request_data.get('keywords'))
+        self.obj.__ac_local_roles_block__ = getattr(
+            self.dossier_template, '__ac_local_roles_block__', None)
+        RoleAssignmentManager(self.dossier_template).copy_assigments_to(self.obj)
         self.create_dossier_content_from_template(self.obj, self.dossier_template)
         return serialized_dossier
 

--- a/opengever/api/tests/test_templatefolder.py
+++ b/opengever/api/tests/test_templatefolder.py
@@ -712,6 +712,79 @@ class TestDossierFromTemplatePost(IntegrationTestCase):
         self.assertEqual([u'T\xc3\xb6mpl\xc3\xb6te Normal', u'Baumsch\xfctze'],
                          [obj.title for obj in subdossier.listFolderContents()])
 
+    @browsing
+    def test_set_dossier_local_roles_from_template(self, browser):
+        self.login(self.regular_user, browser)
+
+        self.dossiertemplate.__ac_local_roles_block__ = True
+        RoleAssignmentManager(self.dossiertemplate).add_or_update_assignment(
+            SharingRoleAssignment(self.regular_user.getId(),
+                                  ['Reader', 'Contributor', 'Editor']))
+        RoleAssignmentManager(self.dossiertemplate).add_or_update_assignment(
+            SharingRoleAssignment(self.dossier_manager.getId(),
+                                  ['Reader']))
+
+        self.subdossiertemplate.__ac_local_roles_block__ = True
+        RoleAssignmentManager(self.subdossiertemplate).add_or_update_assignment(
+            SharingRoleAssignment(self.regular_user.getId(),
+                                  ['Reader', 'Contributor', 'Editor']))
+        RoleAssignmentManager(self.subdossiertemplate).add_or_update_assignment(
+            SharingRoleAssignment(self.dossier_manager.getId(),
+                                  ['Reader', 'Editor']))
+
+        browser.open(self.leaf_repofolder,
+                     view='@vocabularies/opengever.dossier.DossierTemplatesVocabulary',
+                     headers=self.api_headers)
+        template = browser.json['items'][0]
+
+        data = {'template': template,
+                'title': u'New d\xf6ssier',
+                'responsible': self.regular_user.getId()}
+
+        with self.observe_children(self.leaf_repofolder) as children:
+            browser.open('{}/@dossier-from-template'.format(
+                         self.leaf_repofolder.absolute_url()),
+                         data=json.dumps(data),
+                         headers=self.api_headers)
+
+        dossier = children['added'].pop()
+        self.assertTrue(dossier.__ac_local_roles_block__)
+        self.assertEqual(
+            [
+                {
+                    'cause': 3,
+                    'roles': ['Reader', 'Contributor', 'Editor'],
+                    'reference': None,
+                    'principal': 'kathi.barfuss',
+                },
+                {
+                    'cause': 3,
+                    'roles': ['Reader'],
+                    'reference': None,
+                    'principal': 'dossier_manager',
+                }
+            ], RoleAssignmentManager(dossier).storage._storage()
+        )
+
+        subdossier = dossier.listFolderContents()[1]
+        self.assertTrue(subdossier.__ac_local_roles_block__)
+        self.assertEqual(
+            [
+                {
+                    'cause': 3,
+                    'roles': ['Reader', 'Contributor', 'Editor'],
+                    'reference': None,
+                    'principal': 'kathi.barfuss',
+                },
+                {
+                    'cause': 3,
+                    'roles': ['Reader', 'Editor'],
+                    'reference': None,
+                    'principal': 'dossier_manager',
+                }
+            ], RoleAssignmentManager(subdossier).storage._storage()
+        )
+
 
 class TestTriggerTaskTemplatePost(IntegrationTestCase):
 


### PR DESCRIPTION
This PR fixes an issue where localroles of dossier tempaltes have only been overtaken from subdossiers, but not for the main dossier.

The `CreateDossierFromTemplateCommand` already respect local roles and role inheritance: https://github.com/4teamwork/opengever.core/blob/376083ec4bdff0b69652c0681547750e4d6e150c/opengever/dossier/command.py#L114 but the command will only be used for subdossiers.

This fix updates the api-endpoint to also respect the local roles and role inheritance on the main dossier itself.

For [CA-6493]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-6493]: https://4teamwork.atlassian.net/browse/CA-6493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ