### PR TITLE
Add option to skip generation of httpd.conf

### DIFF
--- a/changes/CA-6418.other
+++ b/changes/CA-6418.other
@@ -1,0 +1,1 @@
+Add option to skip generation of httpd.conf on startup of httpd container. [buchi]

--- a/docker/httpd/README.md
+++ b/docker/httpd/README.md
@@ -69,3 +69,8 @@ Default: http
 The name and port of the portal server.
 
 Default: portal-frontend:80
+
+### `SKIP_HTTPD_CONF`
+
+If defined, generating httpd.conf is skipped at all. Instead a custom httpd.conf
+can be bind mounted into the container.

--- a/docker/httpd/httpd-foreground
+++ b/docker/httpd/httpd-foreground
@@ -2,7 +2,10 @@
 set -e
 
 # Generate httpd.conf based on environment variables
-esh -o /usr/local/apache2/conf/httpd.conf /usr/local/apache2/conf/httpd.conf.esh
+if [ ! -n "${SKIP_HTTPD_CONF+1}" ]; then
+  esh -o /usr/local/apache2/conf/httpd.conf /usr/local/apache2/conf/httpd.conf.esh
+  echo "Created httpd.conf"
+fi
 
 # Apache gets grumpy about PID files pre-existing
 rm -f /usr/local/apache2/logs/httpd.pid


### PR DESCRIPTION
Generating an Apache config file for multi-tenant setups out of environment variables is difficult.
Instead we allow to skip config file generation to allow bind mounting a config file.

For [CA-6418](https://4teamwork.atlassian.net/browse/CA-6418)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)



[CA-6418]: https://4teamwork.atlassian.net/browse/CA-6418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ