### PR TITLE
Add systemmessages permissions

### DIFF
--- a/changes/TI-482.other
+++ b/changes/TI-482.other
@@ -1,0 +1,1 @@
+Add System messages permissions [amo]

--- a/opengever/base/systemmessages/api.zcml
+++ b/opengever/base/systemmessages/api.zcml
@@ -15,7 +15,7 @@
       name="@system-messages"
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"
       factory=".api.post.SystemMessagesPost"
-      permission="cmf.ManagePortal"
+      permission="opengever.systemmessages.ManageSystemMessages"
       />
 
   <plone:service
@@ -23,7 +23,7 @@
       name="@system-messages"
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"
       factory=".api.get.SystemMessagesGet"
-      permission="cmf.ManagePortal"
+      permission="opengever.systemmessages.ManageSystemMessages"
       />
 
   <plone:service
@@ -31,7 +31,7 @@
       name="@system-messages"
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"
       factory=".api.delete.SystemMessagesDelete"
-      permission="cmf.ManagePortal"
+      permission="opengever.systemmessages.ManageSystemMessages"
       />
 
 
@@ -40,6 +40,6 @@
       name="@system-messages"
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"
       factory=".api.patch.SystemMessagesPatch"
-      permission="cmf.ManagePortal"
+      permission="opengever.systemmessages.ManageSystemMessages"
       />
 </configure>

--- a/opengever/base/systemmessages/configure.zcml
+++ b/opengever/base/systemmessages/configure.zcml
@@ -5,6 +5,7 @@
     xmlns:i18n="http://namespaces.zope.org/i18n"
     i18n_domain="opengever.systemmessages">
 
+  <include file="permissions.zcml" />
   <include file="api.zcml" />
 
 </configure>

--- a/opengever/base/systemmessages/permissions.zcml
+++ b/opengever/base/systemmessages/permissions.zcml
@@ -1,0 +1,7 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    i18n_domain="opengever.systemmessages">
+
+  <permission id="opengever.systemmessages.ManageSystemMessages" title="opengever.systemmessages: Manage System Messages" />
+
+</configure>

--- a/opengever/core/lawgiver.zcml
+++ b/opengever/core/lawgiver.zcml
@@ -250,7 +250,8 @@
                    opengever.workspaceclient: Use Workspace Client,
                    plone.app.collection: Add Collection,
                    plone.restapi: Access Plone user information,
-                   Remove GEVER content, 
+                   Remove GEVER content,
+                   opengever.systemmessages: Manage System Messages,
                    "
       />
 

--- a/opengever/core/profiles/default/rolemap.xml
+++ b/opengever/core/profiles/default/rolemap.xml
@@ -426,6 +426,13 @@
       <role name="Administrator" />
     </permission>
 
+    <permission name="opengever.systemmessages: Manage System Messages" acquire="True">
+      <role name="Manager" />
+      <role name="Administrator" />
+      <role name="LimitedAdmin" />
+    </permission>
+
+
   </permissions>
 
 </rolemap>

--- a/opengever/core/upgrades/20240531101009_update_system_messages_permissions/rolemap.xml
+++ b/opengever/core/upgrades/20240531101009_update_system_messages_permissions/rolemap.xml
@@ -1,0 +1,13 @@
+<rolemap>
+
+  <permissions>
+
+    <permission name="opengever.systemmessages: Manage System Messages" acquire="True">
+      <role name="Manager" />
+      <role name="Administrator" />
+      <role name="LimitedAdmin" />
+    </permission>
+
+  </permissions>
+
+</rolemap>

--- a/opengever/core/upgrades/20240531101009_update_system_messages_permissions/upgrade.py
+++ b/opengever/core/upgrades/20240531101009_update_system_messages_permissions/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class UpdateSystemMessagesPermissions(UpgradeStep):
+    """Update system messages permissions.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/readonly/tests/test_all_roles_and_permissions_mapped.py
+++ b/opengever/readonly/tests/test_all_roles_and_permissions_mapped.py
@@ -265,6 +265,7 @@ NON_WRITE_PERMISSIONS = [
     'WebDAV access',
     'WebDAV Lock items',
     'WebDAV Unlock items',
+    'opengever.systemmessages: Manage System Messages',
 ]
 
 


### PR DESCRIPTION
Define new permission `opengever.systemmessages.ManageSystemmessages` to manage System Messages.

The permission is limited to the following roles: `(Manager, Administrator, LimitedAdmin)`

For [TI-482](https://4teamwork.atlassian.net/browse/TI-482)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[TI-482]: https://4teamwork.atlassian.net/browse/TI-482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ