### PR TITLE
Revert "Properly revoke temporary inbox permissions when working with forwardings."

### DIFF
--- a/changes/CA-6354.bugfix
+++ b/changes/CA-6354.bugfix
@@ -1,1 +1,0 @@
-Properly revoke temporary inbox permissions when working with forwardings. [elioschmutz]

--- a/opengever/task/__init__.py
+++ b/opengever/task/__init__.py
@@ -44,9 +44,7 @@ FINAL_TRANSITIONS = [
     'task-transition-open-tested-and-closed',
     'task-transition-in-progress-tested-and-closed',
     'task-transition-resolved-tested-and-closed',
-    'task-transition-planned-skipped',
-    'forwarding-transition-close',
-    'forwarding-transition-assign-to-dossier']
+    'task-transition-planned-skipped']
 
 
 CLOSED_TO_IN_PROGRESS_TRANSITION = 'task-transition-tested-and-closed-in-progress'

--- a/opengever/task/tests/test_localroles.py
+++ b/opengever/task/tests/test_localroles.py
@@ -17,7 +17,6 @@ from zope.component import getUtility
 from zope.event import notify
 from zope.intid.interfaces import IIntIds
 from zope.lifecycleevent import ObjectModifiedEvent
-import json
 
 
 class TestLocalRolesSetter(IntegrationTestCase):
@@ -899,121 +898,6 @@ class TestLocalRolesRevoking(IntegrationTestCase):
               'roles': ['Editor'],
               'reference': Oguid.for_object(self.task),
               'principal': 'fa_inbox_users'}], storage._storage())
-
-    @browsing
-    def test_closing_a_forwarding_revokes_roles_on_inbox(self, browser):
-        self.login(self.secretariat_user, browser=browser)
-
-        storage = RoleAssignmentManager(self.inbox).storage
-        forwarding_oguid = Oguid.for_object(self.inbox_forwarding)
-        self.assertTrue(self.inbox_forwarding.revoke_permissions)
-        self.assertEqual(
-            [
-                {
-                    "cause": 3,
-                    "reference": None,
-                    "roles": ["Contributor", "Editor", "Reader"],
-                    "principal": self.secretariat_user.id,
-                },
-                {
-                    "cause": 3,
-                    "reference": None,
-                    "roles": ["Contributor", "Editor", "Reader"],
-                    "principal": self.dossier_manager.id,
-                },
-                {
-                    "cause": ASSIGNMENT_VIA_TASK,
-                    "roles": ["TaskResponsible"],
-                    "reference": forwarding_oguid,
-                    'principal': self.regular_user.id,
-                },
-                {
-                    "cause": ASSIGNMENT_VIA_TASK_AGENCY,
-                    "roles": ["TaskResponsible"],
-                    "reference": forwarding_oguid,
-                    "principal": "fa_inbox_users",
-                },
-            ], storage._storage())
-
-        browser.open(self.inbox_forwarding, method="POST", headers=self.api_headers,
-                     view='@workflow/forwarding-transition-close')
-
-        self.assertEqual(
-            [
-                {
-                    "cause": 3,
-                    "reference": None,
-                    "roles": ["Contributor", "Editor", "Reader"],
-                    "principal": self.secretariat_user.id,
-                },
-                {
-                    "cause": 3,
-                    "reference": None,
-                    "roles": ["Contributor", "Editor", "Reader"],
-                    "principal": self.dossier_manager.id,
-                },
-            ], storage._storage())
-
-    @browsing
-    def test_assign_forwarding_to_a_dossier_revokes_roles_on_inbox(self, browser):
-        self.login(self.secretariat_user, browser=browser)
-
-        storage = RoleAssignmentManager(self.inbox).storage
-        forwarding_oguid = Oguid.for_object(self.inbox_forwarding)
-        self.assertTrue(self.inbox_forwarding.revoke_permissions)
-        self.assertEqual(
-            [
-                {
-                    "cause": 3,
-                    "reference": None,
-                    "roles": ["Contributor", "Editor", "Reader"],
-                    "principal": self.secretariat_user.id,
-                },
-                {
-                    "cause": 3,
-                    "reference": None,
-                    "roles": ["Contributor", "Editor", "Reader"],
-                    "principal": self.dossier_manager.id,
-                },
-                {
-                    "cause": ASSIGNMENT_VIA_TASK,
-                    "roles": ["TaskResponsible"],
-                    "reference": forwarding_oguid,
-                    'principal': self.regular_user.id,
-                },
-                {
-                    "cause": ASSIGNMENT_VIA_TASK_AGENCY,
-                    "roles": ["TaskResponsible"],
-                    "reference": forwarding_oguid,
-                    "principal": "fa_inbox_users",
-                },
-            ], storage._storage())
-
-        browser.open(
-            self.inbox_forwarding.absolute_url(),
-            view='@assign-to-dossier',
-            method='POST',
-            headers=self.api_headers,
-            data=json.dumps({
-                'target_uid': self.dossier.UID(),
-            }))
-
-        self.assertEqual(201, browser.status_code)
-        self.assertEqual(
-            [
-                {
-                    "cause": 3,
-                    "reference": None,
-                    "roles": ["Contributor", "Editor", "Reader"],
-                    "principal": self.secretariat_user.id,
-                },
-                {
-                    "cause": 3,
-                    "reference": None,
-                    "roles": ["Contributor", "Editor", "Reader"],
-                    "principal": self.dossier_manager.id,
-                },
-            ], storage._storage())
 
 
 class TestLocalRolesReindexing(IntegrationTestCase):


### PR DESCRIPTION
This PR  reverts commit 870684d4391b802dde8100dacfdf34cad06902a4 from the PR: #7818 

The change introduced an issue, where the "@assign-to-dossier" endpoint is broken.

The user loses the necessary permissions after the forwarding has been closed. We then create the successor-task in a after transition hook wich will fail.

We'll fix it in an upcoming PR.

For [CA-6354]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-6354]: https://4teamwork.atlassian.net/browse/CA-6354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ