### PR TITLE
Improve workspace users vocabulary to properly handle no longer available users for restricted workspaces

### DIFF
--- a/changes/TI-922.other
+++ b/changes/TI-922.other
@@ -1,0 +1,1 @@
+Improve workspace users vocabulary to properly handle no longer available users for restricted workspaces [amo]

--- a/opengever/ogds/base/sources.py
+++ b/opengever/ogds/base/sources.py
@@ -527,6 +527,7 @@ class AllUsersSource(AllUsersInboxesAndTeamsSource):
     """Vocabulary of all users.
     """
     provides_raw_queries = False
+    gever_only = False
 
     @property
     def search_only_active_users(self):

--- a/opengever/workspace/tests/test_workspace_sources.py
+++ b/opengever/workspace/tests/test_workspace_sources.py
@@ -36,7 +36,6 @@ class TestWorkspaceSourcesProtection(IntegrationTestCase):
         AllGroupsSource,
         AllUsersAndGroupsSource,
         AllUsersInboxesAndTeamsSource,
-        AllUsersSource,
         ContactsSource,
         CurrentAdminUnitOrgUnitsSource,
         UsersContactsInboxesSource,
@@ -47,6 +46,7 @@ class TestWorkspaceSourcesProtection(IntegrationTestCase):
         WorkspaceContentMemberUsersSource,
         AssignedUsersSource,
         PotentialWorkspaceMembersSource,
+        AllUsersSource,
     ]
 
     def test_whitelisted_teamraum_sources(self):

--- a/opengever/workspace/vocabularies.py
+++ b/opengever/workspace/vocabularies.py
@@ -1,3 +1,4 @@
+from opengever.base.visible_users_and_groups_filter import visible_users_and_groups_filter
 from opengever.ogds.base.sources import AllUsersSource
 from opengever.ogds.base.sources import WorkspaceContentMemberUsersSource
 from opengever.ogds.models.user import User
@@ -74,6 +75,8 @@ class WorkspaceUserVocabulary(SimpleVocabulary):
         try:
             return super(WorkspaceUserVocabulary, self).getTerm(value)
         except LookupError:
+            if not visible_users_and_groups_filter.can_access_principal(value):
+                return SimpleTerm('<not-found>', '<not-found>', '<not-found>')
             return AllUsersSource(api.portal.get()).getTermByToken(value)
 
 


### PR DESCRIPTION
This PR:

- Refactored vocabulary handling to return 'not found' for invalid  users and exceptions. 
- Added tests to ensure correct term management and error handling.

For [TI-922](https://4teamwork.atlassian.net/browse/TI-922)

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[TI-922]: https://4teamwork.atlassian.net/browse/TI-922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ