### PR TITLE
Improve performance of Solr reindexing using DIH

### DIFF
--- a/changes/CA-6790.other
+++ b/changes/CA-6790.other
@@ -1,0 +1,1 @@
+Improve performance of Solr reindexing using data import handler for large indexes. [buchi]

--- a/solr-conf/data-config.xml
+++ b/solr-conf/data-config.xml
@@ -5,6 +5,7 @@
             url="${dataimporter.request.source_url}"
             query="*:*"
             fl="*,ignored_version_:_version_,ignored_path_parent:path_parent,ignored_sequence_number_string:sequence_number_string"
+            cursorMark="true"
             sort="UID asc"/>
   </document>
 </dataConfig>


### PR DESCRIPTION
Use a cursor for pagination instead of paging.
It turns out Solr is very inefficient when using deep paging. This has the effect that reindexing using a data import handler gets slower and slower the more documents have been processed. By using a cursor, the reindexing speed remains the same independant of the retrieved page. See also: https://solr.apache.org/guide/8_11/pagination-of-results.html#performance-problems-with-deep-paging

Comparison reindexing 2.2 M documents:

Using cursors:
Indexing completed. Added/Updated: 2249657 documents. Deleted 0 documents. (Duration: 6h 13m 50s)
Requests: 0 , Fetched: 2,249,657 100/s, Skipped: 0 , Processed: 2,249,657 100/s
Started: about 7 hours ago

Using paging (aborted after 12h):
Indexing since 12:3:9.704
Requests: 0 , Fetched: 1,486,650 34/s, Skipped: 0 , Processed: 1,486,650 34/s
Started: about 12 hours ago

For [CA-6790](https://4teamwork.atlassian.net/browse/CA-6790)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-6790]: https://4teamwork.atlassian.net/browse/CA-6790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ