### PR TITLE
Fix Docker image: remove ZCML include of ftw.tika in Docker image

### DIFF
--- a/changes/GH-7875.bugfix
+++ b/changes/GH-7875.bugfix
@@ -1,0 +1,1 @@
+Fix Docker image: remove ZCML include of ftw.tika in Docker image. [buchi]

--- a/docker/core/etc/site.zcml
+++ b/docker/core/etc/site.zcml
@@ -25,7 +25,6 @@
       component="AccessControl.security.SecurityPolicy" />
 
   <include package="opengever.setup" file="meta.zcml" />
-  <include package="ftw.tika" file="meta.zcml" />
   <include package="five.pt" file="meta.zcml" />
   <include package="plone.resource" file="meta.zcml" />
   <include package="plone.app.dexterity" file="meta.zcml" />


### PR DESCRIPTION

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)
