### PR TITLE
Serialize pending signing job for documents

### DIFF
--- a/changes/TI-661.other
+++ b/changes/TI-661.other
@@ -1,0 +1,1 @@
+Document serialization provides pending_signing_job for a running sign process. [elioschmutz]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -23,6 +23,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
+- Add ``pending_signing_job`` attribute to serialized documents.
 
 
 2024.14.0 (2024-09-24)

--- a/opengever/api/document.py
+++ b/opengever/api/document.py
@@ -13,6 +13,8 @@ from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.document.versioner import Versioner
 from opengever.meeting import is_meeting_feature_enabled
 from opengever.meeting.model import SubmittedDocument
+from opengever.sign.sign import Signer
+from opengever.sign.utils import is_sign_feature_enabled
 from opengever.workspace.utils import is_restricted_workspace_and_guest
 from opengever.workspace.utils import is_within_workspace
 from opengever.workspaceclient import is_workspace_client_feature_enabled
@@ -77,6 +79,9 @@ class SerializeDocumentToJson(GeverSerializeToJson):
         if is_within_workspace(self.context):
             result[u'restrict_downloading_document'] = is_restricted_workspace_and_guest(self.context)
 
+        if is_sign_feature_enabled():
+            self.extend_with_pending_signing_job(result)
+
         additional_metadata = {
             'checked_out': checked_out_by,
             'checked_out_fullname': checked_out_by_fullname,
@@ -129,6 +134,9 @@ class SerializeDocumentToJson(GeverSerializeToJson):
                 result['meeting'] = {'title': meeting.title, '@id': meeting.get_url()}
         else:
             result['submitted_proposal'] = None
+
+    def extend_with_pending_signing_job(self, result):
+        result[u'pending_signing_job'] = Signer(self.context).serialize_pending_signing_job()
 
 
 class DocumentPatch(ContentPatch):

--- a/opengever/api/transition.py
+++ b/opengever/api/transition.py
@@ -385,7 +385,8 @@ class GEVERDocumentWorkflowTransition(GEVERWorkflowTransition):
     def reply(self):
         response = super(GEVERDocumentWorkflowTransition, self).reply()
         if self.transition in self.SIGNING_TRANSITIONS:
-            response['redirect_url'] = Signer(self.context).serialize().get('redirect_url')
+            response['redirect_url'] = Signer(
+                self.context).serialize_pending_signing_job().get('redirect_url')
         return response
 
 

--- a/opengever/core/testserver.py
+++ b/opengever/core/testserver.py
@@ -32,6 +32,7 @@ from zope.schema.vocabulary import SimpleTerm
 from zope.schema.vocabulary import SimpleVocabulary
 import atexit
 import imp
+import opengever.sign.client
 import os
 import pytz
 import transaction
@@ -41,6 +42,8 @@ SOLR_HOSTNAME = os.environ.get('SOLR_HOSTNAME', 'localhost')
 SOLR_PORT = os.environ.get('SOLR_PORT', '55003')
 SOLR_CORE = os.environ.get('SOLR_CORE', 'testserver')
 REUSE_RUNNING_SOLR = os.environ.get('TESTSERVER_REUSE_RUNNING_SOLR', None)
+
+opengever.sign.client.sign_service_client = opengever.sign.client.NullSignServiceClient()
 
 
 class SQLiteBackup(object):

--- a/opengever/document/tests/test_document_workflow.py
+++ b/opengever/document/tests/test_document_workflow.py
@@ -222,15 +222,21 @@ class TestDocumentWorkflow(IntegrationTestCase):
                           api.content.get_state(obj=self.document))
 
         self.assertEqual(self.regular_user.getId(), self.document.finalizer)
+
         self.assertDictEqual(
             {
-                'created': FROZEN_NOW,
+                'created': u'2024-02-18T15:45:00',
                 'job_id': '1',
                 'redirect_url': 'http://external.example.org/signing-requests/123',
-                'signers': ['foo@example.com'],
+                'signers': [
+                    {
+                        'email': 'foo@example.com',
+                        'userid': 'regular_user',
+                    }
+                ],
                 'userid': 'regular_user',
                 'version': 0
-            }, Signer(self.document).metadata_storage.read())
+            }, Signer(self.document).serialize_pending_signing_job())
 
     @requests_mock.Mocker()
     def test_can_start_signing_a_document_in_final_state(self, mocker):
@@ -251,13 +257,18 @@ class TestDocumentWorkflow(IntegrationTestCase):
 
         self.assertDictEqual(
             {
-                'created': FROZEN_NOW,
+                'created': u'2024-02-18T15:45:00',
                 'job_id': '1',
                 'redirect_url': 'http://external.example.org/signing-requests/123',
-                'signers': ['foo@example.com'],
+                'signers': [
+                    {
+                        'email': 'foo@example.com',
+                        'userid': 'regular_user',
+                    }
+                ],
                 'userid': 'regular_user',
                 'version': 0
-            }, Signer(self.document).metadata_storage.read())
+            }, Signer(self.document).serialize_pending_signing_job())
 
     @requests_mock.Mocker()
     def test_sign_transition_is_only_for_internal_use(self, mocker):

--- a/opengever/document/transition.py
+++ b/opengever/document/transition.py
@@ -105,6 +105,7 @@ class DocumentSigningSignedTransitionExtender(TransitionExtender):
             filename=self.get_file_name(),
             create_version=True,
             comment=translate(comment, context=self.request))
+        Signer(self.context).finish_signing()
 
     def get_file_name(self):
         filename, ext = os.path.splitext(self.context.get_filename())

--- a/opengever/document/transition.py
+++ b/opengever/document/transition.py
@@ -80,7 +80,6 @@ class DocumentSignedDraftTransitionExtender(TransitionExtender):
         manager = getMultiAdapter((self.context, self.request),
                                   ICheckinCheckoutManager)
         manager.revert_to_version(finalized_version_number)
-        Signer(self.context).clear_metadata()
 
 
 class ISignSchema(Schema):

--- a/opengever/sign/client.py
+++ b/opengever/sign/client.py
@@ -23,7 +23,7 @@ class SignServiceClient(object):
                   'document_uid': document.UID(),
                   'title': document.title_or_id(),
                   'signers': signers,
-                  })
+                  }).json()
 
     def abort_signing(self, job_id):
         if job_id is None:

--- a/opengever/sign/client.py
+++ b/opengever/sign/client.py
@@ -32,3 +32,6 @@ class SignServiceClient(object):
         return requests.delete(
             '{}/signing-jobs/{}'.format(self.sign_service_url, job_id),
             headers={"Accept": "application/json"})
+
+
+sign_service_client = SignServiceClient()

--- a/opengever/sign/client.py
+++ b/opengever/sign/client.py
@@ -34,4 +34,17 @@ class SignServiceClient(object):
             headers={"Accept": "application/json"})
 
 
+class NullSignServiceClient(object):
+
+    @property
+    def sign_service_url(self):
+        return environ.get('SIGN_SERVICE_URL', '').strip('/')
+
+    def queue_signing(self, document, token, signers):
+        return {}
+
+    def abort_signing(self, job_id):
+        pass
+
+
 sign_service_client = SignServiceClient()

--- a/opengever/sign/pending_signer.py
+++ b/opengever/sign/pending_signer.py
@@ -1,0 +1,25 @@
+from opengever.sign.utils import email_to_userid
+from persistent import Persistent
+from persistent.list import PersistentList
+from plone.restapi.serializer.converters import json_compatible
+
+
+class PendingSigners(PersistentList):
+    def serialize(self):
+        return json_compatible([pending_signer.serialize() for pending_signer in self])
+
+
+class PendingSigner(Persistent):
+    def __init__(self,
+                 userid='',
+                 email='',
+                 ):
+
+        self.userid = userid
+        self.email = email
+
+    def serialize(self):
+        return json_compatible({
+            'userid': self.userid if self.userid else email_to_userid(self.email),
+            'email': self.email,
+        })

--- a/opengever/sign/pending_signing_job.py
+++ b/opengever/sign/pending_signing_job.py
@@ -9,7 +9,7 @@ class PendingSigningJob(Persistent):
     def __init__(self,
                  created=None,
                  userid='',
-                 version='',
+                 version=0,
                  signers=list(),
                  job_id='',
                  redirect_url='',

--- a/opengever/sign/pending_signing_job.py
+++ b/opengever/sign/pending_signing_job.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+from opengever.sign.pending_signer import PendingSigner
+from opengever.sign.pending_signer import PendingSigners
+from persistent import Persistent
+from plone.restapi.serializer.converters import json_compatible
+
+
+class PendingSigningJob(Persistent):
+    def __init__(self,
+                 created=None,
+                 userid='',
+                 version='',
+                 signers=list(),
+                 job_id='',
+                 redirect_url='',
+                 ):
+
+        self.created = created or datetime.now()
+        self.userid = userid
+        self.version = version
+        self.signers = PendingSigners([PendingSigner(email=signer) for signer in signers])
+        self.job_id = job_id
+        self.redirect_url = redirect_url
+
+    def serialize(self):
+        return json_compatible({
+            'created': self.created,
+            'userid': self.userid,
+            'job_id': self.job_id,
+            'redirect_url': self.redirect_url,
+            'signers': self.signers.serialize(),
+            'version': self.version,
+        })

--- a/opengever/sign/sign.py
+++ b/opengever/sign/sign.py
@@ -2,7 +2,7 @@ from base64 import urlsafe_b64decode
 from base64 import urlsafe_b64encode
 from opengever.base.security import as_internal_workflow_transition
 from opengever.document.document import Document
-from opengever.sign.client import SignServiceClient
+from opengever.sign.client import sign_service_client
 from opengever.sign.pending_signing_job import PendingSigningJob
 from opengever.sign.storage import PendingSigningJobStorage
 from opengever.sign.token import TokenManager
@@ -32,7 +32,7 @@ class Signer(object):
 
     def start_signing(self, signers):
         token = self.issue_token()
-        response = SignServiceClient().queue_signing(self.context, token, signers)
+        response = sign_service_client.queue_signing(self.context, token, signers)
 
         self.pending_signing_job = PendingSigningJob(
             userid=api.user.get_current().id,
@@ -71,7 +71,7 @@ class Signer(object):
             return
 
         try:
-            SignServiceClient().abort_signing(pending_signing_job.job_id)
+            sign_service_client.abort_signing(pending_signing_job.job_id)
         except ConnectionError:
             # The user should always be able to abort the job
             pass

--- a/opengever/sign/sign.py
+++ b/opengever/sign/sign.py
@@ -33,7 +33,6 @@ class Signer(object):
     def start_signing(self, signers):
         token = self.issue_token()
         response = SignServiceClient().queue_signing(self.context, token, signers)
-        response = response.json()
 
         self.pending_signing_job = PendingSigningJob(
             userid=api.user.get_current().id,

--- a/opengever/sign/sign.py
+++ b/opengever/sign/sign.py
@@ -51,6 +51,9 @@ class Signer(object):
                 transition=Document.signing_signed_transition,
                 transition_params={'filedata': signed_pdf_data})
 
+    def finish_signing(self):
+        self.pending_signing_job_storage.clear()
+
     @property
     def pending_signing_job(self):
         return self.pending_signing_job_storage.load()

--- a/opengever/sign/storage.py
+++ b/opengever/sign/storage.py
@@ -1,9 +1,7 @@
-from datetime import datetime
-from opengever.base.utils import make_persistent
 from zope.annotation import IAnnotations
 
 
-class MetadataStorage(object):
+class PendingSigningJobStorage(object):
     """Responsible for storing metadata for a currently running sign process.
     """
 
@@ -13,24 +11,12 @@ class MetadataStorage(object):
         self.context = context
         self.annotations = IAnnotations(self.context)
 
-    def store(self, userid, version, signers, job_id, redirect_url):
-        self._set_data({
-            'created': datetime.now(),
-            'userid': userid,
-            'job_id': job_id,
-            'redirect_url': redirect_url,
-            'signers': signers,
-            'version': version,
-        })
+    def store(self, pending_signing_job):
+        self.annotations[self.ANNOTATIONS_KEY] = pending_signing_job
 
-    def read(self):
-        return self._get_data()
+    def load(self):
+        return self.annotations.get(self.ANNOTATIONS_KEY)
 
     def clear(self):
-        self._set_data({})
-
-    def _set_data(self, data):
-        self.annotations[self.ANNOTATIONS_KEY] = make_persistent(data)
-
-    def _get_data(self):
-        return dict(self.annotations.get(self.ANNOTATIONS_KEY, {}))
+        if self.ANNOTATIONS_KEY in self.annotations:
+            del self.annotations[self.ANNOTATIONS_KEY]

--- a/opengever/sign/storage.py
+++ b/opengever/sign/storage.py
@@ -5,7 +5,7 @@ class PendingSigningJobStorage(object):
     """Responsible for storing metadata for a currently running sign process.
     """
 
-    ANNOTATIONS_KEY = 'sign_data'
+    ANNOTATIONS_KEY = 'opengever.sign.pending_signing_job'
 
     def __init__(self, context):
         self.context = context

--- a/opengever/sign/tests/test_client.py
+++ b/opengever/sign/tests/test_client.py
@@ -21,7 +21,7 @@ class TestSigningClient(IntegrationTestCase):
 
         mocker.post(re.compile('/signing-jobs'), json=DEFAULT_MOCK_RESPONSE)
 
-        SignServiceClient().queue_signing(self.document, TOKEN, ['foo.bar@example.com'])
+        response = SignServiceClient().queue_signing(self.document, TOKEN, ['foo.bar@example.com'])
 
         self.assertDictEqual(
             {
@@ -34,6 +34,8 @@ class TestSigningClient(IntegrationTestCase):
                 u'upload_url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-14/@upload-signed-pdf', # noqa
             },
             mocker.last_request.json())
+
+        self.assertDictEqual(DEFAULT_MOCK_RESPONSE, response)
 
     def test_abort_signing_job(self, mocker):
         self.login(self.regular_user)

--- a/opengever/sign/tests/test_pending_signer.py
+++ b/opengever/sign/tests/test_pending_signer.py
@@ -1,0 +1,28 @@
+from opengever.sign.pending_signer import PendingSigner
+from opengever.sign.pending_signer import PendingSigners
+from opengever.testing import IntegrationTestCase
+
+
+class TestPendingSigner(IntegrationTestCase):
+    def test_can_be_serialized(self):
+        signer = PendingSigner(email='foo@example.com')
+
+        self.assertDictEqual(
+            {
+                'email': 'foo@example.com',
+                'userid': 'regular_user'
+            }, signer.serialize())
+
+
+class TestPendingSigners(IntegrationTestCase):
+    def test_can_be_serialized(self):
+        container = PendingSigners()
+        signer1 = PendingSigner(email='foo@example.com')
+        signer2 = PendingSigner(email='bar@example.com')
+
+        container.append(signer1)
+        container.append(signer2)
+
+        self.assertEqual(2, len(container.serialize()))
+        self.assertItemsEqual([signer2.email, signer1.email],
+                              [item.get('email') for item in container.serialize()])

--- a/opengever/sign/tests/test_pending_signing_job.py
+++ b/opengever/sign/tests/test_pending_signing_job.py
@@ -13,7 +13,7 @@ class TestPendingSigningJob(IntegrationTestCase):
             self.assertEqual(
                 FROZEN_NOW,
                 PendingSigningJob(userid='foo.bar',
-                                  version='0',
+                                  version=0,
                                   signers=[],
                                   job_id='0',
                                   redirect_url='').created
@@ -25,7 +25,7 @@ class TestPendingSigningJob(IntegrationTestCase):
         metadata = PendingSigningJob(
             created=FROZEN_NOW,
             userid='foo.bar',
-            version='1',
+            version=1,
             signers=['foo.bar@example.com'],
             job_id='1',
             redirect_url='redirect@example.com')
@@ -34,7 +34,7 @@ class TestPendingSigningJob(IntegrationTestCase):
             {
                 'created': u'2024-02-18T15:45:00',
                 'userid': 'foo.bar',
-                'version': '1',
+                'version': 1,
                 'signers': [
                     {
                         'email': 'foo.bar@example.com',

--- a/opengever/sign/tests/test_pending_signing_job.py
+++ b/opengever/sign/tests/test_pending_signing_job.py
@@ -1,0 +1,46 @@
+from datetime import datetime
+from ftw.testing import freeze
+from opengever.sign.pending_signing_job import PendingSigningJob
+from opengever.testing import IntegrationTestCase
+
+
+FROZEN_NOW = datetime(2024, 2, 18, 15, 45)
+
+
+class TestPendingSigningJob(IntegrationTestCase):
+    def test_create_function_sets_the_creation_date(self):
+        with freeze(FROZEN_NOW):
+            self.assertEqual(
+                FROZEN_NOW,
+                PendingSigningJob(userid='foo.bar',
+                                  version='0',
+                                  signers=[],
+                                  job_id='0',
+                                  redirect_url='').created
+            )
+
+    def test_can_be_serialized(self):
+        self.login(self.regular_user)
+
+        metadata = PendingSigningJob(
+            created=FROZEN_NOW,
+            userid='foo.bar',
+            version='1',
+            signers=['foo.bar@example.com'],
+            job_id='1',
+            redirect_url='redirect@example.com')
+
+        self.assertDictEqual(
+            {
+                'created': u'2024-02-18T15:45:00',
+                'userid': 'foo.bar',
+                'version': '1',
+                'signers': [
+                    {
+                        'email': 'foo.bar@example.com',
+                        'userid': '',
+                    }
+                ],
+                'job_id': '1',
+                'redirect_url': 'redirect@example.com'
+            }, metadata.serialize())

--- a/opengever/sign/tests/test_sign.py
+++ b/opengever/sign/tests/test_sign.py
@@ -70,7 +70,7 @@ class TestSigning(IntegrationTestCase):
         # signing-job should be removed
         self.assertEqual(1, delete_mocker.call_count)
 
-        # pending sign metadata-content should be cleared
+        # pending signing job should be cleared
         self.assertEqual({}, signer.serialize_pending_signing_job())
 
     def test_can_complete_signing_process(self, mocker):
@@ -88,3 +88,6 @@ class TestSigning(IntegrationTestCase):
 
         signed_version = Versioner(self.document).retrieve(1)
         self.assertEqual(u'<DATA>', signed_version.file.data)
+
+        # pending signing job should be cleared
+        self.assertEqual({}, signer.serialize_pending_signing_job())

--- a/opengever/sign/tests/test_sign.py
+++ b/opengever/sign/tests/test_sign.py
@@ -35,13 +35,13 @@ class TestSigning(IntegrationTestCase):
 
         self.assertDictEqual(
             {
-                'created': FROZEN_NOW,
+                'created': u'2024-02-18T15:45:00',
                 'job_id': '1',
                 'redirect_url': 'http://external.example.org/signing-requests/123',
-                'signers': ['foo.bar@example.com'],
+                'signers': [{u'email': u'foo.bar@example.com', u'userid': u''}],
                 'userid': 'regular_user',
                 'version': 0
-            }, signer.serialize())
+            }, signer.serialize_pending_signing_job())
 
     def test_can_issue_and_invalidate_tokens(self, mocker):
         self.login(self.regular_user)
@@ -70,8 +70,8 @@ class TestSigning(IntegrationTestCase):
         # signing-job should be removed
         self.assertEqual(1, delete_mocker.call_count)
 
-        # metadata-content should be cleared
-        self.assertEqual({}, signer.serialize())
+        # pending sign metadata-content should be cleared
+        self.assertEqual({}, signer.serialize_pending_signing_job())
 
     def test_can_complete_signing_process(self, mocker):
         self.login(self.regular_user)

--- a/opengever/sign/tests/test_storage.py
+++ b/opengever/sign/tests/test_storage.py
@@ -1,33 +1,17 @@
-from datetime import datetime
-from ftw.testing import freeze
-from opengever.sign.storage import MetadataStorage
+from opengever.sign.storage import PendingSigningJobStorage
 from opengever.testing import IntegrationTestCase
 
 
-FROZEN_NOW = datetime(2024, 2, 18, 15, 45)
-
-
-class TestMetadataStorage(IntegrationTestCase):
-    def test_can_store_metadata(self):
+class TestPendingSigningJobStorage(IntegrationTestCase):
+    def test_can_store_and_load_data(self):
         self.login(self.regular_user)
-        storage = MetadataStorage(self.document)
+        storage = PendingSigningJobStorage(self.document)
+        storage.store({'userid': 'foo.bar'})
 
-        with freeze(FROZEN_NOW):
-            storage.store(
-                userid='foo.bar',
-                version=1,
-                signers=['foo.bar@example.com'],
-                job_id='123',
-                redirect_url='http://example.com/sign-service'
-            )
+        self.assertDictEqual({'userid': 'foo.bar'}, storage.load())
 
-        self.assertDictEqual(
-            {
-                'created': FROZEN_NOW,
-                'job_id': '123',
-                'redirect_url': 'http://example.com/sign-service',
-                'signers': ['foo.bar@example.com'],
-                'userid': 'foo.bar',
-                'version': 1
-            },
-            storage.read())
+    def test_data_is_stored_on_the_context(self):
+        self.login(self.regular_user)
+        PendingSigningJobStorage(self.subdocument).store({'userid': 'foo.bar'})
+
+        self.assertIsNone(PendingSigningJobStorage(self.document).load())

--- a/opengever/sign/tests/test_utils.py
+++ b/opengever/sign/tests/test_utils.py
@@ -1,0 +1,18 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.sign.utils import email_to_userid
+from opengever.testing import IntegrationTestCase
+
+
+class TestEmailsToUserids(IntegrationTestCase):
+    def test_returns_an_empty_dict_if_no_emails_are_given(self):
+        self.assertEqual('', email_to_userid(None))
+        self.assertEqual('', email_to_userid(''))
+
+    def test_properly_lookup_userid_by_email(self):
+        create(Builder('ogds_user')
+               .having(userid='example.user',
+                       email='example@example.com'))
+
+        self.assertEqual('', email_to_userid('unknown@example.com'))
+        self.assertEqual('example.user', email_to_userid('example@example.com'))

--- a/opengever/sign/utils.py
+++ b/opengever/sign/utils.py
@@ -1,6 +1,15 @@
+from opengever.ogds.models.user import User
 from opengever.sign.interfaces import ISignSettings
 from plone import api
+from sqlalchemy import func
 
 
 def is_sign_feature_enabled():
     return api.portal.get_registry_record('is_feature_enabled', interface=ISignSettings)
+
+
+def email_to_userid(email):
+    if not email:
+        return ''
+    user = User.query.filter(func.lower(User.email) == email.lower()).first()
+    return user.userid if user else ''


### PR DESCRIPTION
This PR makes the pending signing state available for the frontend.

The current implementation has some issues when working with different versions and trying to make it visible to the UI. If we revise a signed document or revert to an old version, we'd loose the information about the signed documents and signers.

Currently, we provide `sign_metadata` which is in fact the `pending_signing_job` state. It gives us information about a pending signing process like the job-id, redirect url and the signers. this could also contain the current state of signers, i.e. who has aborted or not yet signed the document.

But there should be another state, the `signatures`-state itself. This should give us a finalized info about which version is signed by which users. So as soon as the signing-process is finished, the `pending_signing_job` should be removed and all the relevant information should be stored in a list which can then be used when serializing versions or the context itself. 

This allows us to really mark signed versions in the UI, remember reverted signed versions and to separate a pending signing job which can change over time from the effectively signed persistent state.

So this PR introduces the following changes:
- moves all the pending signing job related data to its own persistent classes
- clears the pending signing job state after completing or aborting the signing process
- exposes the pending signing job state for serialized documents
- provides a fake sign service client to make e2e testing possible

I also renamed the annotations key. Since we do not have the sign-feature in production right now we can safely do that without an upgradestep.

For [TI-661]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[TI-661]: https://4teamwork.atlassian.net/browse/TI-661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ