### PR TITLE
Fix webactions provider for setups where userid and username are different

### DIFF
--- a/changes/CA-6237.bugfix
+++ b/changes/CA-6237.bugfix
@@ -1,0 +1,1 @@
+Fix webactions provider for setups where the userid and user name are different. [phgross]

--- a/opengever/webactions/provider.py
+++ b/opengever/webactions/provider.py
@@ -57,8 +57,8 @@ class WebActionsProvider(object):
         return aq_base(aq_inner(self.context)).portal_type in types
 
     @memoize_contextless
-    def _get_permissions(self, userid):
-        permissions = api.user.get_permissions(username=userid, obj=self.context)
+    def _get_permissions(self, username):
+        permissions = api.user.get_permissions(username=username, obj=self.context)
         return set(name for name, value in permissions.items() if value)
 
     def _action_satisfies_permissions(self, action):
@@ -66,8 +66,8 @@ class WebActionsProvider(object):
         if not action_permissions:
             return True
         action_permissions = map(PUBLIC_PERMISSIONS_MAPPING.get, action_permissions)
-        userid = api.user.get_current().getId()
-        user_permissions = self._get_permissions(userid)
+        username = api.user.get_current().getUserName()
+        user_permissions = self._get_permissions(username)
         return any(permission in user_permissions
                    for permission in action_permissions)
 

--- a/opengever/webactions/tests/test_webactions_provider.py
+++ b/opengever/webactions/tests/test_webactions_provider.py
@@ -175,7 +175,8 @@ class TestWebActionProvider(TestWebActionBase):
                 "All action permissions need to be mapped to real permissions")
 
     def test_webaction_provider_respects_permission(self):
-        self.login(self.regular_user)
+        self.login(self.dossier_manager)
+
         storage = get_storage()
         storage.update(0, {"permissions": ['trash']})
         storage.update(1, {"permissions": ['trash', 'edit']})


### PR DESCRIPTION
For [CA-6237]

Note: I switched from regular_user to the dossier_manager in the tests, because the dossier_manager already has a different username than the userid.


## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
