### PR TITLE
Support usernames and groupnames in the sharing API.

### DIFF
--- a/changes/CA-6237-6.other
+++ b/changes/CA-6237-6.other
@@ -1,0 +1,1 @@
+Support usernames and groupnames in the sharing API. [phgross]

--- a/opengever/ogds/models/service.py
+++ b/opengever/ogds/models/service.py
@@ -105,8 +105,15 @@ class OGDSService(object):
         query = self._query_org_units(enabled_only=False, visible_only=False)
         return query.count() > 1
 
-    def fetch_group(self, groupid):
-        return self._query_group().get(groupid)
+    def fetch_group(self, groupid, groupname_as_fallback=False):
+        group = self._query_group().get(groupid)
+        if not group and groupname_as_fallback:
+            group = self.fetch_group_by_groupname(groupid)
+
+        return group
+
+    def fetch_group_by_groupname(self, groupname):
+        return self._query_group().filter_by(groupname=groupname).first()
 
     def _query_admin_units(self, enabled_only=True, visible_only=True):
         query = AdminUnit.query

--- a/opengever/sharing/browser/sharing.py
+++ b/opengever/sharing/browser/sharing.py
@@ -403,6 +403,8 @@ class OpengeverSharingView(SharingView):
         LocalRolesModified event. Needed for adding a Journalentry after a
         role_settings change
         """
+        new_settings = self.convert_loginnames_to_userid(new_settings)
+
         old_local_roles = dict(self.context.get_local_roles())
         self._update_role_settings(new_settings, reindex)
 
@@ -413,6 +415,22 @@ class OpengeverSharingView(SharingView):
             return True
 
         return False
+
+    def convert_loginnames_to_userid(self, settings):
+        for setting in settings:
+            if setting.get('type') == 'group':
+                group = ogds_service().fetch_group(
+                    setting[u'id'], groupname_as_fallback=True)
+                if group and group.groupid != setting[u'id']:
+                    setting[u'id'] = group.groupid
+
+            elif setting.get('type') == 'user':
+                user = ogds_service().fetch_user(
+                    setting[u'id'], username_as_fallback=True)
+                if user and user.userid != setting[u'id']:
+                    setting[u'id'] = user.userid
+
+        return settings
 
     def group_search_results(self):
         """Customization of the original method to also search on the


### PR DESCRIPTION
With the recently introduced differentiation of userid/usernames and group/groupnames the sharing API should support also setting local roles by the username and groupname. So that the API behaves in the same way as before.

For [CA-6237]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-6237]: https://4teamwork.atlassian.net/browse/CA-6237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ