### PR TITLE
Nested task templates: Also pass docs to subtasks that get started

### DIFF
--- a/changes/CA-6450.bugfix
+++ b/changes/CA-6450.bugfix
@@ -1,0 +1,1 @@
+Nested task templates: Also pass docs to subtasks that get started. [lgraf]

--- a/opengever/task/tests/test_task_from_template.py
+++ b/opengever/task/tests/test_task_from_template.py
@@ -376,16 +376,31 @@ class TestSequentialTaskProcess(IntegrationTestCase):
                                                 issuer=self.dossier_responsible.getId(),
                                                 task_type='correction')
                                         .in_state('task-state-planned'))
-        api.content.transition(
-            obj=self.seq_subtask_1,
-            transition='task-transition-open-tested-and-closed')
+
+        # Add a document to verify that all started subtasks also have
+        # relations to the doc if 'pass_documents_to_next_task' is set.
+        doc = create(Builder('document').within(self.seq_subtask_1))
+
+        wf_tool = api.portal.get_tool('portal_workflow')
+        wf_tool.doActionFor(
+            self.seq_subtask_1,
+            'task-transition-open-tested-and-closed',
+            transition_params={
+                'pass_documents_to_next_task': True,
+            }
+        )
 
         self.assertEquals(
             'task-state-open', api.content.get_state(subprocess_task1))
+        self.assertEquals(doc, subprocess_task1.relatedItems[0].to_object)
+
         self.assertEquals(
             'task-state-open', api.content.get_state(subprocess_task2))
+        self.assertEquals(doc, subprocess_task2.relatedItems[0].to_object)
+
         self.assertEquals(
             'task-state-open', api.content.get_state(subprocess_task2_task1))
+        self.assertEquals(doc, subprocess_task2_task1.relatedItems[0].to_object)
 
     def test_starts_sequential_subprocess(self):
         self.login(self.secretariat_user)
@@ -419,16 +434,30 @@ class TestSequentialTaskProcess(IntegrationTestCase):
 
         self.seq_subtask_2.set_tasktemplate_order([subprocess_task1, subprocess_task2])
 
-        api.content.transition(
-            obj=self.seq_subtask_1,
-            transition='task-transition-open-tested-and-closed')
+        # Add a document to verify that all started subtasks also have
+        # relations to the doc if 'pass_documents_to_next_task' is set.
+        doc = create(Builder('document').within(self.seq_subtask_1))
+
+        wf_tool = api.portal.get_tool('portal_workflow')
+        wf_tool.doActionFor(
+            self.seq_subtask_1,
+            'task-transition-open-tested-and-closed',
+            transition_params={
+                'pass_documents_to_next_task': True,
+            }
+        )
 
         self.assertEquals(
             'task-state-open', api.content.get_state(subprocess_task1))
+        self.assertEquals(doc, subprocess_task1.relatedItems[0].to_object)
+
         self.assertEquals(
             'task-state-open', api.content.get_state(subprocess_task1_task1))
+        self.assertEquals(doc, subprocess_task1_task1.relatedItems[0].to_object)
+
         self.assertEquals(
             'task-state-planned', api.content.get_state(subprocess_task2))
+        self.assertEquals(0, len(subprocess_task2.relatedItems))
 
 
 class TestInitialStateForSubtasks(IntegrationTestCase):


### PR DESCRIPTION
Nested task templates: Also pass docs to subtasks that get started:

This will make sure that if a sequential task is started because it is the next one in line, and the user selected `pass_documents_to_next_task`, the documents will be passed (i.e. set as relatedItems) not just to that next task, but also to any subtasks that get started if the next task happens to be a task template.

So in short:
If the user selects `pass_documents_to_next_task`, the documents will always be passed to exactly the same tasks that automatically get started.

For [CA-6450](https://4teamwork.atlassian.net/browse/CA-6450)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-6450]: https://4teamwork.atlassian.net/browse/CA-6450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ