### PR TITLE
Fix OGDS sync log in Docker container

### DIFF
--- a/changes/CA-6435.bugfix
+++ b/changes/CA-6435.bugfix
@@ -1,0 +1,1 @@
+Fix OGDS sync log in Docker container. [buchi]

--- a/docker/core/Dockerfile
+++ b/docker/core/Dockerfile
@@ -80,7 +80,8 @@ RUN mkdir -p /app/var/log /app/var/instance \
  && ln -sf /dev/stderr /app/var/log/instance.log \
  && ln -sf /dev/stdout /app/var/log/instance-json.log \
  && ln -sf /dev/stdout /app/var/log/solr-maintenance.log \
- && ln -sf /data/log/nightly-jobs.log /app/var/log/nightly-jobs.log
+ && ln -sf /data/log/nightly-jobs.log /app/var/log/nightly-jobs.log \
+ && ln -sf /data/log/ogds-update.log /app/var/log/ogds-update.log
 
 RUN ln -sf /dev/null /app/var/log/upgrade_stats.csv
 

--- a/opengever/ogds/base/sync/ogds_updater.py
+++ b/opengever/ogds/base/sync/ogds_updater.py
@@ -150,7 +150,7 @@ def setup_ogds_sync_logfile(logger):
             return
     log_dir = PathFinder().var_log
     file_handler = TimedRotatingFileHandler(
-        os.path.join(log_dir, 'ogds-update.log'),
+        os.path.realpath(os.path.join(log_dir, 'ogds-update.log')),
         when='midnight', backupCount=7)
     file_handler.setLevel(logging.INFO)
     file_handler.setFormatter(logging.Formatter(LOG_FORMAT))


### PR DESCRIPTION
Create symlink and use real path for the rotating file handler in order to get the correct base directory when rotating log.

For [CA-6435](https://4teamwork.atlassian.net/browse/CA-6435)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-6435]: https://4teamwork.atlassian.net/browse/CA-6435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ