### PR TITLE
Include group users in Teamraum participant Excel export

### DIFF
--- a/changes/TI-669.other
+++ b/changes/TI-669.other
@@ -1,0 +1,1 @@
+Include group users in workspace participant Excel export and ensure unique user listing. [amo]

--- a/opengever/globalindex/browser/report.py
+++ b/opengever/globalindex/browser/report.py
@@ -91,8 +91,7 @@ class UserReport(BaseReporterView):
         if not is_administrator():
             raise Unauthorized
 
-    def __call__(self):
-        self.check_permissions()
+    def extract_user_ids_from_request(self):
         user_ids = self.request.form.get("user_ids")
 
         if not user_ids:
@@ -105,10 +104,17 @@ class UserReport(BaseReporterView):
             else:
                 return self.request.RESPONSE.redirect(
                     self.context.absolute_url())
+        return user_ids
 
+    def fetch_users(self):
+        user_ids = self.extract_user_ids_from_request()
         users = [ogds_service().fetch_user(user_id) for user_id in user_ids]
         users = [user for user in users if user]
+        return users
 
+    def __call__(self):
+        self.check_permissions()
+        users = self.fetch_users()
         reporter = XLSReporter(
             self.context.REQUEST,
             self.columns(),

--- a/opengever/workspace/report.py
+++ b/opengever/workspace/report.py
@@ -1,4 +1,5 @@
 from opengever.globalindex.browser.report import UserReport
+from opengever.ogds.models.service import ogds_service
 from zope.i18n import translate
 from zope.i18nmessageid import MessageFactory
 
@@ -20,3 +21,18 @@ class WorkspaceParticipantsReport(UserReport):
 
     def check_permissions(self):
         pass
+
+    def fetch_users(self):
+        user_ids = self.extract_user_ids_from_request()
+        users = set()
+
+        for user_id in user_ids:
+            group_members = ogds_service().fetch_group(user_id)
+            if group_members:
+                users.update(group_members.users)
+            else:
+                user = ogds_service().fetch_user(user_id)
+                if user:
+                    users.add(user)
+
+        return list(users)

--- a/opengever/workspace/tests/test_workspace_participation_reporter.py
+++ b/opengever/workspace/tests/test_workspace_participation_reporter.py
@@ -1,0 +1,109 @@
+from ftw.builder.builder import Builder
+from ftw.builder.builder import create
+from ftw.testbrowser import browsing
+from opengever.ogds.models.service import ogds_service
+from opengever.testing import IntegrationTestCase
+from openpyxl import load_workbook
+from tempfile import NamedTemporaryFile
+
+
+class TestWorkspaceParticipationReporter(IntegrationTestCase):
+
+    @browsing
+    def test_empty_users_report(self, browser):
+        self.login(self.administrator, browser=browser)
+        browser.open(view='workspace_participants_report', data={'user_ids': []})
+
+        self.assertEquals('Error You have not selected any items.',
+                          browser.css('.portalMessage.error').text[0])
+
+    @browsing
+    def test_download_users_xlsx(self, browser):
+        """Test downloading a user report in XLSX format.
+        This test verifies that the user report correctly generates an XLSX file
+        including individual users and users within a group.
+        """
+        self.login(self.administrator, browser=browser)
+
+        # Create a group and add regular_user to the group
+        group_users = ogds_service().find_user(self.regular_user.id)
+        group = create(Builder('ogds_group')
+                       .having(groupid='group1',
+                               title='Group 1', users=[group_users, ]))
+
+        user_ids = {
+            'user_ids': [
+                self.regular_user.id,
+                self.administrator.id,
+                group.groupid
+            ]
+        }
+
+        browser.open(view='workspace_participants_report', data=user_ids)
+        self.assertEqual(browser.status_code, 200)
+        with NamedTemporaryFile(delete=False, suffix='.xlsx') as tmpfile:
+            tmpfile.write(browser.contents)
+            tmpfile.flush()
+            workbook = load_workbook(tmpfile.name)
+
+        task_cells = list(workbook.active.rows)
+
+        # if ror_num != 0 will remove the table header
+        cell_values = [[cell.value for cell in row] for row_num, row in enumerate(task_cells) if row_num != 0]
+        expected_values = [
+            [
+                u'kathi.barfuss',
+                True,
+                u'K\xe4thi',
+                u'B\xe4rfuss',
+                u'B\xe4rfuss K\xe4thi',
+                u'Staatsarchiv',
+                u'Arch',
+                u'Staatskanzlei',
+                u'SK',
+                None,
+                u'foo@example.com',
+                u'bar@example.com',
+                u'http://www.example.com',
+                u'012 34 56 78',
+                u'012 34 56 77',
+                u'012 34 56 76',
+                u'Frau',
+                u'Gesch\xe4ftsf\xfchrerin',
+                u'nix',
+                u'Kappelenweg 13',
+                u'Postfach 1234',
+                u'1234',
+                u'Vorkappelen',
+                u'Schweiz',
+                None
+            ],
+            [
+                u'nicole.kohler',
+                True,
+                u'Nicole',
+                u'Kohler',
+                u'Kohler Nicole',
+                None,
+                None,
+                None,
+                None,
+                None,
+                u'nicole.kohler@gever.local',
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None
+            ]
+        ]
+        self.assertSequenceEqual(expected_values, cell_values)


### PR DESCRIPTION
This PR enhances the workspace participant Excel export feature by including users who are part of groups with permissions in the workspace. Previously, the export only listed users directly authorized in the workspace. With this update, the export will:

- Resolve group members and include users from these groups in the export.
- Ensure that no duplicated users in the export.

For [TI-669](https://4teamwork.atlassian.net/browse/TI-669)

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-669]: https://4teamwork.atlassian.net/browse/TI-669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ