### PR TITLE
Fix path of python interpreter

### DIFF
--- a/docker/testserver/bin/testserver
+++ b/docker/testserver/bin/testserver
@@ -1,4 +1,4 @@
-#!/app/bin/python
+#!/usr/local/bin/python
 
 import sys
 sys.argv.insert(1, 'opengever.core.testserver.OPENGEVER_TESTSERVER')

--- a/docker/testserver/docker-entrypoint.sh
+++ b/docker/testserver/docker-entrypoint.sh
@@ -9,4 +9,4 @@ export ZSERVER_PORT="55001"
 export LISTENER_HOST="0.0.0.0"
 export LISTENER_PORT="55002"
 
-exec "/app/bin/python" "/app/bin/testserver" "-vv"
+exec "/app/bin/testserver" "-vv"


### PR DESCRIPTION
This changed when upgraded base image to Alpine 3.18.


## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)
