### PR TITLE
Add all_admin_units to whitelisted teamraum vocab

### DIFF
--- a/changes/TI-1046.bugfix
+++ b/changes/TI-1046.bugfix
@@ -1,0 +1,1 @@
+Make System Messages available in Teamraum. [ran]

--- a/opengever/workspace/__init__.py
+++ b/opengever/workspace/__init__.py
@@ -41,6 +41,7 @@ WHITELISTED_TEAMRAUM_VOCABULARIES = {
     'opengever.base.ReferenceFormatterVocabulary',
     'opengever.document.document_types',
     'opengever.journal.manual_entry_categories',
+    'opengever.ogds.base.all_admin_units',
     'opengever.propertysheets.PropertySheetAssignmentsVocabulary',
     'opengever.workspace.PossibleWorkspaceFolderParticipantsVocabulary',
     'opengever.workspace.RolesVocabulary',


### PR DESCRIPTION
The term 'opengever.ogds.base.all_admin_units' wasn't in the whitelisted vocabularies for teamraum and therefore was always deemed to be invisible. Therefore creating System Messages worked in Gever, but not in Teamraum. The whitelisted Vocab was updated and problem was fixed:

Before:

<img width="1388" alt="1046_before" src="https://github.com/user-attachments/assets/9b7fbae4-d7a4-4444-9ef6-f9f2c8bd4724">

After:

<img width="1326" alt="1046_after" src="https://github.com/user-attachments/assets/55f31029-b90b-490d-91e5-05b2cdf045ae">




Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [TI-1046]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)



[TI-1046]: https://4teamwork.atlassian.net/browse/TI-1046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ