### PR TITLE
Disallow download in restricted workspaces for guests

### DIFF
--- a/changes/CA-6417a.other
+++ b/changes/CA-6417a.other
@@ -1,0 +1,1 @@
+Disallow file download for guests in restricted workspaces. [buchi]

--- a/changes/CA-6417b.other
+++ b/changes/CA-6417b.other
@@ -1,0 +1,1 @@
+Do not render error page for BadRequest and Forbidden errors. [buchi]

--- a/changes/CA-6417c.other
+++ b/changes/CA-6417c.other
@@ -1,0 +1,1 @@
+Disallow zip export for guests in restricted workspaces. [buchi]

--- a/opengever/base/browser/configure.zcml
+++ b/opengever/base/browser/configure.zcml
@@ -272,6 +272,14 @@
 
   <browser:page
       for="*"
+      name="zip_export"
+      class=".zipexport.GEVERZipExportView"
+      permission="zope2.View"
+      layer="opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
+  <browser:page
+      for="*"
       name="zip_selected"
       class=".zipexport.GEVERZipSelectedExportView"
       permission="zope2.View"

--- a/opengever/base/browser/errors.py
+++ b/opengever/base/browser/errors.py
@@ -5,6 +5,8 @@ from opengever.debug import write_on_read_tracing
 from opengever.debug.write_on_read_tracing import format_instruction
 from Products.Five.browser import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from zExceptions import BadRequest
+from zExceptions import Forbidden
 from zExceptions import NotFound
 from ZODB import POSException
 from zope.component import adapts
@@ -22,6 +24,13 @@ class ErrorHandlingView(BrowserView):
     template = ViewPageTemplateFile('templates/error.pt')
 
     def __call__(self):
+
+        if isinstance(self.context, Forbidden):
+            return self.context.message or 'Forbidden'
+
+        if isinstance(self.context, BadRequest):
+            return self.context.message or 'Bad Request'
+
         self.plone = getSite()
 
         if self.plone:

--- a/opengever/base/browser/zipexport.py
+++ b/opengever/base/browser/zipexport.py
@@ -1,10 +1,25 @@
+from ftw.zipexport.browser.zipexportview import ZipExportView
 from ftw.zipexport.browser.zipexportview import ZipSelectedExportView
 from opengever.base.utils import rewrite_path_list_to_absolute_paths
+from opengever.workspace.utils import is_restricted_workspace_and_guest
+from zExceptions import Forbidden
+
+
+class GEVERZipExportView(ZipExportView):
+
+    def __call__(self):
+        if is_restricted_workspace_and_guest(self.context):
+            raise Forbidden()
+
+        return super(GEVERZipExportView, self).__call__()
 
 
 class GEVERZipSelectedExportView(ZipSelectedExportView):
 
     def __call__(self):
+        if is_restricted_workspace_and_guest(self.context):
+            raise Forbidden()
+
         # XXX: Also make pseudo-relative paths work
         # (as sent by the new gever-ui)
         rewrite_path_list_to_absolute_paths(self.request)

--- a/opengever/document/browser/download.py
+++ b/opengever/document/browser/download.py
@@ -8,6 +8,7 @@ from opengever.document.events import FileCopyDownloadedEvent
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.mail.mail import IOGMailMarker
 from opengever.virusscan.validator import validateDownloadIfNecessary
+from opengever.workspace.utils import is_restricted_workspace_and_guest
 from plone import api
 from plone.memoize import ram
 from plone.memoize.interfaces import ICacheChooser
@@ -18,6 +19,7 @@ from Products.CMFCore.utils import getToolByName
 from Products.Five import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zExceptions import BadRequest
+from zExceptions import Forbidden
 from zope.component import queryMultiAdapter
 from zope.component import queryUtility
 from zope.component.hooks import getSite
@@ -42,6 +44,9 @@ class DocumentishDownload(Download):
     """
 
     def __call__(self):
+        if is_restricted_workspace_and_guest(self.context):
+            raise Forbidden()
+
         if self.is_checked_out_by_another_user():
             current_version_id = self.context.get_current_version_id()
             if current_version_id is None:
@@ -201,6 +206,9 @@ class DocumentDownloadFileVersion(DownloadFileVersion):
     """
 
     def __call__(self):
+        if is_restricted_workspace_and_guest(self.context):
+            raise Forbidden()
+
         DownloadConfirmationHelper(self.context).process_request_form()
 
         self._init_version_file()


### PR DESCRIPTION
Hiding download actions is not sufficient, as documents still can be downloaded by URL-guessing.
Protects download and zip export.

I've also disabled rendering of the error page for `BadRequest` and `Forbidden` errors.
The error page makes look these errors like server-side errors. Further it's quite expensive to render and doesn't provide any useful information for these type of errors. A plain text error message is now displayed instead.

For [CA-6417](https://4teamwork.atlassian.net/browse/CA-6417)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[CA-6417]: https://4teamwork.atlassian.net/browse/CA-6417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ