### PR TITLE
French translation during File Metadata edit fixed

### DIFF
--- a/changes/TI-596.other
+++ b/changes/TI-596.other
@@ -1,0 +1,2 @@
+Fix french translation for limiting dossier depth. [ran]
+(https://4teamwork.atlassian.net/browse/TI-596)

--- a/opengever/repository/locales/fr/LC_MESSAGES/opengever.repository.po
+++ b/opengever/repository/locales/fr/LC_MESSAGES/opengever.repository.po
@@ -45,7 +45,7 @@ msgstr "Déterminez s'il est permis d'ajouter des dossiers d'affaire à ce nivea
 #. Default: "Select if this repostory tree should respect the max subdossier depth restriction."
 #: ./opengever/repository/repositoryfolder.py
 msgid "description_max_subdossier_depth_restriction"
-msgstr ""
+msgstr "Indiquer si le plan de classement doit respecter une profondeur maximale pour ses sous-dossiers."
 
 #. Default: "Attention: Change requires reindexing of \"reference\" and \"sortable_reference\"."
 #: ./opengever/repository/repositoryroot.py
@@ -272,7 +272,7 @@ msgstr "UID"
 #. Default: "Limit maximum dossier depth in this repository folder"
 #: ./opengever/repository/repositoryfolder.py
 msgid "label_respect_max_subdossier_depth_restriction"
-msgstr ""
+msgstr "Limiter le niveau de profondeur maximal de ce dossier dans le plan de classement"
 
 #. Default: "The repository have been successfully deleted."
 #: ./opengever/repository/browser/deletion.py


### PR DESCRIPTION
Missing French Translation was added for limiting dossier depth:

Before:
<img width="751" alt="TI-596_before" src="https://github.com/user-attachments/assets/00a7c592-bd0e-439f-8290-e051197d79f0">

After:
<img width="803" alt="TI-596_after" src="https://github.com/user-attachments/assets/d0b0f404-18bb-4b10-9ddb-1a4da23c467a">


For [TI-596]

## Checklist

- [X] Changelog entry
- [X] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- New translations
  - [X] All msg-strings are unicode



[TI-596]: https://4teamwork.atlassian.net/browse/TI-596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ