### PR TITLE
Disable Z2 access log in Docker deployments

### DIFF
--- a/changes/GH-8030.other
+++ b/changes/GH-8030.other
@@ -1,0 +1,1 @@
+Disable Z2 access log in Docker deployments. [buchi]

--- a/docker/core/entrypoint.d/create_zope_conf.py
+++ b/docker/core/entrypoint.d/create_zope_conf.py
@@ -106,14 +106,6 @@ trusted-proxy 127.0.0.1
   </logfile>
 </eventlog>
 
-<logger access>
-  level WARN
-  <logfile>
-    path STDOUT
-    format %(message)s
-  </logfile>
-</logger>
-
 <http-server>
   address 8080
 </http-server>


### PR DESCRIPTION
We log requests with ftw.structlog which provides all the information from the Z2 log and more.

## Checklist

- [x] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)
