### PR TITLE
Exclude inactive users and groups for non-managers in Sharing tab

### DIFF
--- a/changes/TI-296.other
+++ b/changes/TI-296.other
@@ -1,0 +1,1 @@
+Exclude inactive users and groups for non-managers in Sharing tab. [amo]


### PR DESCRIPTION
Update the `Sharing `endpoint with the following points :

1. In the sharing tab, inactive users and groups are displayed only for managers.
2. In edit mode, inactive users and groups are always displayed

For [TI-296](https://4teamwork.atlassian.net/browse/TI-296)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[TI-296]: https://4teamwork.atlassian.net/browse/TI-296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ