### PR TITLE
Use explicit python2.7 for testserverctl script

### DIFF
--- a/bin/testserverctl
+++ b/bin/testserverctl
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 import argparse
 import os


### PR DESCRIPTION
Make the `testserverctl` script more failsafe by explicitly use a `python2.7` executable. 

This fixes an issue where running e2e tests will fail with:

```
Traceback (most recent call last):
  File "/home/esc/projects/opengever.core/bin/testserverctl", line 5, in <module>
    import xmlrpclib
ModuleNotFoundError: No module named 'xmlrpclib'
```

`xmlrpclib` is not included in `python3`. When running the `testserverctl` script with an environment where `python` points to a `python3` it will fail. By explicitly using a `python2.7` it makes it possible to go with a `python3` as the default.