### PR TITLE
Add new vocabulary: opengever.ogds.base.all_admin_units

### DIFF
--- a/changes/CA-6592-2.feature
+++ b/changes/CA-6592-2.feature
@@ -1,0 +1,1 @@
+Add new vocabulary: opengever.ogds.base.all_admin_units. [elioschmutz]

--- a/opengever/ogds/base/configure.zcml
+++ b/opengever/ogds/base/configure.zcml
@@ -54,6 +54,11 @@
       name="opengever.ogds.base.all_other_admin_units"
       />
 
+  <utility
+      factory=".vocabularies.AllAdminUnitsVocabularyFactory"
+      name="opengever.ogds.base.all_admin_units"
+      />
+
   <adapter factory=".docprops.OGDSUserDocPropertyProvider" />
 
   <genericsetup:registerProfile

--- a/opengever/ogds/base/vocabularies.py
+++ b/opengever/ogds/base/vocabularies.py
@@ -73,6 +73,23 @@ class AllOtherAdminUnitsVocabularyFactory(object):
             yield (unit.id(), unit.label())
 
 
+@implementer(IVocabularyFactory)
+class AllAdminUnitsVocabularyFactory(object):
+    """Vocabulary of all enabled admin units.
+    """
+
+    def __call__(self, context):
+        self.context = context
+        vocab = ContactsVocabulary.create_with_provider(
+            self.key_value_provider)
+        return vocab
+
+    def key_value_provider(self):
+        for unit in ogds_service().all_admin_units(enabled_only=True,
+                                                   visible_only=True):
+            yield (unit.id(), unit.label())
+
+
 @implementer(IQuerySource)
 class ContactsVocabulary(SimpleVocabulary):
     """Base vocabulary for other, more specific vocabularies.


### PR DESCRIPTION
Follow-Up for #7886 

We'll use the `opengever.ogds.base.all_admin_units` vocabulary for e2e testing.

For [CA-6592]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[CA-6592]: https://4teamwork.atlassian.net/browse/CA-6592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ