### PR TITLE
Resolve invitation error when user dose not exists any more

### DIFF
--- a/changes/TI-1036.other
+++ b/changes/TI-1036.other
@@ -1,0 +1,1 @@
+Resolve invitation error when user dose not exists any more. [amo]

--- a/opengever/api/tests/test_participation.py
+++ b/opengever/api/tests/test_participation.py
@@ -1561,6 +1561,40 @@ class TestMyInvitationsGet(IntegrationTestCase):
                 }
             ], response.get('items'))
 
+    @browsing
+    def test_inviter_resolution_with_non_existing_user(self, browser):
+        self.login(self.workspace_owner, browser)
+
+        with freeze(datetime(2018, 4, 30, 10, 30)):
+            iid = getUtility(IInvitationStorage).add_invitation(
+                self.workspace,
+                self.regular_user.getProperty('email'),
+                "Does not exist",
+                'WorkspaceGuest')
+
+        self.login(self.regular_user, browser)
+
+        response = browser.open(
+            self.portal,
+            view='@my-workspace-invitations',
+            method='GET',
+            headers=http_headers(),
+        ).json
+
+        self.assertItemsEqual(
+            [
+                {
+                    u'@id': u'http://nohost/plone/@workspace-invitations/{}'.format(iid),
+                    u'@type': u'virtual.participations.invitation',
+                    u'accept': u'http://nohost/plone/@workspace-invitations/{}/accept'.format(iid),
+                    u'created': u'2018-04-30T10:30:00+00:00',
+                    u'decline': u'http://nohost/plone/@workspace-invitations/{}/decline'.format(iid),
+                    u'inviter_fullname': u'Unknown ID (Does not exist)',
+                    u'title': u'A Workspace',
+                    u'comment': u''
+                }
+            ], response.get('items'))
+
 
 class TestInvitationsPOST(IntegrationTestCase):
 

--- a/opengever/workspace/participation/browser/my_invitations.py
+++ b/opengever/workspace/participation/browser/my_invitations.py
@@ -4,7 +4,7 @@ from opengever.base.model import create_session
 from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.base.role_assignments import SharingRoleAssignment
 from opengever.base.security import elevated_privileges
-from opengever.ogds.base.actor import PloneUserActor
+from opengever.ogds.base.actor import Actor
 from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.ogds.models.group import Group
 from opengever.ogds.models.service import ogds_service
@@ -59,8 +59,7 @@ class MyWorkspaceInvitations(BrowserView):
                     target_title = target.Title()
 
             if target:
-                inviter = PloneUserActor(entry['inviter'],
-                                         user=api.user.get(entry['inviter']))
+                inviter = Actor.lookup(entry['inviter'])
                 yield {'inviter': inviter.get_label(),
                        'target_title': target_title,
                        'iid': entry['iid'],


### PR DESCRIPTION
This pull request addresses a recurring AttributeError encountered by users in Teamraum when handling invitations. The error was traced to an issue where a non-existent inviter was being referenced, leading to a failure in the invitation process.

For [TI-1036](https://4teamwork.atlassian.net/browse/TI-1036)

**Before:**

<img width="1279" alt="before" src="https://github.com/user-attachments/assets/4bfe626c-0539-4101-b878-2ed423546a8c">

**After:**
<img width="1342" alt="after" src="https://github.com/user-attachments/assets/5ff927f4-b399-462c-a388-c31fc8630f52">


## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-1036]: https://4teamwork.atlassian.net/browse/TI-1036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ