### PR TITLE
Enhance local roles with task informed principals reader roles

### DIFF
--- a/changes/TI-114.other
+++ b/changes/TI-114.other
@@ -1,0 +1,1 @@
+Grant view permissions to users informed_principals on task, dossier and related documents. [amo]


### PR DESCRIPTION
The PR:

1. Grant Reader Access on the Task: Provide `Reader `access to informed_principals for viewing the task details.

2. Grant Reader Access on Related Items: Allow `Reader `access for informed_principals on all related items for viewing purposes.

3. Grant TaskResponsible Access on Related Items: Allow `TaskResponsible` access for informed_principals on dossier

4. Revoke Permissions When Task is Closed: Automatically revoke all permissions for informed_principals once the task is closed.

For [TI-114](https://4teamwork.atlassian.net/browse/TI-114)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-114]: https://4teamwork.atlassian.net/browse/TI-114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ