### PR TITLE
Use OpenLDAPLegacy profile as default for ogds-sync

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,7 +102,7 @@ services:
       - 8099:8080
     environment:
       - OGDS_DSN=postgresql://${OGDS_DB_USER:-ogds}:${OGDS_DB_PASSWORD:-secret}@${OGDS_DB_HOST:-ogds}/${OGDS_DB_NAME:-ogds}
-      - LDAP_PROFILE=${LDAP_PROFILE:-OpenLDAP}
+      - LDAP_PROFILE=${LDAP_PROFILE:-OpenLDAPLegacy}
       - LDAP_URL=${LDAP_SERVER_URI:-ldap://ldap:1389}
       - LDAP_BIND_DN=${LDAP_BIND_DN:-cn=admin,dc=dev,dc=onegovgever,dc=ch}
       - LDAP_BIND_PASSWORD=${LDAP_BIND_PASSWORD:-secret}


### PR DESCRIPTION
In ogds-sync 2024.2.0 the OpenLDAP profile was renamed and a new profile was added for new style mapping.
It's now easy to switch between legacy and new style mapping by removing or adding the Legacy suffix.


## Checklist

- [ ] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)
