### PR TITLE
Fix unicode error in kub search

### DIFF
--- a/changes/CA-6649.bugfix
+++ b/changes/CA-6649.bugfix
@@ -1,0 +1,1 @@
+Fix search for participations with umlauts. [elioschmutz]

--- a/opengever/api/tests/test_globalsources.py
+++ b/opengever/api/tests/test_globalsources.py
@@ -134,50 +134,50 @@ class TestGlobalSourcesGetWithKubContacts(KuBIntegrationTestCase):
 
     @browsing
     def test_query_contacts_shows_only_active_contacts(self, mocker, browser):
-        create(Builder('ogds_user').id('kohler.inactive')
-               .having(firstname='Kohler', lastname='Inactive', active=False))
+        create(Builder('ogds_user').id('jurgen.inactive')
+               .having(firstname=u'K\xf6nig', lastname='Inactive', active=False))
 
-        create(Builder('ogds_user').id('kohler.active')
-               .having(firstname='Kohler', lastname='Active', active=True))
+        create(Builder('ogds_user').id('jurgen.active')
+               .having(firstname=u'K\xf6nig', lastname='Active', active=True))
 
         self.login(self.regular_user, browser=browser)
-        query_str = "kohler&is_active=True"
-        self.mock_search(mocker, query_str)
+        query_str = "K%C3%B6nig&is_active=True"
+        url = self.mock_search(mocker, query_str)
 
-        url = '{}/@globalsources/contacts?query=kohler'.format(
+        url = '{}/@globalsources/contacts?query=K%C3%B6nig'.format(
             self.portal.absolute_url())
         browser.open(url, headers=self.api_headers)
 
         self.assertEqual(
             [
-                u'Kohler KUB Active',
-                u'Kohler Nicole (nicole.kohler)',
-                u'Active Kohler (kohler.active)'
+                u'K\xf6nig KUB Active',
+                u'K\xf6nig J\xfcrgen (jurgen.konig)',
+                u'Active K\xf6nig (jurgen.active)'
             ],
             [item.get('title') for item in browser.json["items"]])
 
     @browsing
     def test_query_contacts_shows_all_contacts(self, mocker, browser):
-        create(Builder('ogds_user').id('kohler.inactive')
-               .having(firstname='Kohler', lastname='Inactive', active=False))
+        create(Builder('ogds_user').id('jurgen.inactive')
+               .having(firstname=u'K\xf6nig', lastname='Inactive', active=False))
 
-        create(Builder('ogds_user').id('kohler.active')
-               .having(firstname='Kohler', lastname='Active', active=True))
+        create(Builder('ogds_user').id('jurgen.active')
+               .having(firstname=u'K\xf6nig', lastname='Active', active=True))
 
         self.login(self.regular_user, browser=browser)
-        query_str = "kohler"
+        query_str = "K%C3%B6nig"
         self.mock_search(mocker, query_str)
 
-        url = '{}/@globalsources/all_contacts?query=kohler'.format(
+        url = '{}/@globalsources/all_contacts?query=K%C3%B6nig'.format(
             self.portal.absolute_url())
         browser.open(url, headers=self.api_headers)
 
         self.assertEqual(
             [
-                u'Kohler KUB Active',
-                u'Kohler KUB Inactive',
-                u'Kohler Nicole (nicole.kohler)',
-                u'Inactive Kohler (kohler.inactive)',
-                u'Active Kohler (kohler.active)',
+                u'K\xf6nig KUB Active',
+                u'K\xf6nig KUB Inactive',
+                u'K\xf6nig J\xfcrgen (jurgen.konig)',
+                u'Inactive K\xf6nig (jurgen.inactive)',
+                u'Active K\xf6nig (jurgen.active)'
             ],
             [item.get('title') for item in browser.json["items"]])

--- a/opengever/kub/client.py
+++ b/opengever/kub/client.py
@@ -3,6 +3,7 @@ from opengever.base.sentry import log_msg_to_sentry
 from opengever.kub.interfaces import IKuBSettings
 from persistent.mapping import PersistentMapping
 from plone import api
+from plone.dexterity.utils import safe_utf8
 from plone.memoize import ram
 from time import mktime
 from time import time
@@ -56,10 +57,10 @@ class KuBClient(object):
 
     def query(self, query_str, filters=dict()):
         search_filters = {
-            'q': query_str,
+            'q': safe_utf8(query_str),
         }
         search_filters.update(filters)
-        url = u'{}search?{}'.format(self.kub_api_url, urlencode(search_filters))
+        url = '{}search?{}'.format(self.kub_api_url, urlencode(search_filters))
         res = self.session.get(url)
         return res.json()
 

--- a/opengever/kub/testing.py
+++ b/opengever/kub/testing.py
@@ -25,7 +25,7 @@ class KuBIntegrationTestCase(IntegrationTestCase):
         return url
 
     def mock_search(self, mocker, query_str, **kwargs):
-        url = u'{}search?q={}'.format(self.client.kub_api_url, query_str)
+        url = '{}search?q={}'.format(self.client.kub_api_url, query_str)
         mocker.get(url, json=KUB_RESPONSES[url], **kwargs)
         return url
 
@@ -84,7 +84,7 @@ KUB_RESPONSES = {
         ]
     },
 
-    "http://localhost:8000/api/v2/search?q=kohler&is_active=True": {
+    "http://localhost:8000/api/v2/search?q=K%C3%B6nig&is_active=True": {
         "results": [
             {
                 "htmlUrl": "http://localhost:8000/organizations/30bab83d-300a-4886-97d4-ff592e88a56a",
@@ -93,7 +93,7 @@ KUB_RESPONSES = {
                 "id": "30bab83d-300a-4886-97d4-ff592e88a56a",
                 "organization": None,
                 "modified": "2021-11-13T00:00:00+01:00",
-                "text": "Kohler KUB Active",
+                "text": "K\xc3\xb6nig KUB Active",
                 "thirdPartyId": None,
                 "type": "organization",
                 "typedId": "organization:30bab83d-300a-4886-97d4-ff592e88a56a"
@@ -101,7 +101,7 @@ KUB_RESPONSES = {
         ]
     },
 
-    "http://localhost:8000/api/v2/search?q=kohler": {
+    "http://localhost:8000/api/v2/search?q=K%C3%B6nig": {
         "results": [
             {
                 "htmlUrl": "http://localhost:8000/organizations/30bab83d-300a-4886-97d4-ff592e88a56a",
@@ -110,7 +110,7 @@ KUB_RESPONSES = {
                 "id": "30bab83d-300a-4886-97d4-ff592e88a56a",
                 "organization": None,
                 "modified": "2021-11-13T00:00:00+01:00",
-                "text": "Kohler KUB Active",
+                "text": "K\xc3\xb6nig KUB Active",
                 "thirdPartyId": None,
                 "type": "organization",
                 "typedId": "organization:30bab83d-300a-4886-97d4-ff592e88a56a"
@@ -122,7 +122,7 @@ KUB_RESPONSES = {
                 "id": "8345fcfe-2d67-4b75-af46-c25b2f387448",
                 "organization": "30bab83d-300a-4886-97d4-ff592e88a56a",
                 "modified": "2021-11-18T00:00:00+01:00",
-                "text": "Kohler KUB Inactive",
+                "text": "K\xc3\xb6nig KUB Inactive",
                 "thirdPartyId": None,
                 "type": "membership",
                 "typedId": "membership:8345fcfe-2d67-4b75-af46-c25b2f387448"


### PR DESCRIPTION
This PR fixes an issue introduced in: https://github.com/4teamwork/opengever.core/pull/7863

Search by umlauts was no longer possible.

Sentry: https://sentry.4teamwork.ch/organizations/sentry/issues/123946/?project=17&query=release%3A2024.1.0&referrer=release-issue-stream

## Before
![Bildschirmfoto 2024-01-24 um 10 27 22](https://github.com/4teamwork/opengever.core/assets/557005/74393a17-b3dc-4f0c-95c1-461ea19bae44)

## After
![Bildschirmfoto 2024-01-24 um 10 28 44](https://github.com/4teamwork/opengever.core/assets/557005/876eb7fa-033c-4559-a803-1b18e727f30c)

For [CA-6649]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-6649]: https://4teamwork.atlassian.net/browse/CA-6649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ