### PR TITLE
Fix Document date after drag and drop from E-Mail

### DIFF
--- a/changes/TI-458.bugfix
+++ b/changes/TI-458.bugfix
@@ -1,0 +1,1 @@
+Fix document_date when uploading mails with DnD, use mail header date. [amo]

--- a/opengever/api/tus.py
+++ b/opengever/api/tus.py
@@ -3,6 +3,7 @@ from opengever.api.not_reported_exceptions import BadRequest as NotReportedBadRe
 from opengever.base.interfaces import IDuringContentCreation
 from opengever.document import _
 from opengever.document.interfaces import ICheckinCheckoutManager
+from opengever.mail.mail import OGMail
 from opengever.meeting.proposaltemplate import IProposalTemplate
 from opengever.propertysheets.creation_defaults import initialize_customproperties_defaults
 from opengever.quota.exceptions import ForbiddenByQuota
@@ -70,9 +71,13 @@ class GeverUploadPatch(UploadPatch):
     def add_additional_metadata(self, metadata, obj):
         if not metadata.get("mode", "create") == 'create':
             return
-
         data = {}
-        document_date = metadata.get('document_date')
+        document_date = None
+        if isinstance(obj, OGMail):
+            document_date = obj.document_date
+        else:
+            document_date = metadata.get('document_date')
+
         if document_date:
             data['document_date'] = document_date
 


### PR DESCRIPTION
Fix Update document date on Drag & Drop from Outlook Mail.

For [TI-458](https://4teamwork.atlassian.net/browse/TI-458)

**Before:**

<img width="1096" alt="before" src="https://github.com/4teamwork/opengever.core/assets/160112920/a4e62ac8-091a-4e8f-ba39-d07c187520af">


**After:**

<img width="1100" alt="after" src="https://github.com/4teamwork/opengever.core/assets/160112920/04f32488-5735-4348-a2c2-506932c912e2">


## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-458]: https://4teamwork.atlassian.net/browse/TI-458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ