### PR TITLE
Include workspace title in participant export file name

### DIFF
--- a/changes/TI-670.other
+++ b/changes/TI-670.other
@@ -1,0 +1,1 @@
+Include workspace title in participant export file name. [amo]

--- a/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-03-07 13:42+0000\n"
+"POT-Creation-Date: 2024-07-09 09:15+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -53,6 +53,10 @@ msgstr "Teilnehmer wurde gelöscht"
 #: ./opengever/workspace/participation/browser/participants_view.py
 msgid "Participant invited"
 msgstr "Teilnehmer wurde eingeladen"
+
+#: ./opengever/workspace/report.py
+msgid "Participants"
+msgstr "Teilnehmer"
 
 #: ./opengever/workspace/activities.py
 msgid "Reopened by ${user}"

--- a/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-03-07 13:42+0000\n"
+"POT-Creation-Date: 2024-07-09 09:15+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -63,6 +63,10 @@ msgstr "Participant deleted"
 #: ./opengever/workspace/participation/browser/participants_view.py
 msgid "Participant invited"
 msgstr "Participant invited"
+
+#: ./opengever/workspace/report.py
+msgid "Participants"
+msgstr "Participants"
 
 #. German translation: Wieder eröffnet durch ${user}
 #: ./opengever/workspace/activities.py

--- a/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-03-07 13:42+0000\n"
+"POT-Creation-Date: 2024-07-09 09:15+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -53,6 +53,10 @@ msgstr "Participant supprimé"
 #: ./opengever/workspace/participation/browser/participants_view.py
 msgid "Participant invited"
 msgstr "Participant invité"
+
+#: ./opengever/workspace/report.py
+msgid "Participants"
+msgstr "Participants"
 
 #: ./opengever/workspace/activities.py
 msgid "Reopened by ${user}"

--- a/opengever/workspace/locales/opengever.workspace.pot
+++ b/opengever/workspace/locales/opengever.workspace.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-03-07 13:42+0000\n"
+"POT-Creation-Date: 2024-07-09 09:15+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -55,6 +55,10 @@ msgstr ""
 
 #: ./opengever/workspace/participation/browser/participants_view.py
 msgid "Participant invited"
+msgstr ""
+
+#: ./opengever/workspace/report.py
+msgid "Participants"
 msgstr ""
 
 #: ./opengever/workspace/activities.py

--- a/opengever/workspace/report.py
+++ b/opengever/workspace/report.py
@@ -1,10 +1,22 @@
 from opengever.globalindex.browser.report import UserReport
+from zope.i18n import translate
+from zope.i18nmessageid import MessageFactory
+
+
+_ = MessageFactory('opengever.workspace')
 
 
 class WorkspaceParticipantsReport(UserReport):
     """View that generate an excel spreadsheet which list all selected users
     """
-    filename = "workspace_participants_report.xlsx"
+
+    @property
+    def filename(self):
+        participants = translate(_("Participants"), context=self.request)
+        return "{participants}_{workspace_title}.xlsx".format(
+            participants=participants,
+            workspace_title=self.context.title
+        )
 
     def check_permissions(self):
         pass


### PR DESCRIPTION
Include the workspace title in the participation Excel file when downloading it.
For [TI-670](https://4teamwork.atlassian.net/browse/TI-670)

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-670]: https://4teamwork.atlassian.net/browse/TI-670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ