### PR TITLE
Add info about upcoming nightly processing

### DIFF
--- a/changes/CA-5855.feature
+++ b/changes/CA-5855.feature
@@ -1,0 +1,1 @@
+Add flag to the dossier serialization to know whether the dossier will be processed in the nightly jobs or not [KunzS85]

--- a/opengever/api/dossier.py
+++ b/opengever/api/dossier.py
@@ -7,6 +7,7 @@ from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.behaviors.protect_dossier import IProtectDossier
 from opengever.dossier.behaviors.protect_dossier import IProtectDossierMarker
+from opengever.dossier.resolve import AfterResolveJobs
 from opengever.dossier.utils import get_main_dossier
 from plone.restapi.interfaces import IExpandableElement
 from plone.restapi.interfaces import ISerializeToJson
@@ -37,7 +38,7 @@ class SerializeDossierToJson(GeverSerializeFolderToJson):
             getattr(self.context.aq_inner, '__ac_local_roles_block__', False))
         result[u'is_protected'] = IProtectDossier(self.context).is_dossier_protected() \
             if IProtectDossierMarker.providedBy(self.context) else False
-
+        result[u'has_pending_jobs'] = AfterResolveJobs(self.context).after_resolve_jobs_pending
         extend_with_backreferences(
             result, self.context, self.request, 'relatedDossier')
 

--- a/opengever/api/tests/test_dossier.py
+++ b/opengever/api/tests/test_dossier.py
@@ -33,6 +33,12 @@ class TestDossierSerializer(IntegrationTestCase):
         self.assertIn("blocked_local_roles", browser.json)
 
     @browsing
+    def test_dossier_serializer_contains_is_after_resolved_jobs_pending(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.dossier, method="GET", headers=self.api_headers)
+        self.assertIn("has_pending_jobs", browser.json)
+
+    @browsing
     def test_dossier_serializer_contains_is_protected(self, browser):
         self.login(self.regular_user, browser=browser)
         browser.open(self.dossier, method="GET", headers=self.api_headers)


### PR DESCRIPTION
In this PR we extend the context of the dossier with the information about the discrepancy between the completion of the dossier and its planned dependent processing steps in order to be able to inform the user about this in the UI. 

For [CA-5855]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-5855]: https://4teamwork.atlassian.net/browse/CA-5855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ