### PR TITLE
Change docs publishing server

### DIFF
--- a/sphinx.cfg
+++ b/sphinx.cfg
@@ -64,7 +64,7 @@ inline =
     #!/bin/bash
     export SPHINX_PUBLICATION_LEVEL="published"
     bin/docs-build-public dirhtml
-    rsync -O --chmod=ug+rw,Dg+s -v -a --delete docs/public/_build/dirhtml/* seth.4teamwork.ch:/var/www/docs.onegovgever.ch/
+    rsync -O --chmod=ug+rw,Dg+s -v -a --delete docs/public/_build/dirhtml/* web06p.4teamwork.ch:/var/www/docs.onegovgever.ch/
 
 output = ${buildout:bin-directory}/docs-build-and-publish-public
 mode = 755
@@ -118,7 +118,7 @@ inline =
     #!/bin/bash
     export SPHINX_PUBLICATION_LEVEL="published"
     bin/docs-build-public-fr dirhtml
-    rsync -O --chmod=ug+rw,Dg+s -v -a --delete docs/public-fr/_build/dirhtml/* seth.4teamwork.ch:/var/www/docs-fr.onegovgever.ch/
+    rsync -O --chmod=ug+rw,Dg+s -v -a --delete docs/public-fr/_build/dirhtml/* web06p.4teamwork.ch:/var/www/docs-fr.onegovgever.ch/
 
 output = ${buildout:bin-directory}/docs-build-and-publish-public-fr
 mode = 755
@@ -162,7 +162,7 @@ inline =
     #!/bin/bash
     export SPHINX_PUBLICATION_LEVEL="published"
     bin/docs-build-intern dirhtml
-    rsync -O --chmod=ug+rw,Dg+s -v -a --delete docs/intern/_build/dirhtml/* seth.4teamwork.ch:/var/www/intern.onegovgever.ch/
+    rsync -O --chmod=ug+rw,Dg+s -v -a --delete docs/intern/_build/dirhtml/* web06p.4teamwork.ch:/var/www/intern.onegovgever.ch/
 
 output = ${buildout:bin-directory}/docs-build-and-publish-intern
 mode = 755


### PR DESCRIPTION
Decommission Centos 7 Server seth.4teamwork.ch and use web06p.4teamwork.ch for future publishing of onegovgever docs.
