### PR TITLE
Fix access for workspace admin on export users

### DIFF
--- a/changes/TI-506.bugfix
+++ b/changes/TI-506.bugfix
@@ -1,0 +1,1 @@
+Provide ui-action to export workspace users by adding a new permission.[amo]

--- a/opengever/base/context_actions.py
+++ b/opengever/base/context_actions.py
@@ -69,6 +69,7 @@ class BaseContextActions(object):
         self.maybe_add_untrash_context()
         self.maybe_add_zipexport()
         self.maybe_add_save_minutes_as_pdf()
+        self.maybe_export_workspace_user()
         return self.actions
 
     def add_action(self, action):
@@ -243,6 +244,9 @@ class BaseContextActions(object):
         return False
 
     def is_add_save_minutes_as_pdf_available(self):
+        return False
+
+    def is_export_workspace_users_available(self):
         return False
 
     def maybe_add_add_invitation(self):
@@ -468,3 +472,7 @@ class BaseContextActions(object):
     def maybe_add_save_minutes_as_pdf(self):
         if self.is_add_save_minutes_as_pdf_available():
             self.add_action(u'save_minutes_as_pdf')
+
+    def maybe_export_workspace_user(self):
+        if self.is_export_workspace_users_available():
+            self.add_action(u'export_workspace_participators')

--- a/opengever/core/lawgiver.zcml
+++ b/opengever/core/lawgiver.zcml
@@ -252,6 +252,7 @@
                    plone.restapi: Access Plone user information,
                    Remove GEVER content,
                    opengever.systemmessages: Manage System Messages,
+                   opengever.workspace: Export Workspace Participants
                    "
       />
 

--- a/opengever/core/profiles/default/rolemap.xml
+++ b/opengever/core/profiles/default/rolemap.xml
@@ -432,6 +432,13 @@
       <role name="LimitedAdmin" />
     </permission>
 
+    <permission name="opengever.workspace: Export Workspace Participants" acquire="True">
+      <role name="Manager" />
+      <role name="Administrator" />
+      <role name="LimitedAdmin" />
+      <role name="WorkspaceAdmin" />
+    </permission>
+
 
   </permissions>
 

--- a/opengever/core/upgrades/20240610143303_add_workspace_export_participants_permission/rolemap.xml
+++ b/opengever/core/upgrades/20240610143303_add_workspace_export_participants_permission/rolemap.xml
@@ -1,0 +1,12 @@
+<rolemap>
+
+  <permissions>
+    <permission name="opengever.workspace: Export Workspace Participants" acquire="True">
+      <role name="Manager" />
+      <role name="Administrator" />
+      <role name="LimitedAdmin" />
+      <role name="WorkspaceAdmin" />
+    </permission>
+  </permissions>
+
+</rolemap>

--- a/opengever/core/upgrades/20240610143303_add_workspace_export_participants_permission/upgrade.py
+++ b/opengever/core/upgrades/20240610143303_add_workspace_export_participants_permission/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddWorkspaceExportParticipantsPermission(UpgradeStep):
+    """Add workspace export participants permission.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/readonly/tests/test_all_roles_and_permissions_mapped.py
+++ b/opengever/readonly/tests/test_all_roles_and_permissions_mapped.py
@@ -266,6 +266,7 @@ NON_WRITE_PERMISSIONS = [
     'WebDAV Lock items',
     'WebDAV Unlock items',
     'opengever.systemmessages: Manage System Messages',
+    'opengever.workspace: Export Workspace Participants'
 ]
 
 

--- a/opengever/workspace/actions.py
+++ b/opengever/workspace/actions.py
@@ -74,6 +74,12 @@ class WorkspaceContextActions(BaseContextActions):
     def is_zipexport_available(self):
         return not is_restricted_workspace_and_guest(self.context)
 
+    def is_export_workspace_users_available(self):
+        return api.user.has_permission(
+            'opengever.workspace: Export Workspace Participants',
+            obj=self.context
+        )
+
 
 @adapter(IWorkspaceFolder, IOpengeverBaseLayer)
 class WorkspaceFolderContextActions(BaseContextActions):

--- a/opengever/workspace/configure.zcml
+++ b/opengever/workspace/configure.zcml
@@ -160,7 +160,7 @@
       name="workspace_participants_report"
       for="*"
       class=".report.WorkspaceParticipantsReport"
-      permission="opengever.workspace.AccessAllUsersAndGroups"
+      permission="opengever.workspace.ExportWorkspaceParticipants"
       />
 
 </configure>

--- a/opengever/workspace/permissions.zcml
+++ b/opengever/workspace/permissions.zcml
@@ -30,4 +30,5 @@
 
   <permission id="opengever.workspace.AccessHiddenMembers" title="opengever.workspace: Access hidden members" />
 
+  <permission id="opengever.workspace.ExportWorkspaceParticipants" title="opengever.workspace: Export Workspace Participants" />
 </configure>

--- a/opengever/workspace/report.py
+++ b/opengever/workspace/report.py
@@ -1,6 +1,4 @@
 from opengever.globalindex.browser.report import UserReport
-from plone import api
-from zExceptions import Unauthorized
 
 
 class WorkspaceParticipantsReport(UserReport):
@@ -9,7 +7,4 @@ class WorkspaceParticipantsReport(UserReport):
     filename = "workspace_participants_report.xlsx"
 
     def check_permissions(self):
-        if not api.user.has_permission(
-            'opengever.workspace.AccessAllUsersAndGroups', obj=self.context
-        ):
-            raise Unauthorized
+        pass

--- a/opengever/workspace/tests/test_actions.py
+++ b/opengever/workspace/tests/test_actions.py
@@ -110,7 +110,14 @@ class TestWorkspaceContextActions(IntegrationTestCase):
 
     def test_workspace_context_actions_for_workspace_admins(self):
         self.login(self.workspace_admin)
-        expected_actions = [u'add_invitation', u'edit', u'local_roles', u'share_content', 'zipexport']
+        expected_actions = [
+            u'add_invitation',
+            u'edit',
+            u'local_roles',
+            u'share_content',
+            u'zipexport',
+            u'export_workspace_participators'
+        ]
         self.assertEqual(expected_actions, self.get_actions(self.workspace))
 
     def test_delete_action_only_available_for_deactivated_workspaces(self):
@@ -169,3 +176,27 @@ class TestWorkspaceFolderContextActions(IntegrationTestCase):
         ITrasher(self.workspace_folder).trash()
         expected_actions = [u'delete_workspace_context', u'share_content', u'untrash_context', 'zipexport']
         self.assertEqual(expected_actions, self.get_actions(self.workspace_folder))
+
+
+class TestWorkspaceExportParticipantsContextActions(IntegrationTestCase):
+
+    features = ('workspace', )
+
+    def get_actions(self, context):
+        adapter = queryMultiAdapter((context, self.request), interface=IContextActions)
+        return adapter.get_actions() if adapter else []
+
+    def test_export_workspace_users_action_available_for_workspace_admin(self):
+        self.login(self.workspace_admin)
+        actions = self.get_actions(self.workspace)
+        self.assertIn('export_workspace_participators', actions)
+
+    def test_export_workspace_users_action_available_for_admin(self):
+        self.login(self.administrator)
+        actions = self.get_actions(self.workspace)
+        self.assertIn('export_workspace_participators', actions)
+
+    def test_export_workspace_users_action_not_available_for_other_users(self):
+        self.login(self.workspace_guest)
+        actions = self.get_actions(self.workspace)
+        self.assertNotIn('export_workspace_participators', actions)


### PR DESCRIPTION
- Fix workspace admin permission when export workspace users.
For [TI-506](https://4teamwork.atlassian.net/browse/TI-506)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[TI-506]: https://4teamwork.atlassian.net/browse/TI-506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ