### PR TITLE
Update white_list_prefix and add upgrade step for ISharingConfiguration

### DIFF
--- a/changes/TI-454.other
+++ b/changes/TI-454.other
@@ -1,0 +1,1 @@
+Updated `white_list_prefix` in `ISharingConfiguration` to `^ACL-SVC-GEVER` [amo]

--- a/docs/public-fr/dev-manual/api/config.rst
+++ b/docs/public-fr/dev-manual/api/config.rst
@@ -56,7 +56,7 @@ On peut interroger diverses options de configuration du client GEVER avec l'endp
           "root_url": "http://localhost:8080/fd",
           "sharing_configuration": {
               "black_list_prefix": "^$",
-              "white_list_prefix": "^.+"
+              "white_list_prefix": "^ACL-SVC-GEVER"
           },
           "user_settings": {
               "notify_inbox_actions": true,

--- a/docs/public/dev-manual/api/config.rst
+++ b/docs/public/dev-manual/api/config.rst
@@ -121,7 +121,7 @@ GEVER-Mandanten abgefragt werden.
           "root_url": "http://localhost:8080/fd",
           "sharing_configuration": {
               "black_list_prefix": "^$",
-              "white_list_prefix": "^.+"
+              "white_list_prefix": "^ACL-SVC-GEVER"
           },
           "template_folder_url": "http://localhost:8080/fd/vorlagen",
           "user_settings": {

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -197,7 +197,7 @@ class TestConfig(IntegrationTestCase):
         browser.open(self.config_url, headers=self.api_headers)
         self.assertEqual(browser.status_code, 200)
         self.assertEqual(browser.json.get(u'sharing_configuration'),
-                         {u'white_list_prefix': '^.+', u'black_list_prefix': '^$'})
+                         {u'white_list_prefix': '^ACL-SVC-GEVER', u'black_list_prefix': '^$'})
 
     @browsing
     def test_config_contains_user_settings(self, browser):

--- a/opengever/base/tests/test_configuration_adapter.py
+++ b/opengever/base/tests/test_configuration_adapter.py
@@ -55,7 +55,7 @@ class TestConfigurationAdapter(IntegrationTestCase):
                 ('seen_tours', ['*']),
             ])),
             ('sharing_configuration', OrderedDict([
-                ('white_list_prefix', u'^.+'),
+                ('white_list_prefix', u'^ACL-SVC-GEVER'),
                 ('black_list_prefix', u'^$'),
                 ])),
             ('p7m_extension_replacement', 'eml'),

--- a/opengever/core/upgrades/20240530083526_update_sharing_configuration_white_list_prefix/registry.xml
+++ b/opengever/core/upgrades/20240530083526_update_sharing_configuration_white_list_prefix/registry.xml
@@ -1,0 +1,5 @@
+<registry>
+    <record name="opengever.sharing.interfaces.ISharingConfiguration.white_list_prefix">
+        <value>^ACL-SVC-GEVER</value>
+    </record>
+</registry>

--- a/opengever/core/upgrades/20240530083526_update_sharing_configuration_white_list_prefix/upgrade.py
+++ b/opengever/core/upgrades/20240530083526_update_sharing_configuration_white_list_prefix/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class UpdateSharingConfigurationWhiteListPrefix(UpgradeStep):
+    """update sharing configuration white list prefix.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/sharing/interfaces.py
+++ b/opengever/sharing/interfaces.py
@@ -32,7 +32,7 @@ class ISharingConfiguration(Interface):
         title=u'white list prefix',
         description=u'The prefix pattern for groups which should be displayed'
         'in the sharing view, even if the black list prefix also matches.',
-        default=u"^.+")
+        default=u"^ACL-SVC-GEVER")
 
     black_list_prefix = schema.TextLine(
         title=u'black list prefix',


### PR DESCRIPTION
- Updated `white_list_prefix` default value in `ISharingConfiguration` from `^.+` to `^ACL-SVC-GEVER` to allow a broader range of groups to be displayed in the sharing view.

- Added an upgrade step to update the `white_list_prefix` for existing installations to ensure consistent behavior across all clients.

For [TI-454](https://4teamwork.atlassian.net/browse/TI-454)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- Upgrade-Steps:
  - DB-Schema migration
    - [x] All changes on a model (columns, etc) are included in a DB-schema migration.

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry

[TI-454]: https://4teamwork.atlassian.net/browse/TI-454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ