### PR TITLE
Fix error with file downloads

### DIFF
--- a/changes/TI-953.bugfix
+++ b/changes/TI-953.bugfix
@@ -1,0 +1,1 @@
+Fixes bug that throws error when documents with special characters in their name are downloaded. [pre]

--- a/opengever/document/browser/download.py
+++ b/opengever/document/browser/download.py
@@ -10,6 +10,7 @@ from opengever.mail.mail import IOGMailMarker
 from opengever.virusscan.validator import validateDownloadIfNecessary
 from opengever.workspace.utils import is_restricted_workspace_and_guest
 from plone import api
+from plone.dexterity.utils import safe_utf8
 from plone.memoize import ram
 from plone.memoize.interfaces import ICacheChooser
 from plone.namedfile.browser import Download
@@ -87,8 +88,8 @@ class DocumentishDownload(Download):
         if not self.filename:
             self.filename = getattr(named_file, 'filename', self.fieldname)
 
-        if self.filename and isinstance(self.filename, unicode):
-            self.filename = self.filename.encode('utf-8')
+        if self.filename:
+            self.filename = safe_utf8(self.filename)
 
     def stream_data(self, named_file):
         return stream_data(named_file)

--- a/opengever/document/browser/download.py
+++ b/opengever/document/browser/download.py
@@ -87,7 +87,7 @@ class DocumentishDownload(Download):
         if not self.filename:
             self.filename = getattr(named_file, 'filename', self.fieldname)
 
-        if self.filename:
+        if self.filename and isinstance(self.filename, unicode):
             self.filename = self.filename.encode('utf-8')
 
     def stream_data(self, named_file):

--- a/opengever/document/tests/test_download.py
+++ b/opengever/document/tests/test_download.py
@@ -70,6 +70,12 @@ class TestDocumentDownloadConfirmation(IntegrationTestCase):
         self.assertEqual(self.document.file.data, browser.contents)
 
     @browsing
+    def test_umlaut_download_confirmation_view_for_download(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.document, view='@@download/file/T\xc3\xa4st.docx')
+        self.assertEqual(200, browser.status_code)
+
+    @browsing
     def test_download_lazy_initial_version(self, browser):
         self.login(self.regular_user, browser)
         versioner = Versioner(self.document)


### PR DESCRIPTION
When trying to dowload certain files and giving them a name with special characters there was an error on prod.

This was caused by the filename string getting converted into a byte string, which gever then tries to encode with UTF-8, which doesn't work.

With the fix it is checked that the filename is infact unicode and can be encoded before doing so.


To reproduce this add a file to gever. Now try to download said file by adding `/@@download/file/blä.docx` or another name with ä, ö or ü in it to the trailing part of the URL of the file. Without the change this should lead to an error.


For [TI-953]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[TI-953]: https://4teamwork.atlassian.net/browse/TI-953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ