### PR TITLE
Use TaskResponses if removing a task comment

### DIFF
--- a/changes/TI-992.bugfix
+++ b/changes/TI-992.bugfix
@@ -1,0 +1,1 @@
+Fix an issue where changing remote task state was not possible if the remote task have had a deleted comment. [elioschmutz]

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -994,6 +994,14 @@
       />
 
   <plone:service
+      method="DELETE"
+      name="@responses"
+      for="opengever.task.task.ITask"
+      factory=".task.TaskResponseDelete"
+      permission="cmf.ModifyPortalContent"
+      />
+
+  <plone:service
       method="POST"
       name="@upload-document-copy"
       for="opengever.workspace.interfaces.IWorkspace"

--- a/opengever/api/response.py
+++ b/opengever/api/response.py
@@ -189,6 +189,8 @@ class ResponseDelete(Service):
     """Delete a response.
     """
 
+    response_class = Response
+
     def __init__(self, context, request):
         super(ResponseDelete, self).__init__(context, request)
         self.params = []
@@ -223,7 +225,7 @@ class ResponseDelete(Service):
         return self.reply_no_content()
 
     def create_response(self, deleted_response):
-        response = Response(COMMENT_REMOVED_RESPONSE_TYPE)
+        response = self.response_class(COMMENT_REMOVED_RESPONSE_TYPE)
 
         response.additional_data = PersistentDict({
             'deleted_response_creation_date': deleted_response.created

--- a/opengever/api/task.py
+++ b/opengever/api/task.py
@@ -3,6 +3,7 @@ from opengever.api.actors import serialize_actor_id_to_json_summary
 from opengever.api.add import FolderPost
 from opengever.api.deserializer import GeverDeserializeFromJson
 from opengever.api.globalindex import translate_review_state
+from opengever.api.response import ResponseDelete
 from opengever.api.response import ResponsePost
 from opengever.api.response import SerializeResponseToJson
 from opengever.api.serializer import extend_with_responses
@@ -18,6 +19,7 @@ from opengever.task.helper import task_type_value_helper
 from opengever.task.interfaces import ICommentResponseHandler
 from opengever.task.task import ITask
 from opengever.task.task_response import ITaskResponse
+from opengever.task.task_response import TaskResponse
 from opengever.task.util import TaskAutoResponseChangesTracker
 from opengever.tasktemplates.interfaces import IContainParallelProcess
 from opengever.tasktemplates.interfaces import IContainSequentialProcess
@@ -223,6 +225,13 @@ class TaskResponsePost(ResponsePost):
                 "The current user is not allowed to add comments")
 
         return response_handler.add_response(text)
+
+
+class TaskResponseDelete(ResponseDelete):
+    """Delete a response.
+    """
+
+    response_class = TaskResponse
 
 
 @implementer(IExpandableElement)


### PR DESCRIPTION
We have two response implementations. A `Response` and a `TaskResponse`. The `TaskResponse` is used for tasks only and provides some additional attributes.

When removing a task comment, we currently use a default `Response` object instead a `TaskResponse`. We have several code parts where we check for attributes which are only available on the `TaskResponse`. For example: https://github.com/4teamwork/opengever.core/blob/2fa9dbf08e4ff5eb621186788c398c59382a4c29/opengever/task/browser/close.py#L311 . This will not work for `Reponses` and will raise an error.

This PR fixes this issue by using the `TaskResponse` for deleted comments as we do it already for every other response on tasks.

Providing an upgrade step seems not to be necessary since it is a rare edge-case. The last committed response of an object needs to be a removed comment on a multi-admin unit task.

For [TI-992]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-992]: https://4teamwork.atlassian.net/browse/TI-992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ