### PR TITLE
Include document keywords for documents created from the template

### DIFF
--- a/changes/TI-89.other
+++ b/changes/TI-89.other
@@ -1,0 +1,1 @@
+Provide keywords on the new created Document from template [amo]

--- a/opengever/api/templatefolder.py
+++ b/opengever/api/templatefolder.py
@@ -83,7 +83,7 @@ class DocumentFromTemplatePost(Service):
                                        'role': participation['role']})
 
         command = CreateDocumentFromTemplateCommand(
-            self.context, template, title, recipient, sender, participation_data)
+            self.context, template, title, recipient, sender, participation_data, keywords=template.keywords)
         document = command.execute()
 
         serializer = queryMultiAdapter((document, self.request), ISerializeToJson)

--- a/opengever/api/tests/test_templatefolder.py
+++ b/opengever/api/tests/test_templatefolder.py
@@ -73,6 +73,34 @@ class TestDocumentFromTemplatePost(IntegrationTestCase):
         self.assertEqual(date.today(), document.document_date)
 
     @browsing
+    def test_creates_document_from_template_within_dossier_with_keywords(self, browser):
+        self.login(self.regular_user, browser)
+        expected_keywords = ("keyword-1", "keyword-2")
+        self.docprops_template.keywords = expected_keywords
+
+        browser.open(
+            '{}/@vocabularies/opengever.dossier.DocumentTemplatesVocabulary'.format(
+                self.portal.absolute_url()),
+            headers=self.api_headers)
+
+        template = browser.json['items'][0]
+
+        data = {'template': template, 'title': u'New document'}
+
+        with self.observe_children(self.dossier) as children:
+            browser.open('{}/@document-from-template'.format(
+                self.dossier.absolute_url()),
+                data=json.dumps(data),
+                method='POST',  # Ensure it's a POST request
+                headers=self.api_headers)
+
+        # Check if the document is created successfully
+        self.assertEqual(1, len(children['added']))
+        document = children['added'].pop()
+
+        self.assertEqual(expected_keywords, document.keywords)
+
+    @browsing
     def test_creates_document_from_template_within_task(self, browser):
         self.login(self.regular_user, browser)
 

--- a/opengever/dossier/command.py
+++ b/opengever/dossier/command.py
@@ -15,11 +15,11 @@ class CreateDocumentFromTemplateCommand(CreateDocumentCommand):
     """
 
     def __init__(self, context, template_doc, title, recipient_data=tuple(),
-                 sender_data=tuple(), participation_data=[]):
+                 sender_data=tuple(), participation_data=[], **kwargs):
         data = getattr(template_doc.get_file(), "data", None)
         super(CreateDocumentFromTemplateCommand, self).__init__(
             context, template_doc.get_filename(), data,
-            title=title)
+            title=title, **kwargs)
         self.recipient_data = recipient_data
         self.sender_data = sender_data
         self.participation_data = participation_data

--- a/opengever/dossier/tests/test_command.py
+++ b/opengever/dossier/tests/test_command.py
@@ -34,6 +34,15 @@ class TestCreateDocumentFromTemplateCommand(IntegrationTestCase):
         self.assertEqual(expected_title, document.title)
         self.assertIsNone(document.file)
 
+    def test_create_document_from_template_with_keywords(self):
+        expected_title = 'My title'
+        expected_keywords = ('My keyword1', 'My keyword2')
+        self.login(self.regular_user)
+        template = create(Builder('document'))
+        command = CreateDocumentFromTemplateCommand(self.dossier, template, expected_title, keywords=expected_keywords)
+        document = command.execute()
+        self.assertEqual(expected_keywords, document.keywords)
+
     def test_create_document_from_template_updates_docproperties(self):
         expected_title = 'My title'
         self.login(self.regular_user)


### PR DESCRIPTION
Ensure that document keywords are added to documents generated from the template.
For [TI-89](https://4teamwork.atlassian.net/browse/TI-89)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[TI-89]: https://4teamwork.atlassian.net/browse/TI-89?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ