### PR TITLE
Solr conf: use WordDelimiterGraph only on indexing

### DIFF
--- a/changes/TI-293.other
+++ b/changes/TI-293.other
@@ -1,0 +1,1 @@
+Improve solr performance, no longer using WordDelimiterGraphFilter on querying. [phgross]

--- a/solr-conf/managed-schema
+++ b/solr-conf/managed-schema
@@ -510,7 +510,31 @@
 
     <!-- French -->
     <fieldType name="text_fr" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
+      <analyzer type="index">
+        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <filter class="solr.KeywordRepeatFilterFactory" />
+        <filter class="solr.WordDelimiterGraphFilterFactory"
+                splitOnCaseChange="1"
+                splitOnNumerics="1"
+                stemEnglishPossessive="1"
+                generateWordParts="1"
+                generateNumberParts="1"
+                catenateWords="1"
+                catenateNumbers="1"
+                catenateAll="0"
+                preserveOriginal="1"/>
+        <filter class="solr.FlattenGraphFilterFactory" />
+        <!-- removes l', etc -->
+        <filter class="solr.ElisionFilterFactory" ignoreCase="true" articles="lang/contractions_fr.txt"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <!-- <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_fr.txt" format="snowball" /> -->
+        <filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="true" />
+        <filter class="solr.FrenchLightStemFilterFactory"/>
+        <!-- less aggressive: <filter class="solr.FrenchMinimalStemFilterFactory"/> -->
+        <!-- more aggressive: <filter class="solr.SnowballPorterFilterFactory" language="French"/> -->
+        <filter class="solr.RemoveDuplicatesTokenFilterFactory" />
+      </analyzer>
+      <analyzer type="query">
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
         <filter class="solr.KeywordRepeatFilterFactory" />
         <filter class="solr.WordDelimiterGraphFilterFactory"

--- a/solr-conf/managed-schema
+++ b/solr-conf/managed-schema
@@ -324,17 +324,6 @@
         <charFilter class="solr.ICUNormalizer2CharFilterFactory"/>
         <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-FoldToASCII.txt"/>
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <filter class="solr.WordDelimiterGraphFilterFactory"
-                splitOnCaseChange="1"
-                splitOnNumerics="1"
-                stemEnglishPossessive="1"
-                generateWordParts="1"
-                generateNumberParts="1"
-                catenateWords="1"
-                catenateNumbers="1"
-                catenateAll="0"
-                preserveOriginal="1"/>
-        <filter class="solr.FlattenGraphFilterFactory" />
         <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
         <filter class="solr.LowerCaseFilterFactory"/>
@@ -371,17 +360,6 @@
       <analyzer type="query">
         <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-FoldToASCII.txt"/>
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <filter class="solr.WordDelimiterGraphFilterFactory"
-                splitOnCaseChange="1"
-                splitOnNumerics="1"
-                stemEnglishPossessive="1"
-                generateWordParts="1"
-                generateNumberParts="1"
-                catenateWords="1"
-                catenateNumbers="1"
-                catenateAll="0"
-                preserveOriginal="1"/>
-        <filter class="solr.FlattenGraphFilterFactory" />
         <!-- <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" /> -->
         <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
         <filter class="solr.LowerCaseFilterFactory"/>
@@ -430,17 +408,6 @@
       </analyzer>
       <analyzer type="query">
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <filter class="solr.WordDelimiterGraphFilterFactory"
-                splitOnCaseChange="1"
-                splitOnNumerics="1"
-                stemEnglishPossessive="1"
-                generateWordParts="1"
-                generateNumberParts="1"
-                catenateWords="1"
-                catenateNumbers="1"
-                catenateAll="0"
-                preserveOriginal="1"/>
-        <filter class="solr.FlattenGraphFilterFactory" />
         <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
 <!--         <filter class="solr.StopFilterFactory"
                 ignoreCase="true"
@@ -486,17 +453,6 @@
       </analyzer>
       <analyzer type="query">
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <filter class="solr.WordDelimiterGraphFilterFactory"
-                splitOnCaseChange="1"
-                splitOnNumerics="1"
-                stemEnglishPossessive="1"
-                generateWordParts="1"
-                generateNumberParts="1"
-                catenateWords="1"
-                catenateNumbers="1"
-                catenateAll="0"
-                preserveOriginal="1"/>
-        <filter class="solr.FlattenGraphFilterFactory" />
         <filter class="solr.LowerCaseFilterFactory"/>
         <!-- <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_de.txt" format="snowball" /> -->
         <filter class="solr.KeywordRepeatFilterFactory" />
@@ -537,17 +493,6 @@
       <analyzer type="query">
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
         <filter class="solr.KeywordRepeatFilterFactory" />
-        <filter class="solr.WordDelimiterGraphFilterFactory"
-                splitOnCaseChange="1"
-                splitOnNumerics="1"
-                stemEnglishPossessive="1"
-                generateWordParts="1"
-                generateNumberParts="1"
-                catenateWords="1"
-                catenateNumbers="1"
-                catenateAll="0"
-                preserveOriginal="1"/>
-        <filter class="solr.FlattenGraphFilterFactory" />
         <!-- removes l', etc -->
         <filter class="solr.ElisionFilterFactory" ignoreCase="true" articles="lang/contractions_fr.txt"/>
         <filter class="solr.LowerCaseFilterFactory"/>


### PR DESCRIPTION
This helps to speed up queries of alphanummeric terms, for example "B57.0.346" or similar.

For [TI-293]

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[TI-293]: https://4teamwork.atlassian.net/browse/TI-293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ