### PR TITLE
Fix possible watchers in teamraum

### DIFF
--- a/changes/TI-1221.bugfix
+++ b/changes/TI-1221.bugfix
@@ -1,0 +1,1 @@
+Fixes a bug where it was no longer possible to add watchers in teamraum. [elioschmutz]

--- a/opengever/activity/sources.py
+++ b/opengever/activity/sources.py
@@ -3,6 +3,7 @@ from opengever.ogds.base.sources import AllTeamsSource
 from opengever.ogds.base.sources import AssignedUsersSource
 from opengever.ogds.base.sources import BaseMultipleSourcesQuerySource
 from opengever.ogds.models.user import User
+from opengever.workspace import is_workspace_feature_enabled
 from plone import api
 from sqlalchemy import case
 
@@ -48,10 +49,14 @@ class PossibleWatchersSource(BaseMultipleSourcesQuerySource):
     """A vocabulary source of all users, groups and teams not watching a
     ressource assigned to the current admin unit.
     """
+    gever_only = False
 
     def __init__(self, context):
         self.context = context
         self.terms = []
+
         self.source_instances = [PossibleWatchersSourceUsers(context),
-                                 AllFilteredGroupsSourcePrefixed(context),
-                                 AllTeamsSource(context)]
+                                 AllFilteredGroupsSourcePrefixed(context)]
+
+        if not is_workspace_feature_enabled():
+            self.source_instances.append(AllTeamsSource(context))

--- a/opengever/activity/tests/test_sources.py
+++ b/opengever/activity/tests/test_sources.py
@@ -29,6 +29,15 @@ class TestPossibleWatchersSource(IntegrationTestCase):
         self.assertIn('group:fa_users', [term.token for term in source.search('')])
         self.assertIn('team:1', [term.token for term in source.search('')])
 
+    def test_list_users_and_groups_for_teamraum(self):
+        self.activate_feature('workspace')
+        self.login(self.administrator)
+        source = PossibleWatchersSource(self.task)
+
+        self.assertIn('regular_user', [term.token for term in source.search('')])
+        self.assertIn('group:fa_users', [term.token for term in source.search('')])
+        self.assertNotIn('team:1', [term.token for term in source.search('')])
+
     def test_current_user_is_always_on_first_position_if_available(self):
         self.login(self.regular_user)
         source = PossibleWatchersSource(self.task)

--- a/opengever/workspace/tests/test_workspace_sources.py
+++ b/opengever/workspace/tests/test_workspace_sources.py
@@ -33,7 +33,6 @@ class TestWorkspaceSourcesProtection(IntegrationTestCase):
     BLACKLIST = [
         AllEmailContactsAndUsersSource,
         AllFilteredGroupsSource,
-        AllGroupsSource,
         AllUsersAndGroupsSource,
         AllUsersInboxesAndTeamsSource,
         ContactsSource,
@@ -47,6 +46,7 @@ class TestWorkspaceSourcesProtection(IntegrationTestCase):
         AssignedUsersSource,
         PotentialWorkspaceMembersSource,
         AllUsersSource,
+        AllGroupsSource,
     ]
 
     def test_whitelisted_teamraum_sources(self):
@@ -309,3 +309,39 @@ class TestAssignedUsersSource(IntegrationTestCase):
 
         self.assertEqual(1, len(source.search('hans')))
         self.assertEqual(self.workspace_guest.getId(), source.search('hans')[0].token)
+
+
+class TestWorkspaceAllGoupsSource(IntegrationTestCase):
+
+    features = ('workspace', )
+
+    def test_contains_only_whitelisted_groups(self):
+        self.login(self.regular_user)
+        source = AllGroupsSource(self.portal)
+
+        self.assertNotIn('fa_users', source)
+
+        with self.login(self.workspace_admin):
+            workspace_project_a = create(Builder('workspace').titled(u'Project A').within(self.workspace_root))
+            self.set_roles(workspace_project_a, self.regular_user.getId(), ['WorkspaceMember'])
+            self.set_roles(workspace_project_a, 'fa_users', ['WorkspaceGuest'])
+
+        clear_cache_visible_users_and_groups_filter_cache(self.request)
+
+        self.assertIn('fa_users', source)
+
+    def test_can_search_only_whitelisted_groups(self):
+        self.login(self.regular_user)
+        source = AllGroupsSource(self.portal)
+
+        self.assertEqual([], source.search('Users'))
+
+        with self.login(self.workspace_admin):
+            workspace_project_a = create(Builder('workspace').titled(u'Project A').within(self.workspace_root))
+            self.set_roles(workspace_project_a, self.regular_user.getId(), ['WorkspaceMember'])
+            self.set_roles(workspace_project_a, 'fa_users', ['WorkspaceGuest'])
+
+        clear_cache_visible_users_and_groups_filter_cache(self.request)
+
+        self.assertEqual(1, len(source.search('Users')))
+        self.assertEqual('fa_users', source.search('Users')[0].token)

--- a/opengever/workspace/tests/test_workspace_sources.py
+++ b/opengever/workspace/tests/test_workspace_sources.py
@@ -32,7 +32,6 @@ class TestWorkspaceSourcesProtection(IntegrationTestCase):
 
     BLACKLIST = [
         AllEmailContactsAndUsersSource,
-        AllFilteredGroupsSource,
         AllUsersAndGroupsSource,
         AllUsersInboxesAndTeamsSource,
         ContactsSource,
@@ -47,6 +46,7 @@ class TestWorkspaceSourcesProtection(IntegrationTestCase):
         PotentialWorkspaceMembersSource,
         AllUsersSource,
         AllGroupsSource,
+        AllFilteredGroupsSource,
     ]
 
     def test_whitelisted_teamraum_sources(self):


### PR DESCRIPTION
The PR #7986 extended the possible watchers from users only to watching users, groups and teams. This works fine for gever but not for teamraum.

The group source is not whitelisted in teamraum and teams do not exist in teamraum.

The PR fixes the issue by:
- Whitelist and protect the groups source for teamraum deployments
- only use the users and groups source for teamraum deployments and add the teams-source only for gever deployments.

For [TI-1221]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-1221]: https://4teamwork.atlassian.net/browse/TI-1221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ