### PR TITLE
Add cutom workspace vocb to get users from AllUsers source

### DIFF
--- a/changes/TI-116.other
+++ b/changes/TI-116.other
@@ -1,0 +1,1 @@
+Enhance Workspace member Vocabulary so we can get meeting users even if they removed from workspace. [amo]


### PR DESCRIPTION
Enhance the Workspace member vocabulary so we can get any meeting participants even if they are not part of the workspace any more.

For [TI-116](https://4teamwork.atlassian.net/browse/TI-116)

**Before:**
<img width="642" alt="before" src="https://github.com/4teamwork/opengever.core/assets/160112920/98174106-fa3f-4f41-9eab-2d03fb86a6a3">


**After:**
<img width="647" alt="after" src="https://github.com/4teamwork/opengever.core/assets/160112920/ea2b7549-9995-4cc9-90ed-05a2f0c9289a">


## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-116]: https://4teamwork.atlassian.net/browse/TI-116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ