### PR TITLE
Add ability to restrict workspace mails and documents actions for guests 

### DIFF
--- a/changes/CA-6417.feature
+++ b/changes/CA-6417.feature
@@ -1,0 +1,1 @@
+Adds the option in the workspace to restrict the possibility of printing and downloading content for guests. [KunzS85]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -12,7 +12,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
-
+- Add `restrict_downloading_documents` field to workspace for restricting guests in downlading and printing documents
 
 2024.5.0 (2024-03-07)
 ---------------------

--- a/docs/schema-dumps/opengever.workspace.workspace.schema.json
+++ b/docs/schema-dumps/opengever.workspace.workspace.schema.json
@@ -59,6 +59,12 @@
             "description": "Kann in Kopf- und Fusszeilen von Protokollen verwendet werden.",
             "_zope_schema_type": "NamedImage"
         },
+        "restrict_downloading_documents": {
+            "type": "boolean",
+            "title": "Herunterladen bzw. \u00d6ffnen von Inhalten am Endger\u00e4t f\u00fcr G\u00e4ste einschr\u00e4nken",
+            "description": "",
+            "_zope_schema_type": "Bool"
+        },
         "changed": {
             "type": "string",
             "title": "Zuletzt ver\u00e4ndert",
@@ -98,6 +104,7 @@
         "meeting_template_header",
         "meeting_template_footer",
         "workspace_logo",
+        "restrict_downloading_documents",
         "changed",
         "title",
         "description",

--- a/opengever/api/document.py
+++ b/opengever/api/document.py
@@ -13,6 +13,8 @@ from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.document.versioner import Versioner
 from opengever.meeting import is_meeting_feature_enabled
 from opengever.meeting.model import SubmittedDocument
+from opengever.workspace.utils import is_restricted_workspace_and_guest
+from opengever.workspace.utils import is_within_workspace
 from opengever.workspaceclient import is_workspace_client_feature_enabled
 from opengever.workspaceclient.interfaces import ILinkedDocuments
 from plone.restapi.deserializer import json_body
@@ -66,6 +68,9 @@ class SerializeDocumentToJson(GeverSerializeToJson):
 
         if is_workspace_client_feature_enabled():
             result['is_locked_by_copy_to_workspace'] = obj.is_locked_by_copy_to_workspace()
+
+        if is_within_workspace(self.context):
+            result[u'restrict_downloading_document'] = is_restricted_workspace_and_guest(self.context)
 
         additional_metadata = {
             'checked_out': checked_out_by,

--- a/opengever/api/tests/test_document.py
+++ b/opengever/api/tests/test_document.py
@@ -307,6 +307,17 @@ class TestDocumentSerializer(IntegrationTestCase):
                  u'https://example.com/teamraum/redirect-to-uuid/createworkspace00000000000000005'],
                 browser.json["workspace_document_urls"])
 
+    @browsing
+    def test_document_serialization_contains_workspace_restricted_downloading_document(self, browser):
+        with self.login(self.workspace_admin):
+            self.workspace.restrict_downloading_documents = True
+        self.login(self.workspace_guest, browser)
+
+        browser.open(self.workspace_document, headers={'Accept': 'application/json'})
+        self.assertEqual(browser.status_code, 200)
+
+        self.assertEqual(True, browser.json['restrict_downloading_document'])
+
 
 class TestDocumentPost(IntegrationTestCase):
 

--- a/opengever/bundle/schemas/workspaces.schema.json
+++ b/opengever/bundle/schemas/workspaces.schema.json
@@ -89,6 +89,15 @@
                     "description": "Kann in Kopf- und Fusszeilen von Protokollen verwendet werden.",
                     "_zope_schema_type": "NamedImage"
                 },
+                "restrict_downloading_documents": {
+                    "type": [
+                        "null",
+                        "boolean"
+                    ],
+                    "title": "Herunterladen bzw. \u00d6ffnen von Inhalten am Endger\u00e4t f\u00fcr G\u00e4ste einschr\u00e4nken",
+                    "description": "",
+                    "_zope_schema_type": "Bool"
+                },
                 "changed": {
                     "type": [
                         "null",
@@ -188,6 +197,7 @@
                 "meeting_template_header",
                 "meeting_template_footer",
                 "workspace_logo",
+                "restrict_downloading_documents",
                 "changed",
                 "title",
                 "description",

--- a/opengever/document/actions.py
+++ b/opengever/document/actions.py
@@ -16,6 +16,7 @@ from opengever.private.dossier import IPrivateDossier
 from opengever.private.folder import IPrivateFolder
 from opengever.trash.trash import ITrasher
 from opengever.workspace import is_workspace_feature_enabled
+from opengever.workspace.utils import is_restricted_workspace_and_guest
 from opengever.workspace.utils import is_within_workspace
 from opengever.workspaceclient import is_workspace_client_feature_available
 from opengever.workspaceclient.interfaces import ILinkedWorkspaces
@@ -143,6 +144,18 @@ class WorkspaceDocumentListingActions(BaseDocumentListingActions):
 
     def is_delete_available(self):
         return False
+
+    def is_attach_documents_available(self):
+        return (super(WorkspaceDocumentListingActions, self).is_attach_documents_available()
+                and not is_restricted_workspace_and_guest(self.context))
+
+    def is_zip_selected_available(self):
+        return (super(WorkspaceDocumentListingActions, self).is_zip_selected_available()
+                and not is_restricted_workspace_and_guest(self.context))
+
+    def is_export_documents_available(self):
+        return (super(WorkspaceDocumentListingActions, self).is_export_documents_available()
+                and not is_restricted_workspace_and_guest(self.context))
 
 
 @adapter(IBaseDocument, IOpengeverBaseLayer)

--- a/opengever/document/fileactions.py
+++ b/opengever/document/fileactions.py
@@ -53,7 +53,8 @@ class BaseDocumentFileActions(object):
         return False
 
     def is_oc_view_action_available(self):
-        return self.context.has_file()
+        return (self.context.has_file()
+                and not is_restricted_workspace_and_guest(self.context))
 
     def is_oc_direct_checkout_action_available(self):
         return False
@@ -80,12 +81,14 @@ class BaseDocumentFileActions(object):
         return False
 
     def is_download_copy_action_available(self):
-        return self.context.has_file()
+        return (self.context.has_file()
+                and not is_restricted_workspace_and_guest(self.context))
 
     def is_attach_to_email_action_available(self):
         return (
             is_officeconnector_attach_feature_enabled()
-            and self.context.has_file())
+            and self.context.has_file()
+            and not is_restricted_workspace_and_guest(self.context))
 
     def is_oneoffixx_retry_action_available(self):
         return False
@@ -104,7 +107,8 @@ class BaseDocumentFileActions(object):
         if not mime_type_item:
             return False
 
-        return is_mimetype_supported(mime_type_item[0])
+        return (is_mimetype_supported(mime_type_item[0])
+                and not is_restricted_workspace_and_guest(self.context))
 
     def is_revert_to_version_action_available(self):
         return False
@@ -186,9 +190,9 @@ class DocumentFileActions(BaseDocumentFileActions):
             (self.context, self.request), ICheckinCheckoutManager)
 
         return (
-            self.context.has_file()
+            super(DocumentFileActions, self).is_oc_view_action_available()
+            and self.context.has_file()
             and not manager.is_checked_out_by_current_user()
-            and not is_restricted_workspace_and_guest(self.context)
         )
 
     def is_oc_direct_checkout_action_available(self):
@@ -249,8 +253,7 @@ class DocumentFileActions(BaseDocumentFileActions):
 
         return (
             super(DocumentFileActions, self).is_download_copy_action_available()
-            and not (manager.is_checked_out_by_another_user() and not has_version)
-            and not is_restricted_workspace_and_guest(self.context))
+            and not (manager.is_checked_out_by_another_user() and not has_version))
 
     def is_attach_to_email_action_available(self):
         """Disable attaching documents to email when the document is checked out by
@@ -264,8 +267,7 @@ class DocumentFileActions(BaseDocumentFileActions):
         return (
             super(DocumentFileActions, self).is_attach_to_email_action_available()
             and not (manager.is_checked_out_by_another_user() and not has_version)
-            and not self.context.is_inside_a_template_folder()
-            and not is_restricted_workspace_and_guest(self.context))
+            and not self.context.is_inside_a_template_folder())
 
     def is_oneoffixx_retry_action_available(self):
         return self.context.is_oneoffixx_creatable()
@@ -274,9 +276,7 @@ class DocumentFileActions(BaseDocumentFileActions):
         return self.context.is_docugate_creatable()
 
     def is_open_as_pdf_action_available(self):
-        return (
-            super(DocumentFileActions, self).is_open_as_pdf_action_available()
-            and not is_restricted_workspace_and_guest(self.context))
+        return super(DocumentFileActions, self).is_open_as_pdf_action_available()
 
     def is_revert_to_version_action_available(self):
         manager = getMultiAdapter(

--- a/opengever/document/fileactions.py
+++ b/opengever/document/fileactions.py
@@ -14,6 +14,7 @@ from opengever.trash.trash import ITrasher
 from opengever.wopi import is_wopi_feature_enabled
 from opengever.workspace import is_workspace_feature_enabled
 from opengever.workspace.interfaces import IWorkspaceFolder
+from opengever.workspace.utils import is_restricted_workspace_and_guest
 from plone import api
 from plone.locking.interfaces import ILockable
 from zExceptions import Forbidden
@@ -187,6 +188,7 @@ class DocumentFileActions(BaseDocumentFileActions):
         return (
             self.context.has_file()
             and not manager.is_checked_out_by_current_user()
+            and not is_restricted_workspace_and_guest(self.context)
         )
 
     def is_oc_direct_checkout_action_available(self):
@@ -247,7 +249,8 @@ class DocumentFileActions(BaseDocumentFileActions):
 
         return (
             super(DocumentFileActions, self).is_download_copy_action_available()
-            and not (manager.is_checked_out_by_another_user() and not has_version))
+            and not (manager.is_checked_out_by_another_user() and not has_version)
+            and not is_restricted_workspace_and_guest(self.context))
 
     def is_attach_to_email_action_available(self):
         """Disable attaching documents to email when the document is checked out by
@@ -261,13 +264,19 @@ class DocumentFileActions(BaseDocumentFileActions):
         return (
             super(DocumentFileActions, self).is_attach_to_email_action_available()
             and not (manager.is_checked_out_by_another_user() and not has_version)
-            and not self.context.is_inside_a_template_folder())
+            and not self.context.is_inside_a_template_folder()
+            and not is_restricted_workspace_and_guest(self.context))
 
     def is_oneoffixx_retry_action_available(self):
         return self.context.is_oneoffixx_creatable()
 
     def is_docugate_retry_action_available(self):
         return self.context.is_docugate_creatable()
+
+    def is_open_as_pdf_action_available(self):
+        return (
+            super(DocumentFileActions, self).is_open_as_pdf_action_available()
+            and not is_restricted_workspace_and_guest(self.context))
 
     def is_revert_to_version_action_available(self):
         manager = getMultiAdapter(

--- a/opengever/document/tests/test_actions.py
+++ b/opengever/document/tests/test_actions.py
@@ -92,6 +92,13 @@ class TestDocumentListingActions(IntegrationTestCase):
         self.assertEqual(expected_actions, self.get_actions(self.workspace))
         self.assertEqual(expected_actions, self.get_actions(self.workspace_folder))
 
+    def test_document_actions_in_workspace_and_workspace_folder_with_guest_restriction(self):
+        with self.login(self.workspace_admin):
+            self.workspace.restrict_downloading_documents = True
+        self.login(self.workspace_guest)
+        expected_actions = []
+        self.assertEqual(expected_actions, self.get_actions(self.workspace))
+        self.assertEqual(expected_actions, self.get_actions(self.workspace_folder))
 
 
 class TestWorkspaceClientDocumentListingActions(FunctionalWorkspaceClientTestCase):

--- a/opengever/document/tests/test_actions.py
+++ b/opengever/document/tests/test_actions.py
@@ -93,6 +93,7 @@ class TestDocumentListingActions(IntegrationTestCase):
         self.assertEqual(expected_actions, self.get_actions(self.workspace_folder))
 
 
+
 class TestWorkspaceClientDocumentListingActions(FunctionalWorkspaceClientTestCase):
 
     def get_actions(self, context):
@@ -254,3 +255,11 @@ class TestDocumentContextActions(IntegrationTestCase):
             u'save_document_as_pdf',
         ]
         self.assertEqual(expected_actions, self.get_actions(template))
+
+    def test_document_actions_in_workspace_with_guest_restriction(self):
+        with self.login(self.workspace_admin):
+            self.workspace.restrict_downloading_documents = True
+        self.login(self.workspace_guest)
+
+        expected_actions = [u'share_content']
+        self.assertEqual(expected_actions, self.get_actions(self.workspace))

--- a/opengever/mail/actions.py
+++ b/opengever/mail/actions.py
@@ -20,4 +20,4 @@ class MailContextActions(BaseDocumentContextActions):
         return self.context.can_extract_attachments_to_parent()
 
     def is_oc_view_available(self):
-        return True
+        return self.file_actions.is_oc_view_action_available()

--- a/opengever/workspace/actions.py
+++ b/opengever/workspace/actions.py
@@ -8,6 +8,7 @@ from opengever.workspace.interfaces import IWorkspace
 from opengever.workspace.interfaces import IWorkspaceFolder
 from opengever.workspace.interfaces import IWorkspaceMeeting
 from opengever.workspace.utils import get_containing_workspace
+from opengever.workspace.utils import is_restricted_workspace_and_guest
 from plone import api
 from plone.dexterity.interfaces import IDexterityContainer
 from zExceptions import Forbidden
@@ -70,7 +71,7 @@ class WorkspaceContextActions(BaseContextActions):
         return get_containing_workspace(self.context).access_members_allowed()
 
     def is_zipexport_available(self):
-        return True
+        return not is_restricted_workspace_and_guest(self.context)
 
 
 @adapter(IWorkspaceFolder, IOpengeverBaseLayer)
@@ -101,4 +102,4 @@ class WorkspaceFolderContextActions(BaseContextActions):
         return ITrasher(self.context).verify_may_untrash(raise_on_violations=False)
 
     def is_zipexport_available(self):
-        return True
+        return not is_restricted_workspace_and_guest(self.context)

--- a/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-02-08 15:21+0000\n"
+"POT-Creation-Date: 2024-03-07 13:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -289,6 +289,11 @@ msgstr "Verknüpfte To-do-Liste"
 #: ./opengever/workspace/todo.py
 msgid "label_responsible"
 msgstr "Verantwortlich"
+
+#. Default: "Restrict guests from downloading or opening content on the end device"
+#: ./opengever/workspace/workspace.py
+msgid "label_restrict_downloading_documents"
+msgstr "Herunterladen bzw. Öffnen von Inhalten am Endgerät für Gäste einschränken"
 
 #. Default: "Secretary"
 #: ./opengever/workspace/browser/templates/meeting_minutes.pt

--- a/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-02-08 15:21+0000\n"
+"POT-Creation-Date: 2024-03-07 13:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -324,6 +324,11 @@ msgstr "Related to-do list"
 #: ./opengever/workspace/todo.py
 msgid "label_responsible"
 msgstr "Responsible"
+
+#. Default: "Restrict guests from downloading or opening content on the end device"
+#: ./opengever/workspace/workspace.py
+msgid "label_restrict_downloading_documents"
+msgstr "Restrict guests from downloading or opening content on the end device"
 
 #. Default: "Secretary"
 #: ./opengever/workspace/browser/templates/meeting_minutes.pt

--- a/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-02-08 15:21+0000\n"
+"POT-Creation-Date: 2024-03-07 13:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -289,6 +289,11 @@ msgstr ""
 #: ./opengever/workspace/todo.py
 msgid "label_responsible"
 msgstr "Responsable"
+
+#. Default: "Restrict guests from downloading or opening content on the end device"
+#: ./opengever/workspace/workspace.py
+msgid "label_restrict_downloading_documents"
+msgstr " Limiter le téléchargement ou l'ouverture de contenus sur le poste de travail des invités"
 
 #. Default: "Secretary"
 #: ./opengever/workspace/browser/templates/meeting_minutes.pt

--- a/opengever/workspace/locales/opengever.workspace.pot
+++ b/opengever/workspace/locales/opengever.workspace.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-02-08 15:21+0000\n"
+"POT-Creation-Date: 2024-03-07 13:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -229,7 +229,7 @@ msgstr ""
 msgid "label_end"
 msgstr ""
 
-#. Default: "External reference"
+#. Default: "External Reference"
 #: ./opengever/workspace/todo.py
 msgid "label_external_reference"
 msgstr ""
@@ -291,6 +291,11 @@ msgstr ""
 #: ./opengever/workspace/browser/templates/meeting_minutes.pt
 #: ./opengever/workspace/todo.py
 msgid "label_responsible"
+msgstr ""
+
+#. Default: "Restrict guests from downloading or opening content on the end device"
+#: ./opengever/workspace/workspace.py
+msgid "label_restrict_downloading_documents"
 msgstr ""
 
 #. Default: "Secretary"

--- a/opengever/workspace/tests/test_actions.py
+++ b/opengever/workspace/tests/test_actions.py
@@ -95,6 +95,16 @@ class TestWorkspaceContextActions(IntegrationTestCase):
 
         self.assertEqual([u'zipexport'], self.get_actions(self.workspace))
 
+    def test_workspace_with_guest_restriction_context_actions_for_guests(self):
+        self.login(self.workspace_guest)
+        self.assertEqual([u'share_content', 'zipexport'],
+                         self.get_actions(self.workspace))
+
+        with self.login(self.workspace_admin):
+            self.workspace.restrict_downloading_documents = True
+
+        self.assertEqual([u'share_content'], self.get_actions(self.workspace))
+
     def test_workspace_context_actions_for_workspace_admins(self):
         self.login(self.workspace_admin)
         expected_actions = [u'add_invitation', u'edit', u'local_roles', u'share_content', 'zipexport']

--- a/opengever/workspace/tests/test_actions.py
+++ b/opengever/workspace/tests/test_actions.py
@@ -1,3 +1,5 @@
+from ftw.builder import Builder
+from ftw.builder import create
 from opengever.base.interfaces import IContextActions
 from opengever.base.interfaces import IListingActions
 from opengever.testing import IntegrationTestCase
@@ -104,6 +106,18 @@ class TestWorkspaceContextActions(IntegrationTestCase):
             self.workspace.restrict_downloading_documents = True
 
         self.assertEqual([u'share_content'], self.get_actions(self.workspace))
+
+    def test_workspace_with_guest_restriction_mail_actions_for_guests(self):
+        self.login(self.workspace_guest)
+        with self.login(self.workspace_admin):
+            self.workspace.restrict_downloading_documents = True
+
+        mail = create(Builder('mail')
+                      .within(self.workspace))
+
+        expected_actions = [u'copy_item', u'move_item', u'share_content']
+
+        self.assertEqual(expected_actions, self.get_actions(mail))
 
     def test_workspace_context_actions_for_workspace_admins(self):
         self.login(self.workspace_admin)

--- a/opengever/workspace/utils.py
+++ b/opengever/workspace/utils.py
@@ -84,3 +84,18 @@ def get_context_members_ids(context, actor_type, disregard_block=False):
             break
 
     return list(actor_ids)
+
+
+def is_restricted_workspace_and_guest(context):
+    if not is_within_workspace(context):
+        return False
+
+    workspace = get_containing_workspace(context)
+    restricted = aq_base(workspace).restrict_downloading_documents
+    if not restricted:
+        return False
+
+    non_guest_roles = ['WorkspaceMember', 'WorkspaceAdmin']
+    roles = api.user.get_roles(obj=context)
+    is_guest = not any([r in roles for r in non_guest_roles])
+    return is_guest

--- a/opengever/workspace/workspace.py
+++ b/opengever/workspace/workspace.py
@@ -117,7 +117,6 @@ class IWorkspaceSchema(model.Schema):
                       u'minutes'),
         required=False,
     )
-
     restrict_downloading_documents = schema.Bool(
         title=_(u'label_restrict_downloading_documents',
                 default=u'Restrict guests from downloading or opening content on the end device'),

--- a/opengever/workspace/workspace.py
+++ b/opengever/workspace/workspace.py
@@ -118,6 +118,12 @@ class IWorkspaceSchema(model.Schema):
         required=False,
     )
 
+    restrict_downloading_documents = schema.Bool(
+        title=_(u'label_restrict_downloading_documents',
+                default=u'Restrict guests from downloading or opening content on the end device'),
+        required=False,
+    )
+
     @invariant
     def validate_meeting_minutes_header_and_footer(data):
         try:


### PR DESCRIPTION
This PR adds the option of restricting the action options for guests to the workspace. 
The aim of this is to ensure that guests can only view documents in the team room at this time and to make it as difficult as possible for them to print or download content. These restrictions relate primarily to the new UI.

For [CA-6417]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
- New functionality:
  - [x] for `document` also works for `mail`
- New translations
  - [x] All msg-strings are unicode



[CA-6417]: https://4teamwork.atlassian.net/browse/CA-6417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ