### PR TITLE
Fix performance when checking if a workspace folder can be trashed

### DIFF
--- a/changes/CA-6605.bugfix
+++ b/changes/CA-6605.bugfix
@@ -1,0 +1,1 @@
+Fix performance when checking if a workspace folder can be trashed. [buchi]

--- a/opengever/trash/tests/test_trash.py
+++ b/opengever/trash/tests/test_trash.py
@@ -712,7 +712,7 @@ class TestWorkspaceFolderTrasher(IntegrationTestCase):
         self.assertTrue(ITrashed.providedBy(subfolder))
         self.assertTrue(ITrashed.providedBy(subdocument))
 
-    def test_verify_may_trash_on_workspace_folder_is_recursive(self):
+    def test_cannot_trash_workspace_folder_containing_a_checked_out_document(self):
         self.login(self.manager)
         subfolder = create(Builder('workspace folder')
                            .titled(u'Subfolder')
@@ -725,15 +725,12 @@ class TestWorkspaceFolderTrasher(IntegrationTestCase):
         self.assertTrue(trasher.verify_may_trash())
 
         self.checkout_document(subdocument)
-        with self.assertRaises(TrashError) as exc:
-            trasher.verify_may_trash()
-        self.assertEqual('Document checked out', str(exc.exception))
 
         with self.assertRaises(TrashError) as exc:
             trasher.trash()
         self.assertEqual('Document checked out', str(exc.exception))
 
-    def test_verify_may_trash_on_workspace_folder_recursively_checks_permissions(self):
+    def test_cannot_trash_workspace_folder_containing_a_subfolder_with_insufficient_permissions(self):
         self.login(self.workspace_member)
         subfolder = create(Builder('workspace folder')
                            .titled(u'Subfolder')
@@ -749,7 +746,7 @@ class TestWorkspaceFolderTrasher(IntegrationTestCase):
 
         self.login(self.workspace_admin)
         with self.assertRaises(Unauthorized):
-            trasher.verify_may_trash()
+            trasher.trash()
 
     def test_untrashing_workspace_folder_is_recursive(self):
         self.login(self.manager)
@@ -769,7 +766,7 @@ class TestWorkspaceFolderTrasher(IntegrationTestCase):
         self.assertFalse(ITrashed.providedBy(subfolder))
         self.assertFalse(ITrashed.providedBy(subdocument))
 
-    def test_verify_may_untrash_on_workspace_folder_is_recursive(self):
+    def test_cannot_untrash_workspace_folder_containing_an_untrashed_document(self):
         self.login(self.manager)
         subfolder = create(Builder('workspace folder')
                            .titled(u'Subfolder')
@@ -783,9 +780,6 @@ class TestWorkspaceFolderTrasher(IntegrationTestCase):
         self.assertTrue(trasher.verify_may_untrash())
 
         noLongerProvides(subdocument, ITrashed)
-
-        with self.assertRaises(Unauthorized):
-            trasher.verify_may_untrash()
 
         with self.assertRaises(Unauthorized):
             trasher.untrash()

--- a/opengever/trash/trash.py
+++ b/opengever/trash/trash.py
@@ -239,32 +239,19 @@ class WorkspaceFolderTrasher(DefaultContentTrasher):
     """An object which handles trashing/untrashing workspace folders.
     """
 
-    def _verify_may_trash(self, raise_on_violations=True):
-        if not super(WorkspaceFolderTrasher, self)._verify_may_trash(raise_on_violations):
-            return False
-        for obj in self.context.objectValues():
-            if not ITrasher(obj)._verify_may_trash(raise_on_violations):
-                return False
-        return True
-
-    def _verify_may_untrash(self, raise_on_violations=True):
-        if not super(WorkspaceFolderTrasher, self)._verify_may_untrash(raise_on_violations):
-            return False
-
-        for obj in self.context.objectValues():
-            if not ITrasher(obj)._verify_may_untrash(raise_on_violations):
-                return False
-        return True
-
     def _trash(self):
         super(WorkspaceFolderTrasher, self)._trash()
         for obj in self.context.objectValues():
-            ITrasher(obj)._trash()
+            trasher = ITrasher(obj)
+            trasher._verify_may_trash()
+            trasher._trash()
 
     def _untrash(self):
         super(WorkspaceFolderTrasher, self)._untrash()
         for obj in self.context.objectValues():
-            ITrasher(obj)._untrash()
+            trasher = ITrasher(obj)
+            trasher._verify_may_untrash()
+            trasher._untrash()
 
     def is_trashable(self):
         return True


### PR DESCRIPTION
The current implementation recursively checks if all contained items of a workspace folder can be trashed.
This obviously gets slower, the more items a workspace folder contains and is already unusable if it contains just a few items.

Now, we only check if the workspace folder itself can be trashed and do the check for contained items while performing the trash operation.

For [CA-6605](https://4teamwork.atlassian.net/browse/CA-6605)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)



[CA-6605]: https://4teamwork.atlassian.net/browse/CA-6605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ