### PR TITLE
Don't let rejected tasks prevent the dossier from being closed.

### DIFF
--- a/changes/CA-6451.bugfix
+++ b/changes/CA-6451.bugfix
@@ -1,0 +1,1 @@
+Don't let rejected tasks prevent the dossier from being closed. [lgraf]

--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -321,6 +321,11 @@ class DossierContainer(Container):
             review_state=OPEN_TASK_STATES,
         )
 
+        # Rejected (sub)tasks should not prevent dossier from being closed.
+        active_tasks = [
+            t for t in active_tasks if t.review_state != 'task-state-rejected'
+        ]
+
         return bool(active_tasks)
 
     def has_active_proposals(self):

--- a/opengever/dossier/tests/test_base.py
+++ b/opengever/dossier/tests/test_base.py
@@ -241,10 +241,10 @@ class TestDossierChecks(IntegrationTestCase):
         self.set_workflow_state('task-state-open', *self.dossier_tasks)
         self.assertTrue(self.dossier.has_active_tasks())
 
-    def test_has_active_tasks_true_when_states_rejected(self):
+    def test_has_active_tasks_false_when_states_rejected(self):
         self.login(self.dossier_responsible)
         self.set_workflow_state('task-state-rejected', *self.dossier_tasks)
-        self.assertTrue(self.dossier.has_active_tasks())
+        self.assertFalse(self.dossier.has_active_tasks())
 
     def test_has_active_tasks_true_when_states_resolved(self):
         self.login(self.dossier_responsible)


### PR DESCRIPTION
Don't let rejected tasks prevent the dossier from being closed.

Until this change, rejected (sub) tasks prevented the dossier from being closed, even though the main task containing the subtask could be closed. This inconsistency was because
 - the [check for closing a task](https://github.com/4teamwork/opengever.core/blob/5a7decc9af7f06caab1a89a6a6091fe8fae87d51/opengever/task/browser/transitioncontroller.py#L730) uses [FINSHED_TASK_STATES](https://github.com/4teamwork/opengever.core/blob/5a7decc9af7f06caab1a89a6a6091fe8fae87d51/opengever/task/__init__.py#L23-L27) to make sure all tasks are "finished"
 - whereas the [check for resolving a dossier](https://github.com/4teamwork/opengever.core/blob/5a7decc9af7f06caab1a89a6a6091fe8fae87d51/opengever/dossier/base.py#L317-L322) uses [OPEN_TASK_STATES](https://github.com/4teamwork/opengever.core/blob/5a7decc9af7f06caab1a89a6a6091fe8fae87d51/opengever/task/__init__.py#L9-L15) to ensure no more tasks are "open".

Because `task-state-rejected` is in both those mappings, the behavior is inconsistent.

This inconsistent behavior was introduced in #189, but most likely as an unintended side effect. I suspect we should actually remove  `task-state-rejected` from `OPEN_TASK_STATES`, but this will have an effect on other behavior, which I first want to double-check with Philippe. Therefore, the current fix just adresses the issue locally when resolving dossiers.

For [CA-6451](https://4teamwork.atlassian.net/browse/CA-6451)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-6451]: https://4teamwork.atlassian.net/browse/CA-6451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ