### PR TITLE
Link workspaces by username/groupname

### DIFF
--- a/changes/TI-399.other
+++ b/changes/TI-399.other
@@ -1,0 +1,1 @@
+Add support for linking workspaces by username/groupname. [buchi]

--- a/opengever/api/tests/test_linked_workspaces.py
+++ b/opengever/api/tests/test_linked_workspaces.py
@@ -1980,6 +1980,71 @@ class TestAddParticipationsOnWorkspacePost(FunctionalWorkspaceClientTestCase):
              'test_user_1_': ['WorkspaceAdmin']},
             self.workspace.__ac_local_roles__)
 
+    @browsing
+    def test_participations_are_added_by_username(self, browser):
+        user = create(Builder('ogds_user').having(
+            userid='69d09e3a-c1e1-4878-aa3b-6e85a20e1cc7',
+            username='hugo.boss',
+        ))
+        payload = {
+            'workspace_uid': self.workspace.UID(),
+            'participants': [{"participant": user.userid,
+                              "role": "WorkspaceGuest"}]
+        }
+
+        with patch('opengever.workspaceclient.client.WorkspaceClient.post') as mocked_post:
+            mocked_post.return_value = {}
+            with self.workspace_client_env():
+                browser.login()
+                browser.open(
+                    self.dossier.absolute_url() + '/@linked-workspace-participations',
+                    data=json.dumps(payload),
+                    method='POST',
+                    headers={'Accept': 'application/json',
+                             'Content-Type': 'application/json'},
+                )
+                self.assertEqual(
+                    mocked_post.call_args[1]['json'],
+                    {
+                        'participants': [{
+                            u'role': u'WorkspaceGuest',
+                            u'participant': user.username,
+                        }],
+                    }
+                )
+
+    @browsing
+    def test_participations_are_added_by_groupname(self, browser):
+        group = create(Builder('ogds_group').having(
+            groupid='87175c43-f9cc-44f3-9f6c-105d3d8382bf',
+            groupname='staff',
+        ))
+        payload = {
+            'workspace_uid': self.workspace.UID(),
+            'participants': [{"participant": group.groupid,
+                              "role": "WorkspaceGuest"}]
+        }
+        with patch('opengever.workspaceclient.client.WorkspaceClient.post') as mocked_post:
+            mocked_post.return_value = {}
+            with self.workspace_client_env():
+                browser.login()
+                browser.open(
+                    self.dossier.absolute_url() + '/@linked-workspace-participations',
+                    data=json.dumps(payload),
+                    method='POST',
+                    headers={'Accept': 'application/json',
+                             'Content-Type': 'application/json'},
+                )
+                self.assertEqual(
+                    mocked_post.call_args[1]['json'],
+                    {
+                        'participants': [{
+                            u'role': u'WorkspaceGuest',
+                            u'participant': group.groupname,
+                        }],
+                    }
+                )
+
 
 class TestAddInvitationOnWorkspacePost(FunctionalWorkspaceClientTestCase):
 

--- a/opengever/ogds/base/actor.py
+++ b/opengever/ogds/base/actor.py
@@ -776,7 +776,7 @@ class ActorLookup(object):
             if self.is_plone_user(user):
                 return PloneUserActor(self.identifier, user=user)
             else:
-                return OGDSUserActor(self.identifier, user=user)
+                return OGDSUserActor(user.userid, user=user)
         else:
             return self.create_null_actor()
 
@@ -792,7 +792,7 @@ class ActorLookup(object):
         if not group:
             group = self.load_group()
         if group:
-            return OGDSGroupActor(self.identifier, group=group)
+            return OGDSGroupActor(group.groupid, group=group)
         else:
             return self.create_null_actor()
 

--- a/opengever/ogds/base/actor.py
+++ b/opengever/ogds/base/actor.py
@@ -776,7 +776,12 @@ class ActorLookup(object):
             if self.is_plone_user(user):
                 return PloneUserActor(self.identifier, user=user)
             else:
-                return OGDSUserActor(user.userid, user=user)
+                if ':' in self.identifier:
+                    identifier = '{}:{}'.format(
+                        self.identifier.split(':')[0], user.userid)
+                else:
+                    identifier = user.userid
+                return OGDSUserActor(identifier, user=user)
         else:
             return self.create_null_actor()
 
@@ -792,7 +797,12 @@ class ActorLookup(object):
         if not group:
             group = self.load_group()
         if group:
-            return OGDSGroupActor(group.groupid, group=group)
+            if ':' in self.identifier:
+                identifier = '{}:{}'.format(
+                    self.identifier.split(':')[0], group.groupid)
+            else:
+                identifier = group.groupid
+            return OGDSGroupActor(identifier, group=group)
         else:
             return self.create_null_actor()
 

--- a/opengever/ogds/base/actor.py
+++ b/opengever/ogds/base/actor.py
@@ -81,8 +81,8 @@ class Actor(object):
         self.identifier = identifier
 
     @classmethod
-    def lookup(cls, identifier):
-        return ActorLookup(identifier).lookup()
+    def lookup(cls, identifier, name_as_fallback=False):
+        return ActorLookup(identifier, name_as_fallback=name_as_fallback).lookup()
 
     @classmethod
     def user(cls, identifier, user=None):
@@ -678,8 +678,9 @@ class InteractiveActor(Actor):
 
 class ActorLookup(object):
 
-    def __init__(self, identifier):
+    def __init__(self, identifier, name_as_fallback=False):
         self.identifier = identifier
+        self.name_as_fallback = name_as_fallback
 
     def is_inbox(self):
         return self.identifier.startswith('inbox:')
@@ -758,7 +759,8 @@ class ActorLookup(object):
         if not visible_users_and_groups_filter.can_access_principal(userid):
             return None
 
-        user = ogds_service().fetch_user(userid)
+        user = ogds_service().fetch_user(
+            userid, username_as_fallback=self.name_as_fallback)
         if not user:
             portal = getSite()
             portal_membership = getToolByName(portal, 'portal_membership')
@@ -783,7 +785,8 @@ class ActorLookup(object):
         if not visible_users_and_groups_filter.can_access_principal(groupid):
             return None
 
-        return ogds_service().fetch_group(groupid)
+        return ogds_service().fetch_group(
+            groupid, groupname_as_fallback=self.name_as_fallback)
 
     def create_group_actor(self, group=None):
         if not group:
@@ -802,7 +805,7 @@ class ActorLookup(object):
     def create_interactive_actor(self):
         return InteractiveActor(self.identifier)
 
-    def lookup(self):
+    def lookup(self, name_as_fallback=False):
         if not self.identifier:
             return self.create_null_actor()
 

--- a/opengever/workspaceclient/client.py
+++ b/opengever/workspaceclient/client.py
@@ -28,7 +28,7 @@ class WorkspaceClient(object):
         if not api.user.has_permission('opengever.workspaceclient: Use Workspace Client'):
             raise Unauthorized("User does not have permission to use the WorkspaceClient")
         return WorkspaceSession(self.workspace_url,
-                                api.user.get_current().getId())
+                                api.user.get_current().getUserName())
 
     @property
     def request(self):

--- a/opengever/workspaceclient/linked_workspaces.py
+++ b/opengever/workspaceclient/linked_workspaces.py
@@ -10,6 +10,7 @@ from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.utils import get_main_dossier
 from opengever.journal.handlers import journal_entry_factory
 from opengever.locking.lock import COPIED_TO_WORKSPACE_LOCK
+from opengever.ogds.base.actor import Actor
 from opengever.workspaceclient import _
 from opengever.workspaceclient.client import WorkspaceClient
 from opengever.workspaceclient.exceptions import CopyFromWorkspaceForbidden
@@ -575,9 +576,16 @@ class LinkedWorkspaces(object):
         """ Adds participations on the workspace
         """
         workspace_url = self._get_linked_workspace_url(workspace_uid)
+        participations_by_name = []
+        for participation in participations:
+            actor = Actor.lookup(participation['participant'], name_as_fallback=True)
+            participations_by_name.append({
+                u'participant': actor.login_name,
+                u'role': participation[u'role'],
+            })
         return self.client.post(
             '{}/@participations'.format(workspace_url),
-            json={'participants': participations})
+            json={'participants': participations_by_name})
 
     def add_invitation(self, workspace_uid, invitation_data):
         """ Adds an invitation on the workspace


### PR DESCRIPTION
Links workspaces by username instead of userid and adds participations by user/groupname instead of user/groupid.

This is required for setups with user/groupid not beeing equal to user/groupname, because user/groupids are different per OGDS.

For [TI-399](https://4teamwork.atlassian.net/browse/TI-399)

## Checklist


- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)



[TI-399]: https://4teamwork.atlassian.net/browse/TI-399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ