### PR TITLE
Fix lookup of user in WOPI operations

### DIFF
--- a/changes/CA-6237.bugfix
+++ b/changes/CA-6237.bugfix
@@ -1,0 +1,1 @@
+Fix lookup of user in WOPI operations if username and userid are not equal. [buchi]

--- a/opengever/wopi/browser/wopi.py
+++ b/opengever/wopi/browser/wopi.py
@@ -18,6 +18,7 @@ from plone.namedfile.file import NamedBlobFile
 from plone.namedfile.utils import set_headers
 from plone.namedfile.utils import stream_data
 from plone.protect.interfaces import IDisableCSRFProtection
+from Products.CMFCore.utils import getToolByName
 from Products.Five.browser import BrowserView
 from zExceptions import BadRequest
 from zExceptions import NotFound as zNotFound
@@ -119,7 +120,9 @@ class WOPIView(BrowserView):
             return
 
         method = getattr(self, operation)
-        with api.env.adopt_user(username=userid):
+        acl_users = getToolByName(self.context, 'acl_users')
+        user = acl_users.getUserById(userid)
+        with api.env.adopt_user(user=user):
             return method()
 
     def render_json(self, data):

--- a/opengever/wopi/tests/test_edit.py
+++ b/opengever/wopi/tests/test_edit.py
@@ -15,7 +15,6 @@ from zope.component import getMultiAdapter
 class TestEditView(IntegrationTestCase):
 
     @browsing
-    @skip('WOPI token is using userid, but adopt_user in wopi.py requires username')
     def test_edit_view_returns_form_with_action_and_valid_token(self, browser):
         self.login(self.regular_user, browser=browser)
         browser.open(self.document, view="office_online_edit")
@@ -33,7 +32,7 @@ class TestEditView(IntegrationTestCase):
             validate_access_token(
                 urlsafe_b64decode(access_token),
                 'createtreatydossiers000000000002'),
-            'kathi.barfuss')
+            'regular_user')
 
     @browsing
     def test_UI_language_is_prefered_language(self, browser):

--- a/opengever/wopi/tests/test_validation.py
+++ b/opengever/wopi/tests/test_validation.py
@@ -64,9 +64,12 @@ class TestWOPIValidation(FunctionalTestCase):
         access_token = urlsafe_b64encode(
             create_access_token(TEST_USER_ID, uuid))
 
-        url = '%s/wopi/files/%s' % (
-            portal.absolute_url().replace('0.0.0.0', 'host.docker.internal'),
-            uuid)
+        portal_url = portal.absolute_url()
+        if ZSERVER_HOST == '0.0.0.0':
+            portal_url = portal_url.replace('0.0.0.0', 'host.docker.internal').replace(
+                'localhost', 'host.docker.internal')
+
+        url = '%s/wopi/files/%s' % (portal_url, uuid)
         cmd = [
             'docker',
             'run',

--- a/opengever/wopi/tests/test_validation.py
+++ b/opengever/wopi/tests/test_validation.py
@@ -62,7 +62,7 @@ class TestWOPIValidation(FunctionalTestCase):
 
         uuid = IUUID(document)
         access_token = urlsafe_b64encode(
-            create_access_token(TEST_USER_NAME, uuid))
+            create_access_token(TEST_USER_ID, uuid))
 
         url = '%s/wopi/files/%s' % (
             portal.absolute_url().replace('0.0.0.0', 'host.docker.internal'),

--- a/opengever/wopi/tests/test_wopi.py
+++ b/opengever/wopi/tests/test_wopi.py
@@ -60,7 +60,6 @@ class TestWOPIView(IntegrationTestCase):
         browser.open(url, headers=self.wopi_headers(access_token, url))
         return browser.json
 
-    @skip('WOPI token is using userid, but adopt_user in wopi.py requires username')
     def test_check_file_info_contains_sha256_checksum(self):
         self.assertIn(u'SHA256', self.check_file_info())
         self.assertEqual(
@@ -68,7 +67,6 @@ class TestWOPIView(IntegrationTestCase):
             u'UdYxdJTszEpzFUYlpoIMtrUNwUVetM8mOZKZ1PnOd7I=',
         )
 
-    @skip('WOPI token is using userid, but adopt_user in wopi.py requires username')
     def test_check_file_info_contains_license_check_flag_if_business_user(self):
         self.assertIn(u'LicenseCheckForEditIsEnabled', self.check_file_info())
         self.assertEqual(
@@ -76,12 +74,10 @@ class TestWOPIView(IntegrationTestCase):
             True,
         )
 
-    @skip('WOPI token is using userid, but adopt_user in wopi.py requires username')
     def test_check_file_info_has_no_license_check_flag_if_not_business_user(self):
         api.portal.set_registry_record(name='business_user', interface=IWOPISettings, value=False)
         self.assertNotIn(u'LicenseCheckForEditIsEnabled', self.check_file_info())
 
-    @skip('WOPI token is using userid, but adopt_user in wopi.py requires username')
     def test_check_file_info_contains_host_edit_url(self):
         self.assertIn(u'HostEditUrl', self.check_file_info())
         self.assertEqual(
@@ -89,12 +85,10 @@ class TestWOPIView(IntegrationTestCase):
             u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-14/office_online_edit',
         )
 
-    @skip('WOPI token is using userid, but adopt_user in wopi.py requires username')
     def test_breadcrumbBrandName_is_portal_title(self):
         self.assertIn(u'BreadcrumbBrandName', self.check_file_info())
         self.assertEqual('Plone site', self.check_file_info()[u'BreadcrumbBrandName'])
 
-    @skip('WOPI token is using userid, but adopt_user in wopi.py requires username')
     def test_owner_id_falls_back_to_owner_if_creator_is_missing(self):
         with self.login(self.regular_user):
             self.document.setCreators('')


### PR DESCRIPTION
Fixes Office Online support with setups where userid and username are not equal.

For [CA-6237](https://4teamwork.atlassian.net/browse/CA-6237)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)



[CA-6237]: https://4teamwork.atlassian.net/browse/CA-6237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ