### PR TITLE
Deactivate the edit ui-action for ris proposals

### DIFF
--- a/changes/TI-472.bugfix
+++ b/changes/TI-472.bugfix
@@ -1,0 +1,1 @@
+Deactivate the edit ui-action for ris proposals. [jch]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -13,6 +13,7 @@ Breaking Changes
 Other Changes
 ^^^^^^^^^^^^^
 - The ``@document_from_oneoffixx`` endpoint expects now a file_type attribute.
+- Deactivate the edit ui-action for ris proposals.
 
 
 2024.9.0 (2024-06-13)

--- a/opengever/ris/actions.py
+++ b/opengever/ris/actions.py
@@ -9,3 +9,6 @@ from zope.component import adapter
 class RisProposalContextActions(BaseContextActions):
     def is_create_task_from_proposal_available(self):
         return api.user.has_permission('opengever.task: Add task', obj=self.context)
+
+    def is_edit_available(self):
+        return False

--- a/opengever/ris/tests/test_actions.py
+++ b/opengever/ris/tests/test_actions.py
@@ -12,5 +12,5 @@ class TestRisProposalContextActions(IntegrationTestCase):
     def test_ris_proposal_context_actions(self):
         self.activate_feature('ris')
         self.login(self.regular_user)
-        expected_actions = [u'create_task_from_proposal', u'edit']
+        expected_actions = [u'create_task_from_proposal']
         self.assertEqual(expected_actions, self.get_actions(self.ris_proposal))


### PR DESCRIPTION
Deactivate the edit ui-action for ris proposals


For [TI-472]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- API change:
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))


[TI-472]: https://4teamwork.atlassian.net/browse/TI-472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ