### PR TITLE
Add dossier_review_state solr index.

### DIFF
--- a/changes/TI-479.feature
+++ b/changes/TI-479.feature
@@ -1,0 +1,1 @@
+Add 'dossier_review_state' solr index which provides the review state of the current dossier or the closest parent dossier. [elioschmutz]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -12,7 +12,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
-
+- ``@solrsearch`` and ``@listing``: ``dossier_review_state`` is added as a new solr index.
 
 2024.11.0 (2024-07-30)
 ----------------------

--- a/docs/public/dev-manual/api/listings.rst
+++ b/docs/public/dev-manual/api/listings.rst
@@ -90,6 +90,7 @@ werden. Folgende Felder stehen zur Verfügung:
 - ``document_type_label``: Dokumenttyp (Anzeigewert)
 - ``dossier_type``: Dossiertyp
 - ``dossier_type_label``: Dossiertyp (Anzeigewert)
+- ``dossier_review_state``: Der Status des Dossiers selbst oder des Dossiers, in dem sich der aktuelle Inhalt befindet.
 - ``email``: E-Mail Adresse
 - ``end``: Enddatum des Dossiers
 - ``external_reference``: Externe Referenz für Dossiers oder Fremdzeichen für Dokumente
@@ -184,6 +185,8 @@ siehe Tabelle:
     |``document_type``         |    ja    |   nein  |     nein     |        nein        |  nein   |  nein   |  nein   |   nein   |       nein      |       nein       |       nein      |   nein   |       nein       |     nein    |      nein      |   nein   |
     +--------------------------+----------+---------+--------------+--------------------+---------+---------+---------+----------+-----------------+------------------+-----------------+----------+------------------+-------------+----------------+----------+
     |``dossier_type``          |    nein  |   ja    |     nein     |        nein        |  nein   |  nein   |  nein   |   nein   |       nein      |       nein       |       ja        |   nein   |       nein       |     nein    |      nein      |   nein   |
+    +--------------------------+----------+---------+--------------+--------------------+---------+---------+---------+----------+-----------------+------------------+-----------------+----------+------------------+-------------+----------------+----------+
+    |``dossier_review_state``  |    ja    |   ja    |     nein     |        nein        |  ja     |  nein   |  ja     |   ja     |       ja        |       ja         |       ja        |   ja     |       nein       |     ja      |      ja        |   ja     |
     +--------------------------+----------+---------+--------------+--------------------+---------+---------+---------+----------+-----------------+------------------+-----------------+----------+------------------+-------------+----------------+----------+
     |``end``                   |   nein   |    ja   |     nein     |        nein        |  nein   |  nein   |  nein   |   nein   |       nein      |       nein       |       nein      |    ja    |       nein       |     nein    |      nein      |   nein   |
     +--------------------------+----------+---------+--------------+--------------------+---------+---------+---------+----------+-----------------+------------------+-----------------+----------+------------------+-------------+----------------+----------+

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -657,6 +657,20 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
         self.assertEqual('dossier-state-active', review_states[0])
 
     @browsing
+    def test_filter_by_dossier_review_state(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        view = ('@listing?name=documents&columns:list=title'
+                '&filters.dossier_review_state:record=dossier-state-inactive')
+
+        browser.open(self.repository_root, view=view,
+                     headers=self.api_headers)
+
+        items = browser.json['items']
+        self.assertItemsEqual([self.inactive_document.UID()],
+                              [item.get('UID') for item in items])
+
+    @browsing
     def test_filter_by_is_subdossier(self, browser):
         self.login(self.regular_user, browser=browser)
 

--- a/opengever/base/configure.zcml
+++ b/opengever/base/configure.zcml
@@ -445,6 +445,12 @@
       handler=".handlers.update_touched_date"
       />
 
+  <subscriber
+      for="opengever.dossier.behaviors.dossier.IDossierMarker
+           Products.CMFCore.interfaces.IActionSucceededEvent"
+      handler=".handlers.update_dossier_review_state"
+      />
+
   <adapter
       factory=".indexes.referenceIndexer"
       name="reference"

--- a/opengever/base/handlers.py
+++ b/opengever/base/handlers.py
@@ -25,6 +25,7 @@ from opengever.workspace.interfaces import IToDoList
 from opengever.workspace.interfaces import IWorkspace
 from opengever.workspace.interfaces import IWorkspaceMeeting
 from plone.app.workflow.interfaces import ILocalrolesModifiedEvent
+from Products.CMFCore.interfaces import IFolderish
 from Products.CMFPlone.interfaces import IPloneSiteRoot
 from sqlalchemy import and_
 from zope.component import getUtility
@@ -273,3 +274,18 @@ def update_touched_date_for_move_event(obj, event):
     """
     if obj == event.object:
         update_touched_date(obj, event)
+
+
+def recursive_update_dossier_review_state(context):
+    context.reindexObject(idxs=["dossier_review_state"])
+    if not IFolderish.providedBy(context):
+        return
+
+    for obj in context.listFolderContents():
+        if IDossierMarker.providedBy(obj):
+            continue
+        recursive_update_dossier_review_state(obj)
+
+
+def update_dossier_review_state(obj, event):
+    recursive_update_dossier_review_state(obj)

--- a/opengever/base/solr/fields.py
+++ b/opengever/base/solr/fields.py
@@ -457,6 +457,11 @@ FIELDS_WITH_MAPPING = [
         index='containing_subdossier',
         title=tabbedview_mf(u'label_subdossier'),
     ),
+    ListingField(
+        'dossier_review_state',
+        transform=lambda state: translate(state, domain='plone', context=getRequest()),
+        index='dossier_review_state',
+    ),
     DateListingField(
         'created',
         title=document_mf('label_created', default='Created'),

--- a/opengever/core/upgrades/20240821165540_add_dossier_review_state_index/upgrade.py
+++ b/opengever/core/upgrades/20240821165540_add_dossier_review_state_index/upgrade.py
@@ -1,0 +1,24 @@
+from ftw.upgrade import UpgradeStep
+from opengever.core.upgrade import NightlyIndexer
+
+
+class AddDossierReviewStateIndex(UpgradeStep):
+    """Add dossier review state index.
+    """
+
+    def __call__(self):
+        query = {'portal_type': [
+            'opengever.dossier.businesscasedossier',
+            'opengever.meeting.proposal',
+            'opengever.ris.proposal',
+            'opengever.document.document',
+            'opengever.task.task',
+            'opengever.private.dossier',
+            'ftw.mail.mail',
+            'opengever.meeting.meetingdossier'
+        ]}
+
+        with NightlyIndexer(idxs=["dossier_review_state"],
+                            index_in_solr_only=True) as indexer:
+            for brain in self.brains(query, 'Index dossier_review_state in Solr'):
+                indexer.add_by_brain(brain)

--- a/opengever/dossier/configure.zcml
+++ b/opengever/dossier/configure.zcml
@@ -219,6 +219,11 @@
       />
 
   <adapter
+      factory=".indexers.dossier_review_state"
+      name="dossier_review_state"
+      />
+
+  <adapter
       factory=".indexers.is_subdossier"
       name="is_subdossier"
       />

--- a/opengever/dossier/indexers.py
+++ b/opengever/dossier/indexers.py
@@ -204,6 +204,31 @@ def containing_subdossier(obj):
     return ''
 
 
+TYPES_WITH_DOSSIER_REVIEW_STATE_INDEX = set(('opengever.dossier.businesscasedossier',
+                                             'opengever.meeting.proposal',
+                                             'opengever.ris.proposal',
+                                             'opengever.document.document',
+                                             'opengever.task.task',
+                                             'opengever.private.dossier',
+                                             'ftw.mail.mail',
+                                             'opengever.meeting.meetingdossier'))
+
+
+@indexer(IDexterityContent)
+def dossier_review_state(obj):
+    """Returns the review state of the current dossier or of the dossier of
+    which the current content is contained in.
+    """
+    if obj.portal_type not in TYPES_WITH_DOSSIER_REVIEW_STATE_INDEX:
+        return ''
+
+    while obj and not ISiteRoot.providedBy(obj):
+        if IDossierMarker.providedBy(obj):
+            return api.content.get_state(obj)
+        obj = aq_parent(aq_inner(obj))
+    return ''
+
+
 @indexer(IDossierMarker)
 def is_subdossier(obj):
     return obj.is_subdossier()

--- a/opengever/dossier/tests/test_indexer.py
+++ b/opengever/dossier/tests/test_indexer.py
@@ -562,3 +562,74 @@ class TestProgressIndexer(SolrIntegrationTestCase):
         self.commit_solr()
 
         self.assertIsNone(solr_data_for(self.dossier, 'progress'))
+
+
+class TestDossierReviewStateIndexer(SolrIntegrationTestCase):
+    def test_dossier_review_state_index(self):
+        self.login(self.regular_user)
+
+        api.content.transition(obj=self.subdossier,
+                               transition='dossier-transition-deactivate')
+        self.commit_solr()
+
+        self.assertEquals(
+            u'dossier-state-active',
+            solr_data_for(self.dossier, 'dossier_review_state'),
+        )
+
+        self.assertEquals(
+            u'dossier-state-active',
+            solr_data_for(self.document, 'dossier_review_state'),
+        )
+
+        self.assertEquals(
+            u'dossier-state-active',
+            solr_data_for(self.subtask, 'dossier_review_state'),
+        )
+
+        self.assertEquals(
+            u'dossier-state-inactive',
+            solr_data_for(self.subdossier, 'dossier_review_state'),
+        )
+
+        self.assertEquals(
+            u'dossier-state-inactive',
+            solr_data_for(self.subdocument, 'dossier_review_state'),
+        )
+
+    def test_recursive_update_child_indexes_when_change_dossier_review_state(self):
+        self.login(self.regular_user)
+
+        self.assertEquals(
+            u'dossier-state-active',
+            solr_data_for(self.dossier, 'dossier_review_state'),
+        )
+
+        self.assertEquals(
+            u'dossier-state-active',
+            solr_data_for(self.document, 'dossier_review_state'),
+        )
+
+        self.assertEquals(
+            u'dossier-state-active',
+            solr_data_for(self.subdossier, 'dossier_review_state'),
+        )
+
+        api.content.transition(obj=self.dossier,
+                               transition='dossier-transition-deactivate')
+        self.commit_solr()
+
+        self.assertEquals(
+            u'dossier-state-inactive',
+            solr_data_for(self.dossier, 'dossier_review_state'),
+        )
+
+        self.assertEquals(
+            u'dossier-state-inactive',
+            solr_data_for(self.document, 'dossier_review_state'),
+        )
+
+        self.assertEquals(
+            u'dossier-state-active',
+            solr_data_for(self.subdossier, 'dossier_review_state'),
+        )

--- a/opengever/dossier/tests/test_move_items.py
+++ b/opengever/dossier/tests/test_move_items.py
@@ -319,6 +319,7 @@ class TestMoveItemsUpdatesIndexAndMetadata(SolrIntegrationTestCase, MoveItemsHel
         u'portal_type',
         u'public_trial',
         u'review_state',
+        u'dossier_review_state',  # items can only be moved from active to active dossiers.
         u'sequence_number',
         u'sequence_number_string',
         u'sortable_title',


### PR DESCRIPTION
This PR implements the `dossier_review_state` index. The index provide the state of the current dossier or the closest parent dossier for other content types.

The use case for this index is to filter by contents within a dossier of a specific state. I.e. all documents within an inactive dossier.

ℹ️ there is no need to recreate the solr docker image. The `dossier_review_state` is already defined within the solr-schema: https://github.com/4teamwork/opengever.core/blob/master/solr-conf/managed-schema#L144 but is not in use. I just reused this field for the new indexer.

For [TI-479]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-479]: https://4teamwork.atlassian.net/browse/TI-479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ