### PR TITLE
Reporting view: Use filter query to filter by paths

### DIFF
--- a/changes/CA-6577.other
+++ b/changes/CA-6577.other
@@ -1,0 +1,1 @@
+Reporting view: Use filter query to filter by paths. [lgraf]

--- a/opengever/base/browser/reporting_view.py
+++ b/opengever/base/browser/reporting_view.py
@@ -146,7 +146,7 @@ class SolrReporterView(BaseReporterView):
             sort = 'modified desc'
 
         solr_query['sort'] = sort
-        solr_query['query'] = 'path:({})'.format(' OR '.join([escape(path) for path in paths]))
+        solr_query['fq'] = 'path:({})'.format(' OR '.join([escape(path) for path in paths]))
 
     def _extend_selected_items_query_by_listing(self, solr_query, listing_name):
         listing = queryMultiAdapter((self.context, self.request), name="GET_application_json_@listing")


### PR DESCRIPTION
Reporting view: Use filter query to filter by paths:
Compared to regular queries, a filter query should be chacheable in Solr and result in lower memory usage.

For [CA-6577](https://4teamwork.atlassian.net/browse/CA-6577)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-6577]: https://4teamwork.atlassian.net/browse/CA-6577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ