### PR TITLE
Extend the restriction of possible actions by guests

### DIFF
--- a/changes/CA-6417.other
+++ b/changes/CA-6417.other
@@ -1,0 +1,1 @@
+Hide "share content" and "zipexport" actions for guest access on restricted workspaces [KunzS85]

--- a/opengever/document/actions.py
+++ b/opengever/document/actions.py
@@ -235,7 +235,8 @@ class BaseDocumentContextActions(BaseContextActions):
         return IBumblebeeable.providedBy(self.context)
 
     def is_share_content_available(self):
-        return is_within_workspace(self.context)
+        return (is_within_workspace(self.context)
+                and not is_restricted_workspace_and_guest(self.context))
 
     def is_trash_context_available(self):
         return self.file_actions.is_trash_context_action_available()

--- a/opengever/document/tests/test_actions.py
+++ b/opengever/document/tests/test_actions.py
@@ -263,10 +263,30 @@ class TestDocumentContextActions(IntegrationTestCase):
         ]
         self.assertEqual(expected_actions, self.get_actions(template))
 
+    def test_document_actions_in_workspace_with_guest(self):
+        self.login(self.workspace_guest)
+
+        expected_actions = [
+            u'attach_to_email',
+            u'copy_item',
+            u'download_copy',
+            u'move_item',
+            u'oc_view',
+            u'open_as_pdf',
+            u'revive_bumblebee_preview',
+            u'save_document_as_pdf',
+            u'share_content']
+
+        self.assertEqual(expected_actions,
+                         self.get_actions(self.workspace_document))
+
     def test_document_actions_in_workspace_with_guest_restriction(self):
         with self.login(self.workspace_admin):
             self.workspace.restrict_downloading_documents = True
-        self.login(self.workspace_guest)
 
-        expected_actions = [u'share_content']
-        self.assertEqual(expected_actions, self.get_actions(self.workspace))
+        self.login(self.workspace_guest)
+        document = create(Builder('document')
+                          .within(self.workspace))
+
+        expected_actions_restricted_guest = [u'copy_item', u'move_item', u'revive_bumblebee_preview']
+        self.assertEqual(expected_actions_restricted_guest, self.get_actions(document))

--- a/opengever/mail/tests/test_actions.py
+++ b/opengever/mail/tests/test_actions.py
@@ -80,3 +80,30 @@ class TestMailContextActions(IntegrationTestCase):
             u'revive_bumblebee_preview',
         ]
         self.assertEqual(expected_actions, self.get_actions(mail))
+
+    def test_mail_actions_in_workspace_with_guest(self):
+        self.login(self.workspace_guest)
+
+        expected_actions = [
+            u'attach_to_email',
+            u'copy_item',
+            u'download_copy',
+            u'move_item',
+            u'oc_view',
+            u'open_as_pdf',
+            u'revive_bumblebee_preview',
+            u'share_content']
+
+        self.assertEqual(expected_actions,
+                         self.get_actions(self.workspace_mail))
+
+    def test_mail_actions_in_workspace_with_guest_restriction(self):
+        with self.login(self.workspace_admin):
+            self.workspace.restrict_downloading_documents = True
+
+        self.login(self.workspace_guest)
+        mail = create(Builder('document')
+                      .within(self.workspace))
+
+        expected_actions_restricted_guest = [u'copy_item', u'move_item', u'revive_bumblebee_preview']
+        self.assertEqual(expected_actions_restricted_guest, self.get_actions(mail))

--- a/opengever/workspace/actions.py
+++ b/opengever/workspace/actions.py
@@ -25,7 +25,7 @@ class WorkspaceFolderListingActions(BaseListingActions):
         return True
 
     def is_zip_selected_available(self):
-        return True
+        return not is_restricted_workspace_and_guest(self.context)
 
     def is_trash_content_available(self):
         return api.user.has_permission('opengever.trash: Trash content', obj=self.context)
@@ -68,7 +68,8 @@ class WorkspaceContextActions(BaseContextActions):
         return self.context.is_deletion_allowed()
 
     def is_share_content_available(self):
-        return get_containing_workspace(self.context).access_members_allowed()
+        return (get_containing_workspace(self.context).access_members_allowed()
+                and not is_restricted_workspace_and_guest(self.context))
 
     def is_zipexport_available(self):
         return not is_restricted_workspace_and_guest(self.context)
@@ -93,7 +94,8 @@ class WorkspaceFolderContextActions(BaseContextActions):
         return super(WorkspaceFolderContextActions, self).is_edit_available()
 
     def is_share_content_available(self):
-        return get_containing_workspace(self.context).access_members_allowed()
+        return (get_containing_workspace(self.context).access_members_allowed()
+                and not is_restricted_workspace_and_guest(self.context))
 
     def is_trash_context_available(self):
         return ITrasher(self.context).verify_may_trash(raise_on_violations=False)

--- a/opengever/workspace/tests/test_actions.py
+++ b/opengever/workspace/tests/test_actions.py
@@ -99,25 +99,14 @@ class TestWorkspaceContextActions(IntegrationTestCase):
 
     def test_workspace_with_guest_restriction_context_actions_for_guests(self):
         self.login(self.workspace_guest)
+
         self.assertEqual([u'share_content', 'zipexport'],
                          self.get_actions(self.workspace))
 
         with self.login(self.workspace_admin):
             self.workspace.restrict_downloading_documents = True
 
-        self.assertEqual([u'share_content'], self.get_actions(self.workspace))
-
-    def test_workspace_with_guest_restriction_mail_actions_for_guests(self):
-        self.login(self.workspace_guest)
-        with self.login(self.workspace_admin):
-            self.workspace.restrict_downloading_documents = True
-
-        mail = create(Builder('mail')
-                      .within(self.workspace))
-
-        expected_actions = [u'copy_item', u'move_item', u'share_content']
-
-        self.assertEqual(expected_actions, self.get_actions(mail))
+        self.assertEqual([], self.get_actions(self.workspace))
 
     def test_workspace_context_actions_for_workspace_admins(self):
         self.login(self.workspace_admin)
@@ -159,6 +148,16 @@ class TestWorkspaceFolderContextActions(IntegrationTestCase):
             self.workspace.hide_members_for_guests = True
 
         self.assertEqual([u'zipexport'], self.get_actions(self.workspace_folder))
+
+    def test_workspace_folder_context_actions_for_guests_in_workspace_with_guest_restriction(self):
+        self.login(self.workspace_guest)
+        self.assertEqual([u'share_content', 'zipexport'],
+                         self.get_actions(self.workspace_folder))
+
+        with self.login(self.workspace_admin):
+            self.workspace.restrict_downloading_documents = True
+
+        self.assertEqual([], self.get_actions(self.workspace_folder))
 
     def test_workspace_folder_context_actions_for_workspace_admins(self):
         self.login(self.workspace_admin)


### PR DESCRIPTION
Follow-up PR of: Add ability to restrict workspace mails and documents actions for guests #7909

For [CA-6417]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)



[CA-6417]: https://4teamwork.atlassian.net/browse/CA-6417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ