### PR TITLE
Improve performance when searching for a responsible in tasks and forwardings

### DIFF
--- a/changes/TI-402.other
+++ b/changes/TI-402.other
@@ -1,0 +1,1 @@
+Improve performance when searching for a responsible in tasks and forwardings. [elioschmutz]


### PR DESCRIPTION
This PR improves the `AllUsersInboxesAndTeamsSource` query source when using the REST-API.

Querysources are not batched. If we search for a user or team, we'll query all terms from the DB. Then we iterate over all terms and doing an actor-lookup for each term. This causes a hue performance lost.

We can't really change the API because the old UI still relies on it. We also don't want to completely refactor the ogds-sources and implement batching because it would be too complicated and time consumption. As a quick-fix, we implement a raw-query which will not resolve terms but return the raw values. We can then resolve each value when required.

Performance-Stats: with 2000 query result:

Without this fix: `3500ms`
With this fix:        `200ms`

![Bildschirmfoto 2024-06-12 um 12 36 30](https://github.com/4teamwork/opengever.core/assets/557005/89cdf989-2b21-42fb-aecb-721858d20fe7)

For [TI-402]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-402]: https://4teamwork.atlassian.net/browse/TI-402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ