### PR TITLE
Add option to dump current schemas to bundle loader

### DIFF
--- a/changes/TI-948.other
+++ b/changes/TI-948.other
@@ -1,0 +1,1 @@
+Add option to regenerate bundle schemas on bundle import [TI-948](https://4teamwork.atlassian.net/browse/TI-948)

--- a/docker/core/Dockerfile
+++ b/docker/core/Dockerfile
@@ -68,6 +68,9 @@ RUN --mount=type=cache,target=/root/.cache \
 RUN find /app/opengever -name "*.po" | xargs -I@ sh -c 'msgfmt @ -o "$(dirname @)/$(basename @ .po)".mo' && \
     find /app/plonetheme -name "*.po" | xargs -I@ sh -c 'msgfmt @ -o "$(dirname @)/$(basename @ .po)".mo'
 
+# Plone needs permissions to update bundle schemas on import
+RUN chown -R plone:plone /app/opengever/bundle/schemas
+
 COPY ./docker/core/etc /app/etc
 RUN chown -R plone:plone /app/etc
 COPY ./docker/core/entrypoint.d /app/entrypoint.d

--- a/opengever/bundle/console.py
+++ b/opengever/bundle/console.py
@@ -2,6 +2,7 @@
 from Products.Archetypes import atapi  # noqa # isort:skip
 from opengever.base.interfaces import IOpengeverBaseLayer
 from opengever.base.pathfinder import PathFinder
+from opengever.base.schemadump.schema import OGGBundleJSONSchemaDumpWriter
 from opengever.bundle.config.importer import ConfigImporter
 from opengever.bundle.importer import BundleImporter
 from opengever.core.debughelpers import get_first_plone_site
@@ -33,6 +34,8 @@ def parse_args(argv):
                         help="Don't to intermediate commits")
     parser.add_argument('--no-check-unique-principals', action='store_true',
                         help="Don't to check for OGDS principal name uniqueness")
+    parser.add_argument('--rebuild-schemas', action='store_true',
+                        help="Rebuild schemas with current schemas")
 
     args = parser.parse_args(argv)
     return args
@@ -59,6 +62,11 @@ def import_oggbundle(app, args):
     alsoProvides(plone.REQUEST, IOpengeverBaseLayer)
 
     import_config_from_bundle(app, args)
+
+    if args.rebuild_schemas:
+        log.info('Generating and dumping latest OGGBundle JSON Schemas')
+        writer = OGGBundleJSONSchemaDumpWriter()
+        writer.dump()
 
     importer = BundleImporter(
         plone,


### PR DESCRIPTION
Currently if there are any changes in the Vdexvocabs the bundle importer validates against a wrong JSON Schema. We added a new flag `--rebuild-schemas` which makes a new dump of the current schemas. To make it work on docker containers, we granted the plone user permission to write inside the schemas directory. 

Example command: `bin/instance import opengever/bundle/tests/assets/basic.oggbundle --rebuild-schemas`

For [TI-948](https://4teamwork.atlassian.net/browse/TI-948)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[TI-948]: https://4teamwork.atlassian.net/browse/TI-948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ