### PR TITLE
Add checkbox on repository folders to disable max subdossier depth re…

### DIFF
--- a/changes/CA-6447.feature
+++ b/changes/CA-6447.feature
@@ -1,0 +1,1 @@
+Add checkbox on repository folders to disable max subdossier depth restriction [elioschmutz]

--- a/docs/public/dev-manual/api/schemas/opengever.dossier.templatefolder.inc
+++ b/docs/public/dev-manual/api/schemas/opengever.dossier.templatefolder.inc
@@ -1,0 +1,34 @@
+.. py:class:: opengever.dossier.templatefolder
+
+    Inhaltstyp 'Vorlagenordner'
+
+
+
+   .. py:attribute:: title_de
+
+       :Feldname: :field-title:`Titel (deutsch)`
+       :Datentyp: ``TranslatedTextLine``
+       
+       
+       
+       
+
+
+   .. py:attribute:: title_fr
+
+       :Feldname: :field-title:`Titel (französisch)`
+       :Datentyp: ``TranslatedTextLine``
+       
+       
+       
+       
+
+
+   .. py:attribute:: title_en
+
+       :Feldname: :field-title:`Titel (englisch)`
+       :Datentyp: ``TranslatedTextLine``
+       
+       
+       
+       

--- a/docs/public/dev-manual/api/schemas/opengever.inbox.container.inc
+++ b/docs/public/dev-manual/api/schemas/opengever.inbox.container.inc
@@ -1,0 +1,34 @@
+.. py:class:: opengever.inbox.container
+
+    Inhaltstyp 'Eingangskorb Ordner'
+
+
+
+   .. py:attribute:: title_de
+
+       :Feldname: :field-title:`Titel (deutsch)`
+       :Datentyp: ``TranslatedTextLine``
+       
+       
+       
+       
+
+
+   .. py:attribute:: title_fr
+
+       :Feldname: :field-title:`Titel (französisch)`
+       :Datentyp: ``TranslatedTextLine``
+       
+       
+       
+       
+
+
+   .. py:attribute:: title_en
+
+       :Feldname: :field-title:`Titel (englisch)`
+       :Datentyp: ``TranslatedTextLine``
+       
+       
+       
+       

--- a/docs/public/dev-manual/api/schemas/opengever.inbox.inbox.inc
+++ b/docs/public/dev-manual/api/schemas/opengever.inbox.inbox.inc
@@ -1,0 +1,64 @@
+.. py:class:: opengever.inbox.inbox
+
+    Inhaltstyp 'Eingangskorb'
+
+
+
+   .. py:attribute:: inbox_group
+
+       :Feldname: :field-title:`Eingangskorb Gruppe`
+       :Datentyp: ``TextLine``
+       
+       
+       :Beschreibung: Diese Gruppe wird berechtigt, wenn dem Eingangskorb eine Aufgabe zugewiesen wird.
+       
+
+
+   .. py:attribute:: changed
+
+       :Feldname: :field-title:`Zuletzt verändert`
+       :Datentyp: ``Datetime``
+       
+       
+       
+       
+
+
+   .. py:attribute:: title_de
+
+       :Feldname: :field-title:`Titel (deutsch)`
+       :Datentyp: ``TranslatedTextLine``
+       
+       
+       
+       
+
+
+   .. py:attribute:: title_fr
+
+       :Feldname: :field-title:`Titel (französisch)`
+       :Datentyp: ``TranslatedTextLine``
+       
+       
+       
+       
+
+
+   .. py:attribute:: title_en
+
+       :Feldname: :field-title:`Titel (englisch)`
+       :Datentyp: ``TranslatedTextLine``
+       
+       
+       
+       
+
+
+   .. py:attribute:: responsible_org_unit
+
+       :Feldname: :field-title:`Federführendes Amt`
+       :Datentyp: ``TextLine``
+       
+       
+       
+       

--- a/docs/public/dev-manual/api/schemas/opengever.private.root.inc
+++ b/docs/public/dev-manual/api/schemas/opengever.private.root.inc
@@ -1,0 +1,34 @@
+.. py:class:: opengever.private.root
+
+    Inhaltstyp 'Persönliches Verzeichnis'
+
+
+
+   .. py:attribute:: title_de
+
+       :Feldname: :field-title:`Titel (deutsch)`
+       :Datentyp: ``TranslatedTextLine``
+       
+       
+       
+       
+
+
+   .. py:attribute:: title_fr
+
+       :Feldname: :field-title:`Titel (französisch)`
+       :Datentyp: ``TranslatedTextLine``
+       
+       
+       
+       
+
+
+   .. py:attribute:: title_en
+
+       :Feldname: :field-title:`Titel (englisch)`
+       :Datentyp: ``TranslatedTextLine``
+       
+       
+       
+       

--- a/docs/public/dev-manual/api/schemas/opengever.repository.repositoryfolder.inc
+++ b/docs/public/dev-manual/api/schemas/opengever.repository.repositoryfolder.inc
@@ -74,6 +74,16 @@
        
 
 
+   .. py:attribute:: respect_max_subdossier_depth_restriction
+
+       :Feldname: :field-title:`Maximale Dossier-Tiefe in dieser Ordnungsposition begrenzen`
+       :Datentyp: ``Bool``
+       
+       
+       :Beschreibung: Wählen Sie, ob die Dossier-Tiefe in dieser Ordnungsposition begrenzt werden soll
+       
+
+
    .. py:attribute:: changed
 
        :Feldname: :field-title:`Zuletzt verändert`

--- a/docs/public/dev-manual/api/schemas/opengever.workspace.meetingagendaitem.inc
+++ b/docs/public/dev-manual/api/schemas/opengever.workspace.meetingagendaitem.inc
@@ -44,6 +44,16 @@
        
 
 
+   .. py:attribute:: related_todo_list
+
+       :Feldname: :field-title:`Verknüpfte To-do-Liste`
+       :Datentyp: ``RelationChoice``
+       
+       
+       
+       :Wertebereich: <UID einer verknüpften To-do-Liste
+
+
    .. py:attribute:: changed
 
        :Feldname: :field-title:`Zuletzt verändert`

--- a/docs/public/dev-manual/api/schemas/opengever.workspace.workspace.inc
+++ b/docs/public/dev-manual/api/schemas/opengever.workspace.workspace.inc
@@ -54,6 +54,36 @@
        
 
 
+   .. py:attribute:: meeting_template_header
+
+       :Feldname: :field-title:`Kopfzeile von Meeting-Protokollen`
+       :Datentyp: ``JSONField``
+       
+       
+       :Beschreibung: Dynamische Textinhalte sind {page_number}, {number_of_pages} und {print_date}, sowie die Bild-Platzhalter {customer_logo} und {workspace_logo}
+       
+
+
+   .. py:attribute:: meeting_template_footer
+
+       :Feldname: :field-title:`Fusszeile von Meeting-Protokollen`
+       :Datentyp: ``JSONField``
+       
+       :Default: {"right": "{page_number}/{number_of_pages}", "center": "", "left": "{print_date}"}
+       :Beschreibung: Dynamische Textinhalte sind {page_number}, {number_of_pages} und {print_date}, sowie die Bild-Platzhalter {customer_logo} und {workspace_logo}
+       
+
+
+   .. py:attribute:: workspace_logo
+
+       :Feldname: :field-title:`Teamraum logo`
+       :Datentyp: ``NamedImage``
+       
+       
+       :Beschreibung: Kann in Kopf- und Fusszeilen von Protokollen verwendet werden.
+       
+
+
    .. py:attribute:: changed
 
        :Feldname: :field-title:`Zuletzt verändert`

--- a/docs/schema-dumps/opengever.repository.repositoryfolder.schema.json
+++ b/docs/schema-dumps/opengever.repository.repositoryfolder.schema.json
@@ -48,6 +48,12 @@
             "description": "W\u00e4hlen Sie, ob es in dieser Ordnungsposition erlaubt ist, Gesch\u00e4ftsdossiers hinzuzuf\u00fcgen. Ist diese Option deaktiviert, kann der Benutzer nur Dossiers aus einer Vorlage oder Spezialdossiers erstellen.",
             "_zope_schema_type": "Bool"
         },
+        "respect_max_subdossier_depth_restriction": {
+            "type": "boolean",
+            "title": "Maximale Dossier-Tiefe in dieser Ordnungsposition begrenzen",
+            "description": "W\u00e4hlen Sie, ob die Dossier-Tiefe in dieser Ordnungsposition begrenzt werden soll",
+            "_zope_schema_type": "Bool"
+        },
         "changed": {
             "type": "string",
             "title": "Zuletzt ver\u00e4ndert",
@@ -234,6 +240,7 @@
         "referenced_activity",
         "former_reference",
         "allow_add_businesscase_dossier",
+        "respect_max_subdossier_depth_restriction",
         "changed",
         "classification",
         "privacy_layer",

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -81,6 +81,7 @@ REPOFOLDER_FORM_DEFAULTS = {}
 REPOFOLDER_MISSING_VALUES = {
     'addable_dossier_templates': [],
     'allow_add_businesscase_dossier': True,
+    'respect_max_subdossier_depth_restriction': True,
     'archival_value_annotation': None,
     'date_of_cassation': None,
     'date_of_submission': None,
@@ -340,6 +341,7 @@ PRIVATEFOLDER_REQUIREDS = {
 }
 PRIVATEFOLDER_DEFAULTS = {
     'allow_add_businesscase_dossier': True,
+    'respect_max_subdossier_depth_restriction': True
 }
 PRIVATEFOLDER_FORM_DEFAULTS = {}
 PRIVATEFOLDER_MISSING_VALUES = {

--- a/opengever/bundle/schemas/repofolders.schema.json
+++ b/opengever/bundle/schemas/repofolders.schema.json
@@ -75,6 +75,15 @@
                     "description": "W\u00e4hlen Sie, ob es in dieser Ordnungsposition erlaubt ist, Gesch\u00e4ftsdossiers hinzuzuf\u00fcgen. Ist diese Option deaktiviert, kann der Benutzer nur Dossiers aus einer Vorlage oder Spezialdossiers erstellen.",
                     "_zope_schema_type": "Bool"
                 },
+                "respect_max_subdossier_depth_restriction": {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "title": "Maximale Dossier-Tiefe in dieser Ordnungsposition begrenzen",
+                    "description": "W\u00e4hlen Sie, ob die Dossier-Tiefe in dieser Ordnungsposition begrenzt werden soll",
+                    "_zope_schema_type": "Bool"
+                },
                 "changed": {
                     "type": [
                         "null",
@@ -388,6 +397,7 @@
                 "referenced_activity",
                 "former_reference",
                 "allow_add_businesscase_dossier",
+                "respect_max_subdossier_depth_restriction",
                 "changed",
                 "classification",
                 "privacy_layer",

--- a/opengever/dossier/tests/test_base.py
+++ b/opengever/dossier/tests/test_base.py
@@ -109,6 +109,19 @@ class TestDossierContainer(IntegrationTestCase):
         self.assertNotIn('opengever.dossier.businesscasedossier',
                          [fti.id for fti in subsubsub2.allowedContentTypes()])
 
+    def test_always_allow_subdossiers_if_repository_folder_ignores_subdossier_depth_restriction(self):
+        self.login(self.administrator)
+
+        self.leaf_repofolder.respect_max_subdossier_depth_restriction = True
+
+        self.assertNotIn('opengever.dossier.businesscasedossier',
+                         [fti.id for fti in self.subsubdossier.allowedContentTypes()])
+
+        self.leaf_repofolder.respect_max_subdossier_depth_restriction = False
+
+        self.assertIn('opengever.dossier.businesscasedossier',
+                      [fti.id for fti in self.subsubdossier.allowedContentTypes()])
+
     def test_get_subdossiers_is_recursive_by_default(self):
         self.login(self.dossier_responsible)
         self.assertSequenceEqual(

--- a/opengever/dossier/tests/test_move_items.py
+++ b/opengever/dossier/tests/test_move_items.py
@@ -93,6 +93,26 @@ class TestMoveItems(IntegrationTestCase, MoveItemsHelper):
         self.assert_does_not_contain(self.leaf_repofolder, [resolvable_dossier_title])
         self.assert_contains(self.empty_dossier, [resolvable_dossier_title])
 
+    @browsing
+    def test_moving_dossier_respects_containing_repository_subdossier_restriction_property(self, browser):
+        self.login(self.manager, browser)
+        resolvable_dossier_title = self.resolvable_dossier.title.encode("utf-8")
+        self.assert_contains(self.leaf_repofolder, [resolvable_dossier_title])
+        self.assert_does_not_contain(self.empty_dossier, [resolvable_dossier_title])
+        self.move_items([self.resolvable_dossier],
+                        source=self.leaf_repofolder,
+                        target=self.empty_dossier)
+        self.assert_contains(self.leaf_repofolder, [resolvable_dossier_title])
+        self.assert_does_not_contain(self.empty_dossier, [resolvable_dossier_title])
+
+        self.leaf_repofolder.respect_max_subdossier_depth_restriction = False
+
+        self.move_items([self.resolvable_dossier],
+                        source=self.leaf_repofolder,
+                        target=self.empty_dossier)
+        self.assert_does_not_contain(self.leaf_repofolder, [resolvable_dossier_title])
+        self.assert_contains(self.empty_dossier, [resolvable_dossier_title])
+
     def test_render_documents_tab_when_no_items_are_selected(self):
         self.login(self.regular_user)
         view = self.dossier.restrictedTraverse('move_items')

--- a/opengever/dossier/tests/test_utils.py
+++ b/opengever/dossier/tests/test_utils.py
@@ -1,3 +1,4 @@
+from opengever.dossier.utils import get_containing_repository_folder
 from opengever.dossier.utils import is_dossierish_portal_type
 from opengever.testing import IntegrationTestCase
 from plone import api
@@ -21,3 +22,14 @@ class TestDossierUtils(IntegrationTestCase):
                 if is_dossierish_portal_type(portal_type_name)
             ]
         )
+
+    def test_get_containing_repository_folder_returns_leaf_repo_folder_if_available(self):
+        self.login(self.regular_user)
+
+        self.assertEqual(self.leaf_repofolder,
+                         get_containing_repository_folder(self.dossier))
+
+        self.assertEqual(self.leaf_repofolder,
+                         get_containing_repository_folder(self.subdossier))
+
+        self.assertIsNone(get_containing_repository_folder(self.private_dossier))

--- a/opengever/dossier/utils.py
+++ b/opengever/dossier/utils.py
@@ -1,3 +1,4 @@
+from Acquisition import aq_chain
 from Acquisition import aq_inner
 from Acquisition import aq_parent
 from opengever.dossier.behaviors.dossier import IDossierMarker
@@ -5,6 +6,7 @@ from opengever.dossier.dossiertemplate.behaviors import IDossierTemplateMarker
 from opengever.dossier.dossiertemplate.behaviors import IDossierTemplateSchema
 from opengever.dossier.interfaces import IDossierContainerTypes
 from opengever.inbox.inbox import IInbox
+from opengever.repository.interfaces import IRepositoryFolder
 from opengever.workspace.interfaces import IWorkspace
 from plone import api
 from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
@@ -53,6 +55,12 @@ def get_main_dossier(obj):
         obj = aq_parent(aq_inner(obj))
 
     return dossier
+
+
+def get_containing_repository_folder(obj):
+    for obj in aq_chain(obj):
+        if IRepositoryFolder.providedBy(obj):
+            return obj
 
 
 def is_dossierish_portal_type(portal_type_name):

--- a/opengever/repository/locales/de/LC_MESSAGES/opengever.repository.po
+++ b/opengever/repository/locales/de/LC_MESSAGES/opengever.repository.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2022-12-06 14:01+0000\n"
+"POT-Creation-Date: 2024-02-16 15:21+0000\n"
 "PO-Revision-Date: 2014-11-25 11:31+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -47,6 +47,11 @@ msgstr "Wählen Sie, ob es in dieser Ordnungsposition erlaubt ist, Geschäftsdos
 #: ./opengever/repository/repositoryroot.py
 msgid "description_reference_number_addendum"
 msgstr "Achtung: Änderung erfordert Neuindexierung von \"reference\" und \"sortable_reference\"."
+
+#. Default: "Select if this repostory tree should respect the max subdossier depth restriction."
+#: ./opengever/repository/repositoryfolder.py
+msgid "description_max_subdossier_depth_restriction"
+msgstr "Wählen Sie, ob die Dossier-Tiefe in dieser Ordnungsposition begrenzt werden soll"
 
 #. Default: "No nested repositorys available."
 #: ./opengever/repository/browser/templates/referenceprefixmanager.pt
@@ -254,6 +259,11 @@ msgstr "Titel der Ordnungsposition (englisch)"
 #: ./opengever/repository/browser/excel_export.py
 msgid "label_repositoryfolder_title_fr"
 msgstr "Titel der Ordnungsposition (französisch)"
+
+#. Default: "Limit maximum dossier depth in this repository folder"
+#: ./opengever/repository/repositoryfolder.py
+msgid "label_respect_max_subdossier_depth_restriction"
+msgstr "Maximale Dossier-Tiefe in dieser Ordnungsposition begrenzen"
 
 #. Default: "The repository have been successfully deleted."
 #: ./opengever/repository/browser/deletion.py

--- a/opengever/repository/locales/en/LC_MESSAGES/opengever.repository.po
+++ b/opengever/repository/locales/en/LC_MESSAGES/opengever.repository.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2022-12-06 14:01+0000\n"
+"POT-Creation-Date: 2024-02-16 15:21+0000\n"
 "PO-Revision-Date: 2014-11-25 11:31+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -53,6 +53,11 @@ msgstr "Choose whether the user is allowed to add regular business case dossiers
 #: ./opengever/repository/repositoryroot.py
 msgid "description_reference_number_addendum"
 msgstr "Attention: Change requires reindexing of \"reference\" and \"sortable_reference\"."
+
+#. Default: "Select if this repostory tree should respect the max subdossier depth restriction."
+#: ./opengever/repository/repositoryfolder.py
+msgid "description_max_subdossier_depth_restriction"
+msgstr ""
 
 #. German translation: Keine untergeordnete Ordnungspositionen verfügbar.
 #. Default: "No nested repositorys available."
@@ -293,6 +298,11 @@ msgstr "Repositoryfolder title"
 #: ./opengever/repository/browser/excel_export.py
 msgid "label_repositoryfolder_title_fr"
 msgstr "Repositoryfolder title (French)"
+
+#. Default: "Limit maximum dossier depth in this repository folder"
+#: ./opengever/repository/repositoryfolder.py
+msgid "label_respect_max_subdossier_depth_restriction"
+msgstr ""
 
 #. German translation: Die Ordnungsposition wurde erfolgreich gelöscht.
 #. Default: "The repository have been successfully deleted."

--- a/opengever/repository/locales/fr/LC_MESSAGES/opengever.repository.po
+++ b/opengever/repository/locales/fr/LC_MESSAGES/opengever.repository.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-12-06 14:01+0000\n"
+"POT-Creation-Date: 2024-02-16 15:21+0000\n"
 "PO-Revision-Date: 2017-12-03 11:31+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-repository/fr/>\n"
@@ -46,6 +46,11 @@ msgstr "Déterminez s'il est permis d'ajouter des dossiers d'affaire à ce nivea
 #: ./opengever/repository/repositoryroot.py
 msgid "description_reference_number_addendum"
 msgstr "Attention: La modification de ce champ requiert une réindexation de \"reference\" et \"sortable_reference\"."
+
+#. Default: "Select if this repostory tree should respect the max subdossier depth restriction."
+#: ./opengever/repository/repositoryfolder.py
+msgid "description_max_subdossier_depth_restriction"
+msgstr ""
 
 #. Default: "No nested repositorys available."
 #: ./opengever/repository/browser/templates/referenceprefixmanager.pt
@@ -253,6 +258,11 @@ msgstr "Titre du numéro de classement (anglais)"
 #: ./opengever/repository/browser/excel_export.py
 msgid "label_repositoryfolder_title_fr"
 msgstr "Titre du numéro de classement"
+
+#. Default: "Limit maximum dossier depth in this repository folder"
+#: ./opengever/repository/repositoryfolder.py
+msgid "label_respect_max_subdossier_depth_restriction"
+msgstr ""
 
 #. Default: "The repository have been successfully deleted."
 #: ./opengever/repository/browser/deletion.py

--- a/opengever/repository/locales/opengever.repository.pot
+++ b/opengever/repository/locales/opengever.repository.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-12-06 14:01+0000\n"
+"POT-Creation-Date: 2024-02-16 15:21+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -46,6 +46,11 @@ msgstr ""
 #. Default: "Attention: Change requires reindexing of \"reference\" and \"sortable_reference\"."
 #: ./opengever/repository/repositoryroot.py
 msgid "description_reference_number_addendum"
+msgstr ""
+
+#. Default: "Select if this repostory tree should respect the max subdossier depth restriction."
+#: ./opengever/repository/repositoryfolder.py
+msgid "description_max_subdossier_depth_restriction"
 msgstr ""
 
 #. Default: "No nested repositorys available."
@@ -253,6 +258,11 @@ msgstr ""
 #. Default: "Repositoryfolder title (French)"
 #: ./opengever/repository/browser/excel_export.py
 msgid "label_repositoryfolder_title_fr"
+msgstr ""
+
+#. Default: "Limit maximum dossier depth in this repository folder"
+#: ./opengever/repository/repositoryfolder.py
+msgid "label_respect_max_subdossier_depth_restriction"
 msgstr ""
 
 #. Default: "The repository have been successfully deleted."

--- a/opengever/repository/repositoryfolder.py
+++ b/opengever/repository/repositoryfolder.py
@@ -31,6 +31,7 @@ class IRepositoryFolderSchema(model.Schema):
             u'referenced_activity',
             u'former_reference',
             u'allow_add_businesscase_dossier',
+            u'respect_max_subdossier_depth_restriction',
         ],
     )
 
@@ -78,6 +79,17 @@ class IRepositoryFolderSchema(model.Schema):
                       default=u'Choose if the user is allowed to add '
                               u'businesscase dossiers or only dossiers from a '
                               u' dossiertemplate.'),
+        required=False,
+        missing_value=True,
+        default=True,
+    )
+
+    respect_max_subdossier_depth_restriction = schema.Bool(
+        title=_(u'label_respect_max_subdossier_depth_restriction',
+                default=u'Limit maximum dossier depth in this repository folder'),
+        description=_(u'description_max_subdossier_depth_restriction',
+                      default=u'Select if this repostory tree should respect '
+                              u'the max subdossier depth restriction.'),
         required=False,
         missing_value=True,
         default=True,
@@ -151,6 +163,8 @@ class RepositoryFolder(content.Container):
         return True
 
     def is_dossier_structure_addable(self, depth=1):
+        if not self.respect_max_subdossier_depth_restriction:
+            return True
         return check_subdossier_depth_allowed(depth - 1)
 
 


### PR DESCRIPTION
This PR adds a checkbox for repository folders to disable max subdossier depth restriction. The value will not be inherited to subsequent repofolders.

By default, the subdossier depth restriction will be respected.

For [CA-6447]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- New translations
  - [x] All msg-strings are unicode
- Change in schema definition:
  - [x] If `missing_value` is specified, then `default` has to be set to the same value


[CA-6447]: https://4teamwork.atlassian.net/browse/CA-6447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ