### PR TITLE
Restricted workspaces

### DIFF
--- a/changes/CA-6417.other
+++ b/changes/CA-6417.other
@@ -1,1 +1,1 @@
-Hide "share content" and "zipexport" actions for guest access on restricted workspaces [KunzS85]
+Disallow all download and share related actions for guests in restricted workspaces. [elioschmutz]

--- a/changes/CA-6417a.other
+++ b/changes/CA-6417a.other
@@ -1,1 +1,0 @@
-Disallow file download for guests in restricted workspaces. [buchi]

--- a/changes/CA-6417c.other
+++ b/changes/CA-6417c.other
@@ -1,1 +1,0 @@
-Disallow zip export for guests in restricted workspaces. [buchi]

--- a/opengever/api/copy_.py
+++ b/opengever/api/copy_.py
@@ -8,10 +8,12 @@ from opengever.document.behaviors import IBaseDocument
 from opengever.document.handlers import _update_docproperties
 from opengever.document.handlers import DISABLE_DOCPROPERTY_UPDATE_FLAG
 from opengever.locking.lock import MEETING_EXCERPT_LOCK
+from opengever.workspace.utils import is_restricted_workspace_and_guest
 from plone import api
 from plone.locking.interfaces import ILockable
 from plone.restapi.deserializer import json_body
 from plone.restapi.services.copymove.copymove import Copy
+from zExceptions import Forbidden
 from zope.container.interfaces import INameChooser
 from zope.i18n import translate
 import six
@@ -54,6 +56,9 @@ class Copy(Copy):
                 raise NotReportedForbidden(
                     _('copy_object_disallowed',
                       default=u'You are not allowed to copy this object'))
+
+            if is_restricted_workspace_and_guest(obj):
+                raise Forbidden()
 
     def get_object(self, key):
         """Copied from the baseclass but uses utils get_obj_by_path

--- a/opengever/api/save_document_as_pdf.py
+++ b/opengever/api/save_document_as_pdf.py
@@ -3,11 +3,13 @@ from opengever.document.browser.save_pdf_document_under import trigger_conversio
 from opengever.document.forms import create_destination_document
 from opengever.document.forms import is_version_convertable
 from opengever.document.versioner import Versioner
+from opengever.workspace.utils import is_restricted_workspace_and_guest
 from plone import api
 from plone.protect.interfaces import IDisableCSRFProtection
 from plone.restapi.deserializer import json_body
 from plone.restapi.services import Service
 from zExceptions import BadRequest
+from zExceptions import Forbidden
 from zope.interface import alsoProvides
 
 
@@ -31,6 +33,9 @@ class SaveDocumentAsPdfPost(Service):
         if not document:
             raise BadRequest(
                 "Property 'document_uid' is required and should be a UID of a document")
+
+        if is_restricted_workspace_and_guest(document):
+            raise Forbidden()
 
         version_id = data.get('version_id', None)
         if version_id and not isinstance(version_id, int):

--- a/opengever/bumblebee/browser/open_pdf.py
+++ b/opengever/bumblebee/browser/open_pdf.py
@@ -2,7 +2,9 @@ from ftw import bumblebee
 from ftw.bumblebee.mimetypes import is_mimetype_supported
 from opengever.bumblebee import is_bumblebee_feature_enabled
 from opengever.bumblebee.events import PDFDownloadedEvent
+from opengever.workspace.utils import is_restricted_workspace_and_guest
 from Products.Five import BrowserView
+from zExceptions import Forbidden
 from zExceptions import NotFound
 from zope.event import notify
 
@@ -13,6 +15,9 @@ class OpenMailPDFView(BrowserView):
     def __call__(self):
         if not is_bumblebee_feature_enabled():
             raise NotFound
+
+        if is_restricted_workspace_and_guest(self.context):
+            raise Forbidden()
 
         filename = self.request.get('filename')
         if not filename:

--- a/opengever/document/actions.py
+++ b/opengever/document/actions.py
@@ -176,6 +176,8 @@ class BaseDocumentContextActions(BaseContextActions):
             return False
         if self.context.is_checked_out():
             return False
+        if is_restricted_workspace_and_guest(self.context):
+            return False
         return api.user.has_permission('Copy or Move', obj=self.context)
 
     def is_create_forwarding_available(self):
@@ -214,6 +216,8 @@ class BaseDocumentContextActions(BaseContextActions):
         if self.context.is_checked_out():
             return False
         if not api.user.has_permission('Copy or Move', obj=self.context):
+            return False
+        if is_restricted_workspace_and_guest(self.context):
             return False
         return self.context.is_movable()
 

--- a/opengever/document/tests/test_actions.py
+++ b/opengever/document/tests/test_actions.py
@@ -288,5 +288,5 @@ class TestDocumentContextActions(IntegrationTestCase):
         document = create(Builder('document')
                           .within(self.workspace))
 
-        expected_actions_restricted_guest = [u'copy_item', u'move_item', u'revive_bumblebee_preview']
+        expected_actions_restricted_guest = [u'revive_bumblebee_preview']
         self.assertEqual(expected_actions_restricted_guest, self.get_actions(document))

--- a/opengever/mail/browser/attachment.py
+++ b/opengever/mail/browser/attachment.py
@@ -1,11 +1,17 @@
 from ftw.mail.attachment import AttachmentView as FtwAtachmentView
 from opengever.base.behaviors.utils import set_attachment_content_disposition
+from opengever.workspace.utils import is_restricted_workspace_and_guest
 from plone import api
+from zExceptions import Forbidden
 
 
 class AttachmentView(FtwAtachmentView):
     """Returns the attachment at the position specified in the request.
     """
+    def render(self):
+        if is_restricted_workspace_and_guest(self.context):
+            raise Forbidden()
+        return super(AttachmentView, self).render()
 
     def set_content_type(self, content_type, filename):
         if content_type == 'application/octet-stream':

--- a/opengever/mail/tests/test_actions.py
+++ b/opengever/mail/tests/test_actions.py
@@ -105,5 +105,5 @@ class TestMailContextActions(IntegrationTestCase):
         mail = create(Builder('document')
                       .within(self.workspace))
 
-        expected_actions_restricted_guest = [u'copy_item', u'move_item', u'revive_bumblebee_preview']
+        expected_actions_restricted_guest = [u'revive_bumblebee_preview']
         self.assertEqual(expected_actions_restricted_guest, self.get_actions(mail))

--- a/opengever/officeconnector/service.py
+++ b/opengever/officeconnector/service.py
@@ -9,6 +9,7 @@ from opengever.officeconnector.helpers import is_officeconnector_checkout_featur
 from opengever.officeconnector.helpers import parse_document_uids
 from opengever.oneoffixx import is_oneoffixx_feature_enabled
 from opengever.workspace import is_workspace_feature_enabled
+from opengever.workspace.utils import is_restricted_workspace_and_guest
 from plone import api
 from plone.protect import createToken
 from plone.rest import Service
@@ -64,12 +65,14 @@ class OfficeConnectorAttachURL(OfficeConnectorURL):
     """
 
     def render(self):
-        if is_officeconnector_attach_feature_enabled():
-            payload = {'action': 'attach'}
-            return self.create_officeconnector_url_json(payload)
+        if not is_officeconnector_attach_feature_enabled():
+            raise NotFound
 
-        # Fail per default
-        raise NotFound
+        if is_restricted_workspace_and_guest(self.context):
+            raise Forbidden()
+
+        payload = {'action': 'attach'}
+        return self.create_officeconnector_url_json(payload)
 
 
 class OfficeConnectorCheckoutURL(OfficeConnectorURL):


### PR DESCRIPTION
This is a follow-up PR for #7909 

The PR disables some more ui-actions and protects endpoints for guests within a restricted workspace.

For [TI-16]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- New functionality:
  - [x] for `document` also works for `mail`
  - [x] for `task` also works for `forwarding`


[TI-16]: https://4teamwork.atlassian.net/browse/TI-16?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ