### PR TITLE
Add getObjPositionInParent to serialization for documents/mails

### DIFF
--- a/changes/HG-4035-1.feature
+++ b/changes/HG-4035-1.feature
@@ -1,0 +1,1 @@
+Include getObjPositionInParent in serialization for documents/mails. [deiferni]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -13,6 +13,8 @@ Other Changes
 ^^^^^^^^^^^^^
 - Add `related_todo_list` field to workspace agenda items.
 
+- Add `getObjPositionInParent` metadata to documents and mails.
+
 
 2024.1.0 (2024-01-11)
 ---------------------

--- a/opengever/api/document.py
+++ b/opengever/api/document.py
@@ -20,6 +20,7 @@ from plone.restapi.interfaces import IExpandableElement
 from plone.restapi.interfaces import IJsonCompatible
 from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.services.content.update import ContentPatch
+from Products.CMFPlone.CatalogTool import getObjPositionInParent
 from zExceptions import Forbidden
 from zope.component import adapter
 from zope.component import getMultiAdapter
@@ -71,6 +72,7 @@ class SerializeDocumentToJson(GeverSerializeToJson):
             'checked_out_fullname': checked_out_by_fullname,
             'checkout_collaborators': list(obj.get_collaborators()),
             'file_mtime': obj.get_file_mtime(),
+            'getObjPositionInParent': getObjPositionInParent(obj)(),
             'is_collaborative_checkout': obj.is_collaborative_checkout(),
             'is_locked': obj.is_locked(),
             'containing_dossier': obj.containing_dossier_title(),

--- a/opengever/api/tests/test_document.py
+++ b/opengever/api/tests/test_document.py
@@ -60,6 +60,16 @@ class TestDocumentSerializer(IntegrationTestCase):
         self.assertEqual('.msg', browser.json.get(u'file_extension'))
 
     @browsing
+    def test_document_serialization_contains_position_in_parent(self, browser):
+        self.login(self.regular_user, browser)
+
+        browser.open(self.subdocument, headers={'Accept': 'application/json'})
+        self.assertEqual(0, browser.json['getObjPositionInParent'])
+
+        browser.open(self.empty_document, headers={'Accept': 'application/json'})
+        self.assertEqual(2, browser.json['getObjPositionInParent'])
+
+    @browsing
     def test_contains_additional_metadata(self, browser):
         self.login(self.regular_user, browser)
 

--- a/opengever/api/tests/test_mail.py
+++ b/opengever/api/tests/test_mail.py
@@ -51,6 +51,16 @@ class TestGetMail(IntegrationTestCase):
         self.assertEqual(expected_message, browser.json.get('original_message'))
 
     @browsing
+    def test_mail_serialization_contains_position_in_parent(self, browser):
+        self.login(self.regular_user, browser)
+
+        browser.open(self.subdocument, headers={'Accept': 'application/json'})
+        self.assertEqual(0, browser.json['getObjPositionInParent'])
+
+        browser.open(self.mail_msg, headers={'Accept': 'application/json'})
+        self.assertEqual(8, browser.json['getObjPositionInParent'])
+
+    @browsing
     def test_mail_serialization_contains_attachments(self, browser):
         self.login(self.regular_user, browser)
         mail = create(Builder('mail')


### PR DESCRIPTION
With this PR we enable serializing`getObjPositionInParent` for documents/mails in REST API responses. It is a follow-up for https://github.com/4teamwork/opengever.core/pull/7869 which enabled indexing in Solr.

These changes are motivated by the following requirements in RI(S)PV:
- After creating content in GEVER we would like to know the position of the new object directly from the `POST` response
- Without this change we would have to make a 2nd request to fetch the object position

I've chosen to re-use the default plone indexer for serialization. IMO this is fine but i can of course use the adapter that is used by the indexer directly if that is preferred.

_Dear reviewer(s) please have a good and thorough look here, I feel very rusty with this codebase and errors are very likely!_

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [HG-4035](https://4teamwork.atlassian.net/browse/HG-4035)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
- New functionality:
  - [x] for `document` also works for `mail`


[HG-4035]: https://4teamwork.atlassian.net/browse/HG-4035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ