### PR TITLE
Add ris base url to config endpoint

### DIFF
--- a/changes/TI-71.other
+++ b/changes/TI-71.other
@@ -1,0 +1,1 @@
+Add ris_base_url to config endpoint. [jch]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -3,6 +3,13 @@
 API Changelog
 =============
 
+2024.8.0 (unreleased)
+---------------------
+
+Other Changes
+^^^^^^^^^^^^^
+- Add ris_base_url to config endpoint.
+
 2024.7.0 (2024-04-23)
 ---------------------
 

--- a/docs/public/dev-manual/api/config.rst
+++ b/docs/public/dev-manual/api/config.rst
@@ -123,6 +123,7 @@ GEVER-Mandanten abgefragt werden.
           "portal_url": "https://dev.onegovgever.ch/portal",
           "private_folder_url": "http://localhost:8080/fd/private/john.doe",
           "recently_touched_limit": 10,
+          "ris_base_url": "http://localhost:3000",
           "root_url": "http://localhost:8080/fd",
           "sharing_configuration": {
               "black_list_prefix": "^$",
@@ -157,6 +158,10 @@ cas_url
 bumblebee_notifications_url
 
     Websocket URL, um Änderungen über Vorschaubilder zu erhalten
+
+ris_base_url
+
+    RIS Base URL, für die Navigation ins RIS um Anträge zu erstellen
 
 features
     Optional aktivierbare Features:

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -9,6 +9,7 @@ from opengever.base.date_time import utcnow_tz_aware
 from opengever.base.model import create_session
 from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.private import enable_opengever_private
+from opengever.ris.interfaces import IRisSettings
 from opengever.testing import IntegrationTestCase
 from opengever.testing.readonly import ZODBStorageInReadonlyMode
 from pkg_resources import get_distribution
@@ -129,6 +130,16 @@ class TestConfig(IntegrationTestCase):
         browser.open(self.config_url, headers=self.api_headers)
         self.assertEqual(browser.status_code, 200)
         self.assertEqual(browser.json.get(u'recently_touched_limit'), 10)
+
+    @browsing
+    def test_config_contains_ris_base_url(self, browser):
+        api.portal.set_registry_record('base_url', u'http://localhost:3000', IRisSettings)
+
+        self.login(self.regular_user, browser)
+
+        browser.open(self.config_url, headers=self.api_headers)
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual(browser.json.get(u'ris_base_url'), u'http://localhost:3000')
 
     @browsing
     def test_config_contains_cas_url(self, browser):

--- a/opengever/base/configuration.py
+++ b/opengever/base/configuration.py
@@ -39,6 +39,7 @@ from opengever.ogds.models.user_settings import UserSettings
 from opengever.oneoffixx.interfaces import IOneoffixxSettings
 from opengever.readonly import is_in_readonly_mode
 from opengever.repository.interfaces import IRepositoryFolderRecords
+from opengever.ris.interfaces import IRisSettings
 from opengever.sharing.interfaces import ISharingConfiguration
 from opengever.task.interfaces import ITaskSettings
 from opengever.tasktemplates.interfaces import ITaskTemplateSettings
@@ -78,6 +79,7 @@ class GeverSettingsAdpaterV1(object):
         config['apps_url'] = os.environ.get('APPS_ENDPOINT_URL')
         config['application_type'] = self.get_application_type()
         config['bumblebee_notifications_url'] = bumblebee.get_service_v3().get_notifications_url()
+        config['ris_base_url'] = self.get_ris_base_url()
         config['is_readonly'] = is_in_readonly_mode()
         return config
 
@@ -98,6 +100,12 @@ class GeverSettingsAdpaterV1(object):
         if api.portal.get_registry_record('is_feature_enabled', interface=IWorkspaceSettings):
             return 'teamraum'
         return 'gever'
+
+    def get_ris_base_url(self):
+        ris_base_url = api.portal.get_registry_record(name='base_url', interface=IRisSettings)
+        if ris_base_url:
+            return ris_base_url.rstrip("/")
+        return ''
 
     def get_user_settings(self):
         setting = UserSettings.query.filter_by(userid=api.user.get_current().id).one_or_none()

--- a/opengever/base/tests/test_configuration_adapter.py
+++ b/opengever/base/tests/test_configuration_adapter.py
@@ -2,6 +2,7 @@ from collections import OrderedDict
 from contextlib import contextmanager
 from opengever.base.interfaces import IGeverSettings
 from opengever.kub.interfaces import IKuBSettings
+from opengever.ris.interfaces import IRisSettings
 from opengever.testing import IntegrationTestCase
 from pkg_resources import get_distribution
 from plone import api
@@ -13,6 +14,7 @@ class TestConfigurationAdapter(IntegrationTestCase):
     def setUp(self):
         super(TestConfigurationAdapter, self).setUp()
         os.environ['BUMBLEBEE_PUBLIC_URL'] = 'http://bumblebee.local/'
+        api.portal.set_registry_record('base_url', u'http://localhost:3000', IRisSettings)
 
     def test_configuration(self):
         expected_configuration = OrderedDict([
@@ -116,6 +118,7 @@ class TestConfigurationAdapter(IntegrationTestCase):
             ('apps_url', None),
             ('application_type', 'gever'),
             ('bumblebee_notifications_url', 'http://bumblebee.local/YnVtYmxlYmVl/api/notifications'),
+            ('ris_base_url', 'http://localhost:3000'),
             ('is_readonly', False),
             ])
 
@@ -135,6 +138,7 @@ class TestConfigurationAdapter(IntegrationTestCase):
             ('apps_url', None),
             ('application_type', 'gever'),
             ('bumblebee_notifications_url', 'http://bumblebee.local/YnVtYmxlYmVl/api/notifications'),
+            ('ris_base_url', 'http://localhost:3000'),
             ('is_readonly', False),
             ])
         configuration = IGeverSettings(self.portal).get_config()
@@ -172,6 +176,7 @@ class TestConfigurationAdapter(IntegrationTestCase):
             ('apps_url', 'http://example.com/api/apps'),
             ('application_type', 'gever'),
             ('bumblebee_notifications_url', 'http://bumblebee.local/YnVtYmxlYmVl/api/notifications'),
+            ('ris_base_url', 'http://localhost:3000'),
             ('is_readonly', False),
             ])
 


### PR DESCRIPTION
The ris base url is used in the gever-ui to open the ris to create proposals.

For [TI-71]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))


[TI-71]: https://4teamwork.atlassian.net/browse/TI-71?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ