### PR TITLE
Disable colorization if env variable has an empty value

### DIFF
--- a/changes/GH-8025.other
+++ b/changes/GH-8025.other
@@ -1,0 +1,1 @@
+Disable colorization if env variable has an empty value. [buchi]

--- a/opengever/base/colorization.py
+++ b/opengever/base/colorization.py
@@ -10,4 +10,4 @@ COLORS = {
 
 def get_color():
     color = os.environ.get('GEVER_COLORIZATION', None)
-    return COLORS.get(color, color)
+    return COLORS.get(color, color or None)


### PR DESCRIPTION
Allows us to disable colorization without removing the env variable which is more convenient for Docker Compose deployments.

## Checklist

- [x] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)

