### PR TITLE
Fix setting CAS server URL on setup

### DIFF
--- a/changes/OPS-97.bugfix
+++ b/changes/OPS-97.bugfix
@@ -1,0 +1,1 @@
+Fix setting CAS server URL on setup. [lgraf]

--- a/opengever/bundle/config/importer.py
+++ b/opengever/bundle/config/importer.py
@@ -79,7 +79,7 @@ class ConfigImporter(object):
             # Update placeholder URL with real one based on admin unit
             cas_server_url = build_cas_server_url('portal/cas')
 
-        self.portal.acl_users.cas_auth.cas_server_url = cas_server_url
+        self.portal.acl_users.cas_auth._cas_server_url = cas_server_url
 
         # Rename session cookie
         # During Plone site creation, this will have been suffixed with the


### PR DESCRIPTION
This fixes "AttributeError: can't set attribute" during policyless setup:

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/app/opengever/setup/zopectl.py", line 116, in setup
    import_bundle(deployment.site, options.bundle_path)
  File "/app/opengever/setup/zopectl.py", line 179, in import_bundle
    importer.run()
  File "/app/opengever/bundle/config/importer.py", line 34, in run
    self.update_casauth_settings()
  File "/app/opengever/bundle/config/importer.py", line 82, in update_casauth_settings
    self.portal.acl_users.cas_auth.cas_server_url = cas_server_url
AttributeError: can't set attribute
```

When the distinction between an internal CAS server URL and the regular CAS server URL was introduced in 4teamwork/ftw.casauth#23, `cas_plugin.cas_server_url` was made into a read only property, and the actual attribute that now holds the CAS server URL was renamed to `cas_plugin._cas_server_url`.

For [OPS-97](https://4teamwork.atlassian.net/browse/OPS-97)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)



[OPS-97]: https://4teamwork.atlassian.net/browse/OPS-97?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ