### PR TITLE
Extend is_convertable in bumblebee service

### DIFF
--- a/changes/CA-6496.other
+++ b/changes/CA-6496.other
@@ -1,0 +1,1 @@
+ Extension of the is_convertabe method for suppressing the conversion to PDF in case of missing file extension

--- a/opengever/bumblebee/service.py
+++ b/opengever/bumblebee/service.py
@@ -12,7 +12,8 @@ class GeverBumblebeeService(BumblebeeServiceV3):
     def is_convertable(self, document):
         if not is_bumblebee_feature_enabled():
             return False
-
+        if not document.get_file_extension():
+            return False
         return super(GeverBumblebeeService, self).is_convertable(document)
 
     def get_not_digitally_available_placeholder_image_url(self, format_name=None):

--- a/opengever/bumblebee/tests/test_document_adapter.py
+++ b/opengever/bumblebee/tests/test_document_adapter.py
@@ -12,6 +12,12 @@ class TestDocumentAdapter(FunctionalTestCase):
         self.assertTrue(
             IBumblebeeDocument(document_with_file).is_convertable())
 
+    def test_document_with_file_whitout_extension_is_not_digitally_available(self):
+        document_without_extension = create(Builder("document")
+                                            .attach_file_containing(u'lorem ipsum', u'filename_without_extension'))
+        self.assertFalse(
+            IBumblebeeDocument(document_without_extension).is_convertable())
+
     def test_document_without_file_is_not_digitally_available(self):
         document_without_file = create(Builder("document"))
         self.assertFalse(


### PR DESCRIPTION
This PR extends the check for convertibility to PDF. If a file does not have a file extension, it will not be allowed for conversion via Bumblebee. 
Without this check, the file is sent for conversion but not processed and remains in the pickup folder. This must be avoided.

For [CA-6496]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- New functionality:
  - [x] for `document` also works for `mail`


[CA-6496]: https://4teamwork.atlassian.net/browse/CA-6496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ