### PR TITLE
Use ogds-sync service for syncing users and groups

### DIFF
--- a/changes/CA-6237a.other
+++ b/changes/CA-6237a.other
@@ -1,0 +1,1 @@
+Use ogds-sync service for syncing users and groups. [buchi]

--- a/development.cfg
+++ b/development.cfg
@@ -80,6 +80,7 @@ environment-vars +=
     SABLON_URL http://localhost:8091/
     PDFLATEX_URL http://localhost:8092/
     WEASYPRINT_URL http://localhost:8093/
+    OGDS_SYNC_URL http://localhost:8099/
 
 zcml +=
   opengever.core

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,7 @@ services:
       - 8099:8080
     environment:
       - OGDS_DSN=postgresql://${OGDS_DB_USER}:${OGDS_DB_PASSWORD}@${OGDS_DB_HOST}/${OGDS_DB_NAME}
-      - LDAP_PROFILE=DS389
+      - LDAP_PROFILE=DS389Legacy
       - LDAP_URL=${LDAP_SERVER_URI}
       - LDAP_BIND_DN=${LDAP_BIND_DN}
       - LDAP_BIND_PASSWORD=${LDAP_BIND_PASSWORD}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,7 @@ services:
       - SABLON_URL=http://sablon:8080/
       - PDFLATEX_URL=http://pdflatex:8080/
       - WEASYPRINT_URL=http://weasyprint:8080/
+      - OGDS_SYNC_URL=http://ogds-sync:8099/
     depends_on:
       - zeoserver
       - ogds

--- a/opengever/examplecontent/profiles/default-ska/unit_creation/org_units.json
+++ b/opengever/examplecontent/profiles/default-ska/unit_creation/org_units.json
@@ -3,7 +3,7 @@
     "unit_id": "ska-sk",
     "title": "Sekretariat Staatskanzlei",
     "admin_unit_id": "ska",
-    "users_group_id": "og_demo-ftw_users",
-    "inbox_group_id": "og_demo-ftw_users"
+    "users_group_name": "og_demo-ftw_users",
+    "inbox_group_name": "og_demo-ftw_users"
   }
 ]

--- a/opengever/examplecontent/profiles/default/unit_creation/org_units.json
+++ b/opengever/examplecontent/profiles/default/unit_creation/org_units.json
@@ -3,13 +3,13 @@
     "unit_id": "stv",
     "title": "Steuerverwaltung",
     "admin_unit_id": "fd",
-    "users_group_id": "og_demo-ftw_users",
-    "inbox_group_id": "og_demo-ftw_users"
+    "users_group_name": "og_demo-ftw_users",
+    "inbox_group_name": "og_demo-ftw_users"
   }, {
     "unit_id": "afi",
     "title": "Amt für Informatik",
     "admin_unit_id": "fd",
-    "users_group_id": "og_demo-ftw_users",
-    "inbox_group_id": "og_demo-ftw_users"
+    "users_group_name": "og_demo-ftw_users",
+    "inbox_group_name": "og_demo-ftw_users"
   }
 ]

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/profiles/units/unit_creation/org_units.json.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/profiles/units/unit_creation/org_units.json.bob
@@ -1,7 +1,7 @@
 [
   {
-    "inbox_group_id": "{{{orgunit.inbox_group}}}",
-    "users_group_id": "{{{orgunit.users_group}}}",
+    "inbox_group_name": "{{{orgunit.inbox_group}}}",
+    "users_group_name": "{{{orgunit.users_group}}}",
     "admin_unit_id": "{{{adminunit.id}}}",
     "unit_id": "{{{orgunit.id}}}",
     "title": "{{{orgunit.title}}}"}

--- a/opengever/setup/creation/orgunit.py
+++ b/opengever/setup/creation/orgunit.py
@@ -19,12 +19,8 @@ class OrgUnitCreator(UnitCreator):
                            'inbox_group_id')
 
     def apply_development_config(self, item):
-        if self.is_policyless:
-            item['users_group_name'] = DEVELOPMENT_USERS_GROUP
-            item['inbox_group_name'] = DEVELOPMENT_USERS_GROUP
-        else:
-            item['users_group_id'] = DEVELOPMENT_USERS_GROUP
-            item['inbox_group_id'] = DEVELOPMENT_USERS_GROUP
+        item['users_group_name'] = DEVELOPMENT_USERS_GROUP
+        item['inbox_group_name'] = DEVELOPMENT_USERS_GROUP
 
     def preprocess(self, item):
         users_group_name = item.get('users_group_name')


### PR DESCRIPTION
If an ogds-sync url is configured, the service is used for syncing instead of the built-in syncer.
Configure url for local development.

Fixes initial setup of local development as the ogds-sync service is also used for setup.
ogds-sync >= 2024.1.0 is required.

Use legacy ogds-sync profile for development. As long as we use the ldap plugin for development, we have to stick with the legacy sync (username=userid).

For [CA-6237](https://4teamwork.atlassian.net/browse/CA-6237)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-6237]: https://4teamwork.atlassian.net/browse/CA-6237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ