### PR TITLE
Add customFields support in IKUBSettings to include them in Docprops

### DIFF
--- a/changes/TI-691.other
+++ b/changes/TI-691.other
@@ -1,0 +1,1 @@
+Enhance the IKUBSettings interface by adding new fields that allow the integration of customFields into the Docprops. [amo]

--- a/opengever/core/upgrades/20240814102603_add_kub_doc_property_additional_fields/registry.xml
+++ b/opengever/core/upgrades/20240814102603_add_kub_doc_property_additional_fields/registry.xml
@@ -1,0 +1,7 @@
+
+<registry>
+    <records interface="opengever.kub.interfaces.IKuBSettings">
+        <value key="additional_docproperty_fields">
+        </value>
+    </records>
+</registry>

--- a/opengever/core/upgrades/20240814102603_add_kub_doc_property_additional_fields/upgrade.py
+++ b/opengever/core/upgrades/20240814102603_add_kub_doc_property_additional_fields/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddKubDocPropertyAdditionalFields(UpgradeStep):
+    """Add kub doc property additional fields.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/dossiertransfer/tests/test_api_get.py
+++ b/opengever/dossiertransfer/tests/test_api_get.py
@@ -1077,7 +1077,7 @@ class TestDossierTransfersGetFullContent(KuBIntegrationTestCase):
             u'country': u'',
             u'countryIdISO2': u'',
             u'created': u'2021-11-17T00:00:00+01:00',
-            u'customValues': {},
+            u'customValues': {u'sorgerecht': u'Geteilt'},
             u'dateOfBirth': u'1992-05-15',
             u'dateOfDeath': None,
             u'description': u'',

--- a/opengever/kub/interfaces.py
+++ b/opengever/kub/interfaces.py
@@ -16,3 +16,12 @@ class IKuBSettings(Interface):
                                            default=list(),
                                            missing_value=list(),
                                            value_type=schema.TextLine())
+
+    additional_docproperty_fields = schema.List(
+        title=u"Additional DocProperties",
+        description=u"List of additional field ids available as DocProperties.",
+        required=False,
+        default=list(),
+        missing_value=list(),
+        value_type=schema.ASCIILine(),
+    )

--- a/opengever/kub/testing.py
+++ b/opengever/kub/testing.py
@@ -361,7 +361,7 @@ KUB_RESPONSES = {
         },
         "primaryUrl": None,
         "text": "Dupont Jean",
-        "customValues": {}
+        "customValues": {"sorgerecht": "Geteilt"}
     },
 
     "http://localhost:8000/api/v2/resolve/membership:8345fcfe-2d67-4b75-af46-c25b2f387448": {
@@ -720,7 +720,7 @@ KUB_RESPONSES = {
         "primaryUrl": None,
         "text": "4Teamwork",
         "spvCommittee": False,
-        "customValues": {}
+        "customValues": {"ort": "Bern"}
     },
 
     "http://localhost:8000/api/v2/resolve/invalid-id": ["Invalid uuid"],

--- a/opengever/kub/tests/test_docprops.py
+++ b/opengever/kub/tests/test_docprops.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from mock import patch
 from opengever.kub.docprops import KuBEntityDocPropertyProvider
 from opengever.kub.entity import KuBEntity
 from opengever.kub.testing import KUB_RESPONSES
@@ -57,6 +58,25 @@ class TestKuBEntityDocPropertyProvider(KuBIntegrationTestCase):
              'ogg.phone.number': None,
              'ogg.url.url': None},
             properties)
+
+    @patch('opengever.kub.docprops.get_additional_doc_properties', return_value=['sorgerecht',])
+    def test_docproperties_for_kub_person_with_custom_fields(self, mocker, mock_get_additional_doc_properties):
+        self.mock_get_by_id(mocker, self.person_jean)
+        entity = KuBEntity(self.person_jean)
+        properties = KuBEntityDocPropertyProvider(entity).get_properties()
+
+        self.assertIn('ogg.person.sorgerecht', properties)
+        self.assertEqual(properties['ogg.person.sorgerecht'], "Geteilt")
+
+    @patch('opengever.kub.docprops.get_additional_doc_properties', return_value=['ort'])
+    def test_docproperties_for_kub_organization_with_custom_fields(self, mocker, mock_get_additional_doc_properties):
+        self.mock_get_by_id(mocker, self.org_ftw)
+        entity = KuBEntity(self.org_ftw)
+
+        properties = KuBEntityDocPropertyProvider(entity).get_properties()
+
+        self.assertIn('ogg.organization.ort', properties)
+        self.assertEqual(properties['ogg.organization.ort'], "Bern")
 
     def test_zip_code_docproperty_is_swiss_or_foreign_zip_code(self, mocker):
         url = self.mock_get_by_id(mocker, self.person_jean)


### PR DESCRIPTION
This PR introduces :

- Added configurable DocProperties
 - Introduced a new registry property to define which KuB fields are available as DocProperties 
 - Updated the DocProperties Crawlers to respect the new configuration without causing errors if a field is unavailable.

For [TI-691](https://4teamwork.atlassian.net/browse/TI-691)

**Default (Before):**
<img width="463" alt="Before" src="https://github.com/user-attachments/assets/74488914-7fe3-463f-8ef8-57a2cd6b1f3d">

**With Custom Doc Props (After)**

<img width="498" alt="after" src="https://github.com/user-attachments/assets/9ed64b9a-8ffe-47d1-9f23-71f0232a4431">


## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-691]: https://4teamwork.atlassian.net/browse/TI-691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ