### PR TITLE
Update tabbed logic for proposals to include old and new SPV

### DIFF
--- a/changes/TI-777.bugfix
+++ b/changes/TI-777.bugfix
@@ -1,0 +1,1 @@
+Modify Tabbed (proposals_tab) logic to show / hide based on alt and new SPV.[amo]

--- a/opengever/repository/browser/tabbed.py
+++ b/opengever/repository/browser/tabbed.py
@@ -1,6 +1,7 @@
-from opengever.meeting.interfaces import IMeetingSettings
+from opengever.meeting import is_meeting_feature_enabled
 from opengever.repository import _
 from opengever.repository.interfaces import IRepositoryFolderRecords
+from opengever.ris import is_ris_feature_enabled
 from opengever.tabbedview import GeverTabbedView
 from plone import api
 from plone.registry.interfaces import IRegistry
@@ -107,11 +108,10 @@ class RepositoryFolderTabbedView(GeverTabbedView):
 
     @property
     def proposals_tab(self):
-        meeting_settings = getUtility(IRegistry).forInterface(IMeetingSettings)
-        meeting_enabled = getattr(meeting_settings, 'is_feature_enabled', False)
+        any_spv_enabled = any([is_ris_feature_enabled(), is_meeting_feature_enabled()])
         repository_settings = getUtility(IRegistry).forInterface(IRepositoryFolderRecords)
         proposals_tab_enabled = getattr(repository_settings, 'show_proposals_tab', False)
-        if meeting_enabled and proposals_tab_enabled:
+        if proposals_tab_enabled and any_spv_enabled:
             return {
                 'id': 'proposals',
                 'title': _(u'label_proposals', default=u'Proposals'),

--- a/opengever/repository/tests/test_repositoryfolder_tabs.py
+++ b/opengever/repository/tests/test_repositoryfolder_tabs.py
@@ -248,3 +248,41 @@ class TestRepositoryFolderProposalsTabWithMeeting(IntegrationTestCase):
             ['', u'Antrag f\xfcr Kreiselbau', '', 'Pending', 'Pending', u'Kommission f\xfcr Verkehr', '', '', 'Ziegler Robert (robert.ziegler)'],  # noqa
         ]
         self.assertEqual(expected_rows, [row.css('td,span').text for row in browser.css('.listing tr')])
+
+
+class TestRepositoryFolderProposalsTab(IntegrationTestCase):
+
+    @browsing
+    def test_not_visible(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.branch_repofolder)
+        expected_tabs = ['Dossiers', 'Documents', 'Tasks', 'Info']
+        self.assertEqual(tabbedview.tabs().text, expected_tabs)
+
+    @browsing
+    def test_not_visible_no_feature_enabled(self, browser):
+        api.portal.set_registry_record('show_proposals_tab', False, IRepositoryFolderRecords)
+        self.login(self.regular_user, browser)
+        browser.open(self.branch_repofolder)
+        expected_tabs = ['Dossiers', 'Documents', 'Tasks', 'Info']
+        self.assertEqual(tabbedview.tabs().text, expected_tabs)
+
+    @browsing
+    def test_not_visible_when_deactivating_ris_and_deactivating_meeting(self, browser):
+        self.deactivate_feature('ris')
+        self.deactivate_feature('meeting')
+        api.portal.set_registry_record('show_proposals_tab', True, IRepositoryFolderRecords)
+        self.login(self.regular_user, browser)
+        browser.open(self.branch_repofolder)
+        expected_tabs = ['Dossiers', 'Documents', 'Tasks', 'Info', ]
+        self.assertEqual(tabbedview.tabs().text, expected_tabs)
+
+    @browsing
+    def test_visible_when_activating_ris_and_deactivating_meeting(self, browser):
+        self.activate_feature('ris')
+        self.deactivate_feature('meeting')
+
+        self.login(self.regular_user, browser)
+        browser.open(self.branch_repofolder)
+        expected_tabs = ['Dossiers', 'Documents', 'Tasks', 'Info', 'Proposals']
+        self.assertEqual(tabbedview.tabs().text, expected_tabs)


### PR DESCRIPTION
Add logic to the Proposals tab, enabling it to display when either the `proposal `feature or any of the `spv` features `(RIS or Meeting)` are activated.

For [TI-777](https://4teamwork.atlassian.net/browse/TI-777)

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-777]: https://4teamwork.atlassian.net/browse/TI-777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ