### PR TITLE
Remove save document as pdf action for guests in restricted workspaces

### DIFF
--- a/opengever/document/actions.py
+++ b/opengever/document/actions.py
@@ -291,5 +291,9 @@ class DocumentSchemaContextActions(BaseDocumentContextActions):
     def is_save_document_as_pdf_available(self):
         if self.is_trashed:
             return False
+
+        if is_restricted_workspace_and_guest(self.context):
+            return False
+
         is_convertable = IBumblebeeServiceV3(self.request).is_convertable(self.context)
         return not self.context.is_checked_out() and is_convertable

--- a/opengever/document/tests/test_actions.py
+++ b/opengever/document/tests/test_actions.py
@@ -289,5 +289,5 @@ class TestDocumentContextActions(IntegrationTestCase):
                           .within(self.workspace)
                           .with_dummy_content())
 
-        expected_actions_restricted_guest = [u'revive_bumblebee_preview', 'save_document_as_pdf']
+        expected_actions_restricted_guest = [u'revive_bumblebee_preview']
         self.assertEqual(expected_actions_restricted_guest, self.get_actions(document))

--- a/opengever/document/tests/test_actions.py
+++ b/opengever/document/tests/test_actions.py
@@ -286,7 +286,8 @@ class TestDocumentContextActions(IntegrationTestCase):
 
         self.login(self.workspace_guest)
         document = create(Builder('document')
-                          .within(self.workspace))
+                          .within(self.workspace)
+                          .with_dummy_content())
 
-        expected_actions_restricted_guest = [u'revive_bumblebee_preview']
+        expected_actions_restricted_guest = [u'revive_bumblebee_preview', 'save_document_as_pdf']
         self.assertEqual(expected_actions_restricted_guest, self.get_actions(document))


### PR DESCRIPTION
This PR removes the `Download as pdf` action for guests within a restricted workspace.

This is a follow-up PR for #7931 

We had tests for this case, but unfortunately, the tested document was nod a bumblebeeable document, thus the action was disabled by default in the tests. I split up this PR into two commits to make it clear what happens.

For [CA-6417]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
