### PR TITLE
Temporarily pass a dummy filename to oneoffixx

### DIFF
--- a/changes/TI-456.bugfix
+++ b/changes/TI-456.bugfix
@@ -1,0 +1,1 @@
+Temporarily pass a dummy filename to oneoffixx, to support at least word templates. [phgross]

--- a/opengever/oneoffixx/command.py
+++ b/opengever/oneoffixx/command.py
@@ -1,4 +1,5 @@
 from opengever.base.command import BaseObjectCreatorCommand
+from zope.annotation.interfaces import IAnnotations
 
 
 class CreateDocumentFromOneOffixxTemplateCommand(BaseObjectCreatorCommand):
@@ -10,4 +11,11 @@ class CreateDocumentFromOneOffixxTemplateCommand(BaseObjectCreatorCommand):
 
     def execute(self):
         obj = super(CreateDocumentFromOneOffixxTemplateCommand, self).execute()
+
+        # XXX Temporarily pass a *.docx filename to oneoffixx to support at
+        # least word templates. Before Office Connector no longer needs a
+        # filename and we support all kind of templates.
+        annotations = IAnnotations(obj)
+        annotations["filename"] = 'oneoffixx_from_template.docx'
+
         return obj.as_shadow_document()

--- a/opengever/oneoffixx/service.py
+++ b/opengever/oneoffixx/service.py
@@ -2,6 +2,7 @@ from opengever.api.add import GeverFolderPost
 from opengever.officeconnector.helpers import create_oc_url
 from opengever.oneoffixx import is_oneoffixx_feature_enabled
 from zExceptions import NotFound
+from zope.annotation.interfaces import IAnnotations
 
 
 class CreateDocumentFromOneOffixxTemplate(GeverFolderPost):
@@ -36,3 +37,11 @@ class CreateDocumentFromOneOffixxTemplate(GeverFolderPost):
             'url': create_oc_url(
                 self.request, self.obj, dict(action='oneoffixx'),),
         }
+
+    def before_deserialization(self, obj):
+
+        # XXX Temporarily pass a *.docx filename to oneoffixx to support at
+        # least word templates. Before Office Connector no longer needs a
+        # filename and we support all kind of templates.
+        annotations = IAnnotations(obj)
+        annotations["filename"] = 'oneoffixx_from_template.docx'


### PR DESCRIPTION
Before Office Connector no longer needs a filename and we support all kind of templates, we support at least word templates. The Office Connector change will be implemented with https://4teamwork.atlassian.net/browse/TI-455

This change can be reverted, as soon the OC is updated and rolled out.

Needs backport to 2024.8.x

For [TI-456]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)



[TI-456]: https://4teamwork.atlassian.net/browse/TI-456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ