### PR TITLE
Remove default network from compose file:

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -206,13 +206,6 @@ volumes:
   ogds:
   clam_db:
 
-networks:
-  default:
-    ipam:
-      driver: default
-      config:
-        - subnet: 172.16.4.0/24
-
 secrets:
   gldt:
     environment: GITLAB_DEPLOY_TOKEN


### PR DESCRIPTION
Remove default network from compose file:
This network leads to `"Pool overlaps with other one on this address space"` when working with several GEVER checkouts locally, because the network is left over unless the deployments are always stopped with `docker-compose down`.

And it was only intended to prevent docker from allocating huge network blocks, which can be prevented by by adding something like this to the docker daemon cfg:

```
"default-address-pools": [
       {
           "base": "172.17.0.0/12",
           "size": 24
        }
],
```
