### PR TITLE
Add todos related to agenda items to the pdf export in teamroom

### DIFF
--- a/changes/TI-917.others
+++ b/changes/TI-917.others
@@ -1,0 +1,1 @@
+Add the todos related to the agenda items to the pdf export [pre]

--- a/opengever/workspace/browser/meeting_pdf.py
+++ b/opengever/workspace/browser/meeting_pdf.py
@@ -13,6 +13,7 @@ from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.component import getMultiAdapter
 from zope.i18n import translate
 import requests
+import datetime as date
 
 
 logger = getLogger('opengever.workspace')
@@ -132,6 +133,12 @@ class MeetingMinutesPDFView(BrowserView):
             obj = item.getObject()
             text = obj.text.output if obj.text else ''
             decision = obj.decision.output if obj.decision else ''
+
+            related_todo_items = []
+            if obj.related_todo_list:
+                related_todo_items = obj.related_todo_list.to_object.values()
+                related_todo_items = related_todo_items.slice(0, related_todo_items.actual_result_count)
+
             related_items = [item.to_object for item in obj.relatedItems if item.to_object]
             data['agenda_items'].append({
                 'number': '{}. '.format(i + 1),
@@ -140,7 +147,19 @@ class MeetingMinutesPDFView(BrowserView):
                 'decision': decision,
                 'related_items': [
                     {'title': item.Title(), 'url': item.absolute_url()}
-                    for item in related_items]
+                    for item in related_items
+                ],
+                'related_todo_items': [
+                    {
+                        'responsible': display_name(todo.responsible),
+                        'title': todo.title,
+                        'deadline': self.context.toLocalizedTime(
+                            datetime.combine(todo.deadline, datetime.min.time())
+                        )
+                        if todo.deadline else ''
+                    }
+                    for todo in related_todo_items
+                ]
             })
 
         data['header'], data['footer'] = self.prepare_header_and_footer()

--- a/opengever/workspace/browser/meeting_pdf.py
+++ b/opengever/workspace/browser/meeting_pdf.py
@@ -13,7 +13,6 @@ from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.component import getMultiAdapter
 from zope.i18n import translate
 import requests
-import datetime as date
 
 
 logger = getLogger('opengever.workspace')

--- a/opengever/workspace/browser/templates/meeting_minutes.pt
+++ b/opengever/workspace/browser/templates/meeting_minutes.pt
@@ -65,13 +65,32 @@ a {
   text-decoration: none;
   color: black;
 }
-.attendees ul {
+.hidden-list-style ul {
   padding-left: 0;
   list-style-type: none;
 }
 .guests ul {
   padding-left: 0;
   list-style-type: none;
+}
+tr.todo {
+  padding-bottom: 15px;
+}
+td.todo {
+  padding-left: 0px;
+  padding-bottom: 15px;
+}
+td.todo.todo_title {
+  width: 430px;
+}
+td.todo.todo_responsible {
+  width: 90px;
+}
+td.todo.todo_deadline {
+  width: 90px;
+}
+table.todo {
+  margin-top: 5px;
 }
 @page {
   size: A4;
@@ -106,7 +125,7 @@ a {
 
   <h1 i18n:translate="heading_meeting_minutes">Meeting Minutes: <span i18n:name="title" tal:replace="context/title">Title</span></h1>
 
-  <table class="borderless" >
+  <table class="borderless">
     <tr tal:condition="context/location">
       <th><span i18n:translate="label_location">Location</span>:</th>
       <td tal:content="context/location"></td>
@@ -127,7 +146,7 @@ a {
       <th><span i18n:translate="label_secretary">Secretary</span>:</th>
       <td tal:content="options/secretary"></td>
     </tr>
-    <tr tal:condition="options/attendees" class="attendees">
+    <tr tal:condition="options/attendees" class="hidden-list-style">
       <th><span i18n:translate="label_attendees">Attendees</span>:</th>
       <td>
         <ul>
@@ -171,7 +190,24 @@ a {
         </tal:repeat>
       </ul>
     </div>
+    <div tal:condition="nocall: agenda_item/related_todo_items">
+      <b><span i18n:translate="label_todos">Todos:</span></b>
+      <table class="borderless todo">
+          <tal:repeat tal:repeat="todo agenda_item/related_todo_items">
+            <tr class="todo">
+              <td class="todo todo_title">
+                <span tal:content="todo/title"/>
+              </td>
+              <td class="todo todo_responsible">
+                <span tal:content="todo/responsible"/>
+              </td>
+              <td class="todo todo_deadline">
+                <span tal:content="todo/deadline"/>
+              </td>
+            </tr>
+          </tal:repeat>
+      </table>
+    </div>
   </tal:repeat>
-
 </body>
 </html>

--- a/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-08-19 12:52+0000\n"
+"POT-Creation-Date: 2024-08-21 07:37+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -353,6 +353,11 @@ msgstr "To-do kommentiert"
 #: ./opengever/workspace/activities.py
 msgid "label_todo_reopened_activity"
 msgstr "To-do wieder eröffnet"
+
+#. Default: "Todos:"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
+msgid "label_todos"
+msgstr "To-dos"
 
 #. Default: "Trash"
 #: ./opengever/workspace/browser/tabbed.py

--- a/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-08-19 12:52+0000\n"
+"POT-Creation-Date: 2024-08-21 07:37+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -396,6 +396,11 @@ msgstr "To-do commented"
 #: ./opengever/workspace/activities.py
 msgid "label_todo_reopened_activity"
 msgstr "To-do reopened"
+
+#. Default: "Todos:"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
+msgid "label_todos"
+msgstr "To-dos"
 
 #. German translation: Papierkorb
 #. Default: "Trash"

--- a/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-08-19 12:52+0000\n"
+"POT-Creation-Date: 2024-08-21 07:37+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -353,6 +353,11 @@ msgstr "ToDo commenté"
 #: ./opengever/workspace/activities.py
 msgid "label_todo_reopened_activity"
 msgstr "ToDo rouvert"
+
+#. Default: "Todos:"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
+msgid "label_todos"
+msgstr "ToDos"
 
 #. Default: "Trash"
 #: ./opengever/workspace/browser/tabbed.py

--- a/opengever/workspace/locales/opengever.workspace.pot
+++ b/opengever/workspace/locales/opengever.workspace.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-08-19 12:52+0000\n"
+"POT-Creation-Date: 2024-08-21 07:37+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -355,6 +355,11 @@ msgstr ""
 #. Default: "ToDo reopened"
 #: ./opengever/workspace/activities.py
 msgid "label_todo_reopened_activity"
+msgstr ""
+
+#. Default: "Todos:"
+#: ./opengever/workspace/browser/templates/meeting_minutes.pt
+msgid "label_todos"
 msgstr ""
 
 #. Default: "Trash"


### PR DESCRIPTION
This PR implements adding the todos that agenda items have in teamroom to the pdf-export.

For [TI-917]


### Before -> After
![Before -> After](https://github.com/user-attachments/assets/5256039f-1812-41ca-b0b6-8d7bf7353ac7)


## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[TI-917]: https://4teamwork.atlassian.net/browse/TI-917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ