### PR TITLE
Improve Repository Root Excel Export

### DIFF
--- a/changes/TI-131.other
+++ b/changes/TI-131.other
@@ -1,0 +1,1 @@
+Enhance Repository Root Excel Export by adding folder UID and relative path [amo]

--- a/opengever/repository/browser/excel_export.py
+++ b/opengever/repository/browser/excel_export.py
@@ -3,6 +3,7 @@ from opengever.base.interfaces import IReferenceNumberFormatter
 from opengever.base.interfaces import IReferenceNumberSettings
 from opengever.base.reporter import StringTranslater
 from opengever.base.reporter import XLSReporter
+from opengever.base.solr.fields import to_relative_path
 from opengever.repository import _
 from opengever.repository.interfaces import IRepositoryFolder
 from opengever.sharing.security import disabled_permission_check
@@ -141,8 +142,20 @@ def generate_report(request, context):
         u'label_groupnames_with_local_or_inherited_taskresponsible_role',
         default=u'Task responsible',
     ))
+
+    label_repositoryfolder_uid = repository_translater(_(
+        u'label_repositoryfolder_uid',
+        default=u'UID',
+    ))
+    label_repositoryfolder_path = repository_translater(_(
+        u'label_repositoryfolder_path',
+        default=u'Path',
+    ))
+
     column_map = (
         {'id': 'get_repository_number', 'title': label_repository_number, 'fold_by_method': repository_number_to_outine_level, 'callable': True},  # noqa
+        {'id': 'get_folder_uid', 'title': label_repositoryfolder_uid, 'callable': True},
+        {'id': 'get_folder_path', 'title': label_repositoryfolder_path, 'callable': True},
         {'id': 'title_de', 'title': label_repositoryfolder_title_de},
         {'id': 'title_fr', 'title': label_repositoryfolder_title_fr},
         {'id': 'title_en', 'title': label_repositoryfolder_title_en},
@@ -227,6 +240,17 @@ class RepositoryFolderWrapper(object):
             if role['roles'].get(rolename):
                 groups.append(role.get('id'))
         return groups
+
+    def get_folder_path(self):
+        """"Returns the relative path of the repository folder
+        Example:
+            If the physical path components are ('', 'fd', 'ordnungssystem')
+            this method returns 'ordnungssystem'.
+        """
+        return to_relative_path('/'.join(self._repofolder.getPhysicalPath()))
+
+    def get_folder_uid(self):
+        return self._repofolder.UID()
 
     def get_groupnames_with_local_reader_role(self):
         return self.get_groupnames_with_local_role('Reader')

--- a/opengever/repository/locales/de/LC_MESSAGES/opengever.repository.po
+++ b/opengever/repository/locales/de/LC_MESSAGES/opengever.repository.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2024-02-16 15:21+0000\n"
+"POT-Creation-Date: 2024-05-03 12:03+0000\n"
 "PO-Revision-Date: 2014-11-25 11:31+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -43,15 +43,15 @@ msgstr "Hinzufügen von Geschäftsdossiers erlauben"
 msgid "description_allow_add_businesscase_dossier"
 msgstr "Wählen Sie, ob es in dieser Ordnungsposition erlaubt ist, Geschäftsdossiers hinzuzufügen. Ist diese Option deaktiviert, kann der Benutzer nur Dossiers aus einer Vorlage oder Spezialdossiers erstellen."
 
-#. Default: "Attention: Change requires reindexing of \"reference\" and \"sortable_reference\"."
-#: ./opengever/repository/repositoryroot.py
-msgid "description_reference_number_addendum"
-msgstr "Achtung: Änderung erfordert Neuindexierung von \"reference\" und \"sortable_reference\"."
-
 #. Default: "Select if this repostory tree should respect the max subdossier depth restriction."
 #: ./opengever/repository/repositoryfolder.py
 msgid "description_max_subdossier_depth_restriction"
 msgstr "Wählen Sie, ob die Dossier-Tiefe in dieser Ordnungsposition begrenzt werden soll"
+
+#. Default: "Attention: Change requires reindexing of \"reference\" and \"sortable_reference\"."
+#: ./opengever/repository/repositoryroot.py
+msgid "description_reference_number_addendum"
+msgstr "Achtung: Änderung erfordert Neuindexierung von \"reference\" und \"sortable_reference\"."
 
 #. Default: "No nested repositorys available."
 #: ./opengever/repository/browser/templates/referenceprefixmanager.pt
@@ -245,6 +245,11 @@ msgstr "Ordnungspositionsnummer"
 msgid "label_repositoryfolder_description"
 msgstr "Beschreibung (optional)"
 
+#. Default: "Path"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_repositoryfolder_path"
+msgstr "Pfad"
+
 #. Default: "Repositoryfolder title (German)"
 #: ./opengever/repository/browser/excel_export.py
 msgid "label_repositoryfolder_title_de"
@@ -259,6 +264,11 @@ msgstr "Titel der Ordnungsposition (englisch)"
 #: ./opengever/repository/browser/excel_export.py
 msgid "label_repositoryfolder_title_fr"
 msgstr "Titel der Ordnungsposition (französisch)"
+
+#. Default: "UID"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_repositoryfolder_uid"
+msgstr "UID"
 
 #. Default: "Limit maximum dossier depth in this repository folder"
 #: ./opengever/repository/repositoryfolder.py

--- a/opengever/repository/locales/en/LC_MESSAGES/opengever.repository.po
+++ b/opengever/repository/locales/en/LC_MESSAGES/opengever.repository.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2024-02-16 15:21+0000\n"
+"POT-Creation-Date: 2024-05-03 12:03+0000\n"
 "PO-Revision-Date: 2014-11-25 11:31+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -49,15 +49,15 @@ msgstr "Allow creation of regular business case dossiers"
 msgid "description_allow_add_businesscase_dossier"
 msgstr "Choose whether the user is allowed to add regular business case dossiers or only dossiers created from a dossier template."
 
-#. Default: "Attention: Change requires reindexing of \"reference\" and \"sortable_reference\"."
-#: ./opengever/repository/repositoryroot.py
-msgid "description_reference_number_addendum"
-msgstr "Attention: Change requires reindexing of \"reference\" and \"sortable_reference\"."
-
 #. Default: "Select if this repostory tree should respect the max subdossier depth restriction."
 #: ./opengever/repository/repositoryfolder.py
 msgid "description_max_subdossier_depth_restriction"
 msgstr ""
+
+#. Default: "Attention: Change requires reindexing of \"reference\" and \"sortable_reference\"."
+#: ./opengever/repository/repositoryroot.py
+msgid "description_reference_number_addendum"
+msgstr "Attention: Change requires reindexing of \"reference\" and \"sortable_reference\"."
 
 #. German translation: Keine untergeordnete Ordnungspositionen verfügbar.
 #. Default: "No nested repositorys available."
@@ -282,6 +282,11 @@ msgstr "Repository number"
 msgid "label_repositoryfolder_description"
 msgstr "Repositoryfolder description"
 
+#. Default: "Path"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_repositoryfolder_path"
+msgstr "Path"
+
 #. German translation: Titel der Ordnungsposition
 #. Default: "Repositoryfolder title (German)"
 #: ./opengever/repository/browser/excel_export.py
@@ -298,6 +303,11 @@ msgstr "Repositoryfolder title"
 #: ./opengever/repository/browser/excel_export.py
 msgid "label_repositoryfolder_title_fr"
 msgstr "Repositoryfolder title (French)"
+
+#. Default: "UID"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_repositoryfolder_uid"
+msgstr "UID"
 
 #. Default: "Limit maximum dossier depth in this repository folder"
 #: ./opengever/repository/repositoryfolder.py

--- a/opengever/repository/locales/fr/LC_MESSAGES/opengever.repository.po
+++ b/opengever/repository/locales/fr/LC_MESSAGES/opengever.repository.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-02-16 15:21+0000\n"
+"POT-Creation-Date: 2024-05-03 12:03+0000\n"
 "PO-Revision-Date: 2017-12-03 11:31+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-repository/fr/>\n"
@@ -42,15 +42,15 @@ msgstr "Permettre l'ajout de dossiers d'affaire"
 msgid "description_allow_add_businesscase_dossier"
 msgstr "Déterminez s'il est permis d'ajouter des dossiers d'affaire à ce niveau. Si cette option est désactivée, l'utilisateur ne peut créer que des dossiers spéciaux ou bien des dossiers à partir d'un modèle."
 
-#. Default: "Attention: Change requires reindexing of \"reference\" and \"sortable_reference\"."
-#: ./opengever/repository/repositoryroot.py
-msgid "description_reference_number_addendum"
-msgstr "Attention: La modification de ce champ requiert une réindexation de \"reference\" et \"sortable_reference\"."
-
 #. Default: "Select if this repostory tree should respect the max subdossier depth restriction."
 #: ./opengever/repository/repositoryfolder.py
 msgid "description_max_subdossier_depth_restriction"
 msgstr ""
+
+#. Default: "Attention: Change requires reindexing of \"reference\" and \"sortable_reference\"."
+#: ./opengever/repository/repositoryroot.py
+msgid "description_reference_number_addendum"
+msgstr "Attention: La modification de ce champ requiert une réindexation de \"reference\" et \"sortable_reference\"."
 
 #. Default: "No nested repositorys available."
 #: ./opengever/repository/browser/templates/referenceprefixmanager.pt
@@ -244,6 +244,11 @@ msgstr "Numéro de classement"
 msgid "label_repositoryfolder_description"
 msgstr "Description (optionnel)"
 
+#. Default: "Path"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_repositoryfolder_path"
+msgstr "Chemin"
+
 #. Default: "Repositoryfolder title (German)"
 #: ./opengever/repository/browser/excel_export.py
 msgid "label_repositoryfolder_title_de"
@@ -258,6 +263,11 @@ msgstr "Titre du numéro de classement (anglais)"
 #: ./opengever/repository/browser/excel_export.py
 msgid "label_repositoryfolder_title_fr"
 msgstr "Titre du numéro de classement"
+
+#. Default: "UID"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_repositoryfolder_uid"
+msgstr "UID"
 
 #. Default: "Limit maximum dossier depth in this repository folder"
 #: ./opengever/repository/repositoryfolder.py

--- a/opengever/repository/locales/opengever.repository.pot
+++ b/opengever/repository/locales/opengever.repository.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-02-16 15:21+0000\n"
+"POT-Creation-Date: 2024-05-03 12:03+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -43,14 +43,14 @@ msgstr ""
 msgid "description_allow_add_businesscase_dossier"
 msgstr ""
 
-#. Default: "Attention: Change requires reindexing of \"reference\" and \"sortable_reference\"."
-#: ./opengever/repository/repositoryroot.py
-msgid "description_reference_number_addendum"
-msgstr ""
-
 #. Default: "Select if this repostory tree should respect the max subdossier depth restriction."
 #: ./opengever/repository/repositoryfolder.py
 msgid "description_max_subdossier_depth_restriction"
+msgstr ""
+
+#. Default: "Attention: Change requires reindexing of \"reference\" and \"sortable_reference\"."
+#: ./opengever/repository/repositoryroot.py
+msgid "description_reference_number_addendum"
 msgstr ""
 
 #. Default: "No nested repositorys available."
@@ -245,6 +245,11 @@ msgstr ""
 msgid "label_repositoryfolder_description"
 msgstr ""
 
+#. Default: "Path"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_repositoryfolder_path"
+msgstr ""
+
 #. Default: "Repositoryfolder title (German)"
 #: ./opengever/repository/browser/excel_export.py
 msgid "label_repositoryfolder_title_de"
@@ -258,6 +263,11 @@ msgstr ""
 #. Default: "Repositoryfolder title (French)"
 #: ./opengever/repository/browser/excel_export.py
 msgid "label_repositoryfolder_title_fr"
+msgstr ""
+
+#. Default: "UID"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_repositoryfolder_uid"
 msgstr ""
 
 #. Default: "Limit maximum dossier depth in this repository folder"

--- a/opengever/repository/tests/test_excel_export.py
+++ b/opengever/repository/tests/test_excel_export.py
@@ -53,7 +53,10 @@ class TestRepositoryRootExcelExport(IntegrationTestCase):
             u'Task responsible local or inherited roles': u'',
             u'Task responsible local roles': u'',
             u'Valid from': u'',
-            u'Valid until': u''
+            u'Valid until': u'',
+            u'UID': u'createrepositorytree000000000001',
+            u'Path': u'ordnungssystem',
+
         }
         self.assertEqual(imported_data[0], expected_reporoot)
         expected_repofolder = {
@@ -88,6 +91,10 @@ class TestRepositoryRootExcelExport(IntegrationTestCase):
             u'Task responsible local or inherited roles': u'',
             u'Task responsible local roles': u'',
             u'Valid from': u'',
-            u'Valid until': u''
+            u'Valid until': u'',
+            u'UID': u'createrepositorytree000000000002',
+            u'Path': u'ordnungssystem/fuhrung',
+
+
         }
         self.assertEqual(imported_data[1], expected_repofolder)


### PR DESCRIPTION
Improves the repository root Excel export feature by adding the folder UID and relative path to each entry
For [TI-131](https://4teamwork.atlassian.net/browse/TI-131)


**before**:

<img width="759" alt="before" src="https://github.com/4teamwork/opengever.core/assets/160112920/508e8e59-2ae9-4db6-9b2e-288e2ef69f6e">

**After**:
<img width="1548" alt="after" src="https://github.com/4teamwork/opengever.core/assets/160112920/adb4ede1-a0c9-4f55-9217-79dcca7da038">


## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[TI-131]: https://4teamwork.atlassian.net/browse/TI-131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ