### PR TITLE
Make determining Solr facet labels more robust:

### DIFF
--- a/changes/TI-1210.bugfix
+++ b/changes/TI-1210.bugfix
@@ -1,0 +1,1 @@
+Make determining Solr facet labels more robust. [lgraf]

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -109,7 +109,7 @@ class SolrQueryBaseService(Service, RequestPayloadMixin):
                     continue
                 facet_counts[field.field_name][facet] = {
                     "count": count,
-                    "label": field.index_value_to_label(facet)
+                    "label": field.safe_index_value_to_label(facet)
                 }
 
         return facet_counts

--- a/opengever/base/tests/test_solr_listing_fields.py
+++ b/opengever/base/tests/test_solr_listing_fields.py
@@ -1,0 +1,21 @@
+from opengever.base.solr.fields import SimpleListingField
+from unittest import TestCase
+
+
+class MyCustomField(SimpleListingField):
+
+    def index_value_to_label(self, value):
+        colors = {'red': 'RED'}
+        return colors[value]
+
+
+class TestSolrListingFields(TestCase):
+
+    def test_safe_index_value_to_label(self):
+        field = MyCustomField('color')
+
+        with self.assertRaises(KeyError):
+            field.index_value_to_label('doesnt-exist')
+
+        self.assertEqual('RED', field.safe_index_value_to_label('red'))
+        self.assertEqual('doesnt-exist', field.safe_index_value_to_label('doesnt-exist'))


### PR DESCRIPTION
Solr may still return facet values for values that are not in the index any more, even after restarting Solr. So we may encounter facet values that refer to non-existent objects, like renamed OrgUnits.

In case of a missing facet label, logging will look like this:
```python
2024-09-19 13:58:56 ERROR opengever.base.solr Failed to transform value u'inbox:doesntexist' for field 'responsible':
2024-09-19 13:58:56 ERROR opengever.base.solr OrgUnit new for identifier inbox:doesntexist is missing.
Traceback (most recent call last):
  File "/opengever/base/solr/fields.py", line 308, in index_value_to_label
    transformed = self.transform(value)
  File "/eggs/plone.memoize-1.1.2-py2.7.egg/plone/memoize/volatile.py", line 71, in replacement
    cached_value = cache[key] = fun(*args, **kwargs)
  File "/opengever/base/helpers.py", line 26, in display_name
    return Actor.lookup(userid).get_label(with_principal=False)
  File "/opengever/ogds/base/actor.py", line 85, in lookup
    return ActorLookup(identifier, name_as_fallback=name_as_fallback).lookup()
  File "/opengever/ogds/base/actor.py", line 826, in lookup
    return self.create_inbox_actor()
  File "/opengever/ogds/base/actor.py", line 693, in create_inbox_actor
    org_unit_id, self.identifier)
AssertionError: OrgUnit new for identifier inbox:doesntexist is missing.
```


For [TI-1210](https://4teamwork.atlassian.net/browse/TI-1210)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)



[TI-1210]: https://4teamwork.atlassian.net/browse/TI-1210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ