### PR TITLE
Provide new field guests on Meeting

### DIFF
--- a/changes/TI-918.other
+++ b/changes/TI-918.other
@@ -1,0 +1,1 @@
+Provide new field `guests` on IWorkspaceMeetingSchema. [amo]

--- a/docs/schema-dumps/opengever.workspace.meeting.schema.json
+++ b/docs/schema-dumps/opengever.workspace.meeting.schema.json
@@ -58,6 +58,13 @@
             "_zope_schema_type": "List",
             "default": []
         },
+        "guests": {
+            "type": "array",
+            "title": "G\u00e4ste",
+            "description": "",
+            "_zope_schema_type": "List",
+            "default": []
+        },
         "title": {
             "type": "string",
             "title": "Titel",
@@ -92,6 +99,7 @@
         "location",
         "videoconferencing_url",
         "attendees",
+        "guests",
         "title",
         "description",
         "changed"

--- a/opengever/workspace/browser/meeting_pdf.py
+++ b/opengever/workspace/browser/meeting_pdf.py
@@ -119,6 +119,7 @@ class MeetingMinutesPDFView(BrowserView):
         data['chair'] = display_name(self.context.chair)
         data['secretary'] = display_name(self.context.secretary)
         data['attendees'] = []
+        data['guests'] = self.context.guests
         presence_states = IWorkspaceMeetingAttendeesPresenceStateStorage(self.context).get_all()
         for attendee in self.context.attendees:
             state = translate(ALLOWED_ATTENDEES_PRESENCE_STATES[presence_states[attendee]],

--- a/opengever/workspace/browser/templates/meeting_minutes.pt
+++ b/opengever/workspace/browser/templates/meeting_minutes.pt
@@ -69,6 +69,10 @@ a {
   padding-left: 0;
   list-style-type: none;
 }
+.guests ul {
+  padding-left: 0;
+  list-style-type: none;
+}
 @page {
   size: A4;
   margin-left: 2.5cm;
@@ -129,6 +133,16 @@ a {
         <ul>
           <tal:repeat tal:repeat="attendee options/attendees">
             <li tal:content="attendee"></li>
+          </tal:repeat>
+        </ul>
+      </td>
+    </tr>
+    <tr tal:condition="options/guests" class="guests">
+      <th><span i18n:translate="label_guests">Guests</span>:</th>
+      <td>
+        <ul>
+          <tal:repeat tal:repeat="guest options/guests">
+            <li tal:content="guest"></li>
           </tal:repeat>
         </ul>
       </td>

--- a/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-07-09 09:15+0000\n"
+"POT-Creation-Date: 2024-08-19 12:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -244,6 +244,12 @@ msgstr "Ordner"
 #: ./opengever/workspace/workspace.py
 msgid "label_gever_url"
 msgstr "GEVER URL"
+
+#. Default: "Guests"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
+#: ./opengever/workspace/workspace_meeting.py
+msgid "label_guests"
+msgstr "Gäste"
 
 #. Default: "Hide workspace members for workspace guests"
 #: ./opengever/workspace/workspace.py

--- a/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-07-09 09:15+0000\n"
+"POT-Creation-Date: 2024-08-19 12:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -274,6 +274,12 @@ msgstr "Folders"
 #: ./opengever/workspace/workspace.py
 msgid "label_gever_url"
 msgstr "GEVER URL"
+
+#. Default: "Guests"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
+#: ./opengever/workspace/workspace_meeting.py
+msgid "label_guests"
+msgstr "Guests"
 
 #. Default: "Hide workspace members for workspace guests"
 #: ./opengever/workspace/workspace.py

--- a/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-07-09 09:15+0000\n"
+"POT-Creation-Date: 2024-08-19 12:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -244,6 +244,12 @@ msgstr "Répertoires"
 #: ./opengever/workspace/workspace.py
 msgid "label_gever_url"
 msgstr "GEVER URL"
+
+#. Default: "Guests"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
+#: ./opengever/workspace/workspace_meeting.py
+msgid "label_guests"
+msgstr "Invitées"
 
 #. Default: "Hide workspace members for workspace guests"
 #: ./opengever/workspace/workspace.py

--- a/opengever/workspace/locales/opengever.workspace.pot
+++ b/opengever/workspace/locales/opengever.workspace.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-07-09 09:15+0000\n"
+"POT-Creation-Date: 2024-08-19 12:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -246,6 +246,12 @@ msgstr ""
 #. Default: "GEVER URL"
 #: ./opengever/workspace/workspace.py
 msgid "label_gever_url"
+msgstr ""
+
+#. Default: "Guests"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
+#: ./opengever/workspace/workspace_meeting.py
+msgid "label_guests"
 msgstr ""
 
 #. Default: "Hide workspace members for workspace guests"

--- a/opengever/workspace/workspace_meeting.py
+++ b/opengever/workspace/workspace_meeting.py
@@ -88,6 +88,15 @@ class IWorkspaceMeetingSchema(model.Schema):
         default=list()
     )
 
+    form.order_after(guests='attendees')
+    guests = schema.List(
+        title=_(u"label_guests", default=u"Guests"),
+        required=False,
+        value_type=schema.TextLine(),
+        default=list(),
+        missing_value=list(),
+    )
+
 
 class WorkspaceMeeting(Container):
     implements(IWorkspaceMeeting)


### PR DESCRIPTION
The PR
- Provided a new field `guests` on the `IWorkspaceMeetingSchema` which allow the users to add `guests` to a meeting.
- Add the guest field to the generated protokoll pdf. 


For [TI-918](https://4teamwork.atlassian.net/browse/TI-918)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- New translations
  - [x] All msg-strings are unicode


[TI-918]: https://4teamwork.atlassian.net/browse/TI-918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ