### PR TITLE
Implement group and teams watchers

### DIFF
--- a/changes/TI-407-2.other
+++ b/changes/TI-407-2.other
@@ -1,0 +1,1 @@
+Remove deprecated 'referenced_users' property from 'GET @watcher' endpoint [elioschmutz]

--- a/changes/TI-407.bugfix
+++ b/changes/TI-407.bugfix
@@ -1,0 +1,1 @@
+A user can now add itself as a regular watcher even if he is already watching by anoter watcher role [elioschmutz]

--- a/changes/TI-407.feature
+++ b/changes/TI-407.feature
@@ -1,0 +1,1 @@
+Groups and teams can be added as watchers [elioschmutz]

--- a/changes/TI-407.feature
+++ b/changes/TI-407.feature
@@ -1,1 +1,1 @@
-Groups and teams can be added as watchers [elioschmutz]
+Groups and teams can be added and removed as watchers [elioschmutz]

--- a/changes/TI-407.other
+++ b/changes/TI-407.other
@@ -1,0 +1,1 @@
+The "POST @watcher" endpoint requires an "actor_id" an no longer a "userid" [elioschmutz]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -12,6 +12,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- The ``@possible-watchers`` endpoint returns groups and teams
 - The ``@document_from_oneoffixx`` endpoint expects now a file_type attribute.
 - Deactivate the edit ui-action for ris proposals.
 - Dossier POST supports now the creation of participations.

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -8,6 +8,7 @@ API Changelog
 
 Breaking Changes
 ^^^^^^^^^^^^^^^^
+- The ``DELETE @watcher`` endpoint requires a path parameter with the actor-id
 - The ``POST @watcher`` endpoint requires an ``actor_id`` an no longer a ``userid``
 
 Other Changes

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -8,7 +8,7 @@ API Changelog
 
 Breaking Changes
 ^^^^^^^^^^^^^^^^
-
+- The ``POST @watcher`` endpoint requires an ``actor_id`` an no longer a ``userid``
 
 Other Changes
 ^^^^^^^^^^^^^

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -8,6 +8,7 @@ API Changelog
 
 Breaking Changes
 ^^^^^^^^^^^^^^^^
+- Remove deprecated ``referenced_users`` property from ``GET @watcher`` endpoint.
 - The ``DELETE @watcher`` endpoint requires a path parameter with the actor-id
 - The ``POST @watcher`` endpoint requires an ``actor_id`` an no longer a ``userid``
 

--- a/docs/public/dev-manual/api/watchers.rst
+++ b/docs/public/dev-manual/api/watchers.rst
@@ -138,13 +138,13 @@ Ein Benutzer kann mittels POST-Requests als Beobachter mit der Rolle ``regular_w
 Beobachter entfernen
 --------------------
 
-Mittels DELETE-Requests kann die Rolle ``regular_watcher`` eines Beobachters von einem Inhalt wieder entfernt werden.
+Mittels DELETE-Requests kann die Rolle ``regular_watcher`` vom eigenen Beobachter oder einer Gruppe oder Team entfernt werden.
 
 **Beispiel-Request**:
 
    .. sourcecode:: http
 
-       DELETE /task-1/@watchers HTTP/1.1
+       DELETE /task-1/@watchers/group:1 HTTP/1.1
        Accept: application/json
 
 **Beispiel-Response**:

--- a/docs/public/dev-manual/api/watchers.rst
+++ b/docs/public/dev-manual/api/watchers.rst
@@ -5,8 +5,6 @@ Beobachter
 
 Der ``@watchers`` Endpoint dient dazu, für Dokumente, Aufgaben und Weiterleitungen Beobachter zu registrieren.
 
-Diese Endpoints liefern zur Zeit sowohl ``referenced_users`` als auch ``referenced_actors`` zurück. ``referenced_users`` wird in einer späteren Version jedoch nicht mehr unterstützt werden, und wird durch ``referenced_actors`` abgelöst.
-
 Auflistung
 ----------
 
@@ -29,18 +27,6 @@ Ein Beobachter kann verschiedene Rollen haben, beispielsweise die Rollen Auftrag
 
       {
         "@id": "https://example.org/ordnungssystem/fuehrung/dossier-23/task-1/@watchers",
-        "referenced_users": [
-          {
-            "@id": "https://example.org/@users/peter.mueller",
-            "id": "peter.mueller",
-            "fullname": "Mueller Peter"
-          },
-          {
-            "@id": "https://example.org/@users/rolf.ziegler",
-            "id": "rolf.ziegler",
-            "fullname": "Ziegler Rolf"
-          }
-        ],
         "referenced_actors": [
           {
             "@id": "https://example.org/@actors/peter.mueller",
@@ -101,7 +87,6 @@ Die Beobachter können als Komponente eines Inhalts direkt über den ``expand``-
       "@components": {
         "watchers": {
           "@id": "https://example.org/ordnungssystem/fuehrung/dossier-23/task-1/@listing-stats",
-          "referenced_users": ["..."],
           "referenced_actors": ["..."],
           "referenced_watcher_roles": ["..."],
           "watchers_and_roles": { "...": "..." }

--- a/docs/public/dev-manual/api/watchers.rst
+++ b/docs/public/dev-manual/api/watchers.rst
@@ -125,7 +125,7 @@ Ein Benutzer kann mittels POST-Requests als Beobachter mit der Rolle ``regular_w
        Accept: application/json
 
        {
-         "userid": "peter.mueller"
+         "actor_id": "peter.mueller"
        }
 
 **Beispiel-Response**:

--- a/docs/public/dev-manual/api/watchers.rst
+++ b/docs/public/dev-manual/api/watchers.rst
@@ -156,9 +156,9 @@ Mittels DELETE-Requests kann die Rolle ``regular_watcher`` eines Beobachters von
 
 Liste von möglichen Beobachtern
 -------------------------------
-Der ``@possible-watchers``-Endpoint liefert eine Liste von Benutzern welche als Beobachter für den aktuellen Kontext hinzugefügt werden können.
+Der ``@possible-watchers``-Endpoint liefert eine Liste von Actors welche als Beobachter für den aktuellen Kontext hinzugefügt werden können.
 
-Weil es üblich ist, dass man sich selbst als Beobachter hinzufügen möchte, wird der eigene Benutzer in der Sortierreihenfolge immer zuoberst dargestellt. Alle restlichen Benutzer werden nach Name und Vorname sortiert. Der eigene Benutzer sowie alle anderen Benutzer werden nur dann angezeigt, wenn diese noch keine Beobachter-Rolle besitzen.
+Weil es üblich ist, dass man sich selbst als Beobachter hinzufügen möchte, wird der eigene Benutzer in der Sortierreihenfolge immer zuoberst dargestellt. Alle restlichen Actors werden Typ (Benutzer, Gruppen, Teams) und nach Name und Vorname oder Titel sortiert. Der eigene Benutzer sowie alle anderen Actors werden nur dann angezeigt, wenn diese noch keine Beobachter-Rolle besitzen.
 
 **Beispiel-Request:**
 
@@ -187,6 +187,10 @@ Weil es üblich ist, dass man sich selbst als Beobachter hinzufügen möchte, wi
             "title": "Ziegler Rolf (rolf.ziegler)",
             "token": "rolf.ziegler"
           },
+          {
+            "title": "Team Blue",
+            "token": "team:1"
+          },
           { "...": "..." },
         ],
         "items_total": 17
@@ -200,6 +204,7 @@ Mit dem ``query``-Parameter können die Resultate gefiltert werden. Es werden di
 - Nachname
 - E-Mail
 - Userid
+- Gruppen oder Team Titel
 
 beim filtern berücksichtigt.
 

--- a/opengever/activity/sources.py
+++ b/opengever/activity/sources.py
@@ -1,4 +1,5 @@
 from opengever.activity import notification_center
+from opengever.activity.roles import WATCHER_ROLE
 from opengever.ogds.base.sources import AssignedUsersSource
 from opengever.ogds.models.user import User
 from plone import api
@@ -47,8 +48,8 @@ class PossibleWatchersSource(AssignedUsersSource):
         watcher-role on the current context.
         """
         center = notification_center()
-        regular_watchers = center.get_subscriptions(self.context)
-        userids = set([subscription.watcher.actorid for subscription in regular_watchers])
+        userids = set([watcher.actorid for watcher in
+                       center.get_watchers(self.context, role=WATCHER_ROLE)])
 
         if userids:
             query = query.filter(User.userid.notin_(userids))

--- a/opengever/api/tests/test_watchers.py
+++ b/opengever/api/tests/test_watchers.py
@@ -811,5 +811,5 @@ class TestPossibleWatchers(IntegrationTestCase):
         browser.open(url, method='GET', headers=self.api_headers)
 
         self.assertEqual(5, len(browser.json.get('items')))
-        self.assertEqual(18, browser.json.get('items_total'))
+        self.assertEqual(20, browser.json.get('items_total'))
         self.assertIn('batching', browser.json)

--- a/opengever/api/tests/test_watchers.py
+++ b/opengever/api/tests/test_watchers.py
@@ -7,7 +7,6 @@ from opengever.ogds.models.user import User
 from opengever.testing import IntegrationTestCase
 from opengever.testing import solr_data_for
 from opengever.testing import SolrIntegrationTestCase
-from unittest import skip
 import json
 
 
@@ -361,7 +360,7 @@ class TestWatchersSolr(SolrIntegrationTestCase):
         browser.open(self.task.absolute_url() + '/@watchers',
                      method='POST',
                      headers=self.api_headers,
-                     data=json.dumps({"userid": self.regular_user.getId()}))
+                     data=json.dumps({"actor_id": self.regular_user.getId()}))
         self.assertEqual(browser.status_code, 204)
         self.commit_solr()
 
@@ -376,7 +375,7 @@ class TestWatchersSolr(SolrIntegrationTestCase):
         browser.open(self.inbox_forwarding.absolute_url() + '/@watchers',
                      method='POST',
                      headers=self.api_headers,
-                     data=json.dumps({"userid": self.regular_user.getId()}))
+                     data=json.dumps({"actor_id": self.regular_user.getId()}))
         self.assertEqual(browser.status_code, 204)
         self.commit_solr()
 
@@ -391,7 +390,7 @@ class TestWatchersSolr(SolrIntegrationTestCase):
         browser.open(self.document, view='@watchers',
                      method='POST',
                      headers=self.api_headers,
-                     data=json.dumps({"userid": self.regular_user.getId()}))
+                     data=json.dumps({"actor_id": self.regular_user.getId()}))
         self.assertEqual(browser.status_code, 204)
         self.commit_solr()
 
@@ -406,7 +405,7 @@ class TestWatchersSolr(SolrIntegrationTestCase):
         browser.open(self.mail_eml, view='@watchers',
                      method='POST',
                      headers=self.api_headers,
-                     data=json.dumps({"userid": self.regular_user.getId()}))
+                     data=json.dumps({"actor_id": self.regular_user.getId()}))
         self.assertEqual(browser.status_code, 204)
         self.commit_solr()
 
@@ -497,7 +496,7 @@ class TestWatchersPost(IntegrationTestCase):
         browser.open(self.task.absolute_url() + '/@watchers',
                      method='POST',
                      headers=self.api_headers,
-                     data=json.dumps({"userid": self.regular_user.getId()}))
+                     data=json.dumps({"actor_id": self.regular_user.getId()}))
 
         self.assertEqual(browser.status_code, 204)
 
@@ -515,20 +514,20 @@ class TestWatchersPost(IntegrationTestCase):
             browser.open(self.task.absolute_url() + '/@watchers', method='POST',
                          headers=self.api_headers)
         self.assertEqual(
-            {"message": "Property 'userid' is required",
+            {"message": "Property 'actor_id' is required",
              "type": "BadRequest"},
             browser.json)
 
     @browsing
-    def test_post_watchers_with_invalid_userid_raises_bad_request(self, browser):
+    def test_post_watchers_with_invalid_actor_id_raises_bad_request(self, browser):
         self.login(self.regular_user, browser=browser)
         with browser.expect_http_error(400):
             browser.open(self.task.absolute_url() + '/@watchers',
                          method='POST',
                          headers=self.api_headers,
-                         data=json.dumps({"userid": "chaosqueen"}))
+                         data=json.dumps({"actor_id": "chaosqueen"}))
         self.assertEqual(
-            {"message": "userid 'chaosqueen' does not exist",
+            {"message": "Actor 'chaosqueen' does not exist",
              "type": "BadRequest"},
             browser.json)
 
@@ -545,7 +544,7 @@ class TestWatchersPost(IntegrationTestCase):
         browser.open(self.inbox_forwarding.absolute_url() + '/@watchers',
                      method='POST',
                      headers=self.api_headers,
-                     data=json.dumps({"userid": self.regular_user.getId()}))
+                     data=json.dumps({"actor_id": self.regular_user.getId()}))
 
         self.assertEqual(browser.status_code, 204)
 
@@ -565,7 +564,7 @@ class TestWatchersPost(IntegrationTestCase):
         browser.open(self.document, view='@watchers',
                      method='POST',
                      headers=self.api_headers,
-                     data=json.dumps({"userid": self.regular_user.getId()}))
+                     data=json.dumps({"actor_id": self.regular_user.getId()}))
 
         self.assertEqual(browser.status_code, 204)
 
@@ -584,7 +583,7 @@ class TestWatchersPost(IntegrationTestCase):
         self.assertEqual({}, browser.json['watchers_and_roles'])
         browser.open(self.mail_eml, view='@watchers', method='POST',
                      headers=self.api_headers,
-                     data=json.dumps({"userid": self.regular_user.getId()}))
+                     data=json.dumps({"actor_id": self.regular_user.getId()}))
 
         self.assertEqual(browser.status_code, 204)
 
@@ -696,7 +695,7 @@ class TestWatchersDelete(IntegrationTestCase):
         with browser.expect_http_error(400):
             browser.open(self.task.absolute_url() + '/@watchers',
                          method='DELETE', headers=self.api_headers,
-                         data=json.dumps({"userid": self.meeting_user.getId()}))
+                         data=json.dumps({"actor_id": self.meeting_user.getId()}))
         self.assertEqual(
             {"message": "DELETE does not take any data",
              "type": "BadRequest"},
@@ -707,7 +706,6 @@ class TestPossibleWatchers(IntegrationTestCase):
 
     features = ('activity', )
 
-    @skip('Title should contain username instead of userid')
     @browsing
     def test_get_possible_watchers_for_and_object(self, browser):
         center = notification_center()
@@ -751,7 +749,6 @@ class TestPossibleWatchers(IntegrationTestCase):
         self.assertEqual([],
                          [item['token'] for item in browser.json['items']])
 
-    @skip('Title should contain username instead of userid')
     @browsing
     def test_get_possible_watchers_for_document(self, browser):
         center = notification_center()
@@ -779,7 +776,6 @@ class TestPossibleWatchers(IntegrationTestCase):
 
         self.assertEqual(expected_json, browser.json)
 
-    @skip('Title should contain username instead of userid')
     @browsing
     def test_get_possible_watchers_for_mail(self, browser):
         center = notification_center()

--- a/opengever/api/tests/test_watchers.py
+++ b/opengever/api/tests/test_watchers.py
@@ -25,18 +25,6 @@ class TestWatchersGet(SolrIntegrationTestCase):
         expected_json = {
             u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/'
                     u'dossier-1/task-1/@watchers',
-            u'referenced_users': [
-                {
-                    u'@id': u'http://nohost/plone/@users/%s' % self.dossier_responsible.id,
-                    u'fullname': u'Ziegler Robert',
-                    u'id': self.dossier_responsible.id,
-                },
-                {
-                    u'@id': u'http://nohost/plone/@users/%s' % self.regular_user.id,
-                    u'fullname': u'B\xe4rfuss K\xe4thi',
-                    u'id': self.regular_user.id,
-                },
-            ],
             u'referenced_actors': [
                 {
                     u'@id': u'http://nohost/plone/@actors/%s' % self.dossier_responsible.id,
@@ -89,18 +77,6 @@ class TestWatchersGet(SolrIntegrationTestCase):
 
         expected_json = {
             u'@id': u'http://nohost/plone/eingangskorb/eingangskorb_fa/forwarding-1/@watchers',
-            u'referenced_users': [
-                {
-                    u'@id': u'http://nohost/plone/@users/%s' % self.dossier_responsible.id,
-                    u'fullname': u'Ziegler Robert',
-                    u'id': self.dossier_responsible.id,
-                },
-                {
-                    u'@id': u'http://nohost/plone/@users/%s' % self.regular_user.id,
-                    u'fullname': u'B\xe4rfuss K\xe4thi',
-                    u'id': self.regular_user.id,
-                },
-            ],
             u'referenced_actors': [
                 {
                     u'@id': u'http://nohost/plone/@actors/%s' % self.dossier_responsible.id,
@@ -151,13 +127,6 @@ class TestWatchersGet(SolrIntegrationTestCase):
 
         expected_json = {
             u'@id': url,
-            u'referenced_users': [
-                {
-                    u'@id': u'http://nohost/plone/@users/%s' % self.dossier_responsible.id,
-                    u'fullname': u'Ziegler Robert',
-                    u'id': self.dossier_responsible.id,
-                }
-            ],
             u'referenced_actors': [
                 {
                     u'@id': u'http://nohost/plone/@actors/%s' % self.dossier_responsible.id,
@@ -194,13 +163,6 @@ class TestWatchersGet(SolrIntegrationTestCase):
 
         expected_json = {
             u'@id': url,
-            u'referenced_users': [
-                {
-                    u'@id': u'http://nohost/plone/@users/%s' % self.dossier_responsible.id,
-                    u'fullname': u'Ziegler Robert',
-                    u'id': self.dossier_responsible.id,
-                }
-            ],
             u'referenced_actors': [
                 {
                     u'@id': u'http://nohost/plone/@actors/%s' % self.dossier_responsible.id,
@@ -239,17 +201,8 @@ class TestWatchersGet(SolrIntegrationTestCase):
         browser.open(self.task.absolute_url() + '/@watchers',
                      method='GET', headers=self.api_headers)
 
-        # @id for the referenced_users is not correct for teams,
-        # this will have to be fixed.
         expected_json = {
             u'@id': u"{}/@watchers".format(self.task.absolute_url()),
-            u'referenced_users': [
-                {
-                    u'@id': u'http://nohost/plone/@users/team:1',
-                    u'fullname': u'Projekt \xdcberbaung Dorfmatte (Finanz\xe4mt)',
-                    u'id': u'team:1'
-                },
-            ],
             u'referenced_actors': [
                 {
                     u'@id': u'http://nohost/plone/@actors/team:1',
@@ -286,17 +239,8 @@ class TestWatchersGet(SolrIntegrationTestCase):
         browser.open(self.task.absolute_url() + '/@watchers',
                      method='GET', headers=self.api_headers)
 
-        # @id for the referenced_users is not correct for inboxes,
-        # this will have to be fixed.
         expected_json = {
             u'@id': u"{}/@watchers".format(self.task.absolute_url()),
-            u'referenced_users': [
-                {
-                    u'@id': u'http://nohost/plone/@users/inbox:fa',
-                    u'fullname': u'Inbox: Finanz\xe4mt',
-                    u'id': u'inbox:fa'
-                },
-            ],
             u'referenced_actors': [
                 {
                     u'@id': u'http://nohost/plone/@actors/inbox:fa',
@@ -341,7 +285,6 @@ class TestWatchersGet(SolrIntegrationTestCase):
                      method='GET', headers=self.api_headers)
 
         expected_json = {u'@id': self.document.absolute_url() + '/@watchers',
-                         u'referenced_users': [],
                          u'referenced_actors': [],
                          u'referenced_watcher_roles': [],
                          u'watchers_and_roles': {}}

--- a/opengever/api/watchers.py
+++ b/opengever/api/watchers.py
@@ -4,6 +4,7 @@ from opengever.activity.roles import ROLE_TRANSLATIONS
 from opengever.activity.roles import WATCHER_ROLE
 from opengever.activity.sources import PossibleWatchersSource
 from opengever.api.actors import serialize_actor_id_to_json_summary
+from opengever.api.schema.querysources import RawQuerySourceSearchResults
 from opengever.ogds.base.actor import ActorLookup
 from plone import api
 from plone.protect.interfaces import IDisableCSRFProtection
@@ -122,14 +123,14 @@ class PossibleWatchers(Service):
     def reply(self):
         source = PossibleWatchersSource(self.context)
         query = safe_unicode(self.request.form.get('query', ''))
-        results = source.search(query)
+        result = RawQuerySourceSearchResults(source, source.raw_search(query))
 
-        batch = HypermediaBatch(self.request, results)
+        batch = HypermediaBatch(self.request, result.results)
 
         serialized_terms = []
         for term in batch:
             serializer = getMultiAdapter(
-                (term, self.request), interface=ISerializeToJson
+                (result.get_resolved_term(term), self.request), interface=ISerializeToJson
             )
             serialized_terms.append(serializer())
 

--- a/opengever/api/watchers.py
+++ b/opengever/api/watchers.py
@@ -6,6 +6,7 @@ from opengever.activity.sources import PossibleWatchersSource
 from opengever.api.actors import serialize_actor_id_to_json_summary
 from opengever.api.schema.querysources import RawQuerySourceSearchResults
 from opengever.ogds.base.actor import ActorLookup
+from opengever.ogds.base.actor import OGDSUserActor
 from plone import api
 from plone.protect.interfaces import IDisableCSRFProtection
 from plone.restapi.batching import HypermediaBatch
@@ -15,10 +16,12 @@ from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.services import Service
 from Products.CMFPlone.utils import safe_unicode
 from zExceptions import BadRequest
+from zExceptions import Forbidden
 from zope.component import getMultiAdapter
 from zope.i18n import translate
 from zope.interface import alsoProvides
 from zope.interface import implementer
+from zope.publisher.interfaces import IPublishTraverse
 
 
 @implementer(IExpandableElement)
@@ -102,15 +105,27 @@ class WatchersPost(Service):
             raise BadRequest(u"Actor '{}' does not exist".format(self.actor_id))
 
 
+@implementer(IPublishTraverse)
 class WatchersDelete(Service):
+    def __init__(self, context, request):
+        super(WatchersDelete, self).__init__(context, request)
+        self.params = []
+
+    def publishTraverse(self, request, name):
+        # Consume any path segments after /@watchers as parameters
+        self.params.append(name)
+        return self
 
     def reply(self):
         alsoProvides(self.request, IDisableCSRFProtection)
 
         self.extract_data()
-        self.userid = api.user.get_current().getId()
+        actor_id = self.read_params()
+        if not self.can_delete_actor(actor_id):
+            raise Forbidden()
+
         self.center = notification_center()
-        self.center.remove_watcher_from_resource(self.context, self.userid, WATCHER_ROLE)
+        self.center.remove_watcher_from_resource(self.context, actor_id, WATCHER_ROLE)
 
         self.request.response.setStatus(204)
         return None
@@ -119,6 +134,27 @@ class WatchersDelete(Service):
         data = json_body(self.request)
         if data:
             raise BadRequest("DELETE does not take any data")
+
+    def can_delete_actor(self, actor_id):
+        # The user can always remove itslef
+        if actor_id == api.user.get_current().getId():
+            return True
+
+        # The user can never remove another user
+        if isinstance(ActorLookup(actor_id).lookup(), OGDSUserActor):
+            return False
+
+        # the user can remove groups and teams
+        return True
+
+    def read_params(self):
+        if len(self.params) == 0:
+            raise BadRequest("Must supply an actor ID as URL path parameter.")
+
+        if len(self.params) > 1:
+            raise BadRequest("Only actor ID is supported URL path parameter.")
+
+        return self.params[0]
 
 
 class PossibleWatchers(Service):

--- a/opengever/api/watchers.py
+++ b/opengever/api/watchers.py
@@ -48,17 +48,9 @@ class Watchers(object):
                 watchers_and_roles[subscription.watcher.actorid].append(subscription.role)
                 roles.add(subscription.role)
 
-        portal_url = api.portal.get().absolute_url()
-        referenced_users = []
         referenced_actors = []
         for actor_id in watchers_and_roles:
             actor = ActorLookup(actor_id).lookup()
-            referenced_users.append(
-                {
-                    '@id': "{}/@users/{}".format(portal_url, actor_id),
-                    'id': actor_id,
-                    'fullname': actor.get_label(with_principal=False)
-                })
             referenced_actors.append(serialize_actor_id_to_json_summary(actor_id))
 
         referenced_watcher_roles = [
@@ -70,8 +62,6 @@ class Watchers(object):
 
         result['watchers']['watchers_and_roles'] = watchers_and_roles
         result['watchers']['referenced_watcher_roles'] = referenced_watcher_roles
-        # XXX deprecated
-        result['watchers']['referenced_users'] = referenced_users
         result['watchers']['referenced_actors'] = referenced_actors
         return result
 

--- a/opengever/api/watchers.py
+++ b/opengever/api/watchers.py
@@ -87,17 +87,17 @@ class WatchersPost(Service):
 
         self.extract_data()
         self.center = notification_center()
-        self.center.add_watcher_to_resource(self.context, self.userid, WATCHER_ROLE)
+        self.center.add_watcher_to_resource(self.context, self.actor_id, WATCHER_ROLE)
         self.request.response.setStatus(204)
         return super(WatchersPost, self).reply()
 
     def extract_data(self):
         data = json_body(self.request)
-        self.userid = data.get("userid", None)
-        if not self.userid:
-            raise BadRequest("Property 'userid' is required")
-        if not api.user.get(self.userid):
-            raise BadRequest("userid '{}' does not exist".format(self.userid))
+        self.actor_id = data.get("actor_id", None)
+        if not self.actor_id:
+            raise BadRequest("Property 'actor_id' is required")
+        if not api.user.get(self.actor_id):
+            raise BadRequest("Actor '{}' does not exist".format(self.userid))
 
 
 class WatchersDelete(Service):

--- a/opengever/api/watchers.py
+++ b/opengever/api/watchers.py
@@ -96,8 +96,10 @@ class WatchersPost(Service):
         self.actor_id = data.get("actor_id", None)
         if not self.actor_id:
             raise BadRequest("Property 'actor_id' is required")
-        if not api.user.get(self.actor_id):
-            raise BadRequest("Actor '{}' does not exist".format(self.userid))
+        try:
+            PossibleWatchersSource(self.context).getTermByToken(self.actor_id)
+        except LookupError:
+            raise BadRequest(u"Actor '{}' does not exist".format(self.actor_id))
 
 
 class WatchersDelete(Service):

--- a/opengever/api/watchers.py
+++ b/opengever/api/watchers.py
@@ -50,7 +50,6 @@ class Watchers(object):
 
         referenced_actors = []
         for actor_id in watchers_and_roles:
-            actor = ActorLookup(actor_id).lookup()
             referenced_actors.append(serialize_actor_id_to_json_summary(actor_id))
 
         referenced_watcher_roles = [

--- a/opengever/ogds/base/sources.py
+++ b/opengever/ogds/base/sources.py
@@ -132,6 +132,13 @@ class BaseMultipleSourcesQuerySource(BaseQuerySoure):
 
         return term
 
+    def raw_search(self, query_string):
+        self.terms = []
+        for source in self.source_instances:
+            self.terms.extend(source.raw_search(query_string))
+
+        return self.terms
+
     def search(self, query_string):
         self.terms = []
         for source in self.source_instances:
@@ -970,6 +977,9 @@ class AllGroupsSource(BaseSQLModelSource):
             asc(func.lower(Group.title)),
             asc(func.lower(Group.groupid))
         )
+
+    def raw_search(self, query_string):
+        return self.search(query_string)
 
 
 class WorkspaceContentMemberGroupsSource(AllGroupsSource):

--- a/opengever/ogds/base/tests/test_sources.py
+++ b/opengever/ogds/base/tests/test_sources.py
@@ -1056,6 +1056,10 @@ class TestAllGroupsSource(IntegrationTestCase):
         with self.assertRaises(LookupError):
             self.source.getTermByToken('invalid-id')
 
+    def test_provides_raw_search(self):
+        result = self.source.raw_search('projek')
+        self.assertEqual(3, len(result))
+
 
 class TestAllUsersAndGroupsSource(IntegrationTestCase):
 
@@ -1184,6 +1188,10 @@ class TestAllUsersAndGroupsSource(IntegrationTestCase):
                 u'ZZZZ YYYY-foobar (user3)'
             ],
             [term.title for term in self.source.search('foobar')])
+
+    def test_provides_raw_search(self):
+        result = self.source.raw_search('')
+        self.assertEqual(29, len(result))
 
 
 class TestAllFilteredGroupsSource(TestAllGroupsSource):

--- a/opengever/ogds/base/tests/test_sources.py
+++ b/opengever/ogds/base/tests/test_sources.py
@@ -8,6 +8,7 @@ from opengever.ogds.base.interfaces import IAdminUnitConfiguration
 from opengever.ogds.base.sources import AllEmailContactsAndUsersSource
 from opengever.ogds.base.sources import AllFilteredGroupsSource
 from opengever.ogds.base.sources import AllGroupsSource
+from opengever.ogds.base.sources import AllTeamsSource
 from opengever.ogds.base.sources import AllUsersAndGroupsSource
 from opengever.ogds.base.sources import AllUsersInboxesAndTeamsSource
 from opengever.ogds.base.sources import AllUsersSource
@@ -1240,3 +1241,34 @@ class TestAllFilteredGroupsSource(TestAllGroupsSource):
         self.assertEqual(
             [u'fa_inbox_users', u'fa_users'],
             [term.value for term in self.source.search('')])
+
+
+class TestAllTeamsSource(IntegrationTestCase):
+
+    def test_returns_all_teams(self):
+        source = AllTeamsSource(self.portal)
+
+        self.assertItemsEqual([u'team:1', u'team:3', u'team:2'],
+                      [term.value for term in source.search('')])
+
+    def test_can_lookup_terms(self):
+        source = AllTeamsSource(self.portal)
+
+        self.assertIn(u'Projekt \xdcberbaung Dorfmatte (Finanz\xe4mt)',
+                      source.getTerm('team:1').title)
+
+    def test_raises_lookup_error_when_no_term_exists(self):
+        source = AllTeamsSource(self.portal)
+
+        with self.assertRaises(LookupError):
+            source.getTermByToken('team:missing')
+
+        with self.assertRaises(LookupError):
+            source.getTermByToken('group:no-team')
+
+    def test_search_teams(self):
+        source = AllTeamsSource(self.portal)
+        self.assertItemsEqual(
+            [u'Sekretariat Abteilung XY (Finanz\xe4mt)',
+             u'Sekretariat Abteilung Null (Finanz\xe4mt)'],
+            [term.title for term in source.search('Sek')])


### PR DESCRIPTION
Currently, only users are allowed as watchers for resources.

This PR extends the `@possible-watchers` and `@watchers` endpoint to allow groups and teams as watchers beside of users.


For [TI-407]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [x] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed


[TI-407]: https://4teamwork.atlassian.net/browse/TI-407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ