### PR TITLE
Fix tests on master

### DIFF
--- a/opengever/api/tests/test_templatefolder.py
+++ b/opengever/api/tests/test_templatefolder.py
@@ -785,7 +785,7 @@ class TestDossierFromTemplatePost(IntegrationTestCase):
                     'cause': 3,
                     'roles': ['Reader', 'Contributor', 'Editor'],
                     'reference': None,
-                    'principal': 'kathi.barfuss',
+                    'principal': 'regular_user',
                 },
                 {
                     'cause': 3,
@@ -804,7 +804,7 @@ class TestDossierFromTemplatePost(IntegrationTestCase):
                     'cause': 3,
                     'roles': ['Reader', 'Contributor', 'Editor'],
                     'reference': None,
-                    'principal': 'kathi.barfuss',
+                    'principal': 'regular_user',
                 },
                 {
                     'cause': 3,


### PR DESCRIPTION
These tests were executed against an old base of `master`, where the fixture user's user ID was not renamed from `kathi.barfuss` to `regular_user` yet.

That's why the PR on GitHub passed at one point, but once merged into the current master where the rename already happened, they fail.