### PR TITLE
Add related todo list field to workspace agenda items.

### DIFF
--- a/changes/CA-6152.feature
+++ b/changes/CA-6152.feature
@@ -1,0 +1,1 @@
+Add related_todo_list field to workspace agenda items. [elioschmutz]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,6 +11,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- Add `related_todo_list` field to workspace agenda items.
 
 
 2024.1.0 (2024-01-11)

--- a/docs/schema-dumps/opengever.workspace.meetingagendaitem.schema.json
+++ b/docs/schema-dumps/opengever.workspace.meetingagendaitem.schema.json
@@ -29,6 +29,13 @@
             "_zope_schema_type": "RelationList",
             "default": []
         },
+        "related_todo_list": {
+            "type": "string",
+            "title": "Verkn\u00fcpfte To-do-Liste",
+            "description": "",
+            "_zope_schema_type": "RelationChoice",
+            "_vocabulary": "<UID einer verkn\u00fcpften To-do-Liste"
+        },
         "changed": {
             "type": "string",
             "title": "Zuletzt ver\u00e4ndert",
@@ -45,6 +52,7 @@
         "text",
         "decision",
         "relatedItems",
+        "related_todo_list",
         "changed"
     ]
 }

--- a/opengever/base/schemadump/config.py
+++ b/opengever/base/schemadump/config.py
@@ -194,6 +194,9 @@ VOCAB_OVERRIDES = {
     'opengever.workspace.workspace.IWorkspaceSchema': {
         'responsible': u'<G\xfcltige ID eines Teamraum Teilnehmers>',
     },
+    'opengever.workspace.workspace_meeting_agenda_item.IWorkspaceMeetingAgendaItemSchema': {
+        'related_todo_list': u'<UID einer verkn\xfcpften To-do-Liste'
+    }
 }
 
 DEFAULT_OVERRIDES = {

--- a/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-06-27 10:13+0000\n"
+"POT-Creation-Date: 2024-01-15 11:57+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -273,6 +273,11 @@ msgstr "Besitzer"
 #: ./opengever/workspace/workspace_meeting_agenda_item.py
 msgid "label_related_items"
 msgstr "Verweise"
+
+#. Default: "Related todo list"
+#: ./opengever/workspace/workspace_meeting_agenda_item.py
+msgid "label_related_todo_list"
+msgstr "Verknüpfte To-do-Liste"
 
 #. Default: "Responsible"
 #: ./opengever/workspace/browser/templates/meeting_minutes.pt

--- a/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-06-27 10:13+0000\n"
+"POT-Creation-Date: 2024-01-15 11:57+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -307,6 +307,11 @@ msgstr "Owner"
 #: ./opengever/workspace/workspace_meeting_agenda_item.py
 msgid "label_related_items"
 msgstr "Related items"
+
+#. Default: "Related todo list"
+#: ./opengever/workspace/workspace_meeting_agenda_item.py
+msgid "label_related_todo_list"
+msgstr "Related to-do list"
 
 #. German translation: Verantwortlich
 #. Default: "Responsible"

--- a/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-06-27 10:13+0000\n"
+"POT-Creation-Date: 2024-01-15 11:57+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -273,6 +273,11 @@ msgstr "Propriétaire"
 #: ./opengever/workspace/workspace_meeting_agenda_item.py
 msgid "label_related_items"
 msgstr "Renvois"
+
+#. Default: "Related todo list"
+#: ./opengever/workspace/workspace_meeting_agenda_item.py
+msgid "label_related_todo_list"
+msgstr ""
 
 #. Default: "Responsible"
 #: ./opengever/workspace/browser/templates/meeting_minutes.pt

--- a/opengever/workspace/locales/opengever.workspace.pot
+++ b/opengever/workspace/locales/opengever.workspace.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-06-27 10:13+0000\n"
+"POT-Creation-Date: 2024-01-15 11:57+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -275,6 +275,11 @@ msgstr ""
 #: ./opengever/workspace/todo.py
 #: ./opengever/workspace/workspace_meeting_agenda_item.py
 msgid "label_related_items"
+msgstr ""
+
+#. Default: "Related todo list"
+#: ./opengever/workspace/workspace_meeting_agenda_item.py
+msgid "label_related_todo_list"
 msgstr ""
 
 #. Default: "Responsible"

--- a/opengever/workspace/workspace_meeting_agenda_item.py
+++ b/opengever/workspace/workspace_meeting_agenda_item.py
@@ -53,6 +53,15 @@ class IWorkspaceMeetingAgendaItemSchema(model.Schema):
         required=False,
     )
 
+    related_todo_list = RelationChoice(
+        title=_(u'label_related_todo_list', default=u'Related todo list'),
+        source=WorkspacePathSourceBinder(
+            portal_type=("opengever.workspace.todolist"),
+        ),
+        default=None,
+        required=False,
+    )
+
 
 class WorkspaceMeetingAgendaItem(Item):
     implements(IWorkspaceMeetingAgendaItem)


### PR DESCRIPTION
This PR adds a new field for workspace agenda items: `related_todo_list`

It allows us to display todos within a workspace agenda item.

For [CA-6152]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-6152]: https://4teamwork.atlassian.net/browse/CA-6152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ