### PR TITLE
Fix unicode error when logging skipped users in ogds-updater

### DIFF
--- a/changes/TI-1024.bugfix
+++ b/changes/TI-1024.bugfix
@@ -1,0 +1,1 @@
+Fix unicode error when syncing users. [elioschmutz]

--- a/opengever/ogds/base/sync/ogds_updater.py
+++ b/opengever/ogds/base/sync/ogds_updater.py
@@ -669,7 +669,7 @@ class OGDSUpdater(object):
             if userid not in ogds_objects_ci])
 
         for skipped in added - added_ci:
-            logger.info('Not adding duplicate user with deviating case {}'.format(skipped))
+            logger.info(u'Not adding duplicate user with deviating case {}'.format(skipped))
 
         deleted = [k for k in ogds_active_keys if k not in ldap_objects_ci]
         existing = [k for k in ogds_keys if k in ldap_objects_ci]


### PR DESCRIPTION
This PR fixes an issue where syncing the ogds is no longer possible due to a unicode error in the logger:

Sentry: https://sentry.4teamwork.ch/organizations/sentry/issues/135578/?project=17&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=90d&stream_index=2

A skipped user will be logged. If its userid contains an umlaut, it will fail.

For [TI-1024]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-1024]: https://4teamwork.atlassian.net/browse/TI-1024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ