### PR TITLE
Also update `modified` when updating `changed` 

### DIFF
--- a/changes/CA-6552.bugfix
+++ b/changes/CA-6552.bugfix
@@ -1,0 +1,1 @@
+Also update modification date when updating changed timestamp. [lgraf]

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -1501,7 +1501,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
         self.assertEqual(
             [{u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/disposition-2',
               u'UID': u'createdispositionwithsip00000001',
-              u'modified': u'2016-08-31T19:09:33+00:00',
+              u'modified': u'2016-08-31T19:11:33+00:00',
               u'review_state': u'disposition-state-disposed',
               u'title': u'Angebot 30.12.1997'},
              {u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/disposition-1',

--- a/opengever/api/tests/test_solrsearch.py
+++ b/opengever/api/tests/test_solrsearch.py
@@ -606,7 +606,7 @@ class TestSolrSearchGet(SolrIntegrationTestCase):
 
         self.assertEqual([u'2016-08-31T14:07:33+00:00',
                           u'2016-08-31T14:21:33+00:00',
-                          u'2016-08-31T19:01:33+00:00'],
+                          u'2016-08-31T19:07:33+00:00'],
                          [item["modified"] for item in browser.json["items"]])
 
     @browsing

--- a/opengever/base/handlers.py
+++ b/opengever/base/handlers.py
@@ -251,7 +251,8 @@ def maybe_update_changed_date(context, event):
 
 def update_changed_date(context, event):
     IChanged(context).changed = utcnow_tz_aware()
-    context.reindexObject(idxs=["changed"])
+    context.setModificationDate()
+    context.reindexObject(idxs=["changed", "modified"])
 
 
 def update_touched_date(obj, event):

--- a/opengever/core/upgrades/20240119135606_touch_modified_timestamp_for_objects_where_changed_is_newer/upgrade.py
+++ b/opengever/core/upgrades/20240119135606_touch_modified_timestamp_for_objects_where_changed_is_newer/upgrade.py
@@ -1,0 +1,53 @@
+from collections import Counter
+from datetime import timedelta
+from ftw.upgrade import ProgressLogger
+from ftw.upgrade import UpgradeStep
+from opengever.core.upgrade import NightlyIndexer
+from plone import api
+import logging
+
+
+TOLERANCE = timedelta(seconds=5)
+
+log = logging.getLogger('ftw.upgrade')
+
+
+class TouchModifiedTimestampForObjectsWhereChangedIsNewer(UpgradeStep):
+    """Touch modified timestamp for objects where changed is newer.
+    """
+
+    deferrable = True
+
+    def __call__(self):
+        log.info("Checking catalog for items that have a 'changed' "
+                 "timestamp that that is newer than  'modified'...")
+
+        catalog = api.portal.get_tool('portal_catalog')
+        brains = catalog.unrestrictedSearchResults(sort_on='path')
+        total_items = len(brains)
+        log.info('Catalog contains %s items total.' % total_items)
+
+        found_total = 0
+        found_by_type = Counter()
+
+        with NightlyIndexer(idxs=["modified"],
+                            index_in_catalog_only=True) as indexer:
+            msg = "Touching 'modified' for affected objects"
+            for brain in ProgressLogger(msg, brains):
+                changed = brain.changed
+                modified = brain.modified.asdatetime()
+
+                if not changed:
+                    continue
+
+                if changed > (modified + TOLERANCE):
+                    found_total += 1
+                    found_by_type[brain.portal_type] += 1
+                    obj = brain.getObject()
+                    obj.setModificationDate()
+                    indexer.add_by_brain(brain)
+
+        log.info("Updated 'modified' for %s brains." % found_total)
+        for portal_type, count in found_by_type.items():
+            log.info('  %-40s : %s' % (portal_type, count))
+        log.info('(Out of %s total objects in catalog)' % total_items)


### PR DESCRIPTION
Also update `modified` when updating `changed` timestamp:

We rely on `modified` in `solr-sync` to determine which items are out of sync (present on both sides, but with potential difference in metadata contents). However, `modified` gets updated not nearly as consistently as we thought: For example, triggering a workflow transition will not update `modified`.

Therefore, we always update `modified` when we update the higher-level `changed` timestamp. This way, we should at least catch the most important user facing changes to objects.

This includes an upgrade-step which will touch `modified` for all items in the catalog where `changed` is newer than `modified`. It will defer the reindexing of `modified` (and all metadata) to a nightly job, and will only reindex `modified` in ZCatalog, but not Solr. Therefore, the next time `bin/instance solr-sync sync` is run, those objects will be picked up as being out of sync.    

For [CA-6552](https://4teamwork.atlassian.net/browse/CA-6552)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- Upgrade-Steps:
  - [x] Make it deferrable if possible
  - [x] Execute as much as possible conditionally


[CA-6552]: https://4teamwork.atlassian.net/browse/CA-6552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ