### PR TITLE
Adjust column widths to allow space for dates.

### DIFF
--- a/changes/TI-309.other
+++ b/changes/TI-309.other
@@ -1,0 +1,1 @@
+Adjust table columns widths to allow enough space for dates. Slightly decrease "Asigned person" column to increase date columns. [ran]

--- a/opengever/latex/listing.py
+++ b/opengever/latex/listing.py
@@ -213,7 +213,9 @@ class SubDossiersLaTeXListing(DossiersLaTeXListing):
 
         # widen title and responsible columns
         columns[1].width = '40%'
-        columns[2].width = '35%'
+        columns[2].width = '33%'
+        columns[4].width = '6%'
+        columns[5].width = '6%'
         return columns
 
 

--- a/opengever/latex/tests/test_listing.py
+++ b/opengever/latex/tests/test_listing.py
@@ -196,7 +196,7 @@ class TestSubDossierListing(BaseLatexListingTest):
 
         cols = table.xpath(CSSSelector('colgroup col').path)
         self.assertEquals(
-            ['5%', '40%', '35%', '10%', '5%', '5%'],
+            ['5%', '40%', '33%', '10%', '6%', '6%'],
             [col.get('width') for col in cols])
 
     def test_drop_reference_from_default_dossier_listings(self):


### PR DESCRIPTION
Adjust the widths of the columns in the Subdossiers section for the pdf generation to ensure that dates have enough space.
The extra 1% added to the 2 date columns was removed from the "responsible" column. 

For [TI-309]

## Checklist


- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-309]: https://4teamwork.atlassian.net/browse/TI-309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ