### PR TITLE
Allow Manager to list or fetch any dossier transfer.

### DIFF
--- a/changes/TI-5a.other
+++ b/changes/TI-5a.other
@@ -1,0 +1,1 @@
+Allow Manager to list or fetch any dossier transfer. [lgraf]

--- a/opengever/dossiertransfer/api/base.py
+++ b/opengever/dossiertransfer/api/base.py
@@ -114,7 +114,12 @@ class DossierTransferLocator(DossierTransfersBase):
         return query.all()
 
     def extend_with_security_filters(self, query):
-        user_id = api.user.get_current().getId()
+        current_user = api.user.get_current()
+        if current_user.has_role('Manager'):
+            # Managers may always list or fetch any transfer
+            return query
+
+        user_id = current_user.getId()
         local_unit_id = get_current_admin_unit().unit_id
 
         # Nobody may see transfers where the current admin unit is not involved

--- a/opengever/dossiertransfer/tests/test_api_get.py
+++ b/opengever/dossiertransfer/tests/test_api_get.py
@@ -398,3 +398,20 @@ class TestDossierTransfersGetPermissions(IntegrationTestCase):
             results[user_id] = items
 
         self.assertEqual(expected, results)
+
+    @browsing
+    def test_listing_permissions_for_manager(self, browser):
+        self.create_transfers()
+
+        expected = [
+            (1, u'Transfer owned by secretariat_user'),
+            (2, u'Transfer owned by dossier_responsible'),
+            (3, u'Transfer between other admin units'),
+        ]
+
+        self.login(self.manager, browser=browser)
+        browser.open(self.portal, view='@dossier-transfers/',
+                     method='GET', headers=self.api_headers)
+
+        items = [(tf['id'], tf['title']) for tf in browser.json['items']]
+        self.assertEqual(expected, items)


### PR DESCRIPTION
Allow Manager to list or fetch any dossier transfer.

This is to ease development as well as debugging / support later in production.

For [TI-5](https://4teamwork.atlassian.net/browse/TI-5)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-5]: https://4teamwork.atlassian.net/browse/TI-5?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ