### PR TITLE
Allow to close a disposition without any dossiers

### DIFF
--- a/changes/TI-942.other
+++ b/changes/TI-942.other
@@ -1,0 +1,1 @@
+Allow to submit no dossiers within a disposition. [elioschmutz]

--- a/opengever/disposition/browser/removal_protocol.py
+++ b/opengever/disposition/browser/removal_protocol.py
@@ -114,7 +114,7 @@ class RemovalProtocolLaTeXView(MakoLaTeXView):
             'label_dossiers': translate(
                 _('label_dossiers', default="Dossiers"), context=self.request),
             'dossier_listing': dossier_listener.get_listing(
-                self.context.get_dossier_representations()),
+                self.context.get_dossier_representations()) or '-',
             'label_history': translate(
                 _('label_history', default="History"), context=self.request),
             'history': history_listener.get_listing(

--- a/opengever/disposition/disposition.py
+++ b/opengever/disposition/disposition.py
@@ -232,8 +232,8 @@ class IDispositionSchema(model.Schema):
 
     dossiers = RelationList(
         title=_(u'label_dossiers', default=u'Dossiers'),
-        default=[],
-        missing_value=[],
+        default=list(),
+        missing_value=list(),
         value_type=RelationChoice(
             title=u"Dossier",
             source=SolrObjPathSourceBinder(

--- a/opengever/disposition/disposition.py
+++ b/opengever/disposition/disposition.py
@@ -246,7 +246,7 @@ class IDispositionSchema(model.Schema):
                      'opengever.dossier.behaviors.dossier.IDossierMarker'],
                 }),
         ),
-        required=True,
+        required=False,
     )
 
     write_permission(transfer_number='opengever.disposition.EditTransferNumber')

--- a/opengever/disposition/tests/test_disposition.py
+++ b/opengever/disposition/tests/test_disposition.py
@@ -95,9 +95,7 @@ class TestDisposition(SolrIntegrationTestCase):
                      data=data)
         browser.find('Save').click()
 
-        self.assertEquals(['There were some errors.'], error_messages())
-        self.assertEquals(['Required input is missing.'],
-                          browser.css('.fieldErrorBox .error').text)
+        self.assertEqual([], [rel.to_object for rel in browser.context.dossiers])
 
     @browsing
     def test_already_offered_dossiers_cant_be_selected(self, browser):


### PR DESCRIPTION
A user can create disposition by selecting dossiers in the dossier listing.

As soon as the disposition is created, each dossier will be turned into a new review state called: "offered". A user is now able to edit the disposition and remove dossiers which will trigger another workflow transition on dossiers to release them again.

A dossier which is already part of a disposition cannot be added to another disposition.

Currently, we have the following restrictions:
- a disposition cannot be removed
- a disposition requires at least one dossier

This is bad for the following situation: A user creates a disposition "Disposition A" with "Dossier A" and realized that it was a bad selection. There is already an existing disposition "Disposition B". There is no option to `abort` this process. The dossier cannot be used for "Disposition B" because it is already part of "Disposition A". Removing it from "Disposition A" is not possible because the user would need to find another dossier that the list of dossiers is not empty for "Disposition A". Removing the disposition is also not possible.

Implementing the functionality to remove disposition would be a lot of work. We'd need to extend the workflow and would need to add some logic for releasing the connected dossiers again. The delete-permissions in gever are also very strict. So we would need some custom implementation as we did it for repositories. 

That's why I decided to just allow an empty list of dossiers which seems to be a really quick fix for the main issue. By allowing an empty list, a user could now just remove the "Dossier A" and the "Disposition A" can be closed without any dossiers. 

https://github.com/user-attachments/assets/d69245bc-7f17-4a03-bbd9-9412416841a3


For [TI-942]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-942]: https://4teamwork.atlassian.net/browse/TI-942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ