### PR TITLE
Include bumblebee_checksum in document status.

### DIFF
--- a/changes/CA-5913.other
+++ b/changes/CA-5913.other
@@ -1,0 +1,1 @@
+Include bumblebee_checksum in document status. [elioschmutz]

--- a/opengever/base/service.py
+++ b/opengever/base/service.py
@@ -1,3 +1,4 @@
+from ftw.bumblebee.interfaces import IBumblebeeDocument
 from plone import api
 from plone.rest import Service
 from plone.restapi.services.locking.locking import lock_info
@@ -17,6 +18,7 @@ class DocumentStatus(Service):
         payload['checked_out'] = self.context.is_checked_out()
         payload['checked_out_collaboratively'] = self.context.is_collaborative_checkout()
         payload['checked_out_by'] = self.context.checked_out_by()
+        payload['bumblebee_checksum'] = IBumblebeeDocument(self.context).get_checksum()
 
         info = lock_info(self.context)
         payload['locked'] = info['locked']

--- a/opengever/base/tests/test_api.py
+++ b/opengever/base/tests/test_api.py
@@ -18,6 +18,7 @@ class TestDocumentStatus(IntegrationTestCase):
 
         browser.open(self.mail_eml, view='status', headers=self.api_headers)
         expected = {
+            u'bumblebee_checksum': u'65da667b7c265f5aff1068c5216a3cba271fe57d3130ef152221661a45490d66',
             u'checked_out': False,
             u'checked_out_by': None,
             u'checked_out_collaboratively': False,
@@ -39,6 +40,7 @@ class TestDocumentStatus(IntegrationTestCase):
 
         browser.open(self.document, view='status', headers=self.api_headers)
         expected = {
+            u'bumblebee_checksum': '51d6317494eccc4a73154625a6820cb6b50dc1455eb4cf26399299d4f9ce77b2',
             u'checked_out': False,
             u'checked_out_by': None,
             u'checked_out_collaboratively': False,
@@ -64,6 +66,7 @@ class TestDocumentStatus(IntegrationTestCase):
         browser.open(self.document, view='status', headers=self.api_headers)
 
         expected = {
+            u'bumblebee_checksum': '51d6317494eccc4a73154625a6820cb6b50dc1455eb4cf26399299d4f9ce77b2',
             u'checked_out': True,
             u'checked_out_by': self.regular_user.getId(),
             u'checked_out_collaboratively': False,
@@ -90,6 +93,7 @@ class TestDocumentStatus(IntegrationTestCase):
             browser.open(self.document, view='status', headers=self.api_headers)
 
         expected = {
+            u'bumblebee_checksum': '51d6317494eccc4a73154625a6820cb6b50dc1455eb4cf26399299d4f9ce77b2',
             u'checked_out': True,
             u'checked_out_by': self.regular_user.getId(),
             u'checked_out_collaboratively': False,
@@ -116,6 +120,7 @@ class TestDocumentStatus(IntegrationTestCase):
             browser.open(self.document, view='status', headers=self.api_headers)
 
         expected = {
+            u'bumblebee_checksum': '51d6317494eccc4a73154625a6820cb6b50dc1455eb4cf26399299d4f9ce77b2',
             u'checked_out': True,
             u'checked_out_by': self.regular_user.id,
             u'checked_out_collaboratively': True,


### PR DESCRIPTION
Include the `bumblebee_checksum` in the document status. This allows us to reload the document preview on the frontend if the checksum has been changed.

For [CA-5913]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-5913]: https://4teamwork.atlassian.net/browse/CA-5913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ