### PR TITLE
Fix copying documents when deployed with Docker

### DIFF
--- a/changes/TI-1009.bugfix
+++ b/changes/TI-1009.bugfix
@@ -1,0 +1,1 @@
+Fix copying documents when deployed with Docker. [buchi]

--- a/docker/core/etc/site.zcml
+++ b/docker/core/etc/site.zcml
@@ -9,6 +9,9 @@
   <include package="Products.Five" />
   <meta:redefinePermission from="zope2.Public" to="zope.Public" />
 
+  <!-- Load patches as early as possible -->
+  <include package="opengever.base.monkey" />
+
   <!-- Load the meta -->
   <include files="package-includes/*-meta.zcml" />
   <five:loadProducts file="meta.zcml"/>

--- a/opengever/base/monkey/configure.zcml
+++ b/opengever/base/monkey/configure.zcml
@@ -1,0 +1,4 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    i18n_domain="opengever.base">
+</configure>


### PR DESCRIPTION
Load monkey patches as early as possible

Because of not using `z3c.autoinclude` with Docker, the order of loading ZCML is different. It turns out that applying the patch for `handleDynamicTypeCopiedEvent` after registering the event handler doesn't work and breaks copying documents.

For [TI-1009](https://4teamwork.atlassian.net/browse/TI-1009)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)



[TI-1009]: https://4teamwork.atlassian.net/browse/TI-1009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ