### PR TITLE
Fix OGDS listing date filters to also work on Oracle:

### DIFF
--- a/changes/CA-6163.bugfix
+++ b/changes/CA-6163.bugfix
@@ -1,0 +1,1 @@
+Fix OGDS listing date filters to also work on Oracle. [lgraf]


### PR DESCRIPTION
We used to pass an ISO formatted date string to SQLAlchemy when constructing the BETWEEN clause. Apparently this datetime string format is not appropriate for Oracle, and it complains with


```
ORA-01861: literal does not match format string
```

Parsing the date strings submitted by the frontend into Python dates and passing those instead lets SQLAlchemy format them correctly for Oracle.



For [CA-6163](https://4teamwork.atlassian.net/browse/CA-6163)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)



[CA-6163]: https://4teamwork.atlassian.net/browse/CA-6163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ