### PR TITLE
Add username fallback for @ogds-users endpoint and user-details view.

### DIFF
--- a/changes/CA-6237-4.bugfix
+++ b/changes/CA-6237-4.bugfix
@@ -1,0 +1,1 @@
+Add username fallback for @ogds-users endpoint and user-details view. [phgross]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -21,6 +21,8 @@ Other Changes
 
 - The dossiers responsible field support now also usernames not just userids.
 
+- The ``@ogds-users`` endpoint supports now also username as parameter not just the userid.
+
 
 2023.14.0 (2023-11-09)
 ----------------------

--- a/opengever/api/ogdsuser.py
+++ b/opengever/api/ogdsuser.py
@@ -32,7 +32,7 @@ class OGDSUserGet(Service):
             return
 
         service = ogds_service()
-        user = service.fetch_user(userid)
+        user = service.fetch_user(userid, username_as_fallback=True)
         serializer = queryMultiAdapter((user, self.request), ISerializeToJson)
         return serializer()
 

--- a/opengever/api/tests/test_ogdsuser.py
+++ b/opengever/api/tests/test_ogdsuser.py
@@ -188,6 +188,22 @@ class TestOGDSUserGet(IntegrationTestCase):
             u'l\xfccklicher.laser',
             browser.json['userid'])
 
+    @browsing
+    def test_also_handles_username_instead_of_userid(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(self.portal,
+                     view='@ogds-users/%s' % self.dossier_manager.getUserName(),
+                     headers=self.api_headers)
+
+        self.assertEqual(200, browser.status_code)
+        self.assertDictContainsSubset(
+            {'@id': u'http://nohost/plone/@ogds-users/%s' % self.dossier_manager.getUserName(),
+             u'userid': self.dossier_manager.id,
+             u'firstname': u'F\xe4ivel',
+             u'lastname': u'Fr\xfchling'},
+            browser.json)
+
 
 class TestAssignedGroupsMethod(OGDSTestCase):
 

--- a/opengever/ogds/base/browser/templates/userdetails_table.pt
+++ b/opengever/ogds/base/browser/templates/userdetails_table.pt
@@ -101,7 +101,7 @@
             <a class="group link-overlay"
                tal:define="groupmembers_url python:view.groupmembers_url(group.groupid)"
                tal:attributes="href groupmembers_url"
-               tal:content="python: group.title or group.groupid"></a>
+               tal:content="python: group.label() or group.groupid"></a>
           </li>
         </ul>
       </td>

--- a/opengever/ogds/base/browser/userdetails.py
+++ b/opengever/ogds/base/browser/userdetails.py
@@ -1,6 +1,5 @@
 from opengever.contact.utils import get_contactfolder_url
 from opengever.ogds.base.utils import groupmembers_url
-from opengever.ogds.models.exceptions import RecordNotFound
 from opengever.ogds.models.service import ogds_service
 from Products.Five import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
@@ -28,9 +27,10 @@ class UserDetails(BrowserView):
     def get_userdata(self):
         """Returns a dict of information about a specific user
         """
-        try:
-            user = ogds_service().find_user(self.userid)
-        except RecordNotFound:
+        user = ogds_service().fetch_user(
+            self.userid, username_as_fallback=True)
+
+        if not user:
             raise NotFound
 
         teams = []

--- a/opengever/ogds/base/tests/test_userdetails.py
+++ b/opengever/ogds/base/tests/test_userdetails.py
@@ -58,6 +58,16 @@ class TestUserDetails(IntegrationTestCase):
             browser.login().open(self.portal, view='@@user-details/not.found')
 
     @browsing
+    def test_supports_username_instead_of_the_userid(self, browser):
+        self.login(self.regular_user, browser)
+
+        browser.open(self.portal,
+                     view='@@user-details/%s' % self.dossier_manager.getUserName())
+
+        self.assertEquals([u'Fr\xfchling F\xe4ivel (faivel.fruhling)'],
+                          browser.css('h1.documentFirstHeading').text)
+
+    @browsing
     def test_list_all_team_memberships(self, browser):
         create_contacts(self)
         self.login(self.regular_user, browser)

--- a/opengever/ogds/models/service.py
+++ b/opengever/ogds/models/service.py
@@ -34,12 +34,22 @@ class OGDSService(object):
             raise RecordNotFound(User, userid)
         return user
 
-    def fetch_user(self, userid):
+    def fetch_user_by_username(self, username):
+        """Returns a User by it's username. When no user or multiple are found,
+        this method raises.
+        """
+        return self._query_user().filter_by(username=username).first()
+
+    def fetch_user(self, userid, username_as_fallback=False):
         """Returns a User by it's userid. None is returned when no user is found.
 
         See #find_user for similar behavior.
         """
-        return self._query_user().get(userid)
+        user = self._query_user().get(userid)
+        if not user and username_as_fallback:
+            user = self.fetch_user_by_username(userid)
+
+        return user
 
     def filter_users(self, query_string):
         return self._query_user().by_searchable_text(query_string)


### PR DESCRIPTION
The @user-details endpoint and the user-details view can now be called also with username as request-parameter, not just userid.

Besides that, the userdetails view uses now the group.label() in the group listing.

For [CA-6237]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- API change:
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))


[CA-6237]: https://4teamwork.atlassian.net/browse/CA-6237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ