### PR TITLE
Add feature-flag to disable the classic ui

### DIFF
--- a/changes/TI-88.other
+++ b/changes/TI-88.other
@@ -1,0 +1,1 @@
+Add feature-flag to disable the classic ui [elioschmutz]

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -67,6 +67,7 @@ class TestConfig(IntegrationTestCase):
                 u'archival_file_conversion': False,
                 u'archival_file_conversion_blacklist': [],
                 u'changed_for_end_date': True,
+                u'classic_ui_enabled': True,
                 u'contacts': 'plone',
                 u'disposition_disregard_retention_period': False,
                 u'disposition_transport_filesystem': False,

--- a/opengever/base/configuration.py
+++ b/opengever/base/configuration.py
@@ -141,6 +141,7 @@ class GeverSettingsAdpaterV1(object):
         features['archival_file_conversion'] = api.portal.get_registry_record('archival_file_conversion_enabled', interface=IDossierResolveProperties)  # noqa
         features['archival_file_conversion_blacklist'] = api.portal.get_registry_record('archival_file_conversion_blacklist', interface=IDossierResolveProperties)  # noqa
         features['changed_for_end_date'] = api.portal.get_registry_record('use_changed_for_end_date', interface=IDossierResolveProperties)  # noqa
+        features['classic_ui_enabled'] = api.portal.get_registry_record('is_classic_ui_enabled', interface=IGeverUI)
         features['contacts'] = self._get_contact_type()
         features['disposition_disregard_retention_period'] = api.portal.get_registry_record('disregard_retention_period', interface=IDispositionSettings)  # noqa
         features['disposition_transport_filesystem'] = api.portal.get_registry_record('enabled', interface=IFilesystemTransportSettings)  # noqa

--- a/opengever/base/interfaces.py
+++ b/opengever/base/interfaces.py
@@ -432,6 +432,10 @@ class IGeverUI(Interface):
         description=u'Whether new GEVER UI is enabled',
         default=True)
 
+    is_classic_ui_enabled = schema.Bool(
+        title=u'Enable the classic UI',
+        default=True)
+
     custom_dashboard_cards = schema.Text(
         title=u'custom dashboard cards',
         description=u'In json format, eg. [{"id": "dossiers", "componentName": "DossiersCard", "'

--- a/opengever/base/tests/test_configuration_adapter.py
+++ b/opengever/base/tests/test_configuration_adapter.py
@@ -64,6 +64,7 @@ class TestConfigurationAdapter(IntegrationTestCase):
                 ('archival_file_conversion', False),
                 ('archival_file_conversion_blacklist', []),
                 ('changed_for_end_date', True),
+                ('classic_ui_enabled', True),
                 ('contacts', 'plone'),
                 ('disposition_disregard_retention_period', False),
                 ('disposition_transport_filesystem', False),

--- a/opengever/core/upgrades/20240524081835_add_setting_to_disable_classic_ui/registry.xml
+++ b/opengever/core/upgrades/20240524081835_add_setting_to_disable_classic_ui/registry.xml
@@ -1,0 +1,5 @@
+<registry>
+  <records interface="opengever.base.interfaces.IGeverUI">
+    <value key="is_classic_ui_enabled">True</value>
+  </records>
+</registry>

--- a/opengever/core/upgrades/20240524081835_add_setting_to_disable_classic_ui/upgrade.py
+++ b/opengever/core/upgrades/20240524081835_add_setting_to_disable_classic_ui/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddSettingToDisableClassicUI(UpgradeStep):
+    """Add setting to disable classic ui.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
This PR adds a feature-flag to disable the classic UI.

It is a marker flag only. So nothing will happen on the backend to prevent access to the classic UI.

The flag will be used by the UI to decide if a link to toggle the UI should be visible or not.

For [TI-88]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-88]: https://4teamwork.atlassian.net/browse/TI-88?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ