### PR TITLE
Strip unknown custom properties

### DIFF
--- a/opengever/dossiertransfer/tests/test_api_perform.py
+++ b/opengever/dossiertransfer/tests/test_api_perform.py
@@ -67,6 +67,16 @@ METADATA_RESP = {
         u'dossiers': [{
             "@id": "http://nohost/plone/ordnungssystem/fuehrung/gemeinderecht/dossier-20",
             "@type": "opengever.dossier.businesscasedossier",
+            "custom_properties": {
+                "IDossier.default": {
+                    "fallart": {
+                        "title": "Zufall",
+                        "token": "Zufall",
+                    },
+                    "fallnummer": 38493,
+                    "location": "Bern",
+                },
+            },
             'relative_path': u'ordnungssystem/fuehrung/gemeinderecht/dossier-20',
             'title': u'A resolvable main dossier',
             'responsible': u'kathi.barfuss',
@@ -242,6 +252,11 @@ class TestPerformDossierTransfer(KuBIntegrationTestCase):
             {
                 u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-21',
                 u'@type': u'opengever.dossier.businesscasedossier',
+                u'custom_properties': {
+                    u'IDossier.default': {
+                        u'location': 'Bern',
+                    },
+                },
                 u'responsible': {
                     u'title': u'K\xf6nig J\xfcrgen (jurgen.konig)',
                     u'token': u'jurgen.konig',


### PR DESCRIPTION
Creating content with unknown custom properties results in a validation error. Therefore we need to strip those before creating the content.

For [TI-161](https://4teamwork.atlassian.net/browse/TI-161)

## Checklist

- [ ] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-161]: https://4teamwork.atlassian.net/browse/TI-161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ