### PR TITLE
Add full content serialization mode for GET /@dossier-transfers

### DIFF
--- a/changes/CA-6591.feature
+++ b/changes/CA-6591.feature
@@ -1,0 +1,1 @@
+Add full_content mode for GET /@dossier-transfers. [lgraf]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -8,7 +8,10 @@ API Changelog
 
 Other Changes
 ^^^^^^^^^^^^^
+- ``GET @dossier-transfers/<id>/blob/<document-UID>``: New endpoint to download document blobs of a dossier transfer.
+- ``GET @dossier-transfers/<id>?full_content=1``: New mode to fetch full content representation for dossier transfers.
 - Add ris_base_url to config endpoint.
+
 
 2024.7.0 (2024-04-23)
 ---------------------

--- a/docs/public/dev-manual/api/dossier_transfers.rst
+++ b/docs/public/dev-manual/api/dossier_transfers.rst
@@ -192,3 +192,82 @@ Mittels eines DELETE Requests können Dossier-Transfers gelöscht werden:
 
       HTTP/1.1 204 No Content
       Content-Type: application/json
+
+
+Dossier-Transfer-Inhalt abrufen
+-------------------------------
+
+Mit einem GET Request auf ``/@dossier-transfers/<id>?full_content=1`` kann
+zusätzlich zu den Metadaten eines Dossier-Transfers eine Serialisierung des
+Inhalts des Transfers abgerufen werden.
+
+Dieser serialisierte Inhalt wird in einem zusätzlichen key ``content``
+zurückgegeben:
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       GET /@dossier-transfers/42?full_content=1 HTTP/1.1
+       Accept: application/json
+
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+          "@id": "http://localhost:8080/fd/@dossier-transfers/4",
+          "...": "...",
+          "content": {
+              "contacts": {
+                  "person:39c2789d-a123-44ba-a3b1-4323d6e941c6": {
+                      "id": "39c2789d-a123-44ba-a3b1-4323d6e941c6",
+                      "firstName": "John",
+                      "fullName": "John Doe",
+                      "...": "..."
+                  }
+              },
+              "documents": [
+                  {
+                      "@id": "http://localhost:8080/fd/dossier-20/dossier-21/document-44",
+                      "@type": "opengever.document.document",
+                      "UID": "a663689540a34538b6f408d4b41baee8",
+                      "...": "..."
+                  }
+              ],
+              "dossiers": [
+                  {
+                      "@id": "http://localhost:8080/fd/dossier-20",
+                      "@type": "opengever.dossier.businesscasedossier",
+                      "UID": "1b6d8dbf1f954bbb9510a1b65d51ede5",
+                      "...": "...",
+                      "participations": [
+                          [
+                              "person:39c2789d-a123-44ba-a3b1-4323d6e941c6",
+                              ["final-drawing", "regard"]
+                          ]
+                      ]
+                  },
+                  {
+                      "@id": "http://localhost:8080/fd/dossier-20/dossier-21",
+                      "@type": "opengever.dossier.businesscasedossier",
+                      "UID": "f510a6bb410f40258b53090bf2f0c545",
+                      "...": "..."
+                  }
+              ]
+          },
+          "...": "..."
+      }
+
+
+Blobs von Dossier-Transfers herunterladen
+-----------------------------------------
+
+Mit einem GET Request auf ``/@dossier-transfers/<transfer-id>/blob/<document-uid>``
+kann das Blob eines Dokuments heruntergeladen werden. Der Request muss dazu einem
+gültigen Token für diesen Transfer authentisiert werden, und das Dokument muss
+in diesem Transfer enthalten sein.

--- a/opengever/api/document.py
+++ b/opengever/api/document.py
@@ -17,6 +17,7 @@ from opengever.workspace.utils import is_restricted_workspace_and_guest
 from opengever.workspace.utils import is_within_workspace
 from opengever.workspaceclient import is_workspace_client_feature_enabled
 from opengever.workspaceclient.interfaces import ILinkedDocuments
+from plone import api
 from plone.restapi.deserializer import json_body
 from plone.restapi.interfaces import IExpandableElement
 from plone.restapi.interfaces import IJsonCompatible
@@ -46,14 +47,18 @@ class SerializeDocumentToJson(GeverSerializeToJson):
 
         version = "current" if kwargs.get('version') is None else kwargs.get('version')
         obj = self.getVersion(version)
-        bumblebee_service = bumblebee.get_service_v3()
-        result['bumblebee_checksum'] = IBumblebeeDocument(obj).get_checksum()
-        result[u'thumbnail_url'] = bumblebee_service.get_representation_url(
-            obj, 'thumbnail')
-        result[u'preview_url'] = bumblebee_service.get_representation_url(
-            obj, 'preview')
-        result[u'pdf_url'] = bumblebee_service.get_representation_url(
-            obj, 'pdf')
+
+        user_id = api.user.get_current().getId()
+        if user_id:
+            # Include Bumblebee URLs for non-anonymous users
+            bumblebee_service = bumblebee.get_service_v3()
+            result['bumblebee_checksum'] = IBumblebeeDocument(obj).get_checksum()
+            result[u'thumbnail_url'] = bumblebee_service.get_representation_url(
+                obj, 'thumbnail')
+            result[u'preview_url'] = bumblebee_service.get_representation_url(
+                obj, 'preview')
+            result[u'pdf_url'] = bumblebee_service.get_representation_url(
+                obj, 'pdf')
         result[u'file_extension'] = obj.get_file_extension()
 
         extend_with_backreferences(

--- a/opengever/base/subscribers.py
+++ b/opengever/base/subscribers.py
@@ -13,6 +13,7 @@ from zope.publisher.interfaces.browser import IBrowserView
 
 ALLOWED_ENDPOINTS = set([
     'GET_application_json_@config',
+    'GET_application_json_@dossier-transfers',
     'GET_application_json_@white-labeling-settings',
     'POST_application_json_@caslogin',
     'POST_application_json_@login',

--- a/opengever/dossiertransfer/api/base.py
+++ b/opengever/dossiertransfer/api/base.py
@@ -85,15 +85,19 @@ class DossierTransferLocator(DossierTransfersBase):
         return False
 
     def _extract_transfer_id(self):
-        # We'll accept zero (listing) or one (get by id) params, but not more
-        if len(self.params) > 1:
+        # We'll accept
+        # - zero (listing)
+        # - one (get by id) or
+        # - three (blob download)
+        # params, but not more
+        if len(self.params) not in (0, 1, 3):
             raise BadRequest(
                 'Must supply either exactly one {transfer_id} path parameter '
-                'to fetch a specific transfer, or no parameter for a '
-                'listing of all transfers.')
+                'to fetch a specific transfer, no parameter for a '
+                'listing of all transfers, or three to fetch a blob.')
 
         # We have a valid number of parameters for the given endpoint
-        if len(self.params) == 1:
+        if len(self.params) in (1, 3):
             try:
                 transfer_id = int(self.params[0])
             except ValueError:
@@ -107,6 +111,9 @@ class DossierTransferLocator(DossierTransfersBase):
             if ogds_user in org_unit.inbox_group.users:
                 return True
         return False
+
+    def is_blob_request(self):
+        return len(self.params) == 3 and self.params[1] == 'blob'
 
     def locate_transfer(self):
         transfer_id = self.transfer_id

--- a/opengever/dossiertransfer/api/base.py
+++ b/opengever/dossiertransfer/api/base.py
@@ -34,7 +34,9 @@ class DossierTransfersBase(Service):
             (transfer, getRequest()), ISerializeToJson)()
 
         if full_content:
-            assert self.has_valid_token()
+            if not self.has_valid_token():
+                raise Unauthorized
+
             with elevated_privileges():
                 serialized['content'] = FullTransferContentSerializer(transfer)()
 

--- a/opengever/dossiertransfer/api/get.py
+++ b/opengever/dossiertransfer/api/get.py
@@ -97,7 +97,6 @@ class DossierTransfersGet(DossierTransferLocator):
                 if document_uid not in transfer.documents:
                     raise Unauthorized
 
-            assert len(brains) == 1
             document = brains[0].getObject()
             namedfile = document.file
 

--- a/opengever/dossiertransfer/api/get.py
+++ b/opengever/dossiertransfer/api/get.py
@@ -9,6 +9,15 @@ class DossierTransfersGet(DossierTransferLocator):
     GET /@dossier-transfers HTTP/1.1
     """
 
+    def check_permission(self):
+        if self.has_valid_token():
+            # Server-to-server requests to fetch the full transfer contents are
+            # performed anonymously, but with a valid token that matches a
+            # particular transfer. We must not restrict these.
+            return
+
+        return super(DossierTransfersGet, self).check_permission()
+
     def reply(self):
         if self.transfer_id:
             # Get transfer by id

--- a/opengever/dossiertransfer/api/post.py
+++ b/opengever/dossiertransfer/api/post.py
@@ -69,8 +69,8 @@ class DossierTransfersPost(DossierTransfersBase):
         session.flush()
 
         token = transfer.issue_token()
-        assert transfer.token == token
-        assert transfer.is_valid_token(token)
+        if not (transfer.token == token and transfer.is_valid_token(token)):
+            raise Unauthorized
 
         serialized_transfer = self.serialize(transfer)
 

--- a/opengever/dossiertransfer/api/post.py
+++ b/opengever/dossiertransfer/api/post.py
@@ -69,8 +69,8 @@ class DossierTransfersPost(DossierTransfersBase):
         session.flush()
 
         token = transfer.issue_token()
-        transfer.validate_token(token)
-        transfer.token = token
+        assert transfer.token == token
+        assert transfer.is_valid_token(token)
 
         serialized_transfer = self.serialize(transfer)
 

--- a/opengever/dossiertransfer/api/serializers.py
+++ b/opengever/dossiertransfer/api/serializers.py
@@ -116,7 +116,10 @@ class DossiersSerializer(object):
             serialized_dossiers.append(serialized)
 
         # We only add participations for the root dossier
-        assert serialized_dossiers[0]['UID'] == self.transfer.root
+        if serialized_dossiers[0]['UID'] != self.transfer.root:
+            raise RuntimeError(
+                'Unexpected first dossier, expected it to match root dossier')
+
         serialized_dossiers[0]['participations'] = ParticipationsSerializer(self.transfer)()
 
         return serialized_dossiers

--- a/opengever/dossiertransfer/api/serializers.py
+++ b/opengever/dossiertransfer/api/serializers.py
@@ -1,9 +1,12 @@
 from opengever.base.interfaces import IOpengeverBaseLayer
+from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossiertransfer.model import DossierTransfer
 from plone import api
 from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.serializer.converters import json_compatible
 from zope.component import adapter
+from zope.component import getMultiAdapter
+from zope.globalrequest import getRequest
 from zope.interface import implementer
 
 
@@ -59,8 +62,54 @@ class FullTransferContentSerializer(object):
     def __call__(self):
         # TODO
         content = {
-            'dossiers': [],
+            'dossiers': DossiersSerializer(self.transfer)(),
             'documents': [],
             'contacts': [],
         }
         return content
+
+
+class DossiersSerializer(object):
+    """Returns the list of (sub)dossiers included in the transfer.
+    """
+
+    ignored_keys = (
+        '@components',
+        'items',
+        'items_total',
+        'next_item',
+        'previous_item',
+    )
+
+    def __init__(self, transfer):
+        self.transfer = transfer
+
+    def __call__(self):
+        # This currently returns a flat list of dossiers, ordered by path
+        # (parents before children, so in the order they should be created).
+        # Depending on what is easiest to use on the deserialization side, we
+        # might want to change this to return a hierarchical structure.
+        serialized_dossiers = []
+
+        catalog = api.portal.get_tool('portal_catalog')
+
+        root_dossier = api.content.uuidToObject(self.transfer.root)
+        query = {
+            'path': '/'.join(root_dossier.getPhysicalPath()),
+            'object_provides': IDossierMarker.__identifier__,
+            'sort_on': 'path',
+        }
+        all_dossiers = catalog.unrestrictedSearchResults(**query)
+
+        for brain in all_dossiers:
+            dossier = brain.getObject()
+            serialized = getMultiAdapter(
+                (dossier, getRequest()), ISerializeToJson)()
+
+            for key in self.ignored_keys:
+                serialized.pop(key, None)
+
+            serialized['@id'] = dossier.absolute_url()
+            serialized_dossiers.append(serialized)
+
+        return serialized_dossiers

--- a/opengever/dossiertransfer/api/serializers.py
+++ b/opengever/dossiertransfer/api/serializers.py
@@ -49,3 +49,18 @@ class SerializeDossierTransferToJson(object):
         result.update({'@id': url})
         result.update({'@type': self.content_type})
         return result
+
+
+class FullTransferContentSerializer(object):
+
+    def __init__(self, transfer):
+        self.transfer = transfer
+
+    def __call__(self):
+        # TODO
+        content = {
+            'dossiers': [],
+            'documents': [],
+            'contacts': [],
+        }
+        return content

--- a/opengever/dossiertransfer/model.py
+++ b/opengever/dossiertransfer/model.py
@@ -6,6 +6,7 @@ from opengever.base.model import USER_ID_LENGTH
 from opengever.base.model import UTCDateTime
 from opengever.base.types import JSONList
 from opengever.base.types import UnicodeCoercingText
+from opengever.dossiertransfer.token import InvalidToken
 from opengever.dossiertransfer.token import TokenManager
 from sqlalchemy import Boolean
 from sqlalchemy import Column
@@ -66,8 +67,12 @@ class DossierTransfer(Base):
     def issue_token(self):
         return TokenManager().issue_token(self)
 
-    def validate_token(self, token):
-        TokenManager().validate_token(self, token)
+    def is_valid_token(self, token):
+        try:
+            TokenManager().validate_token(self, token)
+            return True
+        except InvalidToken:
+            return False
 
     def attributes_hash(self):
         """Create a hash over all attributes that are relevant for security.

--- a/opengever/dossiertransfer/token.py
+++ b/opengever/dossiertransfer/token.py
@@ -18,12 +18,14 @@ class TokenManager(object):
             'attributes_hash': transfer.attributes_hash(),
         }
         token = jwt.encode(claims, self._signing_secret(), algorithm='HS256')
+        transfer.token = token
         return token
 
     def validate_token(self, transfer, token):
         claims = self._decode_token(token)
         if claims:
             if all([
+                token == transfer.token,
                 claims['iss'] == get_current_admin_unit().unit_id,
                 claims['transfer_id'] == transfer.id,
                 claims['attributes_hash'] == transfer.attributes_hash(),

--- a/opengever/testing/builders/sql.py
+++ b/opengever/testing/builders/sql.py
@@ -638,9 +638,21 @@ class DossierTransferBuilder(SqlObjectBuilder):
         if self._with_default_target:
             self._create_target_admin_unit()
 
+        if self.arguments['all_documents']:
+            self.arguments['documents'] = None
+
     def after_create(self, obj):
         TokenManager().issue_token(obj)
         return obj
+
+    def having(self, **kwargs):
+        if self.arguments['all_documents'] and self.arguments['documents']:
+            raise TypeError(
+                "A transfer with `all_documents=True` and a list of "
+                "`documents` would be ambiguous, and therefore isn't allowed"
+            )
+        super(DossierTransferBuilder, self).having(**kwargs)
+        return self
 
     def with_source(self, admin_unit):
         self.arguments['source_id'] = admin_unit.unit_id

--- a/opengever/testing/builders/sql.py
+++ b/opengever/testing/builders/sql.py
@@ -10,6 +10,7 @@ from opengever.base.systemmessages.models import SystemMessage
 from opengever.contact.ogdsuser import OgdsUserToContactAdapter
 from opengever.dossiertransfer.model import DossierTransfer
 from opengever.dossiertransfer.model import TRANSFER_STATE_PENDING
+from opengever.dossiertransfer.token import TokenManager
 from opengever.globalindex.model.reminder_settings import ReminderSetting
 from opengever.globalindex.model.task import Task
 from opengever.locking.model import Lock
@@ -636,6 +637,10 @@ class DossierTransferBuilder(SqlObjectBuilder):
     def before_create(self):
         if self._with_default_target:
             self._create_target_admin_unit()
+
+    def after_create(self, obj):
+        TokenManager().issue_token(obj)
+        return obj
 
     def with_source(self, admin_unit):
         self.arguments['source_id'] = admin_unit.unit_id


### PR DESCRIPTION
This adds a "full content serialization" mode to the `GET /@dossier-transfers/<id>` endpoint.

The `@perform-dossier-transfer` endpoint will use this (in a server-to-server request) to retrieve all the actual content data when performing a transfer.

When invoked with the `?full_content=1` query string parameter, the endpoint also adds serialization of the transfer contents to its response:

```http
GET /@dossier-transfers/42?full_content=1`
```

```json
{
  "@id": "http://localhost:8080/fd/@dossier-transfers/42",
  "@type": "virtual.ogds.dossiertransfer",
  "...": "...",
  
  "content": {
    "dossiers": ["..."],
    "documents": ["..."],
    "contacts": {"..."}
  },
}
```

In this mode,
- **Anonymous** requests are accepted, as long as the contain a **valid JWT token** that matches the respective transfer
- The JWT token is expected in a `X-GEVER-Dossier-Transfer-Token` HTTP header
- The (sub)dossiers, documents and participations/contacts will be serialized ad part of the additional `content` property
- These objects get serialized using the standard `ISerializeToJson` serializers, minus some properties that are only of value to the frontend or otherwise uninteresting  
- These objects get returned as flat lists sorted by `path` (parents before children).
- Participations on the main dossier are included in a `participations` key as part of the dossier metadata. It contains a list of `(participant_id, roles_list)` items where the `participant_id` matches the ID used as the key in the `contents.contacts` dictionary

## Examples:

Overall structure of the additional `content` key:

```json
  "content": {
    "dossiers": ["..."],
    "documents": ["..."],
    "contacts": {"..."}
  },
```

---

Example of the `participations` key on the dossier serialization:
_(not to be confused with the top-level `participations` key for the transfer, which is an optional list of selected participations)_

```json
    "participations": [
        [
            "person:39c2789d-a123-44ba-a3b1-4323d6e941c6",
            ["final-drawing", "regard"]
        ]
    ],
```

The participant_id (`person:...`) used in these participations is guaranteed to match the key used in the `contacts` dictionary.

---

<details>

<summary>Example dossier serialization (click to expand)</summary>

```json
{
    "@id": "http://localhost:8080/fd/ordnungssystem/fuehrung/gemeinderecht/dossier-20",
    "@type": "opengever.dossier.businesscasedossier",
    "UID": "1b6d8dbf1f954bbb9510a1b65d51ede5",
    "allow_discussion": false,
    "archival_value": {
        "title": "Nicht geprüft",
        "token": "unchecked"
    },
    "archival_value_annotation": null,
    "back_references_relatedDossier": [],
    "blocked_local_roles": false,
    "changed": "2024-04-05T06:08:41+00:00",
    "checklist": null,
    "classification": {
        "title": "Nicht klassifiziert",
        "token": "unprotected"
    },
    "container_location": null,
    "container_type": null,
    "created": "2024-03-21T10:51:21+00:00",
    "custody_period": {
        "title": "30",
        "token": "30"
    },
    "custom_properties": null,
    "date_of_cassation": null,
    "date_of_submission": null,
    "description": "Beschreibung des Dossiers",
    "dossier_manager": null,
    "dossier_type": null,
    "email": "1569106123@localhost",
    "end": null,
    "external_reference": null,
    "filing_prefix": null,
    "former_reference_number": null,
    "has_pending_jobs": false,
    "id": "dossier-20",
    "is_folderish": true,
    "is_protected": false,
    "is_subdossier": false,
    "keywords": [],
    "layout": "tabbed_view",
    "modified": "2024-04-05T06:08:41+00:00",
    "number_of_containers": null,
    "oguid": "fd:1569106123",
    "parent": {
        "@id": "http://localhost:8080/fd/ordnungssystem/fuehrung/gemeinderecht",
        "@type": "opengever.repository.repositoryfolder",
        "UID": "e96a0525613f473a8c035cf1945b2561",
        "description": "",
        "is_leafnode": true,
        "review_state": "repositoryfolder-state-active",
        "title": "0.0. Gemeinderecht"
    },
    "participations": [
        [
            "person:39c2789d-a123-44ba-a3b1-4323d6e941c6",
            ["final-drawing", "regard"]
        ]
    ],
    "privacy_layer": {
        "title": "Nein",
        "token": "privacy_layer_no"
    },
    "public_trial": {
        "title": "Nicht geprüft",
        "token": "unchecked"
    },
    "public_trial_statement": "",
    "reading": [],
    "reading_and_writing": [],
    "reference_number": "FD 0.0 / 6",
    "relatedDossier": [],
    "relative_path": "ordnungssystem/fuehrung/gemeinderecht/dossier-20",
    "responses": [],
    "responsible": {
        "title": "Boss Hugo (hugo.boss)",
        "token": "hugo.boss"
    },
    "responsible_actor": {
        "@id": "http://localhost:8080/fd/@actors/hugo.boss",
        "identifier": "hugo.boss"
    },
    "responsible_fullname": "Boss Hugo",
    "retention_period": {
        "title": "5",
        "token": "5"
    },
    "retention_period_annotation": null,
    "review_state": "dossier-state-active",
    "sequence_number": 20,
    "start": "2024-03-21",
    "temporary_former_reference_number": null,
    "title": "Dossier zum Übertragen",
    "touched": "2024-04-05",
    "version": "current"
}
```

</details>



<details>

<summary>Example document serialization (click to expand)</summary>

```json
{
    "@id": "http://localhost:8080/fd/ordnungssystem/fuehrung/gemeinderecht/dossier-20/dossier-21/document-44",
    "@type": "opengever.document.document",
    "UID": "a663689540a34538b6f408d4b41baee8",
    "allow_discussion": false,
    "archival_file": null,
    "archival_file_state": null,
    "back_references_relatedItems": [],
    "changeNote": "",
    "changed": "2024-03-21T10:51:46+00:00",
    "checked_out": null,
    "checked_out_fullname": null,
    "checkout_collaborators": [],
    "classification": {
        "title": "Nicht klassifiziert",
        "token": "unprotected"
    },
    "containing_dossier": "Dossier zum Übertragen",
    "containing_subdossier": "Subdossier zum Übertragen",
    "containing_subdossier_url": "http://localhost:8080/fd/ordnungssystem/fuehrung/gemeinderecht/dossier-20/dossier-21",
    "created": "2024-03-21T10:51:46+00:00",
    "creator": {
        "@id": "http://localhost:8080/fd/@actors/zopemaster",
        "identifier": "zopemaster"
    },
    "current_version_id": 0,
    "custom_properties": null,
    "delivery_date": null,
    "description": "",
    "digitally_available": true,
    "document_author": null,
    "document_date": "2014-07-21",
    "document_type": null,
    "file": {
        "content-type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
        "download": "http://localhost:8080/fd/ordnungssystem/fuehrung/gemeinderecht/dossier-20/dossier-21/document-44/@@download/file",
        "filename": "Beilage.docx",
        "size": 123076
    },
    "file_extension": ".docx",
    "file_mtime": 1711018306.825305,
    "foreign_reference": null,
    "getObjPositionInParent": 0,
    "gever_url": "",
    "id": "document-44",
    "is_collaborative_checkout": false,
    "is_folderish": false,
    "is_locked": false,
    "is_shadow_document": false,
    "keywords": [],
    "layout": "tabbed_view",
    "meeting": null,
    "modified": "2024-03-21T10:51:46+00:00",
    "next_item": {},
    "oguid": "fd:1569106125",
    "parent": {
        "@id": "http://localhost:8080/fd/ordnungssystem/fuehrung/gemeinderecht/dossier-20/dossier-21",
        "@type": "opengever.dossier.businesscasedossier",
        "UID": "f510a6bb410f40258b53090bf2f0c545",
        "description": "Subdossier-Beschreibung",
        "dossier_type": null,
        "is_leafnode": null,
        "is_subdossier": true,
        "review_state": "dossier-state-active",
        "title": "Subdossier zum Übertragen"
    },
    "preserved_as_paper": true,
    "preview": null,
    "previous_item": {},
    "privacy_layer": {
        "title": "Nein",
        "token": "privacy_layer_no"
    },
    "proposal": null,
    "public_trial": {
        "title": "Nicht geprüft",
        "token": "unchecked"
    },
    "public_trial_statement": "",
    "receipt_date": null,
    "reference_number": "FD 0.0 / 6.1 / 44",
    "relatedItems": [],
    "relative_path": "ordnungssystem/fuehrung/gemeinderecht/dossier-20/dossier-21/document-44",
    "review_state": "document-state-draft",
    "sequence_number": 44,
    "submitted_proposal": null,
    "submitted_with": [],
    "teamraum_connect_links": {
        "gever_document": null,
        "workspace_documents": []
    },
    "thumbnail": null,
    "title": "Beilage",
    "trashed": false,
    "version": "current",
    "workspace_document_urls": []
}
```

</details>



<details>

<summary>Example contact serialization (click to expand)</summary>

```json
"contacts": {
    "person:39c2789d-a123-44ba-a3b1-4323d6e941c6": {
        "additional_ui_attributes": [],
        "addresses": [
            {
                "addressLine1": "",
                "addressLine2": "",
                "countryIdISO2": "CH",
                "countryName": "Schweiz",
                "created": "2024-04-04T08:41:36.213757+02:00",
                "dwellingNumber": "",
                "foreignZipCode": "",
                "formattedAddress": "Dammweg 9, 3013 Bern",
                "houseNumber": "",
                "id": "d8f095cc-9f95-418b-b5e9-e982a4ee44b9",
                "isDefault": false,
                "label": "",
                "locality": "",
                "modified": "2024-04-04T08:41:36.213785+02:00",
                "organisationName": "",
                "organisationNameAddOn1": "",
                "organisationNameAddOn2": "",
                "postOfficeBox": "",
                "street": "Dammweg 9",
                "swissZipCode": "3013",
                "swissZipCodeAddOn": "",
                "swissZipCodeId": "",
                "thirdPartyId": null,
                "town": "Bern"
            }
        ],
        "avatar": null,
        "avatarThumbnails": null,
        "country": "",
        "countryIdISO2": "",
        "created": "2024-04-04T08:41:36.189649+02:00",
        "customValues": {
            "1": "Test Char Value",
            "11": "Test Default Char Value",
            "12": [
                "X",
                "Y",
                "Z"
            ],
            "2": "Test Text Value",
            "3": "2022-04-20",
            "4": 420,
            "5": true,
            "6": [
                "A",
                "B",
                "C"
            ],
            "7": 3
        },
        "dateOfBirth": null,
        "dateOfDeath": null,
        "description": "",
        "emailAddresses": [
            {
                "created": "2024-04-04T08:41:36.218299+02:00",
                "email": "foo@example.com",
                "id": "55f21bf3-803a-489c-8eb7-40404380fc22",
                "isDefault": false,
                "label": "wichtig",
                "modified": "2024-04-04T08:41:36.218315+02:00",
                "thirdPartyId": null
            }
        ],
        "firstName": "kevin",
        "fullName": "bier kevin",
        "htmlUrl": "http://127.0.0.1:8000/people/39c2789d-a123-44ba-a3b1-4323d6e941c6",
        "id": "39c2789d-a123-44ba-a3b1-4323d6e941c6",
        "languageOfCorrespondance": null,
        "memberships": [
            {
                "department": "",
                "description": "",
                "emailReceptionType": "to",
                "end": null,
                "id": "714fbad0-f296-45aa-95e2-f0666d1a2806",
                "isDefault": true,
                "organization": {
                    "created": "2024-04-04T08:41:36.321615+02:00",
                    "description": "",
                    "id": "459f32bf-3b36-4ea9-9331-eeb04ffca581",
                    "memberCount": 1,
                    "modified": "2024-04-04T08:41:36.321622+02:00",
                    "name": "Four",
                    "status": 1,
                    "thirdPartyId": null
                },
                "primaryAddress": null,
                "primaryEmail": null,
                "primaryPhoneNumber": null,
                "primaryUrl": null,
                "role": "",
                "start": null,
                "thirdPartyId": null
            }
        ],
        "modified": "2024-04-04T08:41:36.189657+02:00",
        "officialName": "bier",
        "organizations": [
            {
                "created": "2024-04-04T08:41:36.321615+02:00",
                "description": "",
                "id": "459f32bf-3b36-4ea9-9331-eeb04ffca581",
                "memberCount": 1,
                "modified": "2024-04-04T08:41:36.321622+02:00",
                "name": "Four",
                "status": 1,
                "thirdPartyId": null
            }
        ],
        "personType": 42,
        "personTypeTitle": "Geschäftsleiter",
        "phoneNumbers": [
            {
                "created": "2024-04-04T08:41:36.221098+02:00",
                "id": "3fbc51f5-61bb-4cae-9a31-814aa7adbdf0",
                "isDefault": false,
                "label": "sonstwas",
                "modified": "2024-04-04T08:41:36.221108+02:00",
                "otherPhoneCategory": null,
                "phoneCategory": 1,
                "phoneCategoryText": "Private Telefonnummer",
                "phoneNumber": "12 34 5678",
                "thirdPartyId": null
            }
        ],
        "primaryAddress": null,
        "primaryEmail": null,
        "primaryPhoneNumber": null,
        "primaryUrl": null,
        "readableAge": null,
        "salutation": "",
        "sex": null,
        "status": 1,
        "tags": [
            "ninja"
        ],
        "text": "bier kevin",
        "thirdPartyId": null,
        "title": "",
        "type": "person",
        "typedId": "person:39c2789d-a123-44ba-a3b1-4323d6e941c6",
        "url": "http://127.0.0.1:8000/api/v2/people/39c2789d-a123-44ba-a3b1-4323d6e941c6",
        "urls": [
            {
                "created": "2024-04-04T08:41:36.223657+02:00",
                "id": "d82d4d23-c1c1-4fa3-b4c2-fbeb114cedaf",
                "isDefault": false,
                "label": "",
                "modified": "2024-04-04T08:41:36.223667+02:00",
                "thirdPartyId": null,
                "url": "http://foo.example.com"
            }
        ],
        "username": null
    }
}
```

</details>


For [CA-6591](https://4teamwork.atlassian.net/browse/CA-6591)

---

## Note

I quickly tested whether these types of serialized represenations can be used to deserialize objects using the 
`IDeserializeFromJson` deserializers. And it seems to work. Slapping together a class based on the code in [opengever/api/add.py](https://github.com/4teamwork/opengever.core/blob/master/opengever/api/add.py#L36-L224) I was able to use the serialized JSON output for dossiers and documents to recreate the respective objects, and at least _some_ of the fields were correctly set. Might need quite some tweaking, but in principle the approach seems to work. 

---

For [CA-6591](https://4teamwork.atlassian.net/browse/CA-6591)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry
- New functionality:
  - [x] for `document` also works for `mail`


[CA-6591]: https://4teamwork.atlassian.net/browse/CA-6591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ