### PR TITLE
Use Plone 4.3 image based on Alpine 3.18

### DIFF
--- a/changes/GH-7889.other
+++ b/changes/GH-7889.other
@@ -1,0 +1,1 @@
+Update Docker image to Alpine 3.18 and include backports of security fixes for various dependencies. [buchi]

--- a/docker/core/Dockerfile
+++ b/docker/core/Dockerfile
@@ -1,8 +1,7 @@
-FROM 4teamwork/plone:4.3.20 AS build-stage
-
+FROM 4teamwork/plone:4.3.20-alpine3.18 AS builder
 USER root
 
-RUN apk add --virtual .build-deps \
+RUN apk add \
     gcc \
     musl-dev \
     libc-dev \
@@ -11,22 +10,39 @@ RUN apk add --virtual .build-deps \
     libpng-dev \
     libxml2-dev \
     libxslt-dev \
-    python2-dev \
     openldap-dev \
+    openssl1.1-compat-dev \
     libffi-dev \
-    postgresql-dev \
+    libpq \
     gettext
+
+# Fix support for python-ldap<3.4.2 with OpenLDAP 2.6
+RUN echo "INPUT ( libldap.so )" > /usr/lib/libldap_r.so
 
 WORKDIR /app
 
-ENV VIRTUAL_ENV=/app
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ENV PATH="/app/bin:$PATH"
+
+# libpq-dev requires OpenSSL 3 headers. Currently it's not possible to install
+# versions 1.1 and 3 at the same time. For building psycopg2 we temporarily
+# uninstall the 1.1 headers and reinstall them after having built psycopg2.
+RUN --mount=type=cache,target=/root/.cache \
+    apk del \
+    openssl1.1-compat-dev \
+ && apk add --virtual .postgresql-dev \
+    libpq-dev \
+ && pip install \
+    --prefix /app \
+    psycopg2==2.8.6 \
+ && apk del .postgresql-dev \
+ && apk add openssl1.1-compat-dev
 
 COPY ./docker/core/requirements-core.txt ./docker/core/requirements-deployment.txt /app/
 RUN --mount=type=cache,target=/root/.cache \
     --mount=type=secret,id=gldt \
     export GITLAB_DEPLOY_TOKEN=$(cat /run/secrets/gldt) && \
     pip install \
+    --prefix /app \
     --extra-index-url https://__token__:$GITLAB_DEPLOY_TOKEN@git.4teamwork.ch/api/v4/projects/486/packages/pypi/simple \
     -r requirements-core.txt \
     -r requirements-deployment.txt
@@ -40,6 +56,7 @@ RUN --mount=type=cache,target=/root/.cache \
     --mount=type=secret,id=gldt \
     export GITLAB_DEPLOY_TOKEN=$(cat /run/secrets/gldt) && \
     pip install \
+    --prefix /app \
     --extra-index-url https://__token__:$GITLAB_DEPLOY_TOKEN@git.4teamwork.ch/api/v4/projects/486/packages/pypi/simple \
     -e /app/src/collective.js.timeago \
     -e . \
@@ -68,10 +85,8 @@ RUN ln -sf /dev/null /app/var/log/upgrade_stats.csv
 COPY ./docker/core/patches/hashing.py /app/lib/python2.7/site-packages/ftw/bumblebee/hashing.py
 RUN python2.7 -m compileall /app/lib/python2.7/site-packages/ftw/bumblebee/hashing.py
 
-COPY ./docker/core/patches/z3c_autoinclude_utils.py /app/lib/python2.7/site-packages/z3c/autoinclude/utils.py
-RUN python2.7 -m compileall /app/lib/python2.7/site-packages/z3c/autoinclude/utils.py
 
-FROM 4teamwork/plone:4.3.20
+FROM 4teamwork/plone:4.3.20-alpine3.18 AS prod
 
 USER root
 RUN apk add \
@@ -79,7 +94,7 @@ RUN apk add \
     libffi \
     libpq
 
-COPY --from=build-stage /app /app
+COPY --from=builder /app /app
 
 VOLUME /data
 WORKDIR /app

--- a/docker/core/docker-entrypoint.sh
+++ b/docker/core/docker-entrypoint.sh
@@ -2,11 +2,16 @@
 INSTANCE_HOME="/app"
 CONFIG_FILE="/app/etc/zope.conf"
 ZOPE_RUN="/app/bin/runzope"
+ZOPE_CTL="/app/bin/zopectl"
 export INSTANCE_HOME
 
 python /app/entrypoint.d/create_zope_conf.py "$CONFIG_FILE"
-
 python /app/entrypoint.d/create_ogds_zcml.py
 python /app/entrypoint.d/create_solr_zcml.py
 
-exec "$ZOPE_RUN" -C "$CONFIG_FILE" "$@"
+if [ $# -eq 0 ]
+then
+  exec "$ZOPE_RUN" -C "$CONFIG_FILE"
+else
+  exec "$ZOPE_CTL" -C "$CONFIG_FILE" "$@"
+fi

--- a/docker/core/entrypoint.d/create_zope_conf.py
+++ b/docker/core/entrypoint.d/create_zope_conf.py
@@ -25,6 +25,13 @@ def main():
         'zeo_address': env.get('ZEO_ADDRESS', 'zeoserver:8100'),
         'storage': env.get('STORAGE', 'zeoclient')
     }
+
+    if options['debug_mode'] == 'on':
+        # Avoid duplicate log entries on console
+        options['logfile_loglevel'] = 'CRITICAL'
+    else:
+        options['logfile_loglevel'] = 'INFO'
+
     if options['verbose_security'] == 'on':
         options['security_implementation'] = 'python'
 
@@ -95,7 +102,7 @@ trusted-proxy 127.0.0.1
   level INFO
   <logfile>
     path /app/var/log/instance.log
-    level INFO
+    level {logfile_loglevel}
   </logfile>
 </eventlog>
 

--- a/docker/core/etc/site.zcml
+++ b/docker/core/etc/site.zcml
@@ -84,7 +84,6 @@
   <include package="plonetheme.teamraum" file="configure.zcml" />
   <include package="opengever.maintenance" file="configure.zcml" />
   <include package="ftw.bumblebee" file="configure.zcml" />
-  <include package="ftw.tika" file="configure.zcml" />
   <include package="five.pt" file="configure.zcml" />
   <include package="plone.resource" file="configure.zcml" />
   <include package="plone.formwidget.namedfile" file="configure.zcml" />

--- a/docker/core/requirements-core.txt
+++ b/docker/core/requirements-core.txt
@@ -30,7 +30,7 @@ collective.transmogrifier==1.5.2
 collective.usernamelogger==1.4
 collective.vdexvocabulary==0.2.2
 collective.z3cform.datetimewidget==1.2.9
-cryptography==2.8
+cryptography==3.3.2
 cssselect==1.0.3
 cssutils==1.0.2
 dataflake.fakeldap==2.1

--- a/opengever/core/tests/test_versions.py
+++ b/opengever/core/tests/test_versions.py
@@ -4,6 +4,11 @@ import glob
 import os.path
 
 
+EXCLUDED_PACKAGES = set([
+    'cryptography',  # On CentOS 7 we need an older version because of an old OpenSSL version
+])
+
+
 class TestVersionPinnings(TestCase):
 
     def test_buildout_and_docker_versions_are_equal(self):
@@ -11,6 +16,7 @@ class TestVersionPinnings(TestCase):
         docker_versions = self.get_docker_versions()
 
         common_packages = set(buildout_versions.keys()) & set(docker_versions.keys())
+        common_packages -= EXCLUDED_PACKAGES
         for package in common_packages:
             self.assertEqual(
                 buildout_versions[package],


### PR DESCRIPTION
The previous base image was based on Alpine 3.14 which is EOL.

The new base image comes with various improvements described in https://github.com/4teamwork/plone-docker/pull/1

PostgreSQL 15.5 (libpq) and OpenLDAP 2.6.5 (libldap) provided by Alpine 3.18 are newer versions than officially supported by psycopg2 2.8.6 and python-ldap 2.4.45 but seem to work so far.

Bump cryptography to version 3.3.2 to include fix for CVE-2020-36242. We do not bump it in buildout `versions.cfg` because it requires OpenSSL 1.1 which is not available on CentOS 7.


## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)
