### PR TITLE
Implement the sign-feature

### DIFF
--- a/changes/TI-659.feature
+++ b/changes/TI-659.feature
@@ -1,0 +1,1 @@
+Implements the document sign process. [elioschmutz]

--- a/development.cfg
+++ b/development.cfg
@@ -77,6 +77,7 @@ environment-vars +=
     SABLON_URL http://localhost:8091/
     PDFLATEX_URL http://localhost:8092/
     WEASYPRINT_URL http://localhost:8093/
+    SIGN_SERVICE_URL http://localhost:8094/
     OGDS_SYNC_URL http://localhost:8099/
     REDIS_URL redis://localhost:6379/
 
@@ -89,6 +90,7 @@ initialization +=
     os.environ['SABLON_URL'] = 'http://localhost:8091/'
     os.environ['PDFLATEX_URL'] = 'http://localhost:8092/'
     os.environ['WEASYPRINT_URL'] = 'http://localhost:8093/'
+    os.environ['SIGN_SERVICE_URL'] = 'http://localhost:8094/'
 
 [testserver]
 initialization +=
@@ -96,6 +98,8 @@ initialization +=
     os.environ.setdefault('SABLON_URL', 'http://localhost:8091/')
     os.environ.setdefault('PDFLATEX_URL', 'http://localhost:8092/')
     os.environ.setdefault('WEASYPRINT_URL', 'http://localhost:8093/')
+    os.environ.setdefault('SIGN_SERVICE_URL', 'http://localhost:8094/')
+
 
 [docxcompose]
 recipe = zc.recipe.egg:script

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -12,7 +12,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
-
+- ``@upload-signed-pdf``: New endpoint to upload a signed pdf and complete a pending sign process.
 
 2024.13.0 (2024-09-09)
 ----------------------

--- a/docs/public/dev-manual/api/documents_sign.rst
+++ b/docs/public/dev-manual/api/documents_sign.rst
@@ -1,0 +1,53 @@
+Signieren von Dokumenten
+========================
+
+Dokumente können über den Workflow signiert werden. Diese Funktionalität setzt voraus, dass das Sign-Feature aktiviert und korrekt konfiguriert ist.
+
+Nachdem das Feature aktiviert ist, stehen zwei neue Transitionen zur Verfügung, die es erlauben, Dokumente zu signieren:
+
+- **Finalisieren und signieren**: Diese Transition finalisiert das Dokument und signiert es anschliessend.
+- **Signieren**: Diese Transition signiert ein bereits finalisiertes Dokument.
+
+Beispiel
+--------
+
+Um ein Dokument über den Workflow zu signieren, kann die Transition ``document-transition-draft-signing`` verwendet werden.
+
+   **Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       POST /dossier-1/document-1/@workflow/document-transition-draft-signing HTTP/1.1
+       Accept: application/json
+       Content-Type: application/json
+
+Der Request löst den Signaturprozess für das Dokument aus.
+
+Im Rahmen des Signaturprozesses wird ein Access-Token generiert, der dem externen Signaturservice übergeben wird. Dieses Token muss im späteren Request zur Rückführung der signierten PDF-Datei wiederverwendet werden.
+
+Hochladen der signierten PDF-Datei
+----------------------------------
+
+Nachdem das Dokument signiert wurde, kann es über den Endpoint ``@upload-signed-pdf`` hochgeladen werden.
+
+Der Endpoint löst eine interne Workflow-Transition auf dem Dokument aus, die automatisch eine neue Version des Dokuments mit den signierten PDF-Daten erstellt. Als Ersteller dieser neuen Version wird der Benutzer verwendet, der den Signaturprozess initiiert hat.
+
+   **Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       POST /dossier-1/document-1/@upload-signed-pdf HTTP/1.1
+       Accept: application/json
+       Content-Type: application/json
+
+       {
+           "access_token": "<token>",
+           "signed_pdf_data": "<base64-pdf-data>"
+       }
+
+**Parameter:**
+
+- ``access_token``: Das beim Start des Signaturprozesses generierte Token.
+- ``signed_pdf_data``: Die signierten PDF-Daten im Base64-Format, die der externe Service nach der Signatur erzeugt hat.
+
+Sobald das Dokument erfolgreich durch den externen Signaturservice signiert wurde, wird das Dokument in den Status **Signiert** versetzt.

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -24,6 +24,7 @@ Inhalt:
    dossier_participations.rst
    documents.rst
    documents_from_template.rst
+   documents_sign.rst
    extract_attachments.rst
    trash.rst
    versions.rst

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -824,6 +824,15 @@
       />
 
   <plone:service
+      method="POST"
+      name="@workflow"
+      for="opengever.document.document.IDocumentSchema"
+      factory=".transition.GEVERDocumentWorkflowTransition"
+      layer="opengever.base.interfaces.IOpengeverBaseLayer"
+      permission="zope2.View"
+      />
+
+  <plone:service
       method="GET"
       name="@invitations"
       for="opengever.workspace.interfaces.IWorkspace"

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -1856,4 +1856,12 @@
       permission="opengever.api.AccessErrorLog"
       />
 
+  <plone:service
+      method="POST"
+      name="@upload-signed-pdf"
+      for="opengever.document.document.IDocumentSchema"
+      factory=".sign.UploadSignedPdfPost"
+      permission="zope.Public"
+      />
+
 </configure>

--- a/opengever/api/sign.py
+++ b/opengever/api/sign.py
@@ -1,0 +1,49 @@
+from AccessControl import Unauthorized
+from opengever.document.document import Document
+from opengever.sign.sign import Signer
+from opengever.sign.token import InvalidToken
+from plone import api
+from plone.restapi.deserializer import json_body
+from plone.restapi.services import Service
+from zExceptions import BadRequest
+from zExceptions import Forbidden
+
+
+class UploadSignedPdfPost(Service):
+    """Endpoint for uploading a signed pdf to a document and completing the
+    sign process"""
+
+    def __call__(self):
+        if api.content.get_state(obj=self.context) != Document.signing_state:
+            raise Forbidden()
+
+        self.extract_payload()
+        self.signer = Signer(self.context)
+
+        return super(UploadSignedPdfPost, self).__call__()
+
+    def reply(self):
+        with self.signer.adopt_issuer():
+            self.signer.complete_signing(self.signed_pdf_data)
+        self.signer.invalidate_token()
+        self.request.response.setStatus(201)
+        return super(UploadSignedPdfPost, self).reply()
+
+    def check_permission(self):
+        try:
+            self.signer.validate_token(self.access_token)
+        except InvalidToken:
+            raise Unauthorized()
+
+    def extract_payload(self):
+        data = json_body(self.request)
+        access_token = data.get('access_token')
+        if not access_token:
+            raise BadRequest("Property 'access_token' is required")
+
+        signed_pdf_data = data.get('signed_pdf_data')
+        if not signed_pdf_data:
+            raise BadRequest("Property 'signed_pdf_data' is required")
+
+        self.access_token = access_token
+        self.signed_pdf_data = signed_pdf_data

--- a/opengever/api/tests/test_sign.py
+++ b/opengever/api/tests/test_sign.py
@@ -1,0 +1,156 @@
+from base64 import b64encode
+from base64 import urlsafe_b64encode
+from datetime import datetime
+from ftw.testbrowser import browsing
+from opengever.document.document import Document
+from opengever.document.versioner import Versioner
+from opengever.sign.sign import Signer
+from opengever.sign.token import InvalidToken
+from opengever.testing import SolrIntegrationTestCase
+from zExceptions import Forbidden
+from zExceptions import Unauthorized
+import json
+import re
+import requests_mock
+
+
+FROZEN_NOW = datetime(2024, 2, 18, 15, 45)
+
+DEFAULT_MOCK_RESPONSE = {
+    'id': '1',
+    'redirect_url': 'http://external.example.org/signing-requests/123',
+}
+
+
+class TestUploadSignedPdfPost(SolrIntegrationTestCase):
+
+    features = ['sign']
+
+    @browsing
+    def test_raises_forbidden_if_context_is_not_in_signing_state(self, browser):
+        with self.login(self.regular_user):
+            url = self.document.absolute_url() + '/@upload-signed-pdf'
+
+        browser.exception_bubbling = True
+        with self.assertRaises(Forbidden):
+            browser.open(url, method='POST', headers=self.api_headers)
+
+    @browsing
+    @requests_mock.Mocker()
+    def test_access_token_is_required_in_payload(self, browser, mocker):
+        mocker.post(re.compile('/signing-jobs'), json=DEFAULT_MOCK_RESPONSE)
+
+        with self.login(self.regular_user, browser):
+            browser.open(self.document.absolute_url() + '/@workflow/' + Document.draft_signing_transition,
+                         method='POST',
+                         headers=self.api_headers)
+
+            url = self.document.absolute_url() + '/@upload-signed-pdf'
+
+        with browser.expect_http_error(400):
+            browser.open(url,
+                         method='POST',
+                         headers=self.api_headers,
+                         data=json.dumps({'signed_pdf_data': '<data>'}))
+
+        self.assertEqual(
+            {'message': "Property 'access_token' is required",
+             'type': 'BadRequest'},
+            browser.json)
+
+    @browsing
+    @requests_mock.Mocker()
+    def test_signed_pdf_data_is_required_in_payload(self, browser, mocker):
+        mocker.post(re.compile('/signing-jobs'), json=DEFAULT_MOCK_RESPONSE)
+
+        with self.login(self.regular_user, browser):
+            browser.open(self.document.absolute_url() + '/@workflow/' + Document.draft_signing_transition,
+                         method='POST',
+                         headers=self.api_headers)
+
+            url = self.document.absolute_url() + '/@upload-signed-pdf'
+
+        with browser.expect_http_error(400):
+            browser.open(url,
+                         method='POST',
+                         headers=self.api_headers,
+                         data=json.dumps({'access_token': '<token>'}))
+
+        self.assertEqual(
+            {'message': "Property 'signed_pdf_data' is required",
+             'type': 'BadRequest'},
+            browser.json)
+
+    @browsing
+    @requests_mock.Mocker()
+    def test_requires_a_valid_access_token(self, browser, mocker):
+        mocker.post(re.compile('/signing-jobs'), json=DEFAULT_MOCK_RESPONSE)
+
+        with self.login(self.regular_user, browser):
+            browser.open(self.document.absolute_url() + '/@workflow/' + Document.draft_signing_transition,
+                         method='POST',
+                         headers=self.api_headers)
+
+            url = self.document.absolute_url() + '/@upload-signed-pdf'
+
+        browser.exception_bubbling = True
+        with self.assertRaises(Unauthorized):
+            browser.open(url,
+                         method='POST',
+                         headers=self.api_headers,
+                         data=json.dumps({'access_token': urlsafe_b64encode('<invalid-token>'),
+                                          'signed_pdf_data': '<data>'}))
+
+    @browsing
+    @requests_mock.Mocker()
+    def test_can_complete_the_sign_process_by_uploading_the_signed_pdf(self, browser, mocker):
+        mocker.post(re.compile('/signing-jobs'), json=DEFAULT_MOCK_RESPONSE)
+
+        with self.login(self.regular_user, browser=browser):
+            browser.open(self.document.absolute_url() + '/@workflow/' + Document.draft_signing_transition,
+                         method='POST',
+                         headers=self.api_headers)
+
+            self.assertEqual(0, self.document.get_current_version_id(missing_as_zero=True))
+
+            token = urlsafe_b64encode(Signer(self.document).token_manager._get_token())
+            url = self.document.absolute_url() + '/@upload-signed-pdf'
+
+        # Upload the signed version as an anonym user with an access token
+        browser.open(url,
+                     method='POST',
+                     headers=self.api_headers,
+                     data=json.dumps({'access_token': token,
+                                      'signed_pdf_data': b64encode('<DATA>')}))
+
+        self.login(self.regular_user, browser)
+
+        self.assertEqual(1, self.document.get_current_version_id(missing_as_zero=True))
+
+        signed_version = Versioner(self.document).retrieve(1)
+        self.assertEqual(u'<DATA>', signed_version.file.data)
+
+    @browsing
+    @requests_mock.Mocker()
+    def test_complete_signing_invalidates_the_token(self, browser, mocker):
+        mocker.post(re.compile('/signing-jobs'), json=DEFAULT_MOCK_RESPONSE)
+
+        with self.login(self.regular_user, browser=browser):
+            browser.open(self.document.absolute_url() + '/@workflow/' + Document.draft_signing_transition,
+                         method='POST',
+                         headers=self.api_headers)
+
+            token = urlsafe_b64encode(Signer(self.document).token_manager._get_token())
+            url = self.document.absolute_url() + '/@upload-signed-pdf'
+
+            self.assertTrue(Signer(self.document).validate_token(token))
+
+        browser.open(url,
+                     method='POST',
+                     headers=self.api_headers,
+                     data=json.dumps({'access_token': token,
+                                      'signed_pdf_data': b64encode('<DATA>')}))
+
+        self.login(self.regular_user)
+        with self.assertRaises(InvalidToken):
+            Signer(self.document).validate_token(token)

--- a/opengever/api/transition.py
+++ b/opengever/api/transition.py
@@ -10,6 +10,7 @@ from opengever.dossier.resolve import InvalidDates
 from opengever.dossier.resolve import LockingResolveManager
 from opengever.dossier.resolve import MSG_ALREADY_BEING_RESOLVED
 from opengever.dossier.resolve import PreconditionsViolated
+from opengever.sign.sign import Signer
 from plone import api
 from plone.restapi.deserializer import json_body
 from plone.restapi.interfaces import IDeserializeFromJson
@@ -372,6 +373,20 @@ class WorkspaceWorkflowTransition(GEVERWorkflowTransition):
                     message='Workspace contains checked out documents.'))
 
         return super(WorkspaceWorkflowTransition, self).reply()
+
+
+class GEVERDocumentWorkflowTransition(GEVERWorkflowTransition):
+    """This endpoint handles workflow transitions for documents
+    """
+
+    SIGNING_TRANSITIONS = ['document-transition-draft-signing',
+                           'document-transition-final-signing']
+
+    def reply(self):
+        response = super(GEVERDocumentWorkflowTransition, self).reply()
+        if self.transition in self.SIGNING_TRANSITIONS:
+            response['redirect_url'] = Signer(self.context).serialize().get('redirect_url')
+        return response
 
 
 @implementer(IPublishTraverse)

--- a/opengever/base/subscribers.py
+++ b/opengever/base/subscribers.py
@@ -19,6 +19,7 @@ ALLOWED_ENDPOINTS = set([
     'POST_application_json_@login',
     'POST_application_json_@logout',
     'POST_application_json_@login-renew',
+    'POST_application_json_@upload-signed-pdf',
     'customlogo',
     'customlogo_right',
     'dump-content-stats',

--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -481,6 +481,7 @@ class ContentFixtureLayer(NoSolrTestingBase, OpengeverFixture):
         os.environ['BUMBLEBEE_SECRET'] = 'secret'
         os.environ['BUMBLEBEE_INTERNAL_PLONE_URL'] = 'http://nohost/plone'
         os.environ['BUMBLEBEE_PUBLIC_URL'] = 'http://bumblebee'
+        os.environ['SIGN_SERVICE_URL'] = 'http://example.com/'
 
         # Set up ftw.contentstats logging for testing
         self.setup_eventlog()

--- a/opengever/document/configure.zcml
+++ b/opengever/document/configure.zcml
@@ -463,4 +463,29 @@
       name="document-transition-finalize"
       />
 
+  <adapter
+      factory=".transition.DocumentFinalSigningTransitionExtender"
+      name="document-transition-final-signing"
+      />
+
+  <adapter
+      factory=".transition.DocumentDraftSigningTransitionExtender"
+      name="document-transition-draft-signing"
+      />
+
+  <adapter
+      factory=".transition.DocumentSigningFinalTransitionExtender"
+      name="document-transition-signing-final"
+      />
+
+  <adapter
+      factory=".transition.DocumentSigningSignedTransitionExtender"
+      name="document-transition-signing-signed"
+      />
+
+  <adapter
+      factory=".transition.DocumentSignedDraftTransitionExtender"
+      name="document-transition-signed-draft"
+      />
+
 </configure>

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2023-10-06 14:48+0000\n"
+"POT-Creation-Date: 2024-09-12 08:50+0000\n"
 "PO-Revision-Date: 2017-10-13 14:27+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -491,6 +491,11 @@ msgstr "Aktenzeichen"
 msgid "label_document_sequence_number"
 msgstr "Laufnummer"
 
+#. Default: "Document signed"
+#: ./opengever/document/transition.py
+msgid "label_document_signed"
+msgstr "Dokument signiert"
+
 #. Default: "Document Type"
 #: ./opengever/document/behaviors/metadata.py
 msgid "label_document_type"
@@ -665,6 +670,11 @@ msgstr "PDF speichern unter"
 #: ./opengever/document/viewlets/byline.py
 msgid "label_sequence_number"
 msgstr "Laufnummer"
+
+#. Default: "Base64 encoded signed pdf file data"
+#: ./opengever/document/transition.py
+msgid "label_signed_pdf_filedata"
+msgstr "Signierte PDF-File Daten"
 
 #. Default: "from"
 #: ./opengever/document/viewlets/byline.py

--- a/opengever/document/locales/en/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/en/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2023-10-06 14:48+0000\n"
+"POT-Creation-Date: 2024-09-12 08:50+0000\n"
 "PO-Revision-Date: 2017-10-13 14:27+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -584,6 +584,11 @@ msgstr "Reference number"
 msgid "label_document_sequence_number"
 msgstr "Sequence number"
 
+#. Default: "Document signed"
+#: ./opengever/document/transition.py
+msgid "label_document_signed"
+msgstr "Document signed"
+
 #. German translation: Dokumenttyp
 #. Default: "Document Type"
 #: ./opengever/document/behaviors/metadata.py
@@ -787,6 +792,11 @@ msgstr "Save PDF as"
 #: ./opengever/document/viewlets/byline.py
 msgid "label_sequence_number"
 msgstr "Sequence number"
+
+#. Default: "Base64 encoded signed pdf file data"
+#: ./opengever/document/transition.py
+msgid "label_signed_pdf_filedata"
+msgstr "Signed pdf file data"
 
 #. German translation: Dokumentdatum
 #. Default: "from"

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-10-06 14:48+0000\n"
+"POT-Creation-Date: 2024-09-12 08:50+0000\n"
 "PO-Revision-Date: 2017-09-03 08:50+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-document/fr/>\n"
@@ -488,6 +488,11 @@ msgstr "Numéro de référence"
 msgid "label_document_sequence_number"
 msgstr "Numéro courant"
 
+#. Default: "Document signed"
+#: ./opengever/document/transition.py
+msgid "label_document_signed"
+msgstr "Document signé"
+
 #. Default: "Document Type"
 #: ./opengever/document/behaviors/metadata.py
 msgid "label_document_type"
@@ -662,6 +667,11 @@ msgstr "Enregistrer PDF sous"
 #: ./opengever/document/viewlets/byline.py
 msgid "label_sequence_number"
 msgstr "Numéro courant"
+
+#. Default: "Base64 encoded signed pdf file data"
+#: ./opengever/document/transition.py
+msgid "label_signed_pdf_filedata"
+msgstr "Données du fichier pdf signé"
 
 #. Default: "from"
 #: ./opengever/document/viewlets/byline.py

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-10-06 14:48+0000\n"
+"POT-Creation-Date: 2024-09-12 08:50+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -486,6 +486,11 @@ msgstr ""
 msgid "label_document_sequence_number"
 msgstr ""
 
+#. Default: "Document signed"
+#: ./opengever/document/transition.py
+msgid "label_document_signed"
+msgstr ""
+
 #. Default: "Document Type"
 #: ./opengever/document/behaviors/metadata.py
 msgid "label_document_type"
@@ -658,6 +663,11 @@ msgstr ""
 #. Default: "Sequence Number"
 #: ./opengever/document/viewlets/byline.py
 msgid "label_sequence_number"
+msgstr ""
+
+#. Default: "Base64 encoded signed pdf file data"
+#: ./opengever/document/transition.py
+msgid "label_signed_pdf_filedata"
 msgstr ""
 
 #. Default: "from"

--- a/opengever/document/tests/test_document_workflow.py
+++ b/opengever/document/tests/test_document_workflow.py
@@ -1,12 +1,20 @@
+from base64 import b64encode
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from ftw.testing import freeze
 from opengever.base.security import as_internal_workflow_transition
 from opengever.document.document import Document
+from opengever.document.versioner import Versioner
+from opengever.sign.sign import Signer
+from opengever.sign.tests.test_sign import DEFAULT_MOCK_RESPONSE
+from opengever.sign.tests.test_sign import FROZEN_NOW
 from opengever.testing import IntegrationTestCase
 from plone import api
 from plone.api.exc import InvalidParameterError
 from zExceptions import Unauthorized
+import re
+import requests_mock
 
 
 class TestDocumentWorkflow(IntegrationTestCase):
@@ -199,31 +207,62 @@ class TestDocumentWorkflow(IntegrationTestCase):
             api.content.transition(obj=self.document,
                                    transition=Document.final_signing_transition)
 
-    def test_can_start_signing_a_document_in_draft_state(self):
+    @requests_mock.Mocker()
+    def test_can_start_signing_a_document_in_draft_state(self, mocker):
         self.activate_feature('sign')
+        mocker.post(re.compile('/signing-jobs'), json=DEFAULT_MOCK_RESPONSE)
+
         self.login(self.regular_user)
 
-        api.content.transition(obj=self.document,
-                               transition=Document.draft_signing_transition)
+        with freeze(FROZEN_NOW):
+            api.content.transition(obj=self.document,
+                                   transition=Document.draft_signing_transition)
 
         self.assertEquals(Document.signing_state,
                           api.content.get_state(obj=self.document))
 
-    def test_can_start_signing_a_document_in_final_state(self):
+        self.assertEqual(self.regular_user.getId(), self.document.finalizer)
+        self.assertDictEqual(
+            {
+                'created': FROZEN_NOW,
+                'job_id': '1',
+                'redirect_url': 'http://external.example.org/signing-requests/123',
+                'signers': ['foo@example.com'],
+                'userid': 'regular_user',
+                'version': 0
+            }, Signer(self.document).metadata_storage.read())
+
+    @requests_mock.Mocker()
+    def test_can_start_signing_a_document_in_final_state(self, mocker):
         self.activate_feature('sign')
+        mocker.post(re.compile('/signing-jobs'), json=DEFAULT_MOCK_RESPONSE)
+
         self.login(self.regular_user)
 
         api.content.transition(obj=self.document,
                                transition=Document.finalize_transition)
 
-        api.content.transition(obj=self.document,
-                               transition=Document.final_signing_transition)
+        with freeze(FROZEN_NOW):
+            api.content.transition(obj=self.document,
+                                   transition=Document.final_signing_transition)
 
         self.assertEquals(Document.signing_state,
                           api.content.get_state(obj=self.document))
 
-    def test_sign_transition_is_only_for_internal_use(self):
+        self.assertDictEqual(
+            {
+                'created': FROZEN_NOW,
+                'job_id': '1',
+                'redirect_url': 'http://external.example.org/signing-requests/123',
+                'signers': ['foo@example.com'],
+                'userid': 'regular_user',
+                'version': 0
+            }, Signer(self.document).metadata_storage.read())
+
+    @requests_mock.Mocker()
+    def test_sign_transition_is_only_for_internal_use(self, mocker):
         self.activate_feature('sign')
+        mocker.post(re.compile('/signing-jobs'), json=DEFAULT_MOCK_RESPONSE)
         self.login(self.regular_user)
 
         api.content.transition(obj=self.document,
@@ -231,20 +270,45 @@ class TestDocumentWorkflow(IntegrationTestCase):
 
         with self.assertRaises(InvalidParameterError):
             api.content.transition(obj=self.document,
-                                   transition=Document.signing_signed_transition)
+                                   transition=Document.signing_signed_transition,
+                                   transition_params={'filedata': b64encode('<DATA>')})
 
         self.assertEquals(Document.signing_state,
                           api.content.get_state(obj=self.document))
 
         with as_internal_workflow_transition():
             api.content.transition(obj=self.document,
-                                   transition=Document.signing_signed_transition)
+                                   transition=Document.signing_signed_transition,
+                                   transition_params={'filedata': b64encode('<DATA>')})
 
         self.assertEquals(Document.signed_state,
                           api.content.get_state(obj=self.document))
 
-    def test_can_abort_signing_document(self):
+    @requests_mock.Mocker()
+    def test_sign_transition_creates_a_new_version_with_the_given_data(self, mocker):
         self.activate_feature('sign')
+        mocker.post(re.compile('/signing-jobs'), json=DEFAULT_MOCK_RESPONSE)
+        self.login(self.regular_user)
+
+        api.content.transition(obj=self.document,
+                               transition=Document.draft_signing_transition)
+
+        self.assertEqual(0, self.document.get_current_version_id(missing_as_zero=True))
+
+        with as_internal_workflow_transition():
+            api.content.transition(obj=self.document,
+                                   transition=Document.signing_signed_transition,
+                                   transition_params={'filedata': b64encode('<DATA>')})
+
+        self.assertEqual(1, self.document.get_current_version_id(missing_as_zero=True))
+        signed_version = Versioner(self.document).retrieve(1)
+        self.assertEqual(u'<DATA>', signed_version.file.data)
+
+    @requests_mock.Mocker()
+    def test_can_abort_signing_document(self, mocker):
+        self.activate_feature('sign')
+        mocker.post(re.compile('/signing-jobs'), json=DEFAULT_MOCK_RESPONSE)
+        delete_mocker = mocker.delete(re.compile('/signing-jobs/1'))
         self.login(self.regular_user)
         api.content.transition(obj=self.document,
                                transition=Document.draft_signing_transition)
@@ -255,31 +319,51 @@ class TestDocumentWorkflow(IntegrationTestCase):
         api.content.transition(obj=self.document,
                                transition=Document.signing_final_transition)
 
+        self.assertEqual(1, delete_mocker.call_count)
         self.assertEquals(Document.final_state,
                           api.content.get_state(obj=self.document))
 
-    def test_can_abort_signed_document(self):
+    @requests_mock.Mocker()
+    def test_can_revise_signed_document(self, mocker):
         self.activate_feature('sign')
+        mocker.post(re.compile('/signing-jobs'), json=DEFAULT_MOCK_RESPONSE)
         self.login(self.regular_user)
+
+        FINALIZED_FILE_DATA = '<FINALIZED_FILE_DATA>'
+        SIGNED_FILE_DATA = '<SIGNED_FILE_DATA>'
+
+        self.document.update_file(
+            data=FINALIZED_FILE_DATA,
+            create_version=True)
+
+        self.assertEqual(1, self.document.get_current_version_id(missing_as_zero=True))
+
         api.content.transition(obj=self.document,
                                transition=Document.draft_signing_transition)
 
         with as_internal_workflow_transition():
             api.content.transition(obj=self.document,
-                                   transition=Document.signing_signed_transition)
+                                   transition=Document.signing_signed_transition,
+                                   transition_params={'filedata': b64encode(SIGNED_FILE_DATA)})
 
         self.assertEquals(Document.signed_state,
                           api.content.get_state(obj=self.document))
+        self.assertEqual(2, self.document.get_current_version_id(missing_as_zero=True))
+        self.assertEqual(SIGNED_FILE_DATA, self.document.file.data)
 
         api.content.transition(obj=self.document,
                                transition=Document.signed_draft_transition)
 
         self.assertEquals(Document.active_state,
                           api.content.get_state(obj=self.document))
+        self.assertEqual(3, self.document.get_current_version_id(missing_as_zero=True))
+        self.assertEqual(FINALIZED_FILE_DATA, self.document.file.data)
 
     @browsing
-    def test_signing_document_cannot_be_edited(self, browser):
+    @requests_mock.Mocker()
+    def test_signing_document_cannot_be_edited(self, browser, mocker):
         self.activate_feature('sign')
+        mocker.post(re.compile('/signing-jobs'), json=DEFAULT_MOCK_RESPONSE)
         self.login(self.administrator, browser)
         browser.open(self.document, view='edit')
 
@@ -290,8 +374,10 @@ class TestDocumentWorkflow(IntegrationTestCase):
         with self.assertRaises(Unauthorized):
             browser.open(self.document, view='edit')
 
-    def test_signing_document_cannot_be_checked_out(self):
+    @requests_mock.Mocker()
+    def test_signing_document_cannot_be_checked_out(self, mocker):
         self.activate_feature('sign')
+        mocker.post(re.compile('/signing-jobs'), json=DEFAULT_MOCK_RESPONSE)
         self.login(self.administrator)
         self.assertTrue(self.document.is_checkout_permitted())
 
@@ -301,8 +387,10 @@ class TestDocumentWorkflow(IntegrationTestCase):
         self.assertFalse(self.document.is_checkout_permitted())
 
     @browsing
-    def test_signed_document_cannot_be_edited(self, browser):
+    @requests_mock.Mocker()
+    def test_signed_document_cannot_be_edited(self, browser, mocker):
         self.activate_feature('sign')
+        mocker.post(re.compile('/signing-jobs'), json=DEFAULT_MOCK_RESPONSE)
         self.login(self.administrator, browser)
         browser.open(self.document, view='edit')
 
@@ -311,14 +399,17 @@ class TestDocumentWorkflow(IntegrationTestCase):
 
         with as_internal_workflow_transition():
             api.content.transition(obj=self.document,
-                                   transition=Document.signing_signed_transition)
+                                   transition=Document.signing_signed_transition,
+                                   transition_params={'filedata': b64encode('<DATA>')})
 
         browser.exception_bubbling = True
         with self.assertRaises(Unauthorized):
             browser.open(self.document, view='edit')
 
-    def test_signed_document_cannot_be_checked_out(self):
+    @requests_mock.Mocker()
+    def test_signed_document_cannot_be_checked_out(self, mocker):
         self.activate_feature('sign')
+        mocker.post(re.compile('/signing-jobs'), json=DEFAULT_MOCK_RESPONSE)
         self.login(self.administrator)
         self.assertTrue(self.document.is_checkout_permitted())
 
@@ -327,6 +418,7 @@ class TestDocumentWorkflow(IntegrationTestCase):
 
         with as_internal_workflow_transition():
             api.content.transition(obj=self.document,
-                                   transition=Document.signing_signed_transition)
+                                   transition=Document.signing_signed_transition,
+                                   transition_params={'filedata': b64encode('<DATA>')})
 
         self.assertFalse(self.document.is_checkout_permitted())

--- a/opengever/document/transition.py
+++ b/opengever/document/transition.py
@@ -1,10 +1,20 @@
+from base64 import b64decode
 from opengever.base.transition import ITransitionExtender
 from opengever.base.transition import TransitionExtender
+from opengever.document import _
 from opengever.document.document import IDocumentSchema
+from opengever.document.interfaces import ICheckinCheckoutManager
+from opengever.ogds.models.service import ogds_service
+from opengever.sign.sign import Signer
 from plone import api
+from plone.supermodel.model import Schema
+from zope import schema
 from zope.component import adapter
+from zope.component import getMultiAdapter
+from zope.i18n import translate
 from zope.interface import implementer
 from zope.publisher.interfaces.browser import IBrowserRequest
+import os
 
 
 @implementer(ITransitionExtender)
@@ -15,3 +25,93 @@ class DocumentFinalizeTransitionExtender(TransitionExtender):
         """Set finalizer
         """
         self.context.finalizer = api.user.get_current().getId()
+
+
+@implementer(ITransitionExtender)
+@adapter(IDocumentSchema, IBrowserRequest)
+class DocumentFinalSigningTransitionExtender(TransitionExtender):
+
+    def after_transition_hook(self, *args, **kwargs):
+        """Start signing process
+        """
+        actor = ogds_service().fetch_user(api.user.get_current().id)
+        if not actor or not actor.email:
+            raise NoEmailError()
+
+        Signer(self.context).start_signing(signers=[actor.email])
+
+
+@implementer(ITransitionExtender)
+@adapter(IDocumentSchema, IBrowserRequest)
+class DocumentDraftSigningTransitionExtender(TransitionExtender):
+
+    def after_transition_hook(self, *args, **kwargs):
+        finalize_transition_extender = getMultiAdapter(
+            (self.context, self.request),
+            ITransitionExtender,
+            name="document-transition-finalize")
+
+        finalize_transition_extender.after_transition_hook(*args, **kwargs)
+
+        signing_transition_extender = getMultiAdapter(
+            (self.context, self.request),
+            ITransitionExtender,
+            name="document-transition-final-signing")
+
+        signing_transition_extender.after_transition_hook(*args, **kwargs)
+
+
+@implementer(ITransitionExtender)
+@adapter(IDocumentSchema, IBrowserRequest)
+class DocumentSigningFinalTransitionExtender(TransitionExtender):
+
+    def after_transition_hook(self, *args, **kwargs):
+        Signer(self.context).abort_signing()
+
+
+@implementer(ITransitionExtender)
+@adapter(IDocumentSchema, IBrowserRequest)
+class DocumentSignedDraftTransitionExtender(TransitionExtender):
+
+    def after_transition_hook(self, *args, **kwargs):
+        finalized_version_number = self.context.get_current_version_id(
+            missing_as_zero=True) - 1
+
+        manager = getMultiAdapter((self.context, self.request),
+                                  ICheckinCheckoutManager)
+        manager.revert_to_version(finalized_version_number)
+        Signer(self.context).clear_metadata()
+
+
+class ISignSchema(Schema):
+    filedata = schema.ASCIILine(
+        title=_('label_signed_pdf_filedata',
+                default='Base64 encoded signed pdf file data'),
+        required=True,
+    )
+
+
+@implementer(ITransitionExtender)
+@adapter(IDocumentSchema, IBrowserRequest)
+class DocumentSigningSignedTransitionExtender(TransitionExtender):
+
+    schemas = [ISignSchema]
+
+    def after_transition_hook(self, transition, disable_sync, transition_params):
+        filedata = b64decode(transition_params.get('filedata'))
+        comment = _(u'label_document_signed', default=u'Document signed')
+        self.context.update_file(
+            data=filedata,
+            content_type=u'application/pdf',
+            filename=self.get_file_name(),
+            create_version=True,
+            comment=translate(comment, context=self.request))
+
+    def get_file_name(self):
+        filename, ext = os.path.splitext(self.context.get_filename())
+        return u'{}.pdf'.format(filename)
+
+
+class NoEmailError(Exception):
+    """The current user does not have an email defined.
+    """

--- a/opengever/sign/client.py
+++ b/opengever/sign/client.py
@@ -1,0 +1,34 @@
+from ftw.bumblebee.interfaces import IBumblebeeServiceV3
+from os import environ
+from zope.globalrequest import getRequest
+import requests
+
+
+class SignServiceClient(object):
+
+    @property
+    def sign_service_url(self):
+        return environ.get('SIGN_SERVICE_URL', '').strip('/')
+
+    def queue_signing(self, document, token, signers):
+        bumblebee_service = IBumblebeeServiceV3(getRequest())
+
+        return requests.post(
+            '{}/signing-jobs/'.format(self.sign_service_url),
+            headers={"Accept": "application/json"},
+            json={'access_token': token,
+                  'document_url': document.absolute_url(),
+                  'download_url': bumblebee_service.get_download_url(document),
+                  'upload_url': '{}/@upload-signed-pdf'.format(document.absolute_url()),
+                  'document_uid': document.UID(),
+                  'title': document.title_or_id(),
+                  'signers': signers,
+                  })
+
+    def abort_signing(self, job_id):
+        if job_id is None:
+            return
+
+        return requests.delete(
+            '{}/signing-jobs/{}'.format(self.sign_service_url, job_id),
+            headers={"Accept": "application/json"})

--- a/opengever/sign/sign.py
+++ b/opengever/sign/sign.py
@@ -1,0 +1,79 @@
+from base64 import urlsafe_b64decode
+from base64 import urlsafe_b64encode
+from opengever.base.security import as_internal_workflow_transition
+from opengever.document.document import Document
+from opengever.sign.client import SignServiceClient
+from opengever.sign.storage import MetadataStorage
+from opengever.sign.token import TokenManager
+from plone import api
+from plone.dexterity.utils import safe_utf8
+from requests.exceptions import ConnectionError
+
+
+class Signer(object):
+    """Provides all necessary methods to sign an objects through an external
+    service.
+    """
+
+    def __init__(self, context):
+        self.context = context
+        self.token_manager = TokenManager(context)
+        self.metadata_storage = MetadataStorage(context)
+
+    def issue_token(self):
+        return urlsafe_b64encode(self.token_manager.issue_token())
+
+    def validate_token(self, token):
+        return self.token_manager.validate_token(urlsafe_b64decode(safe_utf8(token)))
+
+    def invalidate_token(self):
+        self.token_manager.invalidate_token()
+
+    def start_signing(self, signers):
+        token = self.issue_token()
+        response = SignServiceClient().queue_signing(self.context, token, signers)
+        response = response.json()
+        self.metadata_storage.store(
+            userid=api.user.get_current().id,
+            version=self.context.get_current_version_id(missing_as_zero=True),
+            signers=signers,
+            job_id=response.get('id'),
+            redirect_url=response.get('redirect_url'),
+        )
+        return token
+
+    def complete_signing(self, signed_pdf_data):
+        with as_internal_workflow_transition():
+            api.content.transition(
+                obj=self.context,
+                transition=Document.signing_signed_transition,
+                transition_params={'filedata': signed_pdf_data})
+
+    def abort_signing(self):
+        self.invalidate_token()
+        signing_data = self.metadata_storage.read()
+        try:
+            SignServiceClient().abort_signing(signing_data.get('job_id'))
+        except ConnectionError:
+            # The user should always be able to abort the job
+            pass
+
+        self.clear_metadata()
+
+    def clear_metadata(self):
+        self.metadata_storage.clear()
+
+    def adopt_issuer(self):
+        userid = self.metadata_storage.read().get('userid')
+        user = api.user.get(userid=userid)
+        if not user:
+            raise IssuerNotFound()
+        return api.env.adopt_user(user=user)
+
+    def serialize(self):
+        return self.metadata_storage.read()
+
+
+class IssuerNotFound(Exception):
+    """Sign issuer not found.
+    """

--- a/opengever/sign/storage.py
+++ b/opengever/sign/storage.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+from opengever.base.utils import make_persistent
+from zope.annotation import IAnnotations
+
+
+class MetadataStorage(object):
+    """Responsible for storing metadata for a currently running sign process.
+    """
+
+    ANNOTATIONS_KEY = 'sign_data'
+
+    def __init__(self, context):
+        self.context = context
+        self.annotations = IAnnotations(self.context)
+
+    def store(self, userid, version, signers, job_id, redirect_url):
+        self._set_data({
+            'created': datetime.now(),
+            'userid': userid,
+            'job_id': job_id,
+            'redirect_url': redirect_url,
+            'signers': signers,
+            'version': version,
+        })
+
+    def read(self):
+        return self._get_data()
+
+    def clear(self):
+        self._set_data({})
+
+    def _set_data(self, data):
+        self.annotations[self.ANNOTATIONS_KEY] = make_persistent(data)
+
+    def _get_data(self):
+        return dict(self.annotations.get(self.ANNOTATIONS_KEY, {}))

--- a/opengever/sign/tests/test_client.py
+++ b/opengever/sign/tests/test_client.py
@@ -1,0 +1,45 @@
+from ftw.bumblebee.tests.helpers import DOCX_CHECKSUM
+from opengever.sign.client import SignServiceClient
+from opengever.testing import IntegrationTestCase
+import re
+import requests_mock
+
+
+DEFAULT_MOCK_RESPONSE = {
+    'id': '1',
+    'redirect_url': 'http://external.example.org/signing-requests/123',
+}
+
+TOKEN = '<access-token>'
+
+
+@requests_mock.Mocker()
+class TestSigningClient(IntegrationTestCase):
+
+    def test_add_a_signing_job(self, mocker):
+        self.login(self.regular_user)
+
+        mocker.post(re.compile('/signing-jobs'), json=DEFAULT_MOCK_RESPONSE)
+
+        SignServiceClient().queue_signing(self.document, TOKEN, ['foo.bar@example.com'])
+
+        self.assertDictEqual(
+            {
+                u'access_token': u'<access-token>',
+                u'document_uid': u'createtreatydossiers000000000002',
+                u'document_url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-14', # noqa
+                u'download_url': u'http://nohost/plone/bumblebee_download?checksum={}&uuid=createtreatydossiers000000000002'.format(DOCX_CHECKSUM), # noqa
+                u'signers': ['foo.bar@example.com'],
+                u'title': u'Vertr\xe4gsentwurf',
+                u'upload_url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-14/@upload-signed-pdf', # noqa
+            },
+            mocker.last_request.json())
+
+    def test_abort_signing_job(self, mocker):
+        self.login(self.regular_user)
+
+        mocker.delete(re.compile('/signing-jobs/123'))
+
+        response = SignServiceClient().abort_signing('123')
+
+        self.assertEqual(200, response.status_code)

--- a/opengever/sign/tests/test_sign.py
+++ b/opengever/sign/tests/test_sign.py
@@ -1,0 +1,90 @@
+from base64 import b64encode
+from datetime import datetime
+from ftw.testing import freeze
+from opengever.document.document import Document
+from opengever.document.versioner import Versioner
+from opengever.sign.sign import Signer
+from opengever.sign.token import InvalidToken
+from opengever.testing import IntegrationTestCase
+from plone import api
+import re
+import requests_mock
+
+
+FROZEN_NOW = datetime(2024, 2, 18, 15, 45)
+
+DEFAULT_MOCK_RESPONSE = {
+    'id': '1',
+    'redirect_url': 'http://external.example.org/signing-requests/123',
+}
+
+
+@requests_mock.Mocker()
+class TestSigning(IntegrationTestCase):
+
+    features = ['sign']
+
+    def test_store_signing_document_metadata_when_starting_sign_process(self, mocker):
+        self.login(self.regular_user)
+
+        mocker.post(re.compile('/signing-jobs'), json=DEFAULT_MOCK_RESPONSE)
+        signer = Signer(self.document)
+
+        with freeze(FROZEN_NOW):
+            signer.start_signing(['foo.bar@example.com'])
+
+        self.assertDictEqual(
+            {
+                'created': FROZEN_NOW,
+                'job_id': '1',
+                'redirect_url': 'http://external.example.org/signing-requests/123',
+                'signers': ['foo.bar@example.com'],
+                'userid': 'regular_user',
+                'version': 0
+            }, signer.serialize())
+
+    def test_can_issue_and_invalidate_tokens(self, mocker):
+        self.login(self.regular_user)
+
+        signer = Signer(self.document)
+        token = signer.issue_token()
+        self.assertTrue(signer.validate_token(token))
+
+        signer.invalidate_token()
+        with self.assertRaises(InvalidToken):
+            signer.validate_token(token)
+
+    def test_can_abort_signing_process(self, mocker):
+        self.login(self.regular_user)
+        mocker.post(re.compile('/signing-jobs'), json=DEFAULT_MOCK_RESPONSE)
+        delete_mocker = mocker.delete(re.compile('/signing-jobs/1'))
+
+        signer = Signer(self.document)
+        token = signer.start_signing(['foo.bar@example.com'])
+        signer.abort_signing()
+
+        # current token should be invalidated
+        with self.assertRaises(InvalidToken):
+            signer.validate_token(token)
+
+        # signing-job should be removed
+        self.assertEqual(1, delete_mocker.call_count)
+
+        # metadata-content should be cleared
+        self.assertEqual({}, signer.serialize())
+
+    def test_can_complete_signing_process(self, mocker):
+        self.login(self.regular_user)
+        mocker.post(re.compile('/signing-jobs'), json=DEFAULT_MOCK_RESPONSE)
+        api.content.transition(obj=self.document,
+                               transition=Document.draft_signing_transition)
+
+        self.assertEqual(0, self.document.get_current_version_id(missing_as_zero=True))
+
+        signer = Signer(self.document)
+        signer.complete_signing(b64encode('<DATA>'))
+
+        self.assertEqual(1, self.document.get_current_version_id(missing_as_zero=True))
+
+        signed_version = Versioner(self.document).retrieve(1)
+        self.assertEqual(u'<DATA>', signed_version.file.data)

--- a/opengever/sign/tests/test_storage.py
+++ b/opengever/sign/tests/test_storage.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+from ftw.testing import freeze
+from opengever.sign.storage import MetadataStorage
+from opengever.testing import IntegrationTestCase
+
+
+FROZEN_NOW = datetime(2024, 2, 18, 15, 45)
+
+
+class TestMetadataStorage(IntegrationTestCase):
+    def test_can_store_metadata(self):
+        self.login(self.regular_user)
+        storage = MetadataStorage(self.document)
+
+        with freeze(FROZEN_NOW):
+            storage.store(
+                userid='foo.bar',
+                version=1,
+                signers=['foo.bar@example.com'],
+                job_id='123',
+                redirect_url='http://example.com/sign-service'
+            )
+
+        self.assertDictEqual(
+            {
+                'created': FROZEN_NOW,
+                'job_id': '123',
+                'redirect_url': 'http://example.com/sign-service',
+                'signers': ['foo.bar@example.com'],
+                'userid': 'foo.bar',
+                'version': 1
+            },
+            storage.read())

--- a/opengever/sign/tests/test_token.py
+++ b/opengever/sign/tests/test_token.py
@@ -1,0 +1,46 @@
+from opengever.document.versioner import Versioner
+from opengever.sign.token import InvalidToken
+from opengever.sign.token import TokenManager
+from opengever.testing import IntegrationTestCase
+
+
+class TestTokenManager(IntegrationTestCase):
+    def test_can_issue_a_valid_token(self):
+        self.login(self.regular_user)
+        manager = TokenManager(self.document)
+        manager.validate_token(manager.issue_token())
+
+    def test_issued_token_is_only_valid_for_a_specific_document(self):
+        self.login(self.regular_user)
+        token = TokenManager(self.document).issue_token()
+        with self.assertRaises(InvalidToken):
+            TokenManager(self.subdocument).validate_token(token)
+
+    def test_issued_token_is_only_valid_for_a_specific_document_version(self):
+        self.login(self.regular_user)
+        manager = TokenManager(self.document)
+        token = manager.issue_token()
+
+        self.assertTrue(manager.validate_token(token))
+
+        Versioner(self.document).create_version('new version')
+        with self.assertRaises(InvalidToken):
+            manager.validate_token(token)
+
+    def test_can_invalidate_the_current_token(self):
+        self.login(self.regular_user)
+        manager = TokenManager(self.document)
+        token = manager.issue_token()
+
+        self.assertTrue(manager.validate_token(token))
+
+        manager.invalidate_token()
+        with self.assertRaises(InvalidToken):
+            manager.validate_token(token)
+
+    def test_can_validate_a_token_without_permission(self):
+        with self.login(self.regular_user):
+            manager = TokenManager(self.document)
+            token = manager.issue_token()
+
+        self.assertTrue(manager.validate_token(token))

--- a/opengever/sign/token.py
+++ b/opengever/sign/token.py
@@ -1,0 +1,55 @@
+from opengever.base.security import elevated_privileges
+from opengever.wopi.token import create_access_token
+from opengever.wopi.token import validate_access_token
+from plone.uuid.interfaces import IUUID
+from zope.annotation import IAnnotations
+
+
+class TokenManager(object):
+    """Responsible for issuing and validating access tokens for the sign
+    service.
+
+    Only one token can be valid at the same time for a specific document.
+
+    The issued token is only valid for a specific document version and
+    cannot be used for other documents
+    """
+
+    ANNOTATIONS_KEY = 'sign_token'
+
+    def __init__(self, context):
+        self.context = context
+        self.annotations = IAnnotations(self.context)
+
+    def issue_token(self):
+        token = create_access_token('<sign-service>', self._get_token_scope())
+        self._set_token(token)
+        return token
+
+    def validate_token(self, token):
+        if not token or token != self._get_token():
+            raise InvalidToken()
+
+        if not validate_access_token(token, self._get_token_scope()):
+            raise InvalidToken()
+
+        return True
+
+    def invalidate_token(self):
+        self.annotations[self.ANNOTATIONS_KEY] = None
+
+    def _get_token_scope(self):
+        with elevated_privileges():
+            return '{}-{}'.format(IUUID(self.context),
+                                  self.context.get_current_version_id())
+
+    def _set_token(self, token):
+        self.annotations[self.ANNOTATIONS_KEY] = token
+
+    def _get_token(self):
+        return self.annotations.get(self.ANNOTATIONS_KEY)
+
+
+class InvalidToken(Exception):
+    """Token validation failed.
+    """


### PR DESCRIPTION
This PR implements the signing feature.

The feature extends the newly introduced sign-transitions from #8034 with additional transition extenders which are responsible for starting the sign-process and uploading a new, signed document version.

The signing-flow looks as follow:

![Bildschirmfoto 2024-09-12 um 09 41 40](https://github.com/user-attachments/assets/17dc358e-9d49-4853-abfa-0ed712f3d3da)


ℹ️ the coral-parts are implemented by this PR.

For [TI-659]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[TI-659]: https://4teamwork.atlassian.net/browse/TI-659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ