### PR TITLE
Add new field external_reference to teamroom todo 

### DIFF
--- a/changes/CA-6482.feature
+++ b/changes/CA-6482.feature
@@ -1,0 +1,1 @@
+- Add 'external_reference' field to workspace todo [KunzS85]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -13,8 +13,6 @@ Breaking Changes
 Other Changes
 ^^^^^^^^^^^^^
 - ``POST @dossier-transfers``: New endpoint to create dossier transfers.
-- Add 'external_reference' field to workspace todo 
-
 
 2024.3.0 (2024-02-09)
 ---------------------

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -13,6 +13,7 @@ Breaking Changes
 Other Changes
 ^^^^^^^^^^^^^
 - ``POST @dossier-transfers``: New endpoint to create dossier transfers.
+- Add 'external_reference' field to workspace todo 
 
 
 2024.3.0 (2024-02-09)

--- a/docs/public/dev-manual/api/workspace/todos.rst
+++ b/docs/public/dev-manual/api/workspace/todos.rst
@@ -20,8 +20,9 @@ Ein ToDo erstellen
         "@type": "opengever.workspace.todo",
         "title": "Bitte Dokument reviewen",
         "text": "Das wichtige Dokument muss angeschaut werden.",
-        "deadline": "2018-10-16"
+        "deadline": "2018-10-16",
         "responsible": "john.doe",
+        "external_reference": "www.einexternerinhalt.ch"
       }
 
 

--- a/docs/public/dev-manual/api/workspace/todos.rst
+++ b/docs/public/dev-manual/api/workspace/todos.rst
@@ -22,7 +22,7 @@ Ein ToDo erstellen
         "text": "Das wichtige Dokument muss angeschaut werden.",
         "deadline": "2018-10-16",
         "responsible": "john.doe",
-        "external_reference": "www.einexternerinhalt.ch"
+        "external_reference": "www.example.com"
       }
 
 

--- a/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-01-15 11:57+0000\n"
+"POT-Creation-Date: 2024-02-08 15:21+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -225,6 +225,11 @@ msgstr "Dokumente"
 #: ./opengever/workspace/workspace_meeting.py
 msgid "label_end"
 msgstr "Ende"
+
+#. Default: "External Reference"
+#: ./opengever/workspace/todo.py
+msgid "label_external_reference"
+msgstr "Externe Referenz"
 
 #. Default: "Folders"
 #: ./opengever/workspace/browser/tabbed.py

--- a/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-01-15 11:57+0000\n"
+"POT-Creation-Date: 2024-02-08 15:21+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -254,6 +254,11 @@ msgstr "Documents"
 #: ./opengever/workspace/workspace_meeting.py
 msgid "label_end"
 msgstr "End"
+
+#. Default: "External Reference"
+#: ./opengever/workspace/todo.py
+msgid "label_external_reference"
+msgstr "External reference"
 
 #. German translation: Ordner
 #. Default: "Folders"

--- a/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-01-15 11:57+0000\n"
+"POT-Creation-Date: 2024-02-08 15:21+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -225,6 +225,11 @@ msgstr "Documents"
 #: ./opengever/workspace/workspace_meeting.py
 msgid "label_end"
 msgstr "Fin"
+
+#. Default: "External Reference"
+#: ./opengever/workspace/todo.py
+msgid "label_external_reference"
+msgstr "Référence externe"
 
 #. Default: "Folders"
 #: ./opengever/workspace/browser/tabbed.py

--- a/opengever/workspace/locales/opengever.workspace.pot
+++ b/opengever/workspace/locales/opengever.workspace.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-01-15 11:57+0000\n"
+"POT-Creation-Date: 2024-02-08 15:21+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -227,6 +227,11 @@ msgstr ""
 #. Default: "End"
 #: ./opengever/workspace/workspace_meeting.py
 msgid "label_end"
+msgstr ""
+
+#. Default: "External reference"
+#: ./opengever/workspace/todo.py
+msgid "label_external_reference"
 msgstr ""
 
 #. Default: "Folders"

--- a/opengever/workspace/tests/test_todo.py
+++ b/opengever/workspace/tests/test_todo.py
@@ -136,6 +136,35 @@ class TestAPISupportForTodo(IntegrationTestCase):
         self.assertEqual('todo-4', browser.json['id'])
 
     @browsing
+    def test_create_with_all(self, browser):
+        self.login(self.workspace_member, browser)
+        browser.open(
+            self.workspace, method='POST', headers=self.api_headers,
+            data=json.dumps({
+                'title': 'Ein komplett ausgefuelltes ToDo',
+                '@type': 'opengever.workspace.todo',
+                'text': 'Eine ToDo-Beschreibung',
+                'is_completed': False,
+                'responsible': self.workspace_member.id,
+                'deadline': '2024-02-13',
+                'external_reference': 'www.4teamwork.ch',
+            }))
+
+        self.assertEqual(201, browser.status_code)
+        self.assertDictContainsSubset({
+            'title': 'Ein komplett ausgefuelltes ToDo',
+            '@type': 'opengever.workspace.todo',
+            'text': 'Eine ToDo-Beschreibung',
+            'is_completed': False,
+            'responsible': {
+                u'token': self.workspace_member.id, 
+                u'title': u'Schr\xf6dinger B\xe9atrice (beatrice.schrodinger)',
+            },
+            'deadline': '2024-02-13',
+            'external_reference': 'www.4teamwork.ch',
+        }, browser.json)
+
+    @browsing
     def test_create_with_todo_feature_disabled(self, browser):
         self.deactivate_feature('workspace-todo')
         self.login(self.workspace_member, browser)

--- a/opengever/workspace/todo.py
+++ b/opengever/workspace/todo.py
@@ -70,6 +70,11 @@ class IToDoSchema(model.Schema):
         required=False,
     )
 
+    dexteritytextindexer.searchable('external_reference')
+    external_reference = schema.TextLine(
+        title=_(u'label_external_reference', default='External Reference'),
+        required=False)
+
 
 class ToDo(Container):
     implements(IToDo, IResponseSupported)


### PR DESCRIPTION
With this PR, we add a new text field for external references to the todo's of the teamroom. 
The aim of the change is to be able to provide links to external resources in the UI.
This leads to an extension of the attributes of the todo schema with a text field with the name external_reference.

For [CA-6482]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))


[CA-6482]: https://4teamwork.atlassian.net/browse/CA-6482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ