### PR TITLE
Add new vocabulary: opengever.ogds.base.all_other_admin_units

### DIFF
--- a/changes/CA-6592.feature
+++ b/changes/CA-6592.feature
@@ -1,0 +1,1 @@
+Add new vocabulary: opengever.ogds.base.all_other_admin_units. [elioschmutz]

--- a/opengever/ogds/base/configure.zcml
+++ b/opengever/ogds/base/configure.zcml
@@ -49,6 +49,11 @@
       name="opengever.ogds.base.OtherAssignedClientsVocabulary"
       />
 
+  <utility
+      factory=".vocabularies.AllOtherAdminUnitsVocabularyFactory"
+      name="opengever.ogds.base.all_other_admin_units"
+      />
+
   <adapter factory=".docprops.OGDSUserDocPropertyProvider" />
 
   <genericsetup:registerProfile

--- a/opengever/ogds/base/vocabularies.py
+++ b/opengever/ogds/base/vocabularies.py
@@ -55,6 +55,24 @@ class OtherAssignedClientsVocabularyFactory(object):
             yield (org_unit.id(), org_unit.label())
 
 
+@implementer(IVocabularyFactory)
+class AllOtherAdminUnitsVocabularyFactory(object):
+    """Vocabulary of all enabled admin unids excluding the current.
+    """
+
+    def __call__(self, context):
+        self.context = context
+        vocab = ContactsVocabulary.create_with_provider(
+            self.key_value_provider)
+        return vocab
+
+    def key_value_provider(self):
+        for unit in ogds_service().all_admin_units(enabled_only=True,
+                                                   visible_only=True,
+                                                   omit_current=True):
+            yield (unit.id(), unit.label())
+
+
 @implementer(IQuerySource)
 class ContactsVocabulary(SimpleVocabulary):
     """Base vocabulary for other, more specific vocabularies.

--- a/opengever/ogds/models/service.py
+++ b/opengever/ogds/models/service.py
@@ -91,9 +91,10 @@ class OGDSService(object):
         return self._query_admin_units(
             enabled_only=False, visible_only=False).get(unit_id)
 
-    def all_admin_units(self, enabled_only=True, visible_only=True):
+    def all_admin_units(self, enabled_only=True, visible_only=True, omit_current=False):
         query = self._query_admin_units(enabled_only=enabled_only,
-                                        visible_only=visible_only)
+                                        visible_only=visible_only,
+                                        omit_current=omit_current)
         return query.all()
 
     def has_multiple_admin_units(self, enabled_only=True, visible_only=True):
@@ -115,12 +116,17 @@ class OGDSService(object):
     def fetch_group_by_groupname(self, groupname):
         return self._query_group().filter_by(groupname=groupname).first()
 
-    def _query_admin_units(self, enabled_only=True, visible_only=True):
+    def _query_admin_units(self, enabled_only=True, visible_only=True, omit_current=False):
         query = AdminUnit.query
         if enabled_only:
             query = query.filter_by(enabled=True)
         if visible_only:
             query = query.filter_by(hidden=False)
+        if omit_current:
+            # Avoid circular imports
+            from opengever.ogds.base.utils import get_current_admin_unit
+            current_admin_unit = get_current_admin_unit()
+            query = query.filter(AdminUnit.unit_id != current_admin_unit.unit_id)
         return query
 
     def all_groups(self, active_only=True):


### PR DESCRIPTION
This PR adds a new global vocabulary: `opengever.ogds.base.all_other_admin_units`

The vocabulary lists all enabled, visible admin unit excluding the current. We use this vocabulary for the `dossier-transfer`-Feature.

For [CA-6592]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-6592]: https://4teamwork.atlassian.net/browse/CA-6592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ