### PR TITLE
Add serialized source dossier to dossier transfer if possible

### DIFF
--- a/changes/TI-706.other
+++ b/changes/TI-706.other
@@ -1,0 +1,1 @@
+Expose the serialized source dossier if possible when using the "@dossier-transfer" endpoint. [elioschmutz]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -12,7 +12,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
-
+- ``@dossier-transfer``: Returns the serialized root_item if it is located on the same admin unit and the current user has view permission.
 
 2024.10.0 (2024-07-15)
 ----------------------

--- a/docs/public/dev-manual/api/dossier_transfers.rst
+++ b/docs/public/dev-manual/api/dossier_transfers.rst
@@ -62,6 +62,7 @@ Mittels eines POST Requests kann ein Dossier-Transfer erstellt werden:
         "target": "recipient",
         "source_user": "regular_user",
         "root": "createresolvabledossier000000001",
+        "root_item": {"...": "..."},
         "documents": [
            "document1_uid",
            "document2_uid"
@@ -116,6 +117,7 @@ Mittels eines GET Requests können Dossier-Transfers aufgelistet werden:
             },
             "source_user": "jurgen.konig",
             "root": "createresolvabledossier000000001",
+            "root_item": {"...": "..."},
             "documents": [
               "createresolvabledossier000000003"
             ],
@@ -142,6 +144,7 @@ Mittels eines GET Requests können Dossier-Transfers aufgelistet werden:
             },
             "source_user": "jurgen.konig",
             "root": "createresolvabledossier000000001",
+            "root_item": {"...": "..."},
             "documents": [
               "createresolvabledossier000000003"
             ],


### PR DESCRIPTION
This PR adds the summary serialized brain of the `root` dossier if requesting dossier-transfers through the `@dossier-transfer` endpoint or directly requesting a transfer with `@dossier-transfer/1`.

The root-dossier will only be serialized if:
1. the root is stored on the current admin-unit
2. the user has permission to view the dossier

**Why don't we add the `root_item` to the dossier-transfer serializer?**
The reason is performance. A dossier-transfer is stored in the ogds. The serializer would need to know if the source dossier is stored on the current admin unit and would need to do a catalog query to lookup the dossier. We'd need to do this for every dossier transfer.

For [TI-706]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide]

[TI-706]: https://4teamwork.atlassian.net/browse/TI-706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ