### PR TITLE
Fix flaky test due to different sort orders

### DIFF
--- a/opengever/workspace/tests/test_workspace_participation_reporter.py
+++ b/opengever/workspace/tests/test_workspace_participation_reporter.py
@@ -106,4 +106,4 @@ class TestWorkspaceParticipationReporter(IntegrationTestCase):
                 None
             ]
         ]
-        self.assertSequenceEqual(expected_values, cell_values)
+        self.assertItemsEqual(expected_values, cell_values)


### PR DESCRIPTION
This PR fixes a flaky test due to different sort orders between test-runs.

See test-result of: https://github.com/4teamwork/opengever.core/pull/7993/checks?check_run_id=27514045718

Follow-Up for https://github.com/4teamwork/opengever.core/pull/7992/

For [TI-669]


[TI-669]: https://4teamwork.atlassian.net/browse/TI-669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ