### PR TITLE
Tests: Use different userid for fixture user meeting_user

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -636,7 +636,7 @@ Users
 - ``self.foreign_contributor``: ``james.bond``
 - ``self.limited_admin``: ``limited_admin``
 - ``self.manager``: ``admin``
-- ``self.meeting_user``: ``herbert.jager``
+- ``self.meeting_user``: ``meeting_user``
 - ``self.member_admin``: ``member_admin``
 - ``self.propertysheets_manager``: ``propertysheets_manager``
 - ``self.reader_user``: ``lucklicher.laser``

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -300,7 +300,7 @@ CONTACT_MISSING_VALUES = {
 
 
 PROPOSAL_REQUIREDS = {
-    'issuer': u'herbert.jager',
+    'issuer': u'meeting_user',
     # the oguid should be stable due to `time_based_intids`
     'committee_oguid': u'plone:1010073300',
 }
@@ -322,7 +322,7 @@ PROPOSAL_MISSING_VALUES = {
 
 
 SUBMITTED_PROPOSAL_REQUIREDS = {
-    'issuer': u'herbert.jager',
+    'issuer': u'meeting_user',
 }
 SUBMITTED_PROPOSAL_DEFAULTS = {
     'changed': FROZEN_DATETIME_NOW,

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -2049,6 +2049,7 @@ class OpengeverContentFixture(object):
             'regular_user',
             'webaction_manager',
             'committee_responsible',
+            'meeting_user',
         )
 
         if attrname in users_with_different_userid:


### PR DESCRIPTION
Tests: Use different userid for fixture user `meeting_user`

Corresponding test fixes in gever-ui: https://github.com/4teamwork/gever-ui/issues/2636

For [CA-6237](https://4teamwork.atlassian.net/browse/CA-6237)

## Checklist

- [ ] Changelog entry _(testing changes only)_
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-6237]: https://4teamwork.atlassian.net/browse/CA-6237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ