### PR TITLE
Fix some dossier transfer issues

### DIFF
--- a/opengever/core/upgrades/20240125083502_add_dossier_transfers_sql_table/upgrade.py
+++ b/opengever/core/upgrades/20240125083502_add_dossier_transfers_sql_table/upgrade.py
@@ -37,3 +37,5 @@ class AddDossierTransfersSQLTable(SchemaMigration):
             Column('all_participations', Boolean(), nullable=False),
             Column('token', String(), nullable=True),
         )
+
+        self.ensure_sequence_exists('dossier_transfer_id_seq')

--- a/opengever/dossiertransfer/api/get.py
+++ b/opengever/dossiertransfer/api/get.py
@@ -1,3 +1,4 @@
+from ftw.mail.mail import IMail
 from opengever.base.behaviors.utils import set_attachment_content_disposition
 from opengever.base.security import elevated_privileges
 from opengever.document.behaviors import IBaseDocument
@@ -98,7 +99,11 @@ class DossierTransfersGet(DossierTransferLocator):
                     raise Unauthorized
 
             document = brains[0].getObject()
-            namedfile = document.file
+
+            if IMail.providedBy(document):
+                namedfile = document.message
+            else:
+                namedfile = document.file
 
         filename = getattr(namedfile, 'filename', u'document.bin').encode('utf-8')
         set_attachment_content_disposition(self.request, filename, namedfile)

--- a/opengever/dossiertransfer/api/perform.py
+++ b/opengever/dossiertransfer/api/perform.py
@@ -201,7 +201,12 @@ class PerformDossierTransfer(Service):
             self.strip_unknown_custom_properties(doc, slots)
 
             doc_file = open(self.documents[doc['UID']], 'rb')
-            doc['file']['data'] = doc_file
+
+            if doc['@type'] == 'ftw.mail.mail':
+                doc['message']['data'] = doc_file
+            else:
+                doc['file']['data'] = doc_file
+
             self.objects_by_path[path] = self.create_content(parent, doc)
             doc_file.close()
 

--- a/opengever/dossiertransfer/api/perform.py
+++ b/opengever/dossiertransfer/api/perform.py
@@ -225,7 +225,7 @@ class PerformDossierTransfer(Service):
 
     def add_participation(self, dossier, participation):
         participant_id, roles = participation
-        participant_id = self.contact_id_mapping[participant_id]
+        participant_id = self.contact_id_mapping.get(participant_id, participant_id)
         IParticipationAware(dossier).add_participation(participant_id, roles)
 
     def create_contacts(self):

--- a/opengever/dossiertransfer/tests/test_api_get.py
+++ b/opengever/dossiertransfer/tests/test_api_get.py
@@ -3,6 +3,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testing import freeze
+from ftw.testing import staticuid
 from opengever.base.model import create_session
 from opengever.base.security import elevated_privileges
 from opengever.dossier.behaviors.participation import IParticipationAware
@@ -815,6 +816,121 @@ class TestDossierTransfersGetFullContent(KuBIntegrationTestCase):
         document.pop('file_mtime')
 
         self.assertEqual(expected_document, document)
+
+    @browsing
+    @staticuid()
+    def test_mail_serialization(self, browser):
+        self.login(self.manager)
+
+        with freeze(FROZEN_NOW):
+            selected_mail = create(Builder('mail')
+                                .within(self.resolvable_subdossier)
+                                .with_asset_message('mail_with_one_mail_attachment.eml'))
+
+        transfer = self.create_transfer(all_documents=False, documents=[selected_mail.UID()])
+
+        headers = self.api_headers.copy()
+        headers.update({'X-GEVER-Dossier-Transfer-Token': transfer.token})
+
+        with freeze(FROZEN_NOW):
+            browser.open(
+                self.portal,
+                view='@dossier-transfers/%s/?full_content=1' % transfer.id,
+                method='GET', headers=headers)
+
+        self.assertEqual(200, browser.status_code)
+
+        expected_mail = {
+            u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-8/dossier-9/document-46',
+            u'@type': u'ftw.mail.mail',
+            u'UID': u'testmailserialization00000000001',
+            u'allow_discussion': False,
+            u'archival_file': None,
+            u'archival_file_state': None,
+            u'attachments': [{u'content-type': u'message/rfc822',
+                            u'filename': u'Inneres Testma\u0308il ohne Attachments.eml',
+                            u'position': 2,
+                            u'size': 930}],
+            u'back_references_relatedItems': [],
+            u'changeNote': u'',
+            u'changed': u'2024-02-18T15:45:00+00:00',
+            u'checked_out': None,
+            u'checked_out_fullname': None,
+            u'checkout_collaborators': [],
+            u'classification': {u'title': u'unprotected', u'token': u'unprotected'},
+            u'containing_dossier': u'A resolvable main dossier',
+            u'containing_subdossier': u'Resolvable Subdossier',
+            u'containing_subdossier_url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-8/dossier-9',
+            u'created': u'2024-02-18T15:45:00+00:00',
+            u'creator': {u'@id': u'http://nohost/plone/@actors/admin',
+                        u'identifier': u'admin'},
+            u'current_version_id': 0,
+            u'custom_properties': None,
+            u'delivery_date': None,
+            u'description': u'',
+            u'digitally_available': True,
+            u'document_author': u'B\xe4rfuss K\xe4thi',
+            u'document_date': u'2015-06-30',
+            u'document_type': None,
+            u'file_extension': u'.eml',
+            u'foreign_reference': None,
+            u'getObjPositionInParent': 1,
+            u'gever_url': u'',
+            u'id': u'document-46',
+            u'is_collaborative_checkout': False,
+            u'is_folderish': False,
+            u'is_locked': False,
+            u'is_shadow_document': False,
+            u'keywords': [],
+            u'layout': u'tabbed_view',
+            u'message': {u'content-type': u'message/rfc822',
+                        u'download': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-8/dossier-9/document-46/@@download/message',
+                        u'filename': u'Aeusseres Testmaeil.eml',
+                        u'size': 1951},
+            u'message_source': None,
+            u'modified': u'2024-02-18T15:45:00+00:00',
+            u'next_item': {},
+            u'original_message': None,
+            u'parent': {u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-8/dossier-9',
+                        u'@type': u'opengever.dossier.businesscasedossier',
+                        u'UID': u'createresolvabledossier000000002',
+                        u'description': u'',
+                        u'dossier_type': None,
+                        u'is_leafnode': None,
+                        u'is_subdossier': True,
+                        u'review_state': u'dossier-state-active',
+                        u'title': u'Resolvable Subdossier'},
+            u'preserved_as_paper': True,
+            u'preview': None,
+            u'previous_item': {u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-8/dossier-9/document-28',
+                                u'@type': u'opengever.document.document',
+                                u'description': u'',
+                                u'title': u'Umbau B\xe4rengraben'},
+            u'privacy_layer': {u'title': u'no', u'token': u'privacy_layer_no'},
+            u'public_trial': {u'title': u'not assessed', u'token': u'unchecked'},
+            u'public_trial_statement': None,
+            u'receipt_date': u'2024-02-18',
+            u'reference_number': u'Client1 1.1 / 5.1 / 46',
+            u'relative_path': u'ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-8/dossier-9/document-46',
+            u'review_state': u'mail-state-active',
+            u'sequence_number': 46,
+            u'teamraum_connect_links': {u'gever_document': None,
+                                        u'workspace_documents': []},
+            u'thumbnail': None,
+            u'title': u'\xc4usseres Testm\xe4il',
+            u'trashed': False,
+            u'version': u'current',
+            u'workspace_document_urls': []
+        }
+
+        documents = browser.json['content']['documents']
+        document = documents[0]
+
+        # file_mtime is flaky because it doesn't get frozen with enough precision
+        document.pop('file_mtime')
+        document.pop('oguid')
+
+        self.assertEqual(expected_mail, document)
 
     @requests_mock.Mocker()
     @browsing

--- a/opengever/dossiertransfer/tests/test_api_get.py
+++ b/opengever/dossiertransfer/tests/test_api_get.py
@@ -494,6 +494,11 @@ class TestDossierTransfersGetFullContent(KuBIntegrationTestCase):
             JEAN_PERSON_ID,
             ['regard', 'participation', 'final-drawing'],
         )
+
+        # add a ogds user as a participant
+        handler = IParticipationAware(self.resolvable_dossier)
+        handler.add_participation('robert.ziegler', ['final-drawing'])
+
         self.logout()
 
         headers = self.api_headers.copy()
@@ -566,6 +571,10 @@ class TestDossierTransfersGetFullContent(KuBIntegrationTestCase):
                 [
                     u'person:9af7d7cc-b948-423f-979f-587158c6bc65',
                     [u'regard', u'participation', u'final-drawing'],
+                ],
+                [
+                    u'robert.ziegler',
+                    [u'final-drawing'],
                 ],
             ],
             u'privacy_layer': {

--- a/opengever/dossiertransfer/tests/test_api_perform.py
+++ b/opengever/dossiertransfer/tests/test_api_perform.py
@@ -97,6 +97,10 @@ METADATA_RESP = {
                     u'person:9af7d7cc-b948-423f-979f-587158c6bc65',
                     [u'participation'],
                 ],
+                [
+                    u'robert.ziegler',
+                    [u'regard'],
+                ],
             ],
         }, {
             "@id": "http://nohost/plone/ordnungssystem/fuehrung/gemeinderecht/dossier-20/dossier-21",
@@ -282,7 +286,10 @@ class TestPerformDossierTransfer(KuBIntegrationTestCase):
         dossier = self.leaf_repofolder[resp.json['id']]
         self.assertEqual(
             [(p.contact, p.roles) for p in IParticipationAware(dossier).get_participations()],
-            [('person:20e024c9-db20-4ea1-999a-9deaa80413f4', [u'participation'])])
+            [
+                ('robert.ziegler', [u'regard']),
+                ('person:20e024c9-db20-4ea1-999a-9deaa80413f4', [u'participation']),
+            ])
 
         # Verify that transfer state is set to completed
         self.assertEqual(transfer.state, TRANSFER_STATE_COMPLETED)
@@ -360,7 +367,10 @@ class TestPerformDossierTransfer(KuBIntegrationTestCase):
         dossier = self.leaf_repofolder[resp.json['id']]
         self.assertEqual(
             [(p.contact, p.roles) for p in IParticipationAware(dossier).get_participations()],
-            [('person:9af7d7cc-b948-423f-979f-587158c6bc65', [u'participation'])])
+            [
+                ('person:9af7d7cc-b948-423f-979f-587158c6bc65', [u'participation']),
+                ('robert.ziegler', [u'regard']),
+            ])
 
         # Verify that transfer state is set to completed
         self.assertEqual(transfer.state, TRANSFER_STATE_COMPLETED)

--- a/opengever/dossiertransfer/tests/test_api_perform.py
+++ b/opengever/dossiertransfer/tests/test_api_perform.py
@@ -440,6 +440,11 @@ class TestPersonContactSyncer(KuBIntegrationTestCase):
             self.client.kub_api_url, 'person:ea18df93-0fe7-4615-a859-cde16cc4dd23')
         mocker.get(url, json=KUB_LIST_EMPTY_RESP)
 
+        url = '{}people?{}'.format(
+            self.client.kub_api_url,
+            'first_name=Jean&date_of_birth_max=1980-01-01&date_of_birth_min=1980-01-01&official_name=Dupont')
+        mocker.get(url, json=KUB_LIST_EMPTY_RESP)
+
         url = '{}people'.format(self.client.kub_api_url)
         mocker.post(url, json={'id': '9af7d7cc-b948-423f-979f-587158c6bc65'})
 
@@ -450,6 +455,9 @@ class TestPersonContactSyncer(KuBIntegrationTestCase):
                 {
                     'type': 'person',
                     'text': 'Dupont Jean',
+                    'firstName': 'Jean',
+                    'officialName': 'Dupont',
+                    'dateOfBirth': '1980-01-01',
                     'title': '',
                 }
             )
@@ -473,6 +481,35 @@ class TestPersonContactSyncer(KuBIntegrationTestCase):
                     'text': 'Dupont Jean',
                     'title': '',
                     'thirdPartyId': 'foo:bar',
+                }
+            )
+        )
+
+    @requests_mock.Mocker()
+    @browsing
+    def test_sync_returns_the_type_id_of_a_guessed_kub_person(self, mocker, browser):
+        self.login(self.secretariat_user, browser)
+
+        url = '{}people?third_party_id={}'.format(
+            self.client.kub_api_url, 'person:ea18df93-0fe7-4615-a859-cde16cc4dd23')
+        mocker.get(url, json=KUB_LIST_EMPTY_RESP)
+
+        url = '{}people?{}'.format(
+            self.client.kub_api_url,
+            'first_name=Jean&date_of_birth_max=1980-01-01&date_of_birth_min=1980-01-01&official_name=Dupont')
+        mocker.get(url, json=KUB_LIST_RESP)
+
+        self.assertEqual(
+            'person:20e024c9-db20-4ea1-999a-9deaa80413f4',
+            PersonContactSyncer(self.client).sync(
+                'person:ea18df93-0fe7-4615-a859-cde16cc4dd23',
+                {
+                    'type': 'person',
+                    'text': 'Dupont Jean',
+                    'firstName': 'Jean',
+                    'officialName': 'Dupont',
+                    'dateOfBirth': '1980-01-01',
+                    'title': '',
                 }
             )
         )

--- a/opengever/dossiertransfer/tests/test_api_perform.py
+++ b/opengever/dossiertransfer/tests/test_api_perform.py
@@ -51,28 +51,51 @@ METADATA_RESP = {
                 u'title': u'',
             },
         },
-        u'documents': [{
-            "@id": "http://nohost/plone/ordnungssystem/fuehrung/gemeinderecht/dossier-20/dossier-21/document-44",
-            "@type": "opengever.document.document",
-            "custom_properties": {
-                'IDocumentMetadata.document_type.contract': {
-                    "contract_number": 10033,
+        u'documents': [
+            {
+                "@id": "http://nohost/plone/ordnungssystem/fuehrung/gemeinderecht/dossier-20/dossier-21/document-44",
+                "@type": "opengever.document.document",
+                "custom_properties": {
+                    'IDocumentMetadata.document_type.contract': {
+                        "contract_number": 10033,
+                    },
+                    'IDocumentMetadata.document_type.directive': {
+                        "unknown_number": 42,
+                        "textline": "Foo bar",
+                    },
                 },
-                'IDocumentMetadata.document_type.directive': {
-                    "unknown_number": 42,
-                    "textline": "Foo bar",
+                "UID": "a663689540a34538b6f408d4b41baee8",
+                u'relative_path': u'ordnungssystem/fuehrung/gemeinderecht/dossier-20/dossier-21/document-44',
+                u'title': u'Umbau B\xe4rengraben',
+                'file': {
+                    u'content-type': u'plain/text',
+                    u'download': u'http://nohost/plone/ordnungssystem/fuehrung/gemeinderecht/dossier-20/dossier-21/document-44/@@download/file',  # noqa
+                    u'filename': u'Foobar.txt',
+                    u'size': 6,
                 },
             },
-            "UID": "a663689540a34538b6f408d4b41baee8",
-            u'relative_path': u'ordnungssystem/fuehrung/gemeinderecht/dossier-20/dossier-21/document-44',
-            u'title': u'Umbau B\xe4rengraben',
-            'file': {
-                u'content-type': u'plain/text',
-                u'download': u'http://nohost/plone/ordnungssystem/fuehrung/gemeinderecht/dossier-20/dossier-21/document-44/@@download/file',  # noqa
-                u'filename': u'Foobar.txt',
-                u'size': 6,
+            {
+                "@id": "http://nohost/plone/ordnungssystem/fuehrung/gemeinderecht/dossier-20/dossier-21/document-45",
+                "@type": "ftw.mail.mail",
+                "UID": "f1ff0f7f40fd42a280b7c9094324e58e",
+                u'relative_path': u'ordnungssystem/fuehrung/gemeinderecht/dossier-20/dossier-21/document-45',
+                "attachments": [
+                    {
+                        "content-type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                        "filename": "Enim cum at impedit eos.docx",
+                        "position": 2,
+                        "size": 102554
+                    },
+                ],
+                "message": {
+                    "content-type": "message/rfc822",
+                    "download": "http://localhost:8080/fd/ordnungssystem/bildung/dossier-32/document-45/@@download/message",
+                    "filename": "Mail mit Anhang.eml",
+                    "size": 341476
+                },
+                "title": "Mail mit Anhang",
             },
-        }],
+        ],
         u'dossiers': [{
             "@id": "http://nohost/plone/ordnungssystem/fuehrung/gemeinderecht/dossier-20",
             "@type": "opengever.dossier.businesscasedossier",
@@ -231,6 +254,9 @@ class TestPerformDossierTransfer(KuBIntegrationTestCase):
         url = 'http://example.com/@dossier-transfers/1/blob/a663689540a34538b6f408d4b41baee8'
         mocker.get(url, content='foobar')
 
+        url = 'http://example.com/@dossier-transfers/1/blob/f1ff0f7f40fd42a280b7c9094324e58e'
+        mocker.get(url, content='foobar_mail')
+
         url = '{}people?third_party_id={}'.format(
             self.client.kub_api_url, 'person:9af7d7cc-b948-423f-979f-587158c6bc65')
         mocker.get(url, json=KUB_LIST_RESP)
@@ -258,6 +284,7 @@ class TestPerformDossierTransfer(KuBIntegrationTestCase):
         expected_calls = [
             ('GET', 'http://example.com/@dossier-transfers/1?full_content=1'),
             ('GET', 'http://example.com/@dossier-transfers/1/blob/a663689540a34538b6f408d4b41baee8'),
+            ('GET', 'http://example.com/@dossier-transfers/1/blob/f1ff0f7f40fd42a280b7c9094324e58e'),
             ('GET', 'http://localhost:8000/api/v2/people?third_party_id=person%3A9af7d7cc-b948-423f-979f-587158c6bc65'),
             ('GET', 'http://localhost:8000/api/v2/labels'),
         ]
@@ -313,6 +340,9 @@ class TestPerformDossierTransfer(KuBIntegrationTestCase):
         url = 'http://example.com/@dossier-transfers/1/blob/a663689540a34538b6f408d4b41baee8'
         mocker.get(url, content='foobar')
 
+        url = 'http://example.com/@dossier-transfers/1/blob/f1ff0f7f40fd42a280b7c9094324e58e'
+        mocker.get(url, content='foobar')
+
         url = '{}people?third_party_id={}'.format(
             self.client.kub_api_url, 'person:9af7d7cc-b948-423f-979f-587158c6bc65')
         mocker.get(url, json=KUB_LIST_EMPTY_RESP)
@@ -343,6 +373,7 @@ class TestPerformDossierTransfer(KuBIntegrationTestCase):
         expected_calls = [
             ('GET', 'http://example.com/@dossier-transfers/1?full_content=1'),
             ('GET', 'http://example.com/@dossier-transfers/1/blob/a663689540a34538b6f408d4b41baee8'),
+            ('GET', 'http://example.com/@dossier-transfers/1/blob/f1ff0f7f40fd42a280b7c9094324e58e'),
             ('GET', 'http://localhost:8000/api/v2/people?third_party_id=person%3A9af7d7cc-b948-423f-979f-587158c6bc65'),
             ('POST', 'http://localhost:8000/api/v2/people'),
             ('GET', 'http://localhost:8000/api/v2/labels'),

--- a/opengever/kub/client.py
+++ b/opengever/kub/client.py
@@ -117,6 +117,20 @@ class KuBClient(object):
             logger.exception('Creating person failed')
             return None
 
+    def create_organization(self, data):
+        url = '{}organizations'.format(self.kub_api_url)
+        try:
+            resp = self.session.post(url, json=data)
+            resp.raise_for_status()
+        except requests.RequestException:
+            logger.exception('Creating organization failed')
+            return None
+        try:
+            return resp.json()
+        except requests.JSONDecodeError:
+            logger.exception('Creating organization failed')
+            return None
+
     def list_people(self, filters=None):
         url = '{}people'.format(self.kub_api_url)
         try:
@@ -129,4 +143,18 @@ class KuBClient(object):
             return resp.json()
         except requests.JSONDecodeError:
             logger.exception('Fetching list of people failed')
+            return None
+
+    def list_organizations(self, filters=None):
+        url = '{}organizations'.format(self.kub_api_url)
+        try:
+            resp = self.session.get(url, params=filters)
+            resp.raise_for_status()
+        except requests.RequestException:
+            logger.exception('Fetching list of organizations failed')
+            return None
+        try:
+            return resp.json()
+        except requests.JSONDecodeError:
+            logger.exception('Fetching list of organizations failed')
             return None


### PR DESCRIPTION
This PR adds some fixes for the dossier transfer:

- Properly handle ogds users as dossier participants when performing a dossier transfer
- Fix transfering emails
- Fix upgradestep
- Fix creation of people with memberships and/or username (remove it)
- Fix creation of organizations
- Add contact-guessing for people and organizations


For [TI-349]

## Checklist

- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-349]: https://4teamwork.atlassian.net/browse/TI-349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ