### PR TITLE
Fix upgrade step that touches modified timestamp.

### DIFF
--- a/changes/CA-6552.bugfix
+++ b/changes/CA-6552.bugfix
@@ -1,0 +1,1 @@
+Fix upgrade step that touches modified timestamp. [lgraf]

--- a/opengever/core/upgrades/20240119135606_touch_modified_timestamp_for_objects_where_changed_is_newer/upgrade.py
+++ b/opengever/core/upgrades/20240119135606_touch_modified_timestamp_for_objects_where_changed_is_newer/upgrade.py
@@ -40,7 +40,14 @@ class TouchModifiedTimestampForObjectsWhereChangedIsNewer(UpgradeStep):
                 if not changed:
                     continue
 
-                if changed > (modified + TOLERANCE):
+                needs_touching = False
+                try:
+                    needs_touching = changed > (modified + TOLERANCE)
+                except TypeError:
+                    # Probably a TZ aware vs. naive mismatch
+                    needs_touching = True
+
+                if needs_touching:
                     found_total += 1
                     found_by_type[brain.portal_type] += 1
                     obj = brain.getObject()


### PR DESCRIPTION
Fix upgrade step that touches modified timestamp.

Avoids the upgrade step failing when there's `DateTime`s in the catalog's `modified` that are naive, instead of (as usual) TZ aware (as discovered on ftw GEVER).

For [CA-6552](https://4teamwork.atlassian.net/browse/CA-6552)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-6552]: https://4teamwork.atlassian.net/browse/CA-6552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ