### PR TITLE
Disposition dossier stats: Make upgrade step more robust.

### DIFF
--- a/opengever/core/upgrades/20240429083324_initialize_dossier_stats_on_dispositions/upgrade.py
+++ b/opengever/core/upgrades/20240429083324_initialize_dossier_stats_on_dispositions/upgrade.py
@@ -20,5 +20,6 @@ class InitializeDossierStatsOnDispositions(UpgradeStep):
     def initialize_stats(self, disposition):
         disposition.stats_by_dossier = PersistentDict()
         for dossier in disposition.get_dossiers():
-            stats = disposition.query_stats(dossier)
-            disposition.stats_by_dossier[dossier.UID()] = PersistentDict(stats)
+            if dossier:
+                stats = disposition.query_stats(dossier)
+                disposition.stats_by_dossier[dossier.UID()] = PersistentDict(stats)


### PR DESCRIPTION
Disposition dossier stats: Make upgrade step more robust.

The upgrade step failed when deploying on our DEV:

```
  File "/apps/01-dev.onegovgever.ch-fd/src/opengever.core/opengever/core/upgrades/20240429083324_initialize_dossier_stats_on_dispositions/upgrade.py", line 23, in initialize_stats
    stats = disposition.query_stats(dossier)
  File "/apps/01-dev.onegovgever.ch-fd/src/opengever.core/opengever/disposition/disposition.py", line 418, in query_stats
    path_parent='/'.join(dossier.getPhysicalPath()),
AttributeError: 'NoneType' object has no attribute 'getPhysicalPath'
```

It appears we have some broken dispositions on our DEV system.

This change makes the upgrade step for robust for this case. (Unfortunately, there is no simple feature flag for the `disposition` feature that we could just use to make the upgrade step conditional).

For [TI-2](https://4teamwork.atlassian.net/browse/TI-2)

## Checklist

- [ ] Changelog entry (not necessary, introduced in same release)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
