### PR TITLE
Enhance Disposition with new field responsible

### DIFF
--- a/changes/TI-362.other
+++ b/changes/TI-362.other
@@ -1,0 +1,1 @@
+Add new Field responsible to Disposition.[amo]

--- a/opengever/api/tests/test_vocabularies.py
+++ b/opengever/api/tests/test_vocabularies.py
@@ -46,6 +46,7 @@ NON_SENSITIVE_VOCABUALRIES = [
     'opengever.dossier.participation_roles',
     'opengever.dossier.type_prefixes',
     'opengever.dossier.ValidResolverNamesVocabulary',
+    'opengever.disposition.archivist',
     'opengever.journal.manual_entry_categories',
     'opengever.meeting.ActiveCommitteeVocabulary',
     'opengever.meeting.AdHocAgendaItemTemplatesForCommitteeVocabulary',

--- a/opengever/disposition/configure.zcml
+++ b/opengever/disposition/configure.zcml
@@ -91,4 +91,9 @@
       name="disposition-transition-appraise"
       />
 
+  <!-- Vocabularies -->
+  <utility
+      factory=".vocabularies.ArchivistVocabulary"
+      name="opengever.disposition.archivist"
+      />
 </configure>

--- a/opengever/disposition/configure.zcml
+++ b/opengever/disposition/configure.zcml
@@ -85,6 +85,12 @@
       handler=".handlers.dossier_state_changed"
       />
 
+  <subscriber
+      for="opengever.disposition.interfaces.IDisposition
+           Products.CMFCore.interfaces.IActionSucceededEvent"
+      handler=".events.handle_evaluation_finalize"
+      />
+
   <!-- transitions -->
   <adapter
       factory=".transition.AppraiseTransitionExtender"

--- a/opengever/disposition/disposition.py
+++ b/opengever/disposition/disposition.py
@@ -463,7 +463,7 @@ class Disposition(Container):
         center.add_watcher_to_resource(
             self, self.Creator(), DISPOSITION_RECORDS_MANAGER_ROLE)
 
-        for archivist in self.get_all_archivists():
+        for archivist in Disposition.get_all_archivists():
             center.add_watcher_to_resource(
                 self, archivist, DISPOSITION_ARCHIVIST_ROLE)
 
@@ -483,8 +483,9 @@ class Disposition(Container):
 
         return archivists
 
-    def get_all_archivists(self):
-        archivists_infos = self.get_archivists_infos()
+    @staticmethod
+    def get_all_archivists():
+        archivists_infos = Disposition.get_archivists_infos()
         archivists = []
         for principal, info in archivists_infos:
             if info[0].get('principal_type') == 'group':

--- a/opengever/disposition/disposition.py
+++ b/opengever/disposition/disposition.py
@@ -218,7 +218,7 @@ class IDispositionSchema(model.Schema):
     model.fieldset(
         u'common',
         label=_(u'fieldset_common', default=u'Common'),
-        fields=[u'title', u'dossiers', u'transfer_number', u'transferring_office'],
+        fields=[u'title', u'dossiers', u'transfer_number', u'transferring_office', u'responsible'],
     )
 
     dexteritytextindexer.searchable('title')
@@ -259,6 +259,11 @@ class IDispositionSchema(model.Schema):
         title=_(u"label_transferring_office", default=u"Transferring office"),
         required=False,
         defaultFactory=transferring_office_default
+    )
+    responsible = schema.Choice(
+        title=_(u'responsible', default=u'Responsible'),
+        vocabulary='opengever.disposition.archivist',
+        required=False,
     )
 
 

--- a/opengever/disposition/events.py
+++ b/opengever/disposition/events.py
@@ -1,0 +1,6 @@
+from plone import api
+
+
+def handle_evaluation_finalize(context, event):
+    if not context.responsible and event.action == 'disposition-transition-appraise':
+        context.responsible = api.user.get_current().id

--- a/opengever/disposition/locales/de/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/de/LC_MESSAGES/opengever.disposition.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-04-30 06:43+0000\n"
+"POT-Creation-Date: 2024-06-14 06:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -340,6 +340,11 @@ msgstr "Periode"
 #: ./opengever/disposition/browser/templates/overview.pt
 msgid "progress"
 msgstr "Verlauf"
+
+#. Default: "Responsible"
+#: ./opengever/disposition/disposition.py
+msgid "responsible"
+msgstr "Verantwortlich"
 
 #. Default: "New disposition added by ${user} on admin unit ${admin_unit}"
 #: ./opengever/disposition/activities.py

--- a/opengever/disposition/locales/en/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/en/LC_MESSAGES/opengever.disposition.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-04-30 06:43+0000\n"
+"POT-Creation-Date: 2024-06-14 06:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -401,6 +401,11 @@ msgstr "Period"
 #: ./opengever/disposition/browser/templates/overview.pt
 msgid "progress"
 msgstr "Progress"
+
+#. Default: "Responsible"
+#: ./opengever/disposition/disposition.py
+msgid "responsible"
+msgstr "Responsible"
 
 #. German translation: Neues Angebot hinzugefügt durch ${user} im Mandanten ${admin_unit}
 #. Default: "New disposition added by ${user} on admin unit ${admin_unit}"

--- a/opengever/disposition/locales/fr/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/fr/LC_MESSAGES/opengever.disposition.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-04-30 06:43+0000\n"
+"POT-Creation-Date: 2024-06-14 06:58+0000\n"
 "PO-Revision-Date: 2018-05-22 10:09+0000\n"
 "Last-Translator: Niklaus Johner <Niklaus.johner@4teamwork.ch>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-disposition/fr/>\n"
@@ -342,6 +342,11 @@ msgstr "Période"
 #: ./opengever/disposition/browser/templates/overview.pt
 msgid "progress"
 msgstr "Progrès"
+
+#. Default: "Responsible"
+#: ./opengever/disposition/disposition.py
+msgid "responsible"
+msgstr "Responsable"
 
 #. Default: "New disposition added by ${user} on admin unit ${admin_unit}"
 #: ./opengever/disposition/activities.py

--- a/opengever/disposition/locales/opengever.disposition.pot
+++ b/opengever/disposition/locales/opengever.disposition.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-04-30 06:43+0000\n"
+"POT-Creation-Date: 2024-06-14 06:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -342,6 +342,11 @@ msgstr ""
 #. Default: "Progress"
 #: ./opengever/disposition/browser/templates/overview.pt
 msgid "progress"
+msgstr ""
+
+#. Default: "Responsible"
+#: ./opengever/disposition/disposition.py
+msgid "responsible"
 msgstr ""
 
 #. Default: "New disposition added by ${user} on admin unit ${admin_unit}"

--- a/opengever/disposition/tests/test_events.py
+++ b/opengever/disposition/tests/test_events.py
@@ -1,0 +1,30 @@
+
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+from plone import api
+from zope.event import notify
+from zope.lifecycleevent import modified
+
+
+class TestHandleEvaluationFinalize(IntegrationTestCase):
+
+    @browsing
+    def test_responsible_is_set_on_success(self, browser):
+        self.login(self.archivist, browser)
+        disposition = create(Builder('disposition'))
+        api.content.transition(obj=disposition,
+                               transition='disposition-transition-appraise')
+        notify(modified(disposition))
+        self.assertEqual(disposition.responsible, self.archivist.id)
+
+    @browsing
+    def test_responsible_is_not_changed_if_already_set(self, browser):
+        self.login(self.archivist, browser)
+        disposition = create(Builder('disposition').having(responsible=self.administrator.id))
+        initial_responsible = disposition.responsible
+        api.content.transition(obj=disposition,
+                               transition='disposition-transition-appraise')
+        notify(modified(disposition))
+        self.assertEqual(disposition.responsible, initial_responsible)

--- a/opengever/disposition/vocabularies.py
+++ b/opengever/disposition/vocabularies.py
@@ -1,0 +1,22 @@
+from opengever.disposition.disposition import Disposition
+from opengever.ogds.base.actor import ActorLookup
+from zope.interface import implementer
+from zope.schema.interfaces import IVocabularyFactory
+from zope.schema.vocabulary import SimpleTerm
+from zope.schema.vocabulary import SimpleVocabulary
+
+
+@implementer(IVocabularyFactory)
+class ArchivistVocabulary(object):
+
+    def __call__(self, context):
+        terms = []
+        archivists = Disposition.get_all_archivists()
+        for principal in archivists:
+            term = SimpleTerm(
+                value=principal,
+                token=principal,
+                title=ActorLookup(principal).lookup().get_label()
+            )
+            terms.append(term)
+        return SimpleVocabulary(terms)


### PR DESCRIPTION
The PR Introducing 
- `responsible` field on `Disposition `object with limited selectable to the Archivist role.
- Event handler assigns `responsible` on `Finalize Evaluation`  transition to the current user if no responsible was set.


For [TI-362](https://4teamwork.atlassian.net/browse/TI-362)

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- [x] All msg-strings are unicode



[TI-362]: https://4teamwork.atlassian.net/browse/TI-362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ