### PR TITLE
Fix find-links for Gitlab packages

### DIFF
--- a/development.cfg
+++ b/development.cfg
@@ -9,6 +9,16 @@ extends =
     base-testserver.cfg
     base-qa.cfg
 
+find-links +=
+    https://git.4teamwork.ch/api/v4/projects/486/packages/pypi/simple/docxcompose
+    https://git.4teamwork.ch/api/v4/projects/486/packages/pypi/simple/ftw-bumblebee
+    https://git.4teamwork.ch/api/v4/projects/486/packages/pypi/simple/ftw-flamegraph
+    https://git.4teamwork.ch/api/v4/projects/486/packages/pypi/simple/ftw-zopemaster
+    https://git.4teamwork.ch/api/v4/projects/486/packages/pypi/simple/opengever-core
+    https://git.4teamwork.ch/api/v4/projects/486/packages/pypi/simple/products-ldapmultiplugins
+    https://git.4teamwork.ch/api/v4/projects/486/packages/pypi/simple/products-ldapuserfolder
+    https://git.4teamwork.ch/api/v4/projects/486/packages/pypi/simple/relstorage
+
 always-checkout = false
 
 ogds-db-name = ogds

--- a/sources.cfg
+++ b/sources.cfg
@@ -1,7 +1,6 @@
 [buildout]
 extends =
     http://kgs.4teamwork.ch/sources.cfg
-    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/4teamwork-psc.cfg
 
 extensions += mr.developer
 


### PR DESCRIPTION
- No longer extend from `4teamwork-psc.cfg`. Also removes `isotoma.buildout.basicauth` extension which is no longer needed.

- Add `find-links` for each package as Gitlab's simple index consists of subpages that aren't processed by setuptools.

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)
