### PR TITLE
Add configuration option to filter possible group watchers

### DIFF
--- a/changes/TI-1222.feature
+++ b/changes/TI-1222.feature
@@ -1,0 +1,1 @@
+Add configuration option to filter possible group watchers. [elioschmutz]

--- a/opengever/base/interfaces.py
+++ b/opengever/base/interfaces.py
@@ -342,6 +342,12 @@ class IBaseSettings(Interface):
         description=u'Makes backend errors accessible for users',
         default=False)
 
+    possible_watcher_groups_white_list_regex = schema.TextLine(
+        title=u'white list regex for possible watcher groups',
+        description=u'Regex pattern for groups which should be allowed as'
+        'possible watchers',
+        default=u"^.+")
+
 
 class ISearchSettings(Interface):
 

--- a/opengever/core/upgrades/20240919110844_add_possible_watchers_groups_white_list_setting/registry.xml
+++ b/opengever/core/upgrades/20240919110844_add_possible_watchers_groups_white_list_setting/registry.xml
@@ -1,0 +1,6 @@
+
+<registry>
+    <records interface="opengever.base.interfaces.IBaseSettings">
+        <value key="possible_watcher_groups_white_list_regex">^.+</value>
+    </records>
+</registry>

--- a/opengever/core/upgrades/20240919110844_add_possible_watchers_groups_white_list_setting/upgrade.py
+++ b/opengever/core/upgrades/20240919110844_add_possible_watchers_groups_white_list_setting/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddPossibleWatchersGroupsWhiteListSetting(UpgradeStep):
+    """Add possible watchers groups white list setting.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/ogds/base/sources.py
+++ b/opengever/ogds/base/sources.py
@@ -938,23 +938,21 @@ class CurrentAdminUnitOrgUnitsSourceBinder(object):
 class FilterMixin(object):
     """Filters the searched terms by white and black-listed groups
     """
-
-    def search(self, query_string):
-        terms = super(FilterMixin, self).search(query_string)
+    def terms_filter(self, term):
         black_list_prefix = api.portal.get_registry_record(
             'black_list_prefix', ISharingConfiguration)
         white_list_prefix = api.portal.get_registry_record(
             'white_list_prefix', ISharingConfiguration)
 
-        def terms_filter(term):
-            if re.search(black_list_prefix, term.value):
-                if re.search(white_list_prefix, term.value):
-                    return True
-                return False
-            return True
+        if re.search(black_list_prefix, term.value):
+            if re.search(white_list_prefix, term.value):
+                return True
+            return False
+        return True
 
-        terms = filter(terms_filter, terms)
-        return terms
+    def search(self, query_string):
+        terms = super(FilterMixin, self).search(query_string)
+        return filter(self.terms_filter, terms)
 
 
 class AllGroupsSource(BaseSQLModelSource):


### PR DESCRIPTION
This PR adds a new global configuration option to filter possible group watcher by a regex.

For [TI-1222]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-1222]: https://4teamwork.atlassian.net/browse/TI-1222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ