### PR TITLE
Make documents/mails in dossiers orderable by API clients

### DIFF
--- a/changes/HG-4035.feature
+++ b/changes/HG-4035.feature
@@ -1,0 +1,1 @@
+Make documents/mails in dossiers orderable by API clients. [deiferni]

--- a/opengever/base/handlers.py
+++ b/opengever/base/handlers.py
@@ -13,6 +13,7 @@ from opengever.base.oguid import Oguid
 from opengever.base.security import reindex_object_security_without_children
 from opengever.base.touched import ObjectTouchedEvent
 from opengever.base.touched import should_track_touches
+from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.indexers import TYPES_WITH_CONTAINING_SUBDOSSIER_INDEX
 from opengever.dossier.utils import supports_is_subdossier
 from opengever.globalindex.handlers.task import sync_task
@@ -38,7 +39,8 @@ from zope.sqlalchemy.datamanager import mark_changed
 
 reindex_after_copy = ['created', 'is_locked_by_copy_to_workspace']
 
-CONTAINERS_SUPPORTING_OBJ_POSITION_IN_PARENT = (IWorkspace,
+CONTAINERS_SUPPORTING_OBJ_POSITION_IN_PARENT = (IDossierMarker,
+                                                IWorkspace,
                                                 IToDoList,
                                                 ITaskTemplateFolderSchema,
                                                 IWorkspaceMeeting)

--- a/opengever/base/indexes.py
+++ b/opengever/base/indexes.py
@@ -1,6 +1,7 @@
 from Acquisition import aq_base
 from Acquisition import aq_inner
 from Acquisition import aq_parent
+from ftw.mail.mail import IMail
 from opengever.base.behaviors.changed import IChanged
 from opengever.base.behaviors.changed import IChangedMarker
 from opengever.base.behaviors.touched import ITouched
@@ -33,6 +34,7 @@ from zope.annotation import IAnnotations
 # one of thoes interfaces.
 CONTENTS_SUPPORTING_OBJ_POSITION_IN_PARENT = (
     IDocumentSchema,
+    IMail,
     ITaskTemplate,
     ITaskTemplateFolderSchema,
     IToDo,

--- a/opengever/base/indexes.py
+++ b/opengever/base/indexes.py
@@ -10,6 +10,7 @@ from opengever.base.interfaces import IReferenceNumber
 from opengever.base.model import SORTABLE_TITLE_LENGTH
 from opengever.base.oguid import Oguid
 from opengever.bundle.sections.constructor import BUNDLE_GUID_KEY
+from opengever.document.document import IDocumentSchema
 from opengever.tasktemplates.content.tasktemplate import ITaskTemplate
 from opengever.tasktemplates.content.templatefoldersschema import ITaskTemplateFolderSchema
 from opengever.tasktemplates.interfaces import IPartOfSequentialProcess
@@ -31,6 +32,7 @@ from zope.annotation import IAnnotations
 # 'getObjPositionInParent' index is only calculated for objects providing
 # one of thoes interfaces.
 CONTENTS_SUPPORTING_OBJ_POSITION_IN_PARENT = (
+    IDocumentSchema,
     ITaskTemplate,
     ITaskTemplateFolderSchema,
     IToDo,

--- a/opengever/base/tests/test_contents_reordered_handling.py
+++ b/opengever/base/tests/test_contents_reordered_handling.py
@@ -1,6 +1,7 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from opengever.document.document import IDocumentSchema
 from opengever.tasktemplates.content.tasktemplate import ITaskTemplate
 from opengever.testing import SolrIntegrationTestCase
 from opengever.workspace.interfaces import IToDoList
@@ -80,6 +81,39 @@ class TestContentsReorderedHandler(SolrIntegrationTestCase):
              u'getObjPositionInParent': 1},
             {u'UID': tasktemplate_2.UID(),
              u'getObjPositionInParent': 0},
+            ], browser.json["items"])
+
+    @browsing
+    def test_reindex_getObjPositionInParent_if_reordering_documents_through_the_restapi(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        view = u'/@solrsearch?fl=getObjPositionInParent&depth=1&fq=object_provides:{}'\
+               u'&sort=getObjPositionInParent asc'.format(IDocumentSchema.__identifier__)
+
+        doc_1 = self.document
+        doc_2 = self.decided_proposal.load_model().excerpt_document.resolve_document()
+        doc_3 = self.shadow_document
+
+        browser.open(self.dossier.absolute_url(), view=view,
+                     method='GET', headers=self.api_headers)
+
+        self.assertItemsEqual(
+            [
+                {u'UID': doc_1.UID(), u'getObjPositionInParent': 0},
+                {u'UID': doc_2.UID(), u'getObjPositionInParent': 9},
+                {u'UID': doc_3.UID(), u'getObjPositionInParent': 15},
+            ], browser.json["items"])
+
+        new_order = {'ordering': {'obj_id': doc_2.id, 'delta': -9}}
+        browser.open(self.dossier, data=json.dumps(new_order), method='PATCH', headers=self.api_headers)
+        self.commit_solr()
+
+        browser.open(self.dossier.absolute_url(), view=view, method='GET', headers=self.api_headers)
+        self.assertItemsEqual(
+            [
+                {u'UID': doc_2.UID(), u'getObjPositionInParent': 0},
+                {u'UID': doc_1.UID(), u'getObjPositionInParent': 1},
+                {u'UID': doc_3.UID(), u'getObjPositionInParent': 15},
             ], browser.json["items"])
 
     @browsing

--- a/opengever/base/tests/test_contents_reordered_handling.py
+++ b/opengever/base/tests/test_contents_reordered_handling.py
@@ -8,7 +8,6 @@ import json
 
 
 class TestContentsReorderedHandler(SolrIntegrationTestCase):
-    features = ('workspace', )
 
     @browsing
     def test_reindex_getObjPositionInParent_if_reordering_contents_through_folder_contents(self, browser):
@@ -122,6 +121,7 @@ class TestContentsReorderedHandler(SolrIntegrationTestCase):
 
     @browsing
     def test_reindex_getObjPositionInParent_if_reordering_todos_through_the_restapi(self, browser):
+        self.activate_feature('workspace')
         self.login(self.administrator, browser=browser)
 
         view = u'/@solrsearch?fl=getObjPositionInParent&depth=1'
@@ -157,6 +157,7 @@ class TestContentsReorderedHandler(SolrIntegrationTestCase):
 
     @browsing
     def test_reindex_getObjPositionInParent_if_reordering_todolists_through_the_restapi(self, browser):
+        self.activate_feature('workspace')
         self.login(self.administrator, browser=browser)
 
         view = u'/@solrsearch?fl=getObjPositionInParent&depth=1&fq=object_provides:{}'.format(

--- a/opengever/base/tests/test_indexers.py
+++ b/opengever/base/tests/test_indexers.py
@@ -296,11 +296,13 @@ class TestGetObjPositionInParentIndexer(SolrIntegrationTestCase):
     def test_index_only_for_whitelisted_types(self, browser):
         self.login(self.administrator, browser=browser)
 
-        for obj in [self.document, self.dossier, self.proposal,
+        for obj in [self.dossier, self.proposal,
                     self.leaf_repofolder, self.task, self.workspace,
                     self.tasktemplatefolder]:
             self.assertIsNone(solr_data_for(obj, 'getObjPositionInParent'))
 
+        self.assertEqual(0, solr_data_for(self.document,
+                                          'getObjPositionInParent'))
         self.assertEqual(1, solr_data_for(self.seq_subtask_2,
                                           'getObjPositionInParent'))
         self.assertEqual(0, solr_data_for(self.tasktemplate,

--- a/opengever/document/handlers.py
+++ b/opengever/document/handlers.py
@@ -57,7 +57,9 @@ def document_or_mail_moved_or_added(context, event):
         return
 
     if IObjectMovedEvent.providedBy(event):
-        context.reindexObject(idxs=["reference", "sortable_reference", "metadata"])
+        context.reindexObject(
+            idxs=["getObjPositionInParent", "reference", "sortable_reference", "metadata"]
+        )
 
     if IDocumentSchema.providedBy(context):
         document_moved_or_added(context, event)

--- a/opengever/dossier/tests/test_move_items.py
+++ b/opengever/dossier/tests/test_move_items.py
@@ -403,6 +403,10 @@ class TestMoveItemsUpdatesIndexAndMetadata(SolrIntegrationTestCase, MoveItemsHel
         self.maxDiff = None
         self.login(self.regular_user, browser=browser)
 
+        # ensure pos in parent changes by creating content in target dossier
+        create(Builder('document').within(self.empty_dossier))
+        self.commit_solr()
+
         initial_solrdata = solr_data_for(self.subdocument)
         self.remove_ignored_solrdata(initial_solrdata)
 
@@ -424,6 +428,7 @@ class TestMoveItemsUpdatesIndexAndMetadata(SolrIntegrationTestCase, MoveItemsHel
             '_version_': moved_solrdata['_version_'],
             'containing_dossier': self.empty_dossier.Title(),
             'containing_subdossier': '',
+            'getObjPositionInParent': 1,
             'metadata': 'Client1 1.1 / 4 / 22 Wichtig Subkeyword',
             'modified': paste_time_index,
             'path': moved.absolute_url_path(),

--- a/opengever/dossier/tests/test_move_items.py
+++ b/opengever/dossier/tests/test_move_items.py
@@ -658,6 +658,7 @@ class TestMoveItemsUpdatesIndexAndMetadata(SolrIntegrationTestCase, MoveItemsHel
         modified_solrdata = {
             '_version_': moved_solrdata['_version_'],
             'containing_subdossier': u'2015',
+            'getObjPositionInParent': 0,
             'metadata': 'Client1 1.1 / 1.2 / 29',
             'modified': paste_time_index,
             'path': moved.absolute_url_path(),


### PR DESCRIPTION
With this PR we enable indexing the ordering of documents/mails. These changes make sure that the `getObjPositionInParent` is indexed in Solr for newly added and reordered documents/mails.

These changes are motivated by the following requirements in RI(S)PV:
- The customers want to define an order for documents of an agenda item (a current SPV feature)
- The customers want to define an order for documents of a meeting

See  [HG-4035](https://4teamwork.atlassian.net/browse/HG-4035) for more details.

An agenda item in RIS corresponds to a dossier in GEVER. RIS unfortunately does not have knowledge of all documents of an agenda item as this information is figured out on the fly via GEVER. Thus after some discussion with @phgross a while ago and @buchi some days ago we decided to try to use the already existing ordering of GEVER/Plone to implement this feature in RIS.

We don't want to make these changes visible anywhere in GEVER. From a technical perspective mostly for performance reasons:
- GEVER itself does not provide functionality to order these content types
- GEVER does not respect ordering in any listings
- We don't provide an upgrade to make sure all content is indexed correctly (_ensuring that existing content is indexed correctly will be a client responsibility_)

Thoughts on potential performance impact:
- Indexing of documents/mails will be a tad more expensive as the `getObjPositionInParent` index will be calculated ... values will come from objects already loaded into memory so this should hopefully be negligible
- Meeting-Dossiers that are reordered in RIS are usually relatively small with dozens of documents, not hundreds or thousands
- GEVER will not provide ordering anywhere thus avoiding performance issues when reindexing large dossiers
- We don't provide an automatic upgrade to avoid having to reindex a large amount of documents/mails

_Dear reviewer(s) please have a good and thorough look here, I feel very rusty with this codebase and errors are very likely!_

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [HG-4035](https://4teamwork.atlassian.net/browse/HG-4035)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- New functionality:
  - [x] for `document` also works for `mail`


[HG-4035]: https://4teamwork.atlassian.net/browse/HG-4035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HG-4035]: https://4teamwork.atlassian.net/browse/HG-4035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ