### PR TITLE
Revert sign action

### DIFF
--- a/changes/TI-658-2.other
+++ b/changes/TI-658-2.other
@@ -1,1 +1,0 @@
-Provide document context ui-actions if signing is possible. [elioschmutz]

--- a/opengever/base/context_actions.py
+++ b/opengever/base/context_actions.py
@@ -70,7 +70,6 @@ class BaseContextActions(object):
         self.maybe_add_zipexport()
         self.maybe_add_save_minutes_as_pdf()
         self.maybe_export_workspace_users()
-        self.maybe_add_sign_document()
         return self.actions
 
     def add_action(self, action):
@@ -248,12 +247,6 @@ class BaseContextActions(object):
         return False
 
     def is_export_workspace_users_available(self):
-        return False
-
-    def is_sign_document_available(self):
-        return False
-
-    def is_finalize_and_sign_document_available(self):
         return False
 
     def maybe_add_add_invitation(self):
@@ -483,10 +476,3 @@ class BaseContextActions(object):
     def maybe_export_workspace_users(self):
         if self.is_export_workspace_users_available():
             self.add_action(u'export_workspace_participators')
-
-    def maybe_add_sign_document(self):
-        if self.is_sign_document_available():
-            self.add_action(u'sign')
-
-        if self.is_finalize_and_sign_document_available():
-            self.add_action(u'finalize_and_sign')

--- a/opengever/base/tests/test_utils.py
+++ b/opengever/base/tests/test_utils.py
@@ -11,7 +11,6 @@ from opengever.base.utils import file_checksum
 from opengever.base.utils import get_date_with_delta_excluding_weekends
 from opengever.base.utils import is_administrator
 from opengever.base.utils import is_manager
-from opengever.base.utils import is_transition_allowed
 from opengever.base.utils import safe_int
 from opengever.dossier.utils import find_parent_dossier
 from opengever.testing import IntegrationTestCase
@@ -245,15 +244,3 @@ class TestGetDateWithDeltaExcludingWeekends(TestCase):
             self.assertEqual(
                 date(2023, 4, 3),  # Monday in one month
                 get_date_with_delta_excluding_weekends(datetime.today(), delta).date())
-
-
-class TestIsTransitionAllowed(IntegrationTestCase):
-
-    def test_is_transition_allowed_checks_transition_guards(self):
-        self.login(self.regular_user)
-
-        self.assertTrue(is_transition_allowed(self.document, self.document.finalize_transition))
-
-        self.checkout_document(self.document)
-
-        self.assertFalse(is_transition_allowed(self.document, self.document.finalize_transition))

--- a/opengever/base/utils.py
+++ b/opengever/base/utils.py
@@ -355,15 +355,3 @@ def get_date_with_delta_excluding_weekends(start_date, days_delta):
         if end_date.weekday() not in [5, 6]:
             calculated_delta += 1
     return end_date
-
-
-def is_transition_allowed(obj, transition_id):
-    """Checks if a specific transition is allowed for a specific object.
-
-    This will also check the workflow defined transition-guard functions.
-    """
-    actions = api.portal.get_tool('portal_workflow').listActionInfos(object=obj)
-    for action in actions:
-        if action['category'] == 'workflow' and action['id'] == transition_id:
-            return True
-    return False

--- a/opengever/document/actions.py
+++ b/opengever/document/actions.py
@@ -4,7 +4,6 @@ from opengever.base.browser.edit_public_trial import is_edit_public_trial_status
 from opengever.base.context_actions import BaseContextActions
 from opengever.base.interfaces import IOpengeverBaseLayer
 from opengever.base.listing_actions import BaseListingActions
-from opengever.base.utils import is_transition_allowed
 from opengever.bumblebee import is_bumblebee_feature_enabled
 from opengever.document.behaviors import IBaseDocument
 from opengever.document.document import IDocumentSchema
@@ -15,7 +14,6 @@ from opengever.inbox.inbox import IInbox
 from opengever.meeting import is_meeting_feature_enabled
 from opengever.private.dossier import IPrivateDossier
 from opengever.private.folder import IPrivateFolder
-from opengever.sign.utils import is_sign_feature_enabled
 from opengever.trash.trash import ITrasher
 from opengever.workspace import is_workspace_feature_enabled
 from opengever.workspace.utils import is_restricted_workspace_and_guest
@@ -252,30 +250,6 @@ class BaseDocumentContextActions(BaseContextActions):
 
     def is_unlock_available(self):
         return self.file_actions.is_unlock_available()
-
-    def is_sign_document_available(self):
-        if not is_sign_feature_enabled():
-            return False
-
-        if not api.user.has_permission('opengever.sign: Sign Document', obj=self.context):
-            return False
-
-        if not self.context.is_final_document():
-            return False
-
-        return True
-
-    def is_finalize_and_sign_document_available(self):
-        if not is_sign_feature_enabled():
-            return False
-
-        if not api.user.has_permission('opengever.sign: Sign Document', obj=self.context):
-            return False
-
-        if not is_transition_allowed(self.context, self.context.finalize_transition):
-            return False
-
-        return True
 
 
 @adapter(IDocumentSchema, IOpengeverBaseLayer)

--- a/opengever/document/tests/test_actions.py
+++ b/opengever/document/tests/test_actions.py
@@ -7,7 +7,6 @@ from opengever.testing import IntegrationTestCase
 from opengever.trash.trash import ITrasher
 from opengever.workspaceclient.interfaces import ILinkedWorkspaces
 from opengever.workspaceclient.tests import FunctionalWorkspaceClientTestCase
-from plone import api
 from zope.component import queryMultiAdapter
 import transaction
 
@@ -292,16 +291,3 @@ class TestDocumentContextActions(IntegrationTestCase):
 
         expected_actions_restricted_guest = [u'revive_bumblebee_preview']
         self.assertEqual(expected_actions_restricted_guest, self.get_actions(document))
-
-    def test_include_sign_actions_with_activated_feature(self):
-        self.activate_feature('sign')
-        self.login(self.regular_user)
-
-        self.assertIn('finalize_and_sign', self.get_actions(self.document))
-        self.assertNotIn('sign', self.get_actions(self.document))
-
-        api.content.transition(obj=self.document,
-                               transition=self.document.finalize_transition)
-
-        self.assertNotIn('finalize_and_sign', self.get_actions(self.document))
-        self.assertIn('sign', self.get_actions(self.document))


### PR DESCRIPTION
This PR reverts the sign actions introduced in #7998 according to the comment in https://4teamwork.atlassian.net/browse/TI-659?focusedCommentId=46734

Reason: we'll implement the feature by the workflow, not by actions.

For [TI-659]

## Checklist

- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-659]: https://4teamwork.atlassian.net/browse/TI-659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ