### PR TITLE
Fix Redis requirement for Docker image

### DIFF
--- a/changes/GH-7995.bugfix
+++ b/changes/GH-7995.bugfix
@@ -1,0 +1,1 @@
+Fix Redis requirement for Docker image. [buchi]

--- a/docker/core/requirements-core.txt
+++ b/docker/core/requirements-core.txt
@@ -269,7 +269,7 @@ python-openid==2.2.5
 pytz==2022.1
 PyXB==1.2.5
 Record==2.13.0
-redis=3.5.3
+redis==3.5.3
 repoze.catalog==0.8.3
 repoze.xmliter==0.6
 requests==2.27.1


### PR DESCRIPTION
Building the Docker image is currently broken.

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)

