### PR TITLE
Add ris proposal context action to create tasks

### DIFF
--- a/changes/TI-472.other
+++ b/changes/TI-472.other
@@ -1,0 +1,1 @@
+Add ris proposal context action to create tasks [jch]

--- a/opengever/ris/actions.py
+++ b/opengever/ris/actions.py
@@ -1,0 +1,11 @@
+from opengever.base.context_actions import BaseContextActions
+from opengever.base.interfaces import IOpengeverBaseLayer
+from opengever.ris.proposal import IProposal
+from plone import api
+from zope.component import adapter
+
+
+@adapter(IProposal, IOpengeverBaseLayer)
+class RisProposalContextActions(BaseContextActions):
+    def is_create_task_from_proposal_available(self):
+        return api.user.has_permission('opengever.task: Add task', obj=self.context)

--- a/opengever/ris/configure.zcml
+++ b/opengever/ris/configure.zcml
@@ -12,6 +12,8 @@
 
   <i18n:registerTranslations directory="locales" />
 
+  <adapter factory=".actions.RisProposalContextActions" />
+
   <adapter factory=".sequence.ProposalSequenceNumberGenerator" />
 
 </configure>

--- a/opengever/ris/tests/test_actions.py
+++ b/opengever/ris/tests/test_actions.py
@@ -1,0 +1,16 @@
+from opengever.base.interfaces import IContextActions
+from opengever.testing import IntegrationTestCase
+from zope.component import queryMultiAdapter
+
+
+class TestRisProposalContextActions(IntegrationTestCase):
+
+    def get_actions(self, context):
+        adapter = queryMultiAdapter((context, self.request), interface=IContextActions)
+        return adapter.get_actions() if adapter else []
+
+    def test_ris_proposal_context_actions(self):
+        self.activate_feature('ris')
+        self.login(self.regular_user)
+        expected_actions = [u'create_task_from_proposal', u'edit']
+        self.assertEqual(expected_actions, self.get_actions(self.ris_proposal))


### PR DESCRIPTION
Add ris proposal context action to create tasks, because Köniz wants to create tasks for the proposal in GEVER.

For [TI-472]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [X] Changelog entry
- [X] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-472]: https://4teamwork.atlassian.net/browse/TI-472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ