### PR TITLE
Tests: Use different userid for fixture user webaction_manager

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -645,7 +645,7 @@ Users
 - ``self.secretariat_user``: ``jurgen.konig``
 - ``self.service_user``: ``service_user``
 - ``self.test_user``: ``test_user_1_``
-- ``self.webaction_manager``: ``webaction.manager``
+- ``self.webaction_manager``: ``webaction_manager``
 - ``self.workspace_admin``: ``fridolin.hugentobler``
 - ``self.workspace_guest``: ``hans.peter``
 - ``self.workspace_member``: ``beatrice.schrodinger``

--- a/opengever/api/tests/test_webactions.py
+++ b/opengever/api/tests/test_webactions.py
@@ -58,7 +58,7 @@ class TestWebActionsPost(IntegrationTestCase):
             'unique_name': 'open-in-external-app-title-action',
             'created': '2019-12-31T17:45:00',
             'modified': '2019-12-31T17:45:00',
-            'owner': 'webaction.manager',
+            'owner': 'webaction_manager',
         }, browser.json)
 
     @browsing
@@ -237,7 +237,7 @@ class TestWebActionsGet(IntegrationTestCase):
                 'scope': 'global',
                 'created': '2019-12-31T17:45:00',
                 'modified': '2019-12-31T17:45:00',
-                'owner': 'webaction.manager',
+                'owner': 'webaction_manager',
             }],
         }, browser.json)
 
@@ -304,7 +304,7 @@ class TestWebActionsGet(IntegrationTestCase):
             'scope': 'global',
             'created': '2019-12-31T17:45:00',
             'modified': '2019-12-31T17:45:00',
-            'owner': 'webaction.manager',
+            'owner': 'webaction_manager',
         }, browser.json)
 
     @browsing
@@ -403,7 +403,7 @@ class TestWebActionsPatch(IntegrationTestCase):
             'scope': 'global',
             'created': datetime(2019, 12, 31, 17, 45),
             'modified': datetime(2020, 7, 31, 19, 15),
-            'owner': 'webaction.manager',
+            'owner': 'webaction_manager',
         }, storage.get(action['action_id']))
 
     @browsing

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -2047,6 +2047,7 @@ class OpengeverContentFixture(object):
             'archivist',
             'dossier_manager',
             'regular_user',
+            'webaction_manager',
         )
 
         if attrname in users_with_different_userid:

--- a/opengever/webactions/tests/test_manage_webactions_view.py
+++ b/opengever/webactions/tests/test_manage_webactions_view.py
@@ -38,7 +38,7 @@ class TestReturnedWebactions(IntegrationTestCase):
                              'order': 5,
                              'created': datetime(2018, 4, 20),
                              'modified': datetime(2018, 4, 20),
-                             'owner': 'webaction.manager',
+                             'owner': 'webaction_manager',
                              'scope': 'global'}
 
         self.action2_data = {'target_url': 'http://example.org/endpoint',
@@ -49,7 +49,7 @@ class TestReturnedWebactions(IntegrationTestCase):
                              'order': 10,
                              'created': datetime(2018, 4, 21),
                              'modified': datetime(2018, 4, 21),
-                             'owner': 'webaction.manager',
+                             'owner': 'webaction_manager',
                              'scope': 'global'}
 
         self.action3_data = {'target_url': 'http://example.org/endpoint',
@@ -60,7 +60,7 @@ class TestReturnedWebactions(IntegrationTestCase):
                              'order': 20,
                              'created': datetime(2018, 4, 22),
                              'modified': datetime(2018, 4, 22),
-                             'owner': 'webaction.manager',
+                             'owner': 'webaction_manager',
                              'scope': 'global'}
 
     def get_webactions(self):

--- a/opengever/webactions/tests/test_webactions_provider.py
+++ b/opengever/webactions/tests/test_webactions_provider.py
@@ -175,7 +175,7 @@ class TestWebActionProvider(TestWebActionBase):
                 "All action permissions need to be mapped to real permissions")
 
     def test_webaction_provider_respects_permission(self):
-        self.login(self.dossier_manager)
+        self.login(self.regular_user)
 
         storage = get_storage()
         storage.update(0, {"permissions": ['trash']})


### PR DESCRIPTION
Tests: Use different userid for fixture user `webaction_manager`

Corresponding test fixes in gever-ui: https://github.com/4teamwork/gever-ui/pull/2634

For [CA-6237](https://4teamwork.atlassian.net/browse/CA-6237)

## Checklist

- [ ] Changelog entry _(testing changes only)_
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-6237]: https://4teamwork.atlassian.net/browse/CA-6237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ