### PR TITLE
Improve reporting view performance for path based queries.

### DIFF
--- a/changes/CA-6542.bugfix
+++ b/changes/CA-6542.bugfix
@@ -1,0 +1,1 @@
+Improve reporting view performance for path based queries. [phgross]

--- a/opengever/document/browser/report.py
+++ b/opengever/document/browser/report.py
@@ -32,6 +32,8 @@ class DocumentReporter(SolrReporterView):
 
     field_mapper = DocumentReporterFieldMapper
 
+    corresponding_listing_name = 'dossiers'
+
     column_settings = [
         {
             'id': 'reference',

--- a/opengever/document/tests/test_reporter.py
+++ b/opengever/document/tests/test_reporter.py
@@ -44,10 +44,12 @@ class TestDocumentReporter(SolrIntegrationTestCase):
     def test_document_report(self, browser):
         self.login(self.regular_user, browser=browser)
 
-        browser.open(
-            view='document_report',
-            # /plone/ordnungssystem/...
-            data=self.make_path_param(self.document, self.mail_eml))
+        # /plone/ordnungssystem/...
+        data = self.make_path_param(self.document, self.mail_eml)
+        data['sort_on'] = 'sequence_number'
+        data['sort_order'] = 'desc'
+
+        browser.open(view='document_report', data=data)
 
         workbook = self.load_workbook(browser.contents)
 
@@ -312,10 +314,11 @@ class TestDocumentReporter(SolrIntegrationTestCase):
     def test_document_report_with_pseudorelative_path(self, browser):
         self.login(self.regular_user, browser=browser)
 
-        browser.open(
-            view='document_report',
-            # /ordnungssystem/...
-            data=self.make_pseudorelative_path_param(self.document, self.mail_eml))
+        # /ordnungssystem/...
+        data = self.make_pseudorelative_path_param(self.document, self.mail_eml)
+        data['sort_on'] = 'reference'
+        data['sort_order'] = 'desc'
+        browser.open(view='document_report', data=data)
 
         workbook = self.load_workbook(browser.contents)
 

--- a/opengever/dossier/browser/report.py
+++ b/opengever/dossier/browser/report.py
@@ -31,6 +31,8 @@ class DossierReporter(SolrReporterView):
 
     field_mapper = DossierReporterFieldMapper
 
+    corresponding_listing_name = 'dossiers'
+
     column_settings = (
         {
             'id': 'title',

--- a/opengever/dossier/tests/test_reporter.py
+++ b/opengever/dossier/tests/test_reporter.py
@@ -68,10 +68,11 @@ class TestDossierReporter(SolrIntegrationTestCase):
             [cell.value for cell in rows[2]])
 
     @browsing
-    def test_sorts_rows_according_to_paths_from_request(self, browser):
+    def test_sorts_rows_according_to_the_sort_params_in_request(self, browser):
         self.login(self.regular_user, browser=browser)
 
         paths1 = self.make_path_param(self.dossier, self.inactive_dossier)
+        paths1.update({'sort_on': 'reference', 'sort_order': 'asc'})
         browser.open(view='dossier_report', data=paths1)
 
         workbook = self.load_workbook(browser.contents)
@@ -81,6 +82,7 @@ class TestDossierReporter(SolrIntegrationTestCase):
         self.assertEqual(self.inactive_dossier.title, rows[2][0].value)
 
         paths2 = self.make_path_param(self.inactive_dossier, self.dossier)
+        paths2.update({'sort_on': 'reference', 'sort_order': 'descending'})
         browser.open(view='dossier_report', data=paths2)
 
         workbook = self.load_workbook(browser.contents)

--- a/opengever/meeting/browser/report.py
+++ b/opengever/meeting/browser/report.py
@@ -27,6 +27,8 @@ class ProposalReporter(SolrReporterView):
 
     field_mapper = ProposalReporterFieldMapper
 
+    corresponding_listing_name = 'proposals'
+
     column_settings = [
         {
             'id': 'title',

--- a/opengever/meeting/tests/test_reporter.py
+++ b/opengever/meeting/tests/test_reporter.py
@@ -22,9 +22,9 @@ class TestProposalReporter(SolrIntegrationTestCase):
     def test_proposal_report(self, browser):
         self.login(self.regular_user, browser=browser)
 
-        browser.open(
-            view='proposal_report',
-            data=self.make_path_param(self.proposal, self.draft_proposal))
+        data = self.make_path_param(self.proposal, self.draft_proposal)
+        data.update({'sort_on': 'sequence_number', 'sort_order': 'asc'})
+        browser.open(view='proposal_report', data=data)
 
         workbook = self.load_workbook(browser.contents)
 


### PR DESCRIPTION
The current implementation which sorts using the supplied path sorting, was massively inperformant and led to Solr crashes. Instead we fetch the the current sorting of the listing and use this.

This drops the sorting support for the classic UI, as discussed at the daily that is not really a problem.

For [CA-6524]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[CA-6524]: https://4teamwork.atlassian.net/browse/CA-6524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ