### PR TITLE
Exclude inactive users from teamraum participation excel export

### DIFF
--- a/changes/TI-1086.other
+++ b/changes/TI-1086.other
@@ -1,0 +1,1 @@
+Exclude inactive (users / group users) from teamraum participation excel export. [amo]

--- a/opengever/workspace/report.py
+++ b/opengever/workspace/report.py
@@ -29,10 +29,10 @@ class WorkspaceParticipantsReport(UserReport):
         for user_id in user_ids:
             group_members = ogds_service().fetch_group(user_id)
             if group_members:
-                users.update(group_members.users)
+                users.update([user for user in group_members.users if user.active])
             else:
                 user = ogds_service().fetch_user(user_id)
-                if user:
+                if user and user.active:
                     users.add(user)
 
         return list(users)


### PR DESCRIPTION
This PR:
Updates the` teamraum participation` export to ensure that only active `users `and `group users` are included in the Excel export. Previously, some` deleted / Inactive` users were still being listed (status '`FALSCH`'). With this change, inactive or deleted users will no longer be part of the export.

For [TI-1086](https://4teamwork.atlassian.net/browse/TI-1086)

**Before:**

<img width="874" alt="before" src="https://github.com/user-attachments/assets/b4de0235-668c-4bdd-88dd-67096488760c">


**After:**

<img width="677" alt="after" src="https://github.com/user-attachments/assets/6a40d405-704b-40d1-bd7c-a6bf77a7ca14">


## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-1086]: https://4teamwork.atlassian.net/browse/TI-1086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ