### PR TITLE
Remove @possible-watchers already existing watchers filter

### DIFF
--- a/changes/TI-407-2.feature
+++ b/changes/TI-407-2.feature
@@ -1,0 +1,1 @@
+The @possible-watchers endpoint always includes all possible watchers without removing already watching actors [elioschmutz]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -8,6 +8,7 @@ API Changelog
 
 Breaking Changes
 ^^^^^^^^^^^^^^^^
+- The ``@possible-watchers`` endpoint always includes all possible watchers without removing already watching actors.
 - Remove deprecated ``referenced_users`` property from ``GET @watcher`` endpoint.
 - The ``DELETE @watcher`` endpoint requires a path parameter with the actor-id
 - The ``POST @watcher`` endpoint requires an ``actor_id`` an no longer a ``userid``

--- a/docs/public/dev-manual/api/watchers.rst
+++ b/docs/public/dev-manual/api/watchers.rst
@@ -143,7 +143,7 @@ Liste von möglichen Beobachtern
 -------------------------------
 Der ``@possible-watchers``-Endpoint liefert eine Liste von Actors welche als Beobachter für den aktuellen Kontext hinzugefügt werden können.
 
-Weil es üblich ist, dass man sich selbst als Beobachter hinzufügen möchte, wird der eigene Benutzer in der Sortierreihenfolge immer zuoberst dargestellt. Alle restlichen Actors werden Typ (Benutzer, Gruppen, Teams) und nach Name und Vorname oder Titel sortiert. Der eigene Benutzer sowie alle anderen Actors werden nur dann angezeigt, wenn diese noch keine Beobachter-Rolle besitzen.
+Weil es üblich ist, dass man sich selbst als Beobachter hinzufügen möchte, wird der eigene Benutzer in der Sortierreihenfolge immer zuoberst dargestellt. Alle restlichen Actors werden Typ (Benutzer, Gruppen, Teams) und nach Name und Vorname oder Titel sortiert.
 
 **Beispiel-Request:**
 

--- a/opengever/activity/sources.py
+++ b/opengever/activity/sources.py
@@ -1,22 +1,10 @@
-from opengever.activity import notification_center
-from opengever.activity.roles import WATCHER_ROLE
-from opengever.ogds.base.actor import ActorLookup
 from opengever.ogds.base.sources import AllFilteredGroupsSourcePrefixed
 from opengever.ogds.base.sources import AllTeamsSource
 from opengever.ogds.base.sources import AssignedUsersSource
 from opengever.ogds.base.sources import BaseMultipleSourcesQuerySource
-from opengever.ogds.models.group import Group
-from opengever.ogds.models.team import Team
 from opengever.ogds.models.user import User
 from plone import api
 from sqlalchemy import case
-
-
-def get_watcher_ids(context):
-    """Returns all ids of actors watching the current context
-    """
-    return [watcher.actorid for watcher in
-            notification_center().get_watchers(context, role=WATCHER_ROLE)]
 
 
 class PossibleWatchersSourceUsers(AssignedUsersSource):
@@ -42,7 +30,6 @@ class PossibleWatchersSourceUsers(AssignedUsersSource):
 
     def _extend_query(self, query):
         query = self._current_user_first(query)
-        query = self._filter_not_subscribing_watchers(query)
         return query
 
     def _current_user_first(self, query):
@@ -56,56 +43,6 @@ class PossibleWatchersSourceUsers(AssignedUsersSource):
             ((User.userid == current_user.getId(), 1), ),
             else_=2))
 
-    def _filter_not_subscribing_watchers(self, query):
-        """This function adds the filter clause to only return users without a
-        watcher-role on the current context.
-        """
-        query = query.filter(User.userid.notin_(get_watcher_ids(self.context)))
-        return query
-
-
-class PossibleWatchersSourceGroups(AllFilteredGroupsSourcePrefixed):
-    """A vocabulary source of all groups not watching the current context
-    """
-    @property
-    def base_query(self):
-        query = super(PossibleWatchersSourceGroups, self).base_query
-        return self._filter_not_subscribing_watchers(query)
-
-    @property
-    def search_query(self):
-        query = super(PossibleWatchersSourceGroups, self).search_query
-        return self._filter_not_subscribing_watchers(query)
-
-    def _filter_not_subscribing_watchers(self, query):
-        """This function adds the filter clause to only return groups without a
-        watcher-role on the current context.
-        """
-        group_ids = [watcher.split(':', 1)[-1] for watcher
-                     in get_watcher_ids(self.context)
-                     if watcher.startswith(self.GROUP_PREFIX)]
-        query = query.filter(Group.groupid.notin_(group_ids))
-        return query
-
-
-class PossibleWatchersSourceTeams(AllTeamsSource):
-    """A vocabulary source of all teams not watching the current context
-    """
-    @property
-    def search_query(self):
-        query = super(PossibleWatchersSourceTeams, self).search_query
-        return self._filter_not_subscribing_watchers(query)
-
-    def _filter_not_subscribing_watchers(self, query):
-        """This function adds the filter clause to only return teams without a
-        watcher-role on the current context.
-        """
-        team_ids = [watcher.split(':', 1)[-1] for watcher
-                    in get_watcher_ids(self.context)
-                    if ActorLookup(watcher).is_team()]
-        query = query.filter(Team.team_id.notin_(team_ids))
-        return query
-
 
 class PossibleWatchersSource(BaseMultipleSourcesQuerySource):
     """A vocabulary source of all users, groups and teams not watching a
@@ -116,5 +53,5 @@ class PossibleWatchersSource(BaseMultipleSourcesQuerySource):
         self.context = context
         self.terms = []
         self.source_instances = [PossibleWatchersSourceUsers(context),
-                                 PossibleWatchersSourceGroups(context),
-                                 PossibleWatchersSourceTeams(context)]
+                                 AllFilteredGroupsSourcePrefixed(context),
+                                 AllTeamsSource(context)]

--- a/opengever/activity/tests/test_sources.py
+++ b/opengever/activity/tests/test_sources.py
@@ -18,7 +18,7 @@ class TestPossibleWatchersSource(IntegrationTestCase):
         session = create_session()
         map(session.delete, notification_center().get_subscriptions(self.task))
 
-    def test_list_users_groups_and_teams_not_having_a_watcher_role_on_an_object(self):
+    def test_list_users_groups_and_teams(self):
         self.login(self.regular_user)
         center = notification_center()
         source = PossibleWatchersSource(self.task)
@@ -28,18 +28,6 @@ class TestPossibleWatchersSource(IntegrationTestCase):
         self.assertIn('regular_user', [term.token for term in source.search('')])
         self.assertIn('group:fa_users', [term.token for term in source.search('')])
         self.assertIn('team:1', [term.token for term in source.search('')])
-
-        center.add_watcher_to_resource(self.task, 'regular_user', WATCHER_ROLE)
-        center.add_watcher_to_resource(self.task, 'group:fa_users', WATCHER_ROLE)
-        center.add_watcher_to_resource(self.task, 'team:1', WATCHER_ROLE)
-
-        subscriptions = center.get_subscriptions(self.task)
-        self.assertEqual([u'regular_user', u'group:fa_users', u'team:1'],
-                         [s.watcher.actorid for s in subscriptions])
-
-        self.assertNotIn('regular_user', [term.token for term in source.search('')])
-        self.assertNotIn('group:fa_users', [term.token for term in source.search('')])
-        self.assertNotIn('team:1', [term.token for term in source.search('')])
 
     def test_current_user_is_always_on_first_position_if_available(self):
         self.login(self.regular_user)

--- a/opengever/api/tests/test_watchers.py
+++ b/opengever/api/tests/test_watchers.py
@@ -712,7 +712,6 @@ class TestPossibleWatchers(IntegrationTestCase):
 
     @browsing
     def test_get_possible_watchers_for_and_object(self, browser):
-        center = notification_center()
         self.login(self.regular_user, browser=browser)
         url = self.task.absolute_url() + '/@possible-watchers?query=F%C3%A4ivel'
 
@@ -728,18 +727,8 @@ class TestPossibleWatchers(IntegrationTestCase):
 
         self.assertEqual(expected_json, browser.json)
 
-        center.add_watcher_to_resource(self.task, self.dossier_manager.getId(), WATCHER_ROLE)
-        browser.open(url, method='GET', headers=self.api_headers)
-        expected_json = {
-            u'@id': url,
-            u'items': [],
-            u'items_total': 0}
-
-        self.assertEqual(expected_json, browser.json)
-
     @browsing
     def test_possible_watchers_only_returns_active_users(self, browser):
-        center = notification_center()
         self.login(self.regular_user, browser=browser)
         url = self.task.absolute_url() + '/@possible-watchers?query=F%C3%A4ivel'
 
@@ -755,7 +744,6 @@ class TestPossibleWatchers(IntegrationTestCase):
 
     @browsing
     def test_get_possible_watchers_for_document(self, browser):
-        center = notification_center()
         self.login(self.regular_user, browser=browser)
         url = self.document.absolute_url() + '/@possible-watchers?query=F%C3%A4ivel'
 
@@ -771,18 +759,8 @@ class TestPossibleWatchers(IntegrationTestCase):
 
         self.assertEqual(expected_json, browser.json)
 
-        center.add_watcher_to_resource(self.document, self.dossier_manager.getId(), WATCHER_ROLE)
-        browser.open(url, method='GET', headers=self.api_headers)
-        expected_json = {
-            u'@id': url,
-            u'items': [],
-            u'items_total': 0}
-
-        self.assertEqual(expected_json, browser.json)
-
     @browsing
     def test_get_possible_watchers_for_mail(self, browser):
-        center = notification_center()
         self.login(self.regular_user, browser=browser)
         url = self.mail_eml.absolute_url() + '/@possible-watchers?query=F%C3%A4ivel'
 
@@ -795,15 +773,6 @@ class TestPossibleWatchers(IntegrationTestCase):
                 u'token': self.dossier_manager.getId(),
                 }],
             u'items_total': 1}
-
-        self.assertEqual(expected_json, browser.json)
-
-        center.add_watcher_to_resource(self.mail_eml, self.dossier_manager.getId(), WATCHER_ROLE)
-        browser.open(url, method='GET', headers=self.api_headers)
-        expected_json = {
-            u'@id': url,
-            u'items': [],
-            u'items_total': 0}
 
         self.assertEqual(expected_json, browser.json)
 


### PR DESCRIPTION
Currently, the `@possible-watchers` endpoint returns all possible watchers without the watchers which are currently watching the context. 

This filter makes it complicated and expensive to calculate in the backend and could easily be handled in the frontend if an actor is already watching a specific resource. 

This PR removes these filters and will always return all actors with are possible to watch a context.

This PR implements the review-feedback of: https://github.com/4teamwork/opengever.core/pull/7986#discussion_r1665428959

For [TI-407]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [x] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed


[TI-407]: https://4teamwork.atlassian.net/browse/TI-407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ