### PR TITLE
Provide context action to export workspacefolder participations

### DIFF
--- a/changes/TI-672.other
+++ b/changes/TI-672.other
@@ -1,0 +1,1 @@
+Provide workspace participation export action on workspace folders. [amo]

--- a/opengever/workspace/actions.py
+++ b/opengever/workspace/actions.py
@@ -111,3 +111,9 @@ class WorkspaceFolderContextActions(BaseContextActions):
 
     def is_zipexport_available(self):
         return not is_restricted_workspace_and_guest(self.context)
+
+    def is_export_workspace_users_available(self):
+        return api.user.has_permission(
+            'opengever.workspace: Export Workspace Participants',
+            obj=self.context
+        )

--- a/opengever/workspace/tests/test_actions.py
+++ b/opengever/workspace/tests/test_actions.py
@@ -168,7 +168,14 @@ class TestWorkspaceFolderContextActions(IntegrationTestCase):
 
     def test_workspace_folder_context_actions_for_workspace_admins(self):
         self.login(self.workspace_admin)
-        expected_actions = [u'edit', u'local_roles', u'share_content', u'trash_context', 'zipexport']
+        expected_actions = [
+            u'edit',
+            u'local_roles',
+            u'share_content',
+            u'trash_context',
+            'zipexport',
+            u'export_workspace_participators'
+        ]
         self.assertEqual(expected_actions, self.get_actions(self.workspace_folder))
 
     def test_context_action_for_trashed_workspace_folder(self):


### PR DESCRIPTION
The PR provides an Excel export feature for workspacefolder `participations` via `context action`.

For [TI-672](https://4teamwork.atlassian.net/browse/TI-672)
Related FrontEnd PR [FR PR](https://github.com/4teamwork/gever-ui/pull/2782)

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)




[TI-672]: https://4teamwork.atlassian.net/browse/TI-672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ