### PR TITLE
Inhance system information view with Docproperties

### DIFF
--- a/changes/TI-317.other
+++ b/changes/TI-317.other
@@ -1,0 +1,1 @@
+Provide Docproperty information in system information template  [amo]

--- a/opengever/api/system_information.py
+++ b/opengever/api/system_information.py
@@ -24,6 +24,11 @@ class SystemInformationGet(Service):
             in primary_participation_roles(self.context)}
         for role in available_participation_roles:
             role['primary'] = role.get('token') in primary_participation_role_ids
+            role_id = role.get("token")
+            role['docproperty_key'] = {
+                "person": u"ogg.{}.person.*".format(role_id),
+                "organization": u"ogg.{}.organization.*".format(role_id)
+            }
         infos['dossier_participation_roles'] = available_participation_roles
 
     def add_property_sheet_information(self, infos):
@@ -49,5 +54,7 @@ class SystemInformationGet(Service):
                         assignment_id, assignment_id)
                 } for assignment_id in serialized_sheet.get('assignments')
             ]
+            field_id = serialized_sheet.get("id")
+            serialized_sheet["docproperty_key"] = u"ogg.dossier.cp.{field_id}".format(field_id=field_id)
             propertysheets[sheet.name] = serialized_sheet
         infos['property_sheets'] = propertysheets

--- a/opengever/api/tests/test_system_information.py
+++ b/opengever/api/tests/test_system_information.py
@@ -26,9 +26,36 @@ class TestSystemInformation(IntegrationTestCase):
         browser.open(self.portal.absolute_url() + '/@system-information', headers=self.api_headers)
 
         self.assertEqual([
-            {u'active': True, u'token': u'final-drawing', u'primary': False, u'title': u'Final signature'},
-            {u'active': True, u'token': u'regard', u'primary': True, u'title': u'For your information'},
-            {u'active': True, u'token': u'participation', u'primary': False, u'title': u'Participation'}
+            {
+                u'active': True,
+                u'token': u'final-drawing',
+                u'primary': False,
+                u'docproperty_key': {
+                    u'organization': u'ogg.final-drawing.organization.*',
+                    u'person': u'ogg.final-drawing.person.*'
+                },
+                u'title': u'Final signature'
+            },
+            {
+                u'active': True,
+                u'token': u'regard',
+                u'primary': True,
+                u'docproperty_key': {
+                    u'organization': u'ogg.regard.organization.*',
+                    u'person': u'ogg.regard.person.*'
+                },
+                u'title': u'For your information'
+            },
+            {
+                u'active': True,
+                u'token': u'participation',
+                u'primary': False,
+                u'docproperty_key': {
+                    u'organization': u'ogg.participation.organization.*',
+                    u'person': u'ogg.participation.person.*'
+                },
+                u'title': u'Participation'
+            }
         ], browser.json.get('dossier_participation_roles'))
 
     @browsing
@@ -38,26 +65,23 @@ class TestSystemInformation(IntegrationTestCase):
 
         self.assertEqual(
             [u'dossier_default', u'schema1', u'schema2'],
-            sorted(browser.json.get('property_sheets').keys()))
+            sorted(browser.json.get('property_sheets').keys())
+        )
 
-        self.assertEqual(
-            {
-                u'assignments': [
-                    {
-                        u'id': u'IDocumentMetadata.document_type.directive',
-                        u'title': u'Document (Type: Directive)'
-                    }
-                ],
-                u'fields': [
-                    {
-                        u'available_as_docproperty': False,
-                        u'description': u'',
-                        u'field_type': u'textline',
-                        u'name': u'textline',
-                        u'required': False,
-                        u'title': u'A line of text'
-                    }
-                ],
-                u'id': u'schema2'
-            },
-            browser.json.get('property_sheets').get('schema2'))
+        self.assertEqual({
+
+            u'assignments': [{
+                u'id': u'IDocumentMetadata.document_type.directive',
+                u'title': u'Document (Type: Directive)'
+            }],
+            u'id': u'schema2',
+            u'docproperty_key': u'ogg.dossier.cp.schema2',
+            u'fields': [{
+                u'field_type': u'textline',
+                u'description': u'',
+                u'title': u'A line of text',
+                u'required': False,
+                u'available_as_docproperty': False,
+                u'name': u'textline'
+            }]
+        }, browser.json.get('property_sheets').get('schema2'))


### PR DESCRIPTION
Provide Docproperty information in `@system-information` view
For [TI-317](https://4teamwork.atlassian.net/browse/TI-317)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-317]: https://4teamwork.atlassian.net/browse/TI-317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ