### PR TITLE
Customfields Permissions

### DIFF
--- a/opengever/propertysheets/annotation.py
+++ b/opengever/propertysheets/annotation.py
@@ -3,10 +3,20 @@ from opengever.base.utils import make_persistent
 from opengever.propertysheets.exceptions import BadCustomPropertiesFactoryConfiguration
 from opengever.propertysheets.field import IPropertySheetField
 from persistent.dict import PersistentDict
+from persistent.mapping import PersistentMapping
 from plone.behavior.annotation import AnnotationsFactoryImpl
 from plone.behavior.annotation import AnnotationStorage
 from plone.behavior.interfaces import ISchemaAwareFactory
 from zope.interface import alsoProvides
+
+
+def deep_update(dict_, otherdict):
+    for k, v in otherdict.iteritems():
+        if isinstance(v, (dict, PersistentMapping)):
+            dict_[k] = deep_update(dict_.get(k, {}), v)
+        else:
+            dict_[k] = v
+    return dict_
 
 
 class CustomPropertiesStorageImpl(AnnotationsFactoryImpl):
@@ -74,7 +84,8 @@ class CustomPropertiesStorageImpl(AnnotationsFactoryImpl):
             # we could have an initial stored value of `None`
             if value_to_update is None:
                 value_to_update = PersistentDict()
-            value_to_update.update(new_value)
+
+            deep_update(value_to_update, new_value)
 
             self.__dict__['annotations'][prefixed_name] = value_to_update
 

--- a/opengever/propertysheets/api/base.py
+++ b/opengever/propertysheets/api/base.py
@@ -283,6 +283,8 @@ class PropertySheetWriter(PropertySheetLocator):
                 'default_factory': field_data.get('default_factory'),
                 'default_expression': field_data.get('default_expression'),
                 'default_from_member': field_data.get('default_from_member'),
+                'read_group': field_data.get('read_group', None),
+                'write_group': field_data.get('write_group', None),
             }
 
             schema_definition.add_field(

--- a/opengever/propertysheets/api/definition_serializer.py
+++ b/opengever/propertysheets/api/definition_serializer.py
@@ -37,6 +37,8 @@ class SerializePropertySheetSchemaDefinitionToJson(object):
                 'description': field.description,
                 'required': field.required,
                 'available_as_docproperty': name in docprops,
+                'read_group': self.context.read_group_mapping.get(name),
+                'write_group': self.context.write_group_mapping.get(name),
             }
 
             ps_field.update(self.get_values(field))

--- a/opengever/propertysheets/definition.py
+++ b/opengever/propertysheets/definition.py
@@ -136,13 +136,16 @@ class PropertySheetSchemaDefinition(object):
 
         return cls(name, SchemaClass, assignments=assignments, docprops=docprops)
 
-    def __init__(self, name, schema_class, assignments=None, docprops=[]):
+    def __init__(self, name, schema_class, assignments=None, docprops=[],
+                 read_group_mapping=None, write_group_mapping=None):
         self.name = name
         self.schema_class = schema_class
         if assignments is None:
             assignments = tuple()
         self.assignments = assignments
         self.docprops = docprops
+        self.read_group_mapping = read_group_mapping or {}
+        self.write_group_mapping = write_group_mapping or {}
 
         for field in self.get_fields():
             self._init_field(field[1])
@@ -207,7 +210,8 @@ class PropertySheetSchemaDefinition(object):
     def add_field(self, field_type, name, title, description, required,
                   values=None, default=None, default_factory=None,
                   default_expression=None, default_from_member=None,
-                  available_as_docproperty=False):
+                  available_as_docproperty=False, read_group=None,
+                  write_group=None):
         if field_type not in self.FACTORIES:
             raise InvalidFieldType("Field type '{}' is invalid.".format(field_type))
 
@@ -346,6 +350,11 @@ class PropertySheetSchemaDefinition(object):
             # takes care of this for us.
             attach_member_property_default_factory(field, default_from_member)
 
+        if read_group is not None:
+            self.read_group_mapping[name] = read_group
+        if write_group is not None:
+            self.write_group_mapping[name] = write_group
+
         schema = IEditableSchema(self.schema_class)
         schema.addField(field)
         self._init_field(field)
@@ -414,6 +423,10 @@ class PropertySheetSchemaDefinition(object):
         definition_data['schema'] = serialized_schema
         definition_data['assignments'] = PersistentList(self.assignments)
         definition_data['docprops'] = PersistentList(self.docprops)
+        definition_data['read_group_mapping'] = PersistentMapping(
+            self.read_group_mapping)
+        definition_data['write_group_mapping'] = PersistentMapping(
+            self.write_group_mapping)
         storage[self.name] = definition_data
 
     @classmethod
@@ -422,7 +435,16 @@ class PropertySheetSchemaDefinition(object):
         serialized_schema = definition_data['schema']
         assignments = definition_data['assignments']
         docprops = definition_data.get('docprops', [])
+        read_group_mapping = definition_data.get('read_group_mapping', {})
+        write_group_mapping = definition_data.get('write_group_mapping', {})
         model = loadString(serialized_schema, policy=u'propertysheets')
         schema_class = model.schemata[name]
 
-        return cls(name, schema_class, assignments=assignments, docprops=docprops)
+        return cls(
+            name,
+            schema_class,
+            assignments=assignments,
+            docprops=docprops,
+            read_group_mapping=read_group_mapping,
+            write_group_mapping=write_group_mapping,
+        )

--- a/opengever/propertysheets/metaschema.py
+++ b/opengever/propertysheets/metaschema.py
@@ -94,6 +94,18 @@ class IFieldDefinition(model.Schema):
         required=False,
         default=False,
     )
+    read_group = schema.TextLine(
+        title=_(u'label_read_group', default=u'Read Group'),
+        description=_(u'help_read_group',
+                      default=u'If specified, only members of this group can read the field value.'),
+        required=False,
+    )
+    write_group = schema.TextLine(
+        title=_(u'label_write_group', default=u'Write Group'),
+        description=_(u'help_write_group',
+                      default=u'If specified, only members of this group can write the field value.'),
+        required=False,
+    )
 
     @invariant
     def valid_default_value(obj):


### PR DESCRIPTION
_PR-Description: should contain all the information necessary for an outsider to understand the change without looking at the code or the issue!_

- _Why the change is necessary_
- _What the goal of the change is_
- _How change is achieved (e.g. design decisions)_
- _The author should advertise and sell the change in the PR body_

_Screenshot: whenever useful, but only as a visual aid._


Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [CA-XXXX]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
