### PR TITLE
Add support for ZCML package includes in Docker container

### DIFF
--- a/changes/CA-6435.other
+++ b/changes/CA-6435.other
@@ -1,0 +1,1 @@
+Add support for ZCML package includes in Docker container. [buchi]

--- a/docker/core/docker-entrypoint.sh
+++ b/docker/core/docker-entrypoint.sh
@@ -10,6 +10,7 @@ mkdir -p /data/log
 python /app/entrypoint.d/create_zope_conf.py "$CONFIG_FILE"
 python /app/entrypoint.d/create_ogds_zcml.py
 python /app/entrypoint.d/create_solr_zcml.py
+python /app/entrypoint.d/create_package_includes.py
 
 if [ $# -eq 0 ]
 then

--- a/docker/core/entrypoint.d/create_package_includes.py
+++ b/docker/core/entrypoint.d/create_package_includes.py
@@ -1,0 +1,30 @@
+# Create package includes from environment variables
+
+from os import environ
+
+
+def main():
+    zcml_include_file = '/app/etc/package-includes/999-additional-overrides.zcml'
+    packages = environ.get('ZCML_PACKAGE_INCLUDES', '')
+
+    if not packages:
+        return
+
+    package_includes = '\n'.join(
+        [PACKAGE_INCLUDE.format(package_name=p) for p in packages.split(' ')])
+    zcml = ZCML_TEMPLATE.format(package_includes=package_includes)
+
+    with open(zcml_include_file, 'w') as file_:
+        file_.write(zcml)
+
+
+PACKAGE_INCLUDE = """  <include package="{package_name}" />"""
+ZCML_TEMPLATE = """\
+<configure xmlns="http://namespaces.zope.org/zope">
+{package_includes}
+</configure>
+"""
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This allows us to use existing policies with Docker and easier customization by bind mounting a package into the container instead of single files.

To include a package, it needs to be bind mounted into the container and the environment variable `ZCML_PACKAGE_INCLUDES` needs to be set to the package name. Multiple package names can be specified separated by a space.

Example snippet from opengever.dockerexample:

```
services:
  ogcore:
    volumes:
      - ./opengever/dockerexample:/app/opengever/dockerexample:ro
    environment:
      - ZCML_PACKAGE_INCLUDES=opengever.dockerexample.fd
```

For [CA-6435](https://4teamwork.atlassian.net/browse/CA-6435)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-6435]: https://4teamwork.atlassian.net/browse/CA-6435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ