### PR TITLE
Bump Solr to version 8.11.3

### DIFF
--- a/docker/solr/Dockerfile
+++ b/docker/solr/Dockerfile
@@ -1,4 +1,4 @@
-FROM solr:8.11
+FROM solr:8.11.3
 
 ENV SOLR_OPTS="-Dlog4j2.formatMsgNoLookups=true"
 ENV SOLR_CORES="ogsite"

--- a/versions.cfg
+++ b/versions.cfg
@@ -230,5 +230,5 @@ zope.testrunner = 4.8.1
 zptlint = 0.2.4
 
 [solr]
-url = https://www.apache.org/dyn/closer.lua/lucene/solr/8.11.2/solr-8.11.2.tgz?action=download
-md5sum = 240a3cddf46b9604141f6cfdbc72916d
+url = https://www.apache.org/dyn/closer.lua/lucene/solr/8.11.3/solr-8.11.3.tgz?action=download
+md5sum = 5d687563c2131934b72ac7496ff91f26


### PR DESCRIPTION
Includes fixes for CVE-2023-50291, CVE-2023-50292, CVE-2023-50298, CVE-2023-50386 and CVE-2022-39135.

For [CA-XXXX]

## Checklist

- [ ] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)


