### PR TITLE
Fix migration.log handler

### DIFF
--- a/changes/GH-8003.bugfix
+++ b/changes/GH-8003.bugfix
@@ -1,0 +1,1 @@
+Fix migration.log handler which was broken in releae 2024.6.0. [buchi]

--- a/opengever/bundle/console.py
+++ b/opengever/bundle/console.py
@@ -108,7 +108,7 @@ def setup_logging():
 
     # Also write logs to a dedicated migration log.
     log_dir = PathFinder().var_log
-    file_handler = logging.FileHandler(log_dir, 'migration.log')
+    file_handler = logging.FileHandler(os.path.join(log_dir, 'migration.log'))
     file_handler.setFormatter(stream_handler.formatter)
     file_handler.setLevel(logging.INFO)
     logging.root.addHandler(file_handler)


### PR DESCRIPTION
Was broken in release 2024.6.0

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
