### PR TITLE
Dossier transfer create content

### DIFF
--- a/changes/TI-161.feature
+++ b/changes/TI-161.feature
@@ -1,0 +1,1 @@
+Implement /@perform-dossier-transfer endpoint. [buchi]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -223,9 +223,42 @@ services:
     profiles:
       - testserver
 
+  kub:
+    image: 4teamwork/kub:latest
+    ports:
+      - "3100:8000"
+    depends_on:
+      - kub-db
+    environment:
+      DJANGO_ALLOWED_HOSTS: localhost,127.0.0.1
+      DJANGO_SECRET_KEY: secret
+      DJANGO_DATABASE_HOST: kub-db
+      DJANGO_DATABASE_NAME: kub
+      DJANGO_DATABASE_USER: kub
+      DJANGO_DATABASE_PASSWORD: secret
+      CAS_SERVER_URL: http://ianus-frontend/portal/cas
+      CAS_ROOT_PROXIED_AS: http://localhost:3100
+      ALLOWED_PORTAL_GROUPS: all
+    volumes:
+      - kub_media:/app/media
+    profiles:
+      - kub
+  kub-db:
+    image: postgres:13-alpine
+    volumes:
+      - kub_db:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: kub
+      POSTGRES_PASSWORD: secret
+      POSTGRES_DB: kub
+    profiles:
+      - kub
+
 volumes:
   ogds:
   clam_db:
+  kub_db:
+  kub_media:
 
 secrets:
   gldt:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -135,7 +135,7 @@ services:
       - ./docker/ldap.ldif:/ldifs/ldap.ldif
       - ./var/openldap:/bitnami/openldap
   ianus-frontend:
-    image: ghcr.io/4teamwork/ianus-frontend:2021.4.4
+    image: ghcr.io/4teamwork/ianus-frontend:2024.2.0
     ports:
       - "3000:80"
     depends_on:
@@ -147,14 +147,14 @@ services:
       - all
       - ianus
   ianus-backend:
-    image: ghcr.io/4teamwork/ianus-backend:2021.4.4
+    image: ghcr.io/4teamwork/ianus-backend:2024.2.0
     ports:
       - "8000:8000"
     depends_on:
       - ianus-db
     environment:
       - DJANGO_SECRET_KEY=secret
-      - DJANGO_ALLOWED_HOSTS=localhost,teamraum,gever
+      - DJANGO_ALLOWED_HOSTS=localhost,teamraum,gever,ianus-frontend
       - DJANGO_PATH_PREFIX=/portal
       - DJANGO_SESSION_COOKIE_SECURE=False
       - DJANGO_CSRF_COOKIE_SECURE=False
@@ -174,7 +174,7 @@ services:
       - all
       - ianus
   ianus-db:
-    image: postgres:12-alpine
+    image: postgres:13-alpine
     volumes:
       - ./var/ianus-db:/var/lib/postgresql/data
     environment:

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -13,6 +13,7 @@ Other Changes
 - ``GET @dossier-transfers/<id>?full_content=1``: New mode to fetch full content representation for dossier transfers.
 - Add ris_base_url to config endpoint.
 - ``@listing``: Add ``ris_proposals`` listing.
+- ``POST @perform-dossier-transfer``: New endpoint to perform a dossier transfer.
 
 
 2024.7.0 (2024-04-23)

--- a/docs/public/dev-manual/api/dossier_transfers.rst
+++ b/docs/public/dev-manual/api/dossier_transfers.rst
@@ -271,3 +271,41 @@ Mit einem GET Request auf ``/@dossier-transfers/<transfer-id>/blob/<document-uid
 kann das Blob eines Dokuments heruntergeladen werden. Der Request muss dazu einem
 gültigen Token für diesen Transfer authentisiert werden, und das Dokument muss
 in diesem Transfer enthalten sein.
+
+
+Dossier-Transfer durchführen
+----------------------------
+
+Mit dem ``/@perform-dossier-transfer`` Endpoint kann ein vorher erstellter
+Dossier-Transfer durchgeführt werden. Dabei wird das entsprechende Dossier mit
+seinen Subdossiers, Dokumenten und Beteiligungen auf dem Zielmandant
+in der aufgerufenen Ordnungsposition erstellt.
+
+Im Body muss die Id des Transfers mitgegeben werden.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       POST /ordnungssystem/fuehrung/@perform-dossier-transfer HTTP/1.1
+       Accept: application/json
+       Content-Type: application/json
+
+       {
+         "transfer_id": 42
+       }
+
+Als Antwort wird die Serialisierung des erstellten Dossiers zurückgegeben.
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 201 Created
+      Content-Type: application/json
+
+      {
+        "@id": "http://localhost:8080/fd/fuehrung/dossier-31",
+        "@type": "opengever.dossier.businesscasedossier",
+        "...": "..."
+      }

--- a/opengever/dossiertransfer/api.zcml
+++ b/opengever/dossiertransfer/api.zcml
@@ -34,4 +34,13 @@
       permission="zope2.View"
       />
 
+  <plone:service
+      method="POST"
+      name="@perform-dossier-transfer"
+      for="opengever.repository.interfaces.IRepositoryFolder"
+      factory=".api.perform.PerformDossierTransfer"
+      permission="cmf.AddPortalContent"
+      />
+
+
 </configure>

--- a/opengever/dossiertransfer/api/perform.py
+++ b/opengever/dossiertransfer/api/perform.py
@@ -1,0 +1,246 @@
+from Acquisition import aq_base
+from Acquisition.interfaces import IAcquirer
+from opengever.api.validation import get_validation_errors
+from opengever.base.model import create_session
+from opengever.dossier.behaviors.participation import IParticipationAware
+from opengever.dossiertransfer import is_dossier_transfer_feature_enabled
+from opengever.dossiertransfer.api.schemas import IPerformDossierTransferAPISchema
+from opengever.dossiertransfer.model import DossierTransfer
+from opengever.dossiertransfer.model import TRANSFER_STATE_COMPLETED
+from opengever.kub.client import KuBClient
+from opengever.ogds.base.utils import get_current_admin_unit
+from opengever.ogds.models.service import ogds_service
+from plone import api
+from plone.protect.interfaces import IDisableCSRFProtection
+from plone.restapi.deserializer import json_body
+from plone.restapi.interfaces import IDeserializeFromJson
+from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.services import Service
+from plone.restapi.services.content.utils import add
+from plone.restapi.services.content.utils import create
+from Products.CMFPlone.utils import safe_hasattr
+from zExceptions import BadRequest
+from zExceptions import Forbidden
+from zExceptions import InternalError
+from zope.component import getMultiAdapter
+from zope.component import queryMultiAdapter
+from zope.event import notify
+from zope.interface import alsoProvides
+from zope.lifecycleevent import ObjectCreatedEvent
+import json
+import logging
+import os.path
+import requests
+import shutil
+import tempfile
+import transaction
+
+
+logger = logging.getLogger('opengever.dossiertransfer')
+
+
+class PerformDossierTransfer(Service):
+    """API endpoint to perform a dossier transfer.
+
+    Creates a dossier in the repository folder given by the context.
+
+    POST /@perform-dossier-transfer HTTP/1.1
+
+    {
+      "transfer_id": <transfer_id>
+    }
+    """
+
+    def reply(self):
+        # Disable CSRF protection
+        alsoProvides(self.request, IDisableCSRFProtection)
+
+        if not is_dossier_transfer_feature_enabled():
+            raise BadRequest("Feature 'dossier_transfers' is not enabled.")
+
+        if not self.is_inbox_user():
+            raise Forbidden('Not an inbox user')
+
+        data = json_body(self.request)
+        errors = get_validation_errors(data, IPerformDossierTransferAPISchema)
+
+        if errors:
+            # Structure errors in a way that they can get serialized and
+            # translated by the handler in opengever.api.errors
+            structured_errors = [{
+                'field': field,
+                'error': exc.__class__.__name__,
+                'message': exc.__class__.__doc__.strip()}
+                for field, exc in errors
+            ]
+            raise BadRequest(structured_errors)
+
+        self.transfer_id = data['transfer_id']
+
+        self.transfer = self.locate_transfer()
+        if self.transfer is None:
+            raise BadRequest('Unknown Transfer')
+
+        self.fetch_and_create()
+
+        session = create_session()
+        transfer = session.query(DossierTransfer).get(self.transfer_id)
+        transfer.state = TRANSFER_STATE_COMPLETED
+
+        serializer = queryMultiAdapter(
+            (self.root_obj, self.request), ISerializeToJson)
+        serialized_obj = serializer()
+        serialized_obj["@id"] = self.root_obj.absolute_url()
+        self.request.response.setStatus(201)
+        return serialized_obj
+
+    @property
+    def headers(self):
+        return {
+            'Accept': 'application/json',
+            'X-GEVER-Dossier-Transfer-Token': self.transfer.token,
+        }
+
+    def fetch_and_create(self):
+        self.tempdir = None  # Temporary directory for storing downloaded docs
+        self.documents = {}  # File paths of downloaded documents by UID
+        self.root_obj = None  # Created root object which we return as response
+        self.objects_by_path = {}  # Created objects by source path
+        self.contact_id_mapping = {}  # Source contact id => target contact id
+
+        self.metadata = self.fetch_metadata()
+        if self.metadata is None:
+            raise InternalError('Could not fetch transfer metadata')
+
+        try:
+            self.fetch_documents()
+            self.create_contacts()
+            # Sync DB to reduce conflict propability
+            transaction.begin()
+            self.create_dossiers()
+            self.create_documents()
+        finally:
+            self.cleanup()
+
+    def locate_transfer(self):
+        local_unit_id = get_current_admin_unit().unit_id
+        query = DossierTransfer.query.filter(
+            DossierTransfer.id == self.transfer_id
+        ).filter(
+            DossierTransfer.target_id == local_unit_id)
+        return query.first()
+
+    def is_inbox_user(self):
+        user_id = api.user.get_current().getId()
+        ogds_user = ogds_service().fetch_user(user_id)
+        local_unit = get_current_admin_unit()
+        for org_unit in local_unit.org_units:
+            if ogds_user in org_unit.inbox_group.users:
+                return True
+        return False
+
+    def fetch_metadata(self):
+        url = '{}/@dossier-transfers/{}?full_content=1'.format(
+            self.transfer.source.site_url, self.transfer_id)
+        try:
+            resp = requests.get(url, headers=self.headers)
+            resp.raise_for_status()
+        except requests.exceptions.RequestException:
+            logger.exception('Could not fetch transfer metadata.')
+            return None
+        return json.loads(resp.content)
+
+    def fetch_documents(self):
+        self.tempdir = tempfile.mkdtemp()
+        for doc in self.metadata.get('content', {}).get('documents', []):
+            url = '{}/@dossier-transfers/{}/blob/{}'.format(
+                self.transfer.source.site_url, self.transfer_id, doc['UID'])
+            filepath = os.path.join(self.tempdir, doc['UID'])
+            try:
+                with requests.get(url, headers=self.headers, stream=True) as resp:
+                    resp.raise_for_status()
+                    with open(filepath, 'wb') as f:
+                        for chunk in resp.iter_content(chunk_size=8192):
+                            f.write(chunk)
+            except requests.RequestException:
+                logger.exception('Could not fetch documents.')
+                raise InternalError('Could not fetch documents')
+            self.documents[doc['UID']] = filepath
+
+    def create_dossiers(self):
+        for dossier in self.metadata.get('content', {}).get('dossiers', []):
+            path = dossier[u'relative_path']
+            parent_path = os.path.dirname(path)
+            parent = self.objects_by_path.setdefault(parent_path, self.context)
+
+            obj = self.create_content(parent, dossier)
+            self.objects_by_path[path] = obj
+            if self.root_obj is None:
+                self.root_obj = obj
+
+            for participation in dossier.get('participations', []):
+                self.add_participation(obj, participation)
+
+    def create_documents(self):
+        for doc in self.metadata.get('content', {}).get('documents', []):
+            path = doc[u'relative_path']
+            parent_path = os.path.dirname(path)
+            parent = self.objects_by_path.setdefault(parent_path, self.context)
+
+            doc_file = open(self.documents[doc['UID']], 'rb')
+            doc['file']['data'] = doc_file
+            self.objects_by_path[path] = self.create_content(parent, doc)
+            doc_file.close()
+
+    def create_content(self, parent, data):
+        obj = create(parent, data['@type'], title=data['title'])
+
+        temporarily_wrapped = False
+        if IAcquirer.providedBy(obj) and not safe_hasattr(obj, "aq_base"):
+            obj = obj.__of__(parent)
+            temporarily_wrapped = True
+
+        deserializer = getMultiAdapter((obj, self.request), IDeserializeFromJson)
+        deserializer(validate_all=True, data=data, create=True)
+        if temporarily_wrapped:
+            obj = aq_base(obj)
+
+        notify(ObjectCreatedEvent(obj))
+
+        obj = add(parent, obj, rename=True)
+        return obj
+
+    def add_participation(self, dossier, participation):
+        participant_id, roles = participation
+        participant_id = self.contact_id_mapping[participant_id]
+        IParticipationAware(dossier).add_participation(participant_id, roles)
+
+    def create_contacts(self):
+        kub = KuBClient()
+
+        for contact_id, contact_data in (
+            self.metadata.get("content", {}).get("contacts", {}).items()
+        ):
+            third_party_id = contact_data.get('thirdPartyId') or contact_id
+            existing = kub.list_people(filters={'third_party_id': third_party_id})
+            if existing is None:
+                raise InternalError('Checking for existing contact failed')
+
+            if existing['count'] == 1:
+                self.contact_id_mapping[contact_id] = "person:{}".format(
+                    existing["results"][0]["id"]
+                )
+                continue
+
+            if not contact_data.get('thirdPartyId'):
+                contact_data['thirdPartyId'] = contact_id
+
+            created_data = kub.create_person(contact_data)
+            if created_data is None:
+                raise InternalError('Creating contact failed')
+
+            self.contact_id_mapping[contact_id] = created_data['typeId']
+
+    def cleanup(self):
+        if os.path.exists(self.tempdir):
+            shutil.rmtree(self.tempdir)

--- a/opengever/dossiertransfer/api/perform.py
+++ b/opengever/dossiertransfer/api/perform.py
@@ -168,10 +168,14 @@ class PerformDossierTransfer(Service):
             self.documents[doc['UID']] = filepath
 
     def create_dossiers(self):
+        user_id = api.user.get_current().getId()
+
         for dossier in self.metadata.get('content', {}).get('dossiers', []):
             path = dossier[u'relative_path']
             parent_path = os.path.dirname(path)
             parent = self.objects_by_path.setdefault(parent_path, self.context)
+
+            dossier['responsible'] = user_id
 
             obj = self.create_content(parent, dossier)
             self.objects_by_path[path] = obj

--- a/opengever/dossiertransfer/api/schemas.py
+++ b/opengever/dossiertransfer/api/schemas.py
@@ -16,6 +16,7 @@ from zope.schema import ASCIILine
 from zope.schema import Bool
 from zope.schema import Choice
 from zope.schema import Datetime
+from zope.schema import Int
 from zope.schema import List
 from zope.schema import Text
 from zope.schema import TextLine
@@ -174,6 +175,16 @@ class IDossierTransferAPISchema(Interface):
         else:
             if getattr(self, 'participations', None) is None:
                 raise ParticipationsListRequired()
+
+
+class IPerformDossierTransferAPISchema(Interface):
+    """Schema to describe PerformDossierTransfer API.
+    """
+
+    transfer_id = Int(
+        title=u'Transfer ID',
+        required=True,
+    )
 
 
 class SourceSameAsTarget(Invalid):

--- a/opengever/dossiertransfer/tests/test_api_perform.py
+++ b/opengever/dossiertransfer/tests/test_api_perform.py
@@ -69,7 +69,7 @@ METADATA_RESP = {
             "@type": "opengever.dossier.businesscasedossier",
             'relative_path': u'ordnungssystem/fuehrung/gemeinderecht/dossier-20',
             'title': u'A resolvable main dossier',
-            'responsible': u'jurgen.konig',
+            'responsible': u'kathi.barfuss',
             u'participations': [
                 [
                     u'person:9af7d7cc-b948-423f-979f-587158c6bc65',
@@ -81,7 +81,7 @@ METADATA_RESP = {
             "@type": "opengever.dossier.businesscasedossier",
             'relative_path': u'ordnungssystem/fuehrung/gemeinderecht/dossier-20/dossier-21',
             'title': u'Resolvable Subdossier',
-            'responsible': u'jurgen.konig',
+            'responsible': u'nicole.kohler',
         }],
     },
 }

--- a/opengever/dossiertransfer/tests/test_api_perform.py
+++ b/opengever/dossiertransfer/tests/test_api_perform.py
@@ -1,0 +1,338 @@
+from datetime import datetime
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from ftw.testing import freeze
+from opengever.base.model import create_session
+from opengever.dossier.behaviors.participation import IParticipationAware
+from opengever.dossiertransfer.interfaces import IDossierTransferSettings
+from opengever.dossiertransfer.model import TRANSFER_STATE_COMPLETED
+from opengever.kub.testing import KuBIntegrationTestCase
+from opengever.ogds.base.utils import get_current_admin_unit
+from plone import api
+from zExceptions import BadRequest
+from zExceptions import Forbidden
+import json
+import pytz
+import requests_mock
+import transaction
+
+
+FROZEN_NOW = datetime(2024, 2, 18, 15, 45, tzinfo=pytz.utc)
+
+
+METADATA_RESP = {
+    u'@id': u'http://nohost/plone/@dossier-transfers/1',
+    u'@type': u'virtual.ogds.dossiertransfer',
+    u'id': 1,
+    u'title': u'Transfer Title',
+    u'message': u'Transfer Message',
+    u'created': u'2024-02-18T15:45:00+00:00',
+    u'expires': u'2024-03-19T15:45:00+00:00',
+    u'state': u'pending',
+    u'source': {
+        u'token': u'plone',
+        u'title': u'Hauptmandant',
+    },
+    u'target': {
+        u'token': u'recipient',
+        u'title': u'Remote Recipient',
+    },
+    u'source_user': u'jurgen.konig',
+    u'root': u'createresolvabledossier000000001',
+    u'documents': [u'createresolvabledossier000000003'],
+    u'all_documents': False,
+    u'all_participations': False,
+    u'content': {
+        u'contacts': {
+            u'person:9af7d7cc-b948-423f-979f-587158c6bc65': {
+                u'type': u'person',
+                u'text': u'Dupont Jean',
+                u'title': u'',
+            },
+        },
+        u'documents': [{
+            "@id": "http://nohost/plone/ordnungssystem/fuehrung/gemeinderecht/dossier-20/dossier-21/document-44",
+            "@type": "opengever.document.document",
+            "UID": "a663689540a34538b6f408d4b41baee8",
+            u'relative_path': u'ordnungssystem/fuehrung/gemeinderecht/dossier-20/dossier-21/document-44',
+            u'title': u'Umbau B\xe4rengraben',
+            'file': {
+                u'content-type': u'plain/text',
+                u'download': u'http://nohost/plone/ordnungssystem/fuehrung/gemeinderecht/dossier-20/dossier-21/document-44/@@download/file',  # noqa
+                u'filename': u'Foobar.txt',
+                u'size': 6,
+            },
+        }],
+        u'dossiers': [{
+            "@id": "http://nohost/plone/ordnungssystem/fuehrung/gemeinderecht/dossier-20",
+            "@type": "opengever.dossier.businesscasedossier",
+            'relative_path': u'ordnungssystem/fuehrung/gemeinderecht/dossier-20',
+            'title': u'A resolvable main dossier',
+            'responsible': u'jurgen.konig',
+            u'participations': [
+                [
+                    u'person:9af7d7cc-b948-423f-979f-587158c6bc65',
+                    [u'participation'],
+                ],
+            ],
+        }, {
+            "@id": "http://nohost/plone/ordnungssystem/fuehrung/gemeinderecht/dossier-20/dossier-21",
+            "@type": "opengever.dossier.businesscasedossier",
+            'relative_path': u'ordnungssystem/fuehrung/gemeinderecht/dossier-20/dossier-21',
+            'title': u'Resolvable Subdossier',
+            'responsible': u'jurgen.konig',
+        }],
+    },
+}
+
+KUB_LIST_RESP = {
+    "count": 1,
+    "next": None,
+    "previous": None,
+    "results": [
+        {
+            "created": "2024-04-19T17:34:22.542646+02:00",
+            "firstName": "Anna",
+            "fullName": "Nass Anna",
+            "htmlUrl": "http://localhost:3100/people/20e024c9-db20-4ea1-999a-9deaa80413f4",
+            "id": "20e024c9-db20-4ea1-999a-9deaa80413f4",
+            "isActive": True,
+            "modified": "2024-04-19T17:34:22.542653+02:00",
+            "officialName": "Anna",
+            "personTypeTitle": None,
+            "primaryEmail": {
+                "id": "66285529-85a5-4a28-9ba7-4c07f8f2b12b",
+                "label": "Arbeit",
+                "email": "anna.nass@frucht.ch",
+                "isDefault": True,
+                "thirdPartyId": None,
+                "modified": "2024-04-19T17:34:22.554224+02:00",
+                "created": "2024-04-19T17:34:22.554211+02:00"
+            },
+            "salutation": "Frau",
+            "tags": [],
+            "thirdPartyId": "person:ea18df93-0fe7-4615-a859-cde16cc4dd23",
+            "title": "",
+            "url": "http://localhost:3100/api/v1/people/20e024c9-db20-4ea1-999a-9deaa80413f4",
+            "username": "lpfsdlwp"
+        }
+    ]
+}
+
+KUB_LIST_EMPTY_RESP = {
+    "count": 0,
+    "next": None,
+    "previous": None,
+    "results": []
+}
+
+
+class TestPerformDossierTransfer(KuBIntegrationTestCase):
+
+    features = ('dossier-transfers',)
+
+    @browsing
+    def test_perform_dossier_transfer_raises_bad_request_if_disabled(self, browser):
+        api.portal.set_registry_record(
+            'is_feature_enabled', False, interface=IDossierTransferSettings)
+        self.login(self.regular_user, browser)
+
+        browser.exception_bubbling = True
+        with self.assertRaises(BadRequest):
+            browser.open(
+                self.leaf_repofolder, view='@perform-dossier-transfer',
+                method='POST',
+                headers=self.api_headers,
+            )
+
+    @browsing
+    def test_regular_user_is_not_allowed_to_perform_dossier_transfer(self, browser):
+        self.login(self.regular_user, browser)
+
+        browser.exception_bubbling = True
+        with self.assertRaises(Forbidden):
+            browser.open(
+                self.leaf_repofolder, view='@perform-dossier-transfer',
+                method='POST',
+                headers=self.api_headers,
+            )
+
+    @browsing
+    def test_raises_bad_request_if_invalid_data(self, browser):
+        self.login(self.secretariat_user, browser)
+
+        browser.exception_bubbling = True
+        with self.assertRaises(BadRequest):
+            browser.open(
+                self.leaf_repofolder, view='@perform-dossier-transfer',
+                method='POST',
+                headers=self.api_headers,
+                data='{}',
+            )
+
+    @browsing
+    def test_raises_bad_request_for_unknown_transfer_id(self, browser):
+        self.login(self.secretariat_user, browser)
+
+        browser.exception_bubbling = True
+        with self.assertRaises(BadRequest) as exc:
+            browser.open(
+                self.leaf_repofolder, view='@perform-dossier-transfer',
+                method='POST',
+                headers=self.api_headers,
+                data='{"transfer_id": 4444}',
+            )
+            self.assertEqual(str(exc), 'Unknown Transfer')
+
+    @requests_mock.Mocker()
+    @browsing
+    def test_creates_dossiers_and_documents_with_existing_contact(self, mocker, browser):
+        self.login(self.secretariat_user, browser)
+
+        with freeze(FROZEN_NOW):
+            transfer = create(Builder('dossier_transfer')
+                              .with_target(get_current_admin_unit()))
+            session = create_session()
+            session.add(transfer)
+            session.flush()
+
+        url = '{}/@dossier-transfers/{}?full_content=1'.format(
+            transfer.source.site_url, transfer.id)
+        mocker.get(url, json=METADATA_RESP)
+
+        url = 'http://example.com/@dossier-transfers/1/blob/a663689540a34538b6f408d4b41baee8'
+        mocker.get(url, content='foobar')
+
+        url = '{}people?third_party_id={}'.format(
+            self.client.kub_api_url, 'person:9af7d7cc-b948-423f-979f-587158c6bc65')
+        mocker.get(url, json=KUB_LIST_RESP)
+
+        self.mock_labels(mocker)
+
+        # Disable ftw.testing.TransactionInterceptor for transaction.begin()
+        # as this is used in perform-dossier-transfer for syncing the database
+        # before writing to it. With ftw.testing.TransactionInterceptor this
+        # would rollback the transaction.
+        tx_begin = transaction.begin
+        transaction.begin = lambda: True
+
+        resp = browser.open(
+            self.leaf_repofolder, view='@perform-dossier-transfer',
+            method='POST',
+            headers=self.api_headers,
+            data=json.dumps({"transfer_id": transfer.id}),
+        )
+
+        # Reenable begin() of ftw.testing.TransactionInterceptor
+        transaction.begin = tx_begin
+
+        # Verify that the expected API calls have been made
+        expected_calls = [
+            ('GET', 'http://example.com/@dossier-transfers/1?full_content=1'),
+            ('GET', 'http://example.com/@dossier-transfers/1/blob/a663689540a34538b6f408d4b41baee8'),
+            ('GET', 'http://localhost:8000/api/v2/people?third_party_id=person%3A9af7d7cc-b948-423f-979f-587158c6bc65'),
+            ('GET', 'http://localhost:8000/api/v2/labels'),
+        ]
+        actual_calls = [(m.method, m.url) for m in mocker.request_history]
+        self.assertEqual(actual_calls, expected_calls)
+
+        # Verify key propertes of the response
+        self.assertDictContainsSubset(
+            {
+                u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-21',
+                u'@type': u'opengever.dossier.businesscasedossier',
+                u'responsible': {
+                    u'title': u'K\xf6nig J\xfcrgen (jurgen.konig)',
+                    u'token': u'jurgen.konig',
+                },
+            },
+            resp.json,
+        )
+
+        # Verify that participations are correctly set
+        dossier = self.leaf_repofolder[resp.json['id']]
+        self.assertEqual(
+            [(p.contact, p.roles) for p in IParticipationAware(dossier).get_participations()],
+            [('person:20e024c9-db20-4ea1-999a-9deaa80413f4', [u'participation'])])
+
+        # Verify that transfer state is set to completed
+        self.assertEqual(transfer.state, TRANSFER_STATE_COMPLETED)
+
+    @requests_mock.Mocker()
+    @browsing
+    def test_creates_dossiers_and_documents_with_new_contacts(self, mocker, browser):
+        self.login(self.secretariat_user, browser)
+
+        with freeze(FROZEN_NOW):
+            transfer = create(Builder('dossier_transfer')
+                              .with_target(get_current_admin_unit()))
+            session = create_session()
+            session.add(transfer)
+            session.flush()
+
+        url = '{}/@dossier-transfers/{}?full_content=1'.format(
+            transfer.source.site_url, transfer.id)
+        mocker.get(url, json=METADATA_RESP)
+
+        url = 'http://example.com/@dossier-transfers/1/blob/a663689540a34538b6f408d4b41baee8'
+        mocker.get(url, content='foobar')
+
+        url = '{}people?third_party_id={}'.format(
+            self.client.kub_api_url, 'person:9af7d7cc-b948-423f-979f-587158c6bc65')
+        mocker.get(url, json=KUB_LIST_EMPTY_RESP)
+
+        url = '{}people'.format(self.client.kub_api_url)
+        mocker.post(url, json={'typeId': 'person:9af7d7cc-b948-423f-979f-587158c6bc65'})
+
+        self.mock_labels(mocker)
+
+        # Disable ftw.testing.TransactionInterceptor for transaction.begin()
+        # as this is used in perform-dossier-transfer for syncing the database
+        # before writing to it. With ftw.testing.TransactionInterceptor this
+        # would rollback the transaction.
+        tx_begin = transaction.begin
+        transaction.begin = lambda: True
+
+        resp = browser.open(
+            self.leaf_repofolder, view='@perform-dossier-transfer',
+            method='POST',
+            headers=self.api_headers,
+            data=json.dumps({"transfer_id": transfer.id}),
+        )
+
+        # Reenable begin() of ftw.testing.TransactionInterceptor
+        transaction.begin = tx_begin
+
+        # Verify that the expected API calls have been made
+        expected_calls = [
+            ('GET', 'http://example.com/@dossier-transfers/1?full_content=1'),
+            ('GET', 'http://example.com/@dossier-transfers/1/blob/a663689540a34538b6f408d4b41baee8'),
+            ('GET', 'http://localhost:8000/api/v2/people?third_party_id=person%3A9af7d7cc-b948-423f-979f-587158c6bc65'),
+            ('POST', 'http://localhost:8000/api/v2/people'),
+            ('GET', 'http://localhost:8000/api/v2/labels'),
+        ]
+        actual_calls = [(m.method, m.url) for m in mocker.request_history]
+        self.assertEqual(actual_calls, expected_calls)
+
+        # Verify key propertes of the response
+        self.assertDictContainsSubset(
+            {
+                u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-21',
+                u'@type': u'opengever.dossier.businesscasedossier',
+                u'responsible': {
+                    u'title': u'K\xf6nig J\xfcrgen (jurgen.konig)',
+                    u'token': u'jurgen.konig',
+                },
+            },
+            resp.json,
+        )
+
+        # Verify that participations are set correctly
+        dossier = self.leaf_repofolder[resp.json['id']]
+        self.assertEqual(
+            [(p.contact, p.roles) for p in IParticipationAware(dossier).get_participations()],
+            [('person:9af7d7cc-b948-423f-979f-587158c6bc65', [u'participation'])])
+
+        # Verify that transfer state is set to completed
+        self.assertEqual(transfer.state, TRANSFER_STATE_COMPLETED)

--- a/opengever/kub/client.py
+++ b/opengever/kub/client.py
@@ -10,10 +10,13 @@ from time import time
 from urllib import urlencode
 from wsgiref.handlers import format_date_time
 from zope.annotation import IAnnotations
+import logging
 import requests
 
 
 KUB_API_VERSION = 'v2'
+
+logger = logging.getLogger('kub')
 
 
 class KuBClient(object):
@@ -99,3 +102,31 @@ class KuBClient(object):
                 {item['typedId']: item['label'] for item in resp.json()['results']})
             stamp = mktime(now.timetuple())
             self._storage[self.STORAGE_MODIFIED_KEY] = format_date_time(stamp)
+
+    def create_person(self, data):
+        url = '{}people'.format(self.kub_api_url)
+        try:
+            resp = self.session.post(url, json=data)
+            resp.raise_for_status()
+        except requests.RequestException:
+            logger.exception('Creating person failed')
+            return None
+        try:
+            return resp.json()
+        except requests.JSONDecodeError:
+            logger.exception('Creating person failed')
+            return None
+
+    def list_people(self, filters=None):
+        url = '{}people'.format(self.kub_api_url)
+        try:
+            resp = self.session.get(url, params=filters)
+            resp.raise_for_status()
+        except requests.RequestException:
+            logger.exception('Fetching list of people failed')
+            return None
+        try:
+            return resp.json()
+        except requests.JSONDecodeError:
+            logger.exception('Fetching list of people failed')
+            return None


### PR DESCRIPTION
Performs a dossier transfer at the given repository folder:
- First all documents are fetched and stored in a temporary directory.
- Then all contacts referenced in participations are created if they don't exist yet
- At last the dossier, its subdossiers and documents are created

Checking for existing contacts is done by comparing the `third_party_id`.
If the source doesn't have a `third_party_id`, its id is used instead.

If the creation of dossiers or documents fails, newly created contacts are kept, as they are created externaly in KuB.

For [TI-161](https://4teamwork.atlassian.net/browse/TI-161)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))



[TI-161]: https://4teamwork.atlassian.net/browse/TI-161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ