### PR TITLE
Add `all_contacts` global source

### DIFF
--- a/changes/CA-6490.feature
+++ b/changes/CA-6490.feature
@@ -1,0 +1,1 @@
+Add new @globalsource ``all_contacts`` which returns active and inactive contacts. [elioschmutz]

--- a/changes/CA-6490.other
+++ b/changes/CA-6490.other
@@ -1,0 +1,1 @@
+Update KUB api from v1 to v2. [elioschmutz]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -8,7 +8,7 @@ API Changelog
 
 Breaking Changes
 ^^^^^^^^^^^^^^^^
-
+- Update KUB api from ``v1`` to ``v2``. KUB ``v2023.18.0`` is required.
 
 Other Changes
 ^^^^^^^^^^^^^

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -12,6 +12,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- ``@globalsources``: Add new source ``all_contacts`` which returns active and inactive contacts.
 
 
 2023.15.0 (2023-12-13)

--- a/opengever/api/schema/globalsources.py
+++ b/opengever/api/schema/globalsources.py
@@ -26,6 +26,10 @@ class IGlobalSourceSchema(model.Schema):
     )
 
     contacts = schema.Choice(
+        source=PloneSqlOrKubContactSourceBinder(only_active=True)
+    )
+
+    all_contacts = schema.Choice(
         source=PloneSqlOrKubContactSourceBinder()
     )
 

--- a/opengever/base/addressblock/tests/test_extraction.py
+++ b/opengever/base/addressblock/tests/test_extraction.py
@@ -49,7 +49,7 @@ class TestKuBEntityAddressExtraction(KuBIntegrationTestCase):
 
     def mock_entity(self, mocker, data, **kwargs):
         type_id = ':'.join((data['type'], data['id']))
-        url = 'http://localhost:8000/api/v1/resolve/{}'.format(type_id)
+        url = 'http://localhost:8000/api/v2/resolve/{}'.format(type_id)
         mocker.get(url, json=data, **kwargs)
         return type_id
 

--- a/opengever/contact/sources.py
+++ b/opengever/contact/sources.py
@@ -14,8 +14,11 @@ class PloneSqlOrKubContactSourceBinder(object):
 
     implements(IVocabularyFactory)
 
+    def __init__(self, only_active=False):
+        self.only_active = only_active
+
     def __call__(self, context):
         if is_kub_feature_enabled():
-            return KuBContactsSourceBinder()(context)
+            return KuBContactsSourceBinder(only_active=self.only_active)(context)
 
         return UsersContactsInboxesSourceBinder()(context)

--- a/opengever/kub/client.py
+++ b/opengever/kub/client.py
@@ -11,7 +11,7 @@ from zope.annotation import IAnnotations
 import requests
 
 
-KUB_API_VERSION = 'v1'
+KUB_API_VERSION = 'v2'
 
 
 class KuBClient(object):

--- a/opengever/kub/client.py
+++ b/opengever/kub/client.py
@@ -6,6 +6,7 @@ from plone import api
 from plone.memoize import ram
 from time import mktime
 from time import time
+from urllib import urlencode
 from wsgiref.handlers import format_date_time
 from zope.annotation import IAnnotations
 import requests
@@ -53,8 +54,12 @@ class KuBClient(object):
              'Authorization': 'Token {}'.format(self.kub_service_token)})
         return session
 
-    def query(self, query_str):
-        url = u'{}search?q={}'.format(self.kub_api_url, query_str)
+    def query(self, query_str, filters=dict()):
+        search_filters = {
+            'q': query_str,
+        }
+        search_filters.update(filters)
+        url = u'{}search?{}'.format(self.kub_api_url, urlencode(search_filters))
         res = self.session.get(url)
         return res.json()
 

--- a/opengever/kub/sources.py
+++ b/opengever/kub/sources.py
@@ -15,10 +15,12 @@ class KuBContactsSource(object):
     """This source supports KuB contacts and OGDS Users.
     """
 
-    def __init__(self, context):
+    def __init__(self, context, only_active=False):
         self.context = context
         self.terms = []
         self.client = KuBClient()
+        self.ogds_filters = self.get_ogds_filters(only_active)
+        self.kub_filters = self.get_kub_filters(only_active)
 
     @staticmethod
     def _kub_term(item):
@@ -46,14 +48,29 @@ class KuBContactsSource(object):
         return self._ogds_user_term(user)
 
     def search(self, query_string):
-        response = self.client.query(query_string)
+        response = self.client.query(query_string, filters=self.kub_filters)
         self.terms = [self._kub_term(item) for item in response.get('results', [])]
 
         text_filters = query_string.split()
-        for ogds_user in ogds_service().filter_users(text_filters):
+        for ogds_user in ogds_service().filter_users(text_filters).filter_by(
+                **self.ogds_filters):
             self.terms.append(self._ogds_user_term(ogds_user))
 
         return self.terms
+
+    def get_ogds_filters(self, only_active=False):
+        filters = {}
+        if only_active:
+            filters['active'] = True
+
+        return filters
+
+    def get_kub_filters(self, only_active=False):
+        filters = {}
+        if only_active:
+            filters['is_active'] = True
+
+        return filters
 
 
 @implementer(IContextSourceBinder)
@@ -61,5 +78,8 @@ class KuBContactsSourceBinder(object):
 
     implements(IVocabularyFactory)
 
+    def __init__(self, only_active=False):
+        self.only_active = only_active
+
     def __call__(self, context):
-        return KuBContactsSource(context)
+        return KuBContactsSource(context, only_active=self.only_active)

--- a/opengever/kub/sources.py
+++ b/opengever/kub/sources.py
@@ -46,8 +46,8 @@ class KuBContactsSource(object):
         return self._ogds_user_term(user)
 
     def search(self, query_string):
-        items = self.client.query(query_string)
-        self.terms = [self._kub_term(item) for item in items]
+        response = self.client.query(query_string)
+        self.terms = [self._kub_term(item) for item in response.get('results', [])]
 
         text_filters = query_string.split()
         for ogds_user in ogds_service().filter_users(text_filters):

--- a/opengever/kub/testing.py
+++ b/opengever/kub/testing.py
@@ -84,6 +84,52 @@ KUB_RESPONSES = {
         ]
     },
 
+    "http://localhost:8000/api/v2/search?q=kohler&is_active=True": {
+        "results": [
+            {
+                "htmlUrl": "http://localhost:8000/organizations/30bab83d-300a-4886-97d4-ff592e88a56a",
+                "url": "http://localhost:8000/api/v2/organizations/30bab83d-300a-4886-97d4-ff592e88a56a",
+                "created": "2021-11-13T00:00:00+01:00",
+                "id": "30bab83d-300a-4886-97d4-ff592e88a56a",
+                "organization": None,
+                "modified": "2021-11-13T00:00:00+01:00",
+                "text": "Kohler KUB Active",
+                "thirdPartyId": None,
+                "type": "organization",
+                "typedId": "organization:30bab83d-300a-4886-97d4-ff592e88a56a"
+            },
+        ]
+    },
+
+    "http://localhost:8000/api/v2/search?q=kohler": {
+        "results": [
+            {
+                "htmlUrl": "http://localhost:8000/organizations/30bab83d-300a-4886-97d4-ff592e88a56a",
+                "url": "http://localhost:8000/api/v2/organizations/30bab83d-300a-4886-97d4-ff592e88a56a",
+                "created": "2021-11-13T00:00:00+01:00",
+                "id": "30bab83d-300a-4886-97d4-ff592e88a56a",
+                "organization": None,
+                "modified": "2021-11-13T00:00:00+01:00",
+                "text": "Kohler KUB Active",
+                "thirdPartyId": None,
+                "type": "organization",
+                "typedId": "organization:30bab83d-300a-4886-97d4-ff592e88a56a"
+            },
+            {
+                "htmlUrl": None,
+                "url": "http://localhost:8000/api/v2/memberships/8345fcfe-2d67-4b75-af46-c25b2f387448",
+                "created": "2021-11-18T00:00:00+01:00",
+                "id": "8345fcfe-2d67-4b75-af46-c25b2f387448",
+                "organization": "30bab83d-300a-4886-97d4-ff592e88a56a",
+                "modified": "2021-11-18T00:00:00+01:00",
+                "text": "Kohler KUB Inactive",
+                "thirdPartyId": None,
+                "type": "membership",
+                "typedId": "membership:8345fcfe-2d67-4b75-af46-c25b2f387448"
+            }
+        ]
+    },
+
     "http://localhost:8000/api/v2/resolve/person:9af7d7cc-b948-423f-979f-587158c6bc65": {
         "id": "9af7d7cc-b948-423f-979f-587158c6bc65",
         "personType": None,

--- a/opengever/kub/testing.py
+++ b/opengever/kub/testing.py
@@ -38,49 +38,53 @@ class KuBIntegrationTestCase(IntegrationTestCase):
 # These responses are taken from performing these exact requests against
 # the database defined in "fixtures/gever-testing.json" in the KUB repository.
 KUB_RESPONSES = {
-    "http://localhost:8000/api/v1/search?q=Julie": [
-        {
-            "htmlUrl": "http://localhost:8000/people/0e623708-2d0d-436a-82c6-c1a9c27b65dc",
-            "url": "http://localhost:8000/api/v1/people/0e623708-2d0d-436a-82c6-c1a9c27b65dc",
-            "created": "2021-11-14T00:00:00+01:00",
-            "id": "0e623708-2d0d-436a-82c6-c1a9c27b65dc",
-            "organization": None,
-            "modified": "2021-11-14T00:00:00+01:00",
-            "text": "Dupont Julie",
-            "thirdPartyId": None,
-            "type": "person",
-            "typedId": "person:0e623708-2d0d-436a-82c6-c1a9c27b65dc"
-        }
-    ],
+    "http://localhost:8000/api/v2/search?q=Julie": {
+        "results": [
+            {
+                "htmlUrl": "http://localhost:8000/people/0e623708-2d0d-436a-82c6-c1a9c27b65dc",
+                "url": "http://localhost:8000/api/v2/people/0e623708-2d0d-436a-82c6-c1a9c27b65dc",
+                "created": "2021-11-14T00:00:00+01:00",
+                "id": "0e623708-2d0d-436a-82c6-c1a9c27b65dc",
+                "organization": None,
+                "modified": "2021-11-14T00:00:00+01:00",
+                "text": "Dupont Julie",
+                "thirdPartyId": None,
+                "type": "person",
+                "typedId": "person:0e623708-2d0d-436a-82c6-c1a9c27b65dc"
+            }
+        ]
+    },
 
-    "http://localhost:8000/api/v1/search?q=4Teamwork": [
-        {
-            "htmlUrl": "http://localhost:8000/organizations/30bab83d-300a-4886-97d4-ff592e88a56a",
-            "url": "http://localhost:8000/api/v1/organizations/30bab83d-300a-4886-97d4-ff592e88a56a",
-            "created": "2021-11-13T00:00:00+01:00",
-            "id": "30bab83d-300a-4886-97d4-ff592e88a56a",
-            "organization": None,
-            "modified": "2021-11-13T00:00:00+01:00",
-            "text": "4Teamwork",
-            "thirdPartyId": None,
-            "type": "organization",
-            "typedId": "organization:30bab83d-300a-4886-97d4-ff592e88a56a"
-        },
-        {
-            "htmlUrl": None,
-            "url": "http://localhost:8000/api/v1/memberships/8345fcfe-2d67-4b75-af46-c25b2f387448",
-            "created": "2021-11-18T00:00:00+01:00",
-            "id": "8345fcfe-2d67-4b75-af46-c25b2f387448",
-            "organization": "30bab83d-300a-4886-97d4-ff592e88a56a",
-            "modified": "2021-11-18T00:00:00+01:00",
-            "text": "Dupont Jean - 4Teamwork (CEO)",
-            "thirdPartyId": None,
-            "type": "membership",
-            "typedId": "membership:8345fcfe-2d67-4b75-af46-c25b2f387448"
-        }
-    ],
+    "http://localhost:8000/api/v2/search?q=4Teamwork": {
+        "results": [
+            {
+                "htmlUrl": "http://localhost:8000/organizations/30bab83d-300a-4886-97d4-ff592e88a56a",
+                "url": "http://localhost:8000/api/v2/organizations/30bab83d-300a-4886-97d4-ff592e88a56a",
+                "created": "2021-11-13T00:00:00+01:00",
+                "id": "30bab83d-300a-4886-97d4-ff592e88a56a",
+                "organization": None,
+                "modified": "2021-11-13T00:00:00+01:00",
+                "text": "4Teamwork",
+                "thirdPartyId": None,
+                "type": "organization",
+                "typedId": "organization:30bab83d-300a-4886-97d4-ff592e88a56a"
+            },
+            {
+                "htmlUrl": None,
+                "url": "http://localhost:8000/api/v2/memberships/8345fcfe-2d67-4b75-af46-c25b2f387448",
+                "created": "2021-11-18T00:00:00+01:00",
+                "id": "8345fcfe-2d67-4b75-af46-c25b2f387448",
+                "organization": "30bab83d-300a-4886-97d4-ff592e88a56a",
+                "modified": "2021-11-18T00:00:00+01:00",
+                "text": "Dupont Jean - 4Teamwork (CEO)",
+                "thirdPartyId": None,
+                "type": "membership",
+                "typedId": "membership:8345fcfe-2d67-4b75-af46-c25b2f387448"
+            }
+        ]
+    },
 
-    "http://localhost:8000/api/v1/resolve/person:9af7d7cc-b948-423f-979f-587158c6bc65": {
+    "http://localhost:8000/api/v2/resolve/person:9af7d7cc-b948-423f-979f-587158c6bc65": {
         "id": "9af7d7cc-b948-423f-979f-587158c6bc65",
         "personType": None,
         "personTypeTitle": None,
@@ -269,7 +273,7 @@ KUB_RESPONSES = {
         "modified": "2021-11-17T00:00:00+01:00",
         "created": "2021-11-17T00:00:00+01:00",
         "htmlUrl": "http://localhost:8000/people/9af7d7cc-b948-423f-979f-587158c6bc65",
-        "url": "http://localhost:8000/api/v1/people/9af7d7cc-b948-423f-979f-587158c6bc65",
+        "url": "http://localhost:8000/api/v2/people/9af7d7cc-b948-423f-979f-587158c6bc65",
         "typedId": "person:9af7d7cc-b948-423f-979f-587158c6bc65",
         "type": "person",
         "primaryAddress": {
@@ -302,7 +306,7 @@ KUB_RESPONSES = {
         "customValues": {}
     },
 
-    "http://localhost:8000/api/v1/resolve/membership:8345fcfe-2d67-4b75-af46-c25b2f387448": {
+    "http://localhost:8000/api/v2/resolve/membership:8345fcfe-2d67-4b75-af46-c25b2f387448": {
         "id": "8345fcfe-2d67-4b75-af46-c25b2f387448",
         "person": {
             "created": "2021-11-17T00:00:00+01:00",
@@ -327,7 +331,7 @@ KUB_RESPONSES = {
             "tags": [],
             "thirdPartyId": None,
             "title": "",
-            "url": "http://localhost:8000/api/v1/people/9af7d7cc-b948-423f-979f-587158c6bc65",
+            "url": "http://localhost:8000/api/v2/people/9af7d7cc-b948-423f-979f-587158c6bc65",
             "username": None,
             "countryDisplay": "-------",
             "dateOfBirth": "1992-05-15",
@@ -392,7 +396,7 @@ KUB_RESPONSES = {
             "spvCommittee": False,
             "status": 1,
             "thirdPartyId": None,
-            "url": "http://localhost:8000/api/v1/organizations/30bab83d-300a-4886-97d4-ff592e88a56a",
+            "url": "http://localhost:8000/api/v2/organizations/30bab83d-300a-4886-97d4-ff592e88a56a",
             "organizationType": None,
             "primaryAddress": {
                 "id": "ad0de780-3f62-400c-921a-0feb9e79c062",
@@ -446,7 +450,7 @@ KUB_RESPONSES = {
         "end": None,
         "typedId": "membership:8345fcfe-2d67-4b75-af46-c25b2f387448",
         "type": "membership",
-        "url": "http://localhost:8000/api/v1/memberships/8345fcfe-2d67-4b75-af46-c25b2f387448",
+        "url": "http://localhost:8000/api/v2/memberships/8345fcfe-2d67-4b75-af46-c25b2f387448",
         "text": "Dupont Jean - 4Teamwork (CEO)",
         "primaryEmail": {
             "id": "3bc940de-ee8a-43b0-b373-3f1640122021",
@@ -497,7 +501,7 @@ KUB_RESPONSES = {
         "primaryUrl": None
     },
 
-    "http://localhost:8000/api/v1/resolve/organization:30bab83d-300a-4886-97d4-ff592e88a56a": {
+    "http://localhost:8000/api/v2/resolve/organization:30bab83d-300a-4886-97d4-ff592e88a56a": {
         "id": "30bab83d-300a-4886-97d4-ff592e88a56a",
         "organizationType": None,
         "organizationTypeTitle": None,
@@ -597,7 +601,7 @@ KUB_RESPONSES = {
                     },
                     "status": 1,
                     "thirdPartyId": None,
-                    "url": "http://localhost:8000/api/v1/people/9af7d7cc-b948-423f-979f-587158c6bc65",
+                    "url": "http://localhost:8000/api/v2/people/9af7d7cc-b948-423f-979f-587158c6bc65",
                     "username": None
                 },
                 "role": "CEO",
@@ -629,7 +633,7 @@ KUB_RESPONSES = {
         "htmlUrl": "http://localhost:8000/organizations/30bab83d-300a-4886-97d4-ff592e88a56a",
         "typedId": "organization:30bab83d-300a-4886-97d4-ff592e88a56a",
         "type": "organization",
-        "url": "http://localhost:8000/api/v1/organizations/30bab83d-300a-4886-97d4-ff592e88a56a",
+        "url": "http://localhost:8000/api/v2/organizations/30bab83d-300a-4886-97d4-ff592e88a56a",
         "primaryAddress": {
             "id": "ad0de780-3f62-400c-921a-0feb9e79c062",
             "label": "Standort Bern",
@@ -661,9 +665,9 @@ KUB_RESPONSES = {
         "customValues": {}
     },
 
-    "http://localhost:8000/api/v1/resolve/invalid-id": ["Invalid uuid"],
+    "http://localhost:8000/api/v2/resolve/invalid-id": ["Invalid uuid"],
 
-    "http://localhost:8000/api/v1/resolve/person:0e623708-2d0d-436a-82c6-c1a9c27b65dc": {
+    "http://localhost:8000/api/v2/resolve/person:0e623708-2d0d-436a-82c6-c1a9c27b65dc": {
         "id": "0e623708-2d0d-436a-82c6-c1a9c27b65dc",
         "personType": None,
         "personTypeTitle": None,
@@ -695,7 +699,7 @@ KUB_RESPONSES = {
         "modified": "2021-11-14T00:00:00+01:00",
         "created": "2021-11-14T00:00:00+01:00",
         "htmlUrl": "http://localhost:8000/people/0e623708-2d0d-436a-82c6-c1a9c27b65dc",
-        "url": "http://localhost:8000/api/v1/people/0e623708-2d0d-436a-82c6-c1a9c27b65dc",
+        "url": "http://localhost:8000/api/v2/people/0e623708-2d0d-436a-82c6-c1a9c27b65dc",
         "typedId": "person:0e623708-2d0d-436a-82c6-c1a9c27b65dc",
         "type": "person",
         "primaryAddress": None,
@@ -703,7 +707,7 @@ KUB_RESPONSES = {
         "text": "Dupont Julie",
         "customValues": {}
     },
-    "http://localhost:8000/api/v1/labels": {
+    "http://localhost:8000/api/v2/labels": {
         "results": [
             {
                 "id": "0e623708-2d0d-436a-82c6-c1a9c27b65dc",

--- a/opengever/kub/tests/test_kub_client.py
+++ b/opengever/kub/tests/test_kub_client.py
@@ -19,24 +19,26 @@ class TestKubClient(KuBIntegrationTestCase):
         self.assertEqual(u'en', self.client.session.headers['Accept-Language'])
 
     def test_kub_api_url(self, mocker):
-        self.assertEqual(u'http://localhost:8000/api/v1/',
+        self.assertEqual(u'http://localhost:8000/api/v2/',
                          self.client.kub_api_url)
 
     def test_query_returns_persons(self, mocker):
         query_str = "Julie"
         url = self.mock_search(mocker, query_str)
         resp = self.client.query(query_str)
-        self.assertEqual(1, len(resp))
-        self.assertEqual("person", resp[0]["type"])
+        results = resp.get('results')
+        self.assertEqual(1, len(results))
+        self.assertEqual("person", results[0]["type"])
         self.assertEqual(KUB_RESPONSES[url], resp)
 
     def test_query_returns_memberships_and_organizations(self, mocker):
         query_str = "4Teamwork"
         url = self.mock_search(mocker, query_str)
         resp = self.client.query(query_str)
-        self.assertEqual(2, len(resp))
-        self.assertEqual("organization", resp[0]["type"])
-        self.assertEqual("membership", resp[1]["type"])
+        results = resp.get('results')
+        self.assertEqual(2, len(results))
+        self.assertEqual("organization", results[0]["type"])
+        self.assertEqual("membership", results[1]["type"])
         self.assertEqual(KUB_RESPONSES[url], resp)
 
     def test_get_by_id_handles_persons(self, mocker):

--- a/opengever/kub/tests/test_kub_contact_source.py
+++ b/opengever/kub/tests/test_kub_contact_source.py
@@ -86,3 +86,12 @@ class TestKubContactSource(KuBIntegrationTestCase):
         self.mock_get_by_id(mocker, contact_id)
         with self.assertRaises(LookupError):
             self.source.getTermByToken(contact_id)
+
+    def test_set_active_filter_when_using_only_active(self, mocker):
+        source = KuBContactsSource(None)
+        self.assertEqual({}, source.kub_filters)
+        self.assertEqual({}, source.ogds_filters)
+
+        source = KuBContactsSource(None, only_active=True)
+        self.assertEqual({'is_active': True}, source.kub_filters)
+        self.assertEqual({'active': True}, source.ogds_filters)


### PR DESCRIPTION
This PR adds a new `@globalsource` called `all_contacts` wich will return all active and inactive contacts.

We use this source to display a performant participation filter in the frontend.

⚠️ Requires KUB >= `2023.18.0` (https://github.com/4teamwork/kub/pull/279)

ℹ️ tested on spd ag test deployment.

For [CA-6490]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[HG-4270]: https://4teamwork.atlassian.net/browse/HG-4270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CA-6490]: https://4teamwork.atlassian.net/browse/CA-6490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ