### PR TITLE
Handle pending jobs flag when reactivate dossier

### DIFF
--- a/changes/CA-5855.bugfix
+++ b/changes/CA-5855.bugfix
@@ -1,0 +1,1 @@
+Handle the setting of the pending jobs flag when a dossier is reopened [KunzS85]

--- a/opengever/dossier/reactivate.py
+++ b/opengever/dossier/reactivate.py
@@ -1,5 +1,6 @@
 from opengever.dossier import _
 from opengever.dossier.behaviors.dossier import IDossier
+from opengever.dossier.resolve import AfterResolveJobs
 from opengever.dossier.resolve import PreconditionsViolated
 from plone import api
 from Products.CMFCore.utils import getToolByName
@@ -41,10 +42,14 @@ class Reactivator(object):
 
             self.reset_end_date(dossier)
             self.wft.doActionFor(dossier, 'dossier-transition-reactivate')
+            self.reset_after_resolve_jobs_pending(dossier)
 
     def reset_end_date(self, dossier):
         IDossier(dossier).end = None
         dossier.reindexObject(idxs=['end'])
+
+    def reset_after_resolve_jobs_pending(self, dossier):
+        AfterResolveJobs(dossier).after_resolve_jobs_pending = False
 
 
 class DossierReactivateView(BrowserView):

--- a/opengever/dossier/tests/test_reactivate.py
+++ b/opengever/dossier/tests/test_reactivate.py
@@ -6,6 +6,7 @@ from ftw.testbrowser.pages import statusmessages
 from ftw.testbrowser.pages.statusmessages import error_messages
 from ftw.testbrowser.pages.statusmessages import info_messages
 from opengever.dossier.behaviors.dossier import IDossier
+from opengever.dossier.resolve import AfterResolveJobs
 from opengever.testing import IntegrationTestCase
 from plone import api
 from plone.protect import createToken
@@ -128,6 +129,16 @@ class TestReactivating(IntegrationTestCase):
         self.assertIsNone(IDossier(self.resolvable_dossier).end)
         self.assertIsNone(IDossier(self.resolvable_subdossier).end)
         self.assertIsNone(IDossier(subsub).end)
+
+    @browsing
+    def test_reset_after_resolve_jobs_pending(self, browser):
+        self.login(self.secretariat_user, browser)
+        self.set_workflow_state('dossier-state-resolved',
+                                self.resolvable_subdossier)
+        AfterResolveJobs(self.resolvable_subdossier).after_resolve_jobs_pending = True
+        self.reactivate(self.resolvable_subdossier, browser)
+
+        self.assertFalse(AfterResolveJobs(self.resolvable_subdossier).after_resolve_jobs_pending)
 
 
 class TestReactivatingRESTAPI(TestReactivating):


### PR DESCRIPTION
This PR handles the processing of the pending job flag when a dossier is reopened/reactivated

For [CA-5855]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-5855]: https://4teamwork.atlassian.net/browse/CA-5855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ