### PR TITLE
Handel inactive user invitation

### DIFF
--- a/changes/TI-328.other
+++ b/changes/TI-328.other
@@ -1,0 +1,1 @@
+Handel invitation from inactive user [amo]

--- a/opengever/workspace/participation/__init__.py
+++ b/opengever/workspace/participation/__init__.py
@@ -1,5 +1,5 @@
 from itsdangerous import URLSafeTimedSerializer
-from opengever.ogds.base.actor import PloneUserActor
+from opengever.ogds.base.actor import Actor
 from opengever.workspace import _
 from opengever.workspace.config import workspace_config
 from plone import api
@@ -62,7 +62,7 @@ def get_full_user_info(userid=None, member=None):
     if userid is None:
         userid = member.getId()
 
-    return PloneUserActor(identifier=userid, user=member).get_label()
+    return Actor.lookup(userid).get_label()
 
 
 def can_manage_member(context, actor=None, roles=None):


### PR DESCRIPTION
Handel invitation sent by inactive workspace users

For [TI-328](https://4teamwork.atlassian.net/browse/TI-328)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-328]: https://4teamwork.atlassian.net/browse/TI-328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ