### PR TITLE
Fix handling of custom properties

### DIFF
--- a/opengever/dossiertransfer/api/perform.py
+++ b/opengever/dossiertransfer/api/perform.py
@@ -259,13 +259,21 @@ class PerformDossierTransfer(Service):
             shutil.rmtree(self.tempdir)
 
     def strip_unknown_custom_properties(self, data, slots):
-        for slot, fields in data.get('custom_properties', {}).items():
+        custom_properties = data.get('custom_properties', None)
+        if not custom_properties:
+            return
+
+        for slot, fields in custom_properties.items():
             if slot not in slots:
                 del data['custom_properties'][slot]
+                continue
 
             definition = PropertySheetSchemaStorage().query(slot)
-            fieldnames = definition.get_fieldnames()
+            if definition is None:
+                del data['custom_properties'][slot]
+                continue
 
+            fieldnames = definition.get_fieldnames()
             for field in fields.keys():
                 if field not in fieldnames:
                     del data['custom_properties'][slot][field]

--- a/opengever/dossiertransfer/tests/test_api_perform.py
+++ b/opengever/dossiertransfer/tests/test_api_perform.py
@@ -54,6 +54,15 @@ METADATA_RESP = {
         u'documents': [{
             "@id": "http://nohost/plone/ordnungssystem/fuehrung/gemeinderecht/dossier-20/dossier-21/document-44",
             "@type": "opengever.document.document",
+            "custom_properties": {
+                'IDocumentMetadata.document_type.contract': {
+                    "contract_number": 10033,
+                },
+                'IDocumentMetadata.document_type.directive': {
+                    "unknown_number": 42,
+                    "textline": "Foo bar",
+                },
+            },
             "UID": "a663689540a34538b6f408d4b41baee8",
             u'relative_path': u'ordnungssystem/fuehrung/gemeinderecht/dossier-20/dossier-21/document-44',
             u'title': u'Umbau B\xe4rengraben',
@@ -76,6 +85,9 @@ METADATA_RESP = {
                     "fallnummer": 38493,
                     "location": "Bern",
                 },
+                "IDossier.unknown_slot": {
+                    "key": "value",
+                },
             },
             'relative_path': u'ordnungssystem/fuehrung/gemeinderecht/dossier-20',
             'title': u'A resolvable main dossier',
@@ -89,6 +101,7 @@ METADATA_RESP = {
         }, {
             "@id": "http://nohost/plone/ordnungssystem/fuehrung/gemeinderecht/dossier-20/dossier-21",
             "@type": "opengever.dossier.businesscasedossier",
+            "custom_properties": None,
             'relative_path': u'ordnungssystem/fuehrung/gemeinderecht/dossier-20/dossier-21',
             'title': u'Resolvable Subdossier',
             'responsible': u'nicole.kohler',


### PR DESCRIPTION
Two more fixes:
- Assignment slots can have no definition
- The `custom_properties` property may have a value of `None`

For [TI-161](https://4teamwork.atlassian.net/browse/TI-161)

## Checklist

- [ ] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)



[TI-161]: https://4teamwork.atlassian.net/browse/TI-161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ