### PR TITLE
Respect new file mimetype when retrieve a file from teamraum as a new version

### DIFF
--- a/changes/TI-366.bugfix
+++ b/changes/TI-366.bugfix
@@ -1,0 +1,1 @@
+Respect new file mimetype when retrieve a file from teamraum as a new version. [elioschmutz]

--- a/opengever/workspaceclient/linked_workspaces.py
+++ b/opengever/workspaceclient/linked_workspaces.py
@@ -411,6 +411,8 @@ class LinkedWorkspaces(object):
                             default=u'Document retrieved from teamraum')
         gever_doc.update_file(
             document_repr['file']['data'],
+            content_type=document_repr['file']['content-type'],
+            filename=document_repr['file']['filename'],
             create_version=True,
             comment=translate(version_comment, context=getRequest()))
 

--- a/opengever/workspaceclient/tests/test_linked_workspaces.py
+++ b/opengever/workspaceclient/tests/test_linked_workspaces.py
@@ -548,12 +548,14 @@ class TestLinkedWorkspaces(FunctionalWorkspaceClientTestCase):
 
         initial_content = gever_doc.file.data
         initial_filename = gever_doc.file.filename
+        initial_content_type = gever_doc.file.contentType
 
         self.assertEqual('Test data', initial_content)
         self.assertEqual(u'Testdokumaent.doc', initial_filename)
+        self.assertEqual(u'application/msword', initial_content_type)
 
         new_content = 'Content produced in Workspace'
-        new_filename = u'workspace.doc'
+        new_filename = u'workspace.pdf'
 
         workspace_doc = create(Builder('document')
                                .within(self.workspace)
@@ -583,7 +585,8 @@ class TestLinkedWorkspaces(FunctionalWorkspaceClientTestCase):
             self.assertEqual(1, Versioner(gever_doc).get_current_version_id())
 
             self.assertEqual(new_content, gever_doc.file.data)
-            self.assertEqual(initial_filename, gever_doc.file.filename)
+            self.assertEqual(u'Testdokumaent.pdf', gever_doc.file.filename)
+            self.assertEqual(u'application/pdf', gever_doc.file.contentType)
 
             initial_version = Versioner(gever_doc).retrieve(0)
             initial_version_md = Versioner(gever_doc).retrieve_version(0)
@@ -595,7 +598,8 @@ class TestLinkedWorkspaces(FunctionalWorkspaceClientTestCase):
             self.assertEqual(u'Initial version', initial_version_md.comment)
 
             self.assertEqual(new_content, new_version.file.data)
-            self.assertEqual(initial_filename, new_version.file.filename)
+            self.assertEqual(u'Testdokumaent.pdf', new_version.file.filename)
+            self.assertEqual(u'application/pdf', new_version.file.contentType)
             self.assertEqual(u'Document copied back from teamraum', new_version_md.comment)
 
             document_journal = self.get_journal_entries(gever_doc)


### PR DESCRIPTION
When changing the mimetype of a linked workspace document in teamraum an then retrieve it in gever by creating a new version of a gever-document, the new version will be broken. 

We also have to set the mimetype of the document do be in sync with the blob data.

For [TI-366]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-366]: https://4teamwork.atlassian.net/browse/TI-366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ