### PR TITLE
Fix nested task templates

### DIFF
--- a/changes/TI-485-2.bugfix
+++ b/changes/TI-485-2.bugfix
@@ -1,0 +1,1 @@
+Properly start and close parent tasks within a nested task template structure. [elioschmutz]

--- a/changes/TI-485.bugfix
+++ b/changes/TI-485.bugfix
@@ -1,0 +1,1 @@
+Fix opening subtask in nested tasktemplates contiaining skipped tasks [elioschmutz]

--- a/opengever/task/handlers.py
+++ b/opengever/task/handlers.py
@@ -98,6 +98,13 @@ def review_state_changed(task, event):
     if not task.is_from_tasktemplate or not task.get_is_subtask():
         return
 
+    # If we start working on a subtask always means that we're also working
+    # on the parent task. We need to ensure, that every parent task is in progress.
+    if event.action not in ['task-transition-planned-open',
+                            'task-transition-rejected-skipped',
+                            'task-transition-reassign']:
+        task.maybe_start_parent_task()
+
     if event.action in FINAL_TRANSITIONS:
         task.sync()
         if TaskChecker(task.aq_parent.get_sql_object()).all_subtasks_finished:

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -769,6 +769,17 @@ class Task(Container, TaskReminderSupport):
             api.content.transition(
                 obj=parent, transition='task-transition-in-progress-tested-and-closed')
 
+    def maybe_start_parent_task(self):
+        with elevated_privileges():
+            parent = aq_parent(aq_inner(self))
+            if not parent:
+                return
+
+            if api.content.get_state(parent) != 'task-state-open':
+                return
+
+            parent._set_in_progress()
+
     def get_next_planned_task(self):
         next_task = self.get_sql_object().get_next_task()
         if not next_task:

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -715,6 +715,9 @@ class Task(Container, TaskReminderSupport):
                 next_task.start_subprocess()
 
     def _open_planned_task(self):
+        if api.content.get_state(self) != 'task-state-planned':
+            return
+
         with as_internal_workflow_transition():
             api.content.transition(
                 obj=self, transition='task-transition-planned-open')


### PR DESCRIPTION
This PR fixes some issues related to nested tasks for task templates:

**Skipped subtasks**
closing a predecessor task was not possible if there where skipped task in the tasks to open

**Properly start and close parent tasks within nested task template structure**
When now starting to work on a subtask, all parent tasks will be set in progress. This ensures in a later step, that the full parent structure will be closed if the last subtask gets closed:


https://github.com/4teamwork/opengever.core/assets/557005/60cd68ca-a53d-4208-8282-d3373ffd223a


For [TI-485]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-485]: https://4teamwork.atlassian.net/browse/TI-485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ