### PR TITLE
Implement and serialize signatures

### DIFF
--- a/changes/TI-661-2.other
+++ b/changes/TI-661-2.other
@@ -1,0 +1,1 @@
+Document serialization provides signature information about signed versions. [elioschmutz]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -24,6 +24,7 @@ Breaking Changes
 Other Changes
 ^^^^^^^^^^^^^
 - Add ``pending_signing_job`` attribute to serialized documents.
+- Add ``signatures_by_version`` attribute to serialized documents.
 
 
 2024.14.0 (2024-09-24)

--- a/docs/public/dev-manual/api/documents_sign.rst
+++ b/docs/public/dev-manual/api/documents_sign.rst
@@ -51,3 +51,58 @@ Der Endpoint löst eine interne Workflow-Transition auf dem Dokument aus, die au
 - ``signed_pdf_data``: Die signierten PDF-Daten im Base64-Format, die der externe Service nach der Signatur erzeugt hat.
 
 Sobald das Dokument erfolgreich durch den externen Signaturservice signiert wurde, wird das Dokument in den Status **Signiert** versetzt.
+
+Informationen über die Signaturen abrufen
+-----------------------------------------
+Ein GET-Request auf ein Dokument stellt verschiedene Informationen zu einem aktuellen Signierungs-Auftrag oder zu bereits signierten Versionen zur Verfügung:
+
+  .. sourcecode:: http
+
+    GET /ordnungssystem/dossier-23/document-21 HTTP/1.1
+    Accept: application/json
+
+  .. sourcecode:: http
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    {
+        "@id": "/ordnungssystem/dossier-23/document-21",
+        "...": "...",
+        "pending_signing_job": {
+            "created": "2024-02-18T15:45:00",
+            "userid": "foo.bar",
+            "version": 4,
+            "signers": [
+                {
+                    "email": "foo.bar@example.com",
+                    "userid": ""
+                }
+            ],
+            "job_id": "1",
+            "redirect_url": "redirect@example.com"
+        },
+        "signatures_by_version": {
+            "1": {
+                "id": "abc-123",
+                "version": 1,
+                "created": "2024-02-18T15:45:00",
+                "signatories": [
+                    {
+                        "email": "bar@example.com",
+                        "userid": "bar.example"
+                    },
+                    {
+                        "email": "foor@example.com",
+                        "userid": ""
+                    }
+                ]
+            }
+        }
+    }
+
+**Wichtige:**
+
+Die Version eines aktuellen Signierungs-Auftrages (``pending_signing_job``) zeigt an, welche Version von den Benutzern signiert wird.
+Wenn alle Benutzer das Dokument signiert haben, wird eine neue Version vom Dokument mit dem signierten Dokument erstellt.
+Die Versionen unter den ``signatures_by_version`` zeigt an, welche Versionen effektiv die signierten Daten enthalten.

--- a/opengever/api/document.py
+++ b/opengever/api/document.py
@@ -81,6 +81,7 @@ class SerializeDocumentToJson(GeverSerializeToJson):
 
         if is_sign_feature_enabled():
             self.extend_with_pending_signing_job(result)
+            self.extend_with_signatures(result)
 
         additional_metadata = {
             'checked_out': checked_out_by,
@@ -137,6 +138,9 @@ class SerializeDocumentToJson(GeverSerializeToJson):
 
     def extend_with_pending_signing_job(self, result):
         result[u'pending_signing_job'] = Signer(self.context).serialize_pending_signing_job()
+
+    def extend_with_signatures(self, result):
+        result[u'signatures_by_version'] = Signer(self.context).serialize_signed_versions()
 
 
 class DocumentPatch(ContentPatch):

--- a/opengever/sign/pending_signer.py
+++ b/opengever/sign/pending_signer.py
@@ -1,3 +1,5 @@
+from opengever.sign.signatory import Signatories
+from opengever.sign.signatory import Signatory
 from opengever.sign.utils import email_to_userid
 from persistent import Persistent
 from persistent.list import PersistentList
@@ -7,6 +9,9 @@ from plone.restapi.serializer.converters import json_compatible
 class PendingSigners(PersistentList):
     def serialize(self):
         return json_compatible([pending_signer.serialize() for pending_signer in self])
+
+    def to_signatories(self):
+        return Signatories([pending_signer.to_signatory() for pending_signer in self])
 
 
 class PendingSigner(Persistent):
@@ -20,6 +25,13 @@ class PendingSigner(Persistent):
 
     def serialize(self):
         return json_compatible({
-            'userid': self.userid if self.userid else email_to_userid(self.email),
+            'userid': self.resolved_userid(),
             'email': self.email,
         })
+
+    def resolved_userid(self):
+        return self.userid if self.userid else email_to_userid(self.email)
+
+    def to_signatory(self):
+        return Signatory(userid=self.resolved_userid(),
+                         email=self.email)

--- a/opengever/sign/pending_signing_job.py
+++ b/opengever/sign/pending_signing_job.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from opengever.sign.pending_signer import PendingSigner
 from opengever.sign.pending_signer import PendingSigners
+from opengever.sign.signed_version import SignedVersion
 from persistent import Persistent
 from plone.restapi.serializer.converters import json_compatible
 
@@ -31,3 +32,9 @@ class PendingSigningJob(Persistent):
             'signers': self.signers.serialize(),
             'version': self.version,
         })
+
+    def to_signed_version(self):
+        return SignedVersion(
+            signatories=self.signers.to_signatories(),
+            version=self.version + 1
+        )

--- a/opengever/sign/signatory.py
+++ b/opengever/sign/signatory.py
@@ -1,0 +1,20 @@
+from persistent import Persistent
+from persistent.list import PersistentList
+from plone.restapi.serializer.converters import json_compatible
+
+
+class Signatories(PersistentList):
+    def serialize(self):
+        return json_compatible([signatory.serialize() for signatory in self])
+
+
+class Signatory(Persistent):
+    def __init__(self, userid='', email=''):
+        self.userid = userid
+        self.email = email
+
+    def serialize(self):
+        return json_compatible({
+            'userid': self.userid,
+            'email': self.email,
+        })

--- a/opengever/sign/signed_version.py
+++ b/opengever/sign/signed_version.py
@@ -1,0 +1,47 @@
+from datetime import datetime
+from opengever.sign.signatory import Signatories
+from persistent import Persistent
+from persistent.dict import PersistentDict
+from plone.restapi.serializer.converters import json_compatible
+from uuid import uuid4
+
+
+class SignedVersions(PersistentDict):
+    def add_signed_version(self, signed_version):
+        if signed_version.version in self:
+            raise Exception("Signed version %s already exists" % signed_version.version)
+
+        self[signed_version.version] = signed_version
+
+    def serialize(self):
+        return json_compatible(
+            {
+                version_id: version_item.serialize() for version_id, version_item in self.items()
+            })
+
+
+class SignedVersion(Persistent):
+    def __init__(self,
+                 id_=None,
+                 created=None,
+                 signatories=Signatories(),
+                 version=0,
+                 ):
+
+        if not isinstance(signatories, Signatories):
+            raise TypeError(
+                "Expected 'signatories' to be of type Signatories - "
+                "got %r instead" % signatories)
+
+        self.id_ = id_ or str(uuid4())
+        self.created = created or datetime.now()
+        self.version = version
+        self.signatories = signatories
+
+    def serialize(self):
+        return json_compatible({
+            'id': self.id_,
+            'created': self.created,
+            'signatories': self.signatories.serialize(),
+            'version': self.version,
+        })

--- a/opengever/sign/storage.py
+++ b/opengever/sign/storage.py
@@ -1,3 +1,4 @@
+from opengever.sign.signed_version import SignedVersions
 from zope.annotation import IAnnotations
 
 
@@ -20,3 +21,19 @@ class PendingSigningJobStorage(object):
     def clear(self):
         if self.ANNOTATIONS_KEY in self.annotations:
             del self.annotations[self.ANNOTATIONS_KEY]
+
+
+class SignedVersionsStorage(object):
+    """Storage for signed versions.
+    """
+
+    ANNOTATIONS_KEY = 'opengever.sign.signed_versions'
+
+    def __init__(self, context):
+        self.context = context
+        self.annotations = IAnnotations(self.context)
+
+    def load(self, auto_init=True):
+        if auto_init and self.ANNOTATIONS_KEY not in self.annotations:
+            self.annotations[self.ANNOTATIONS_KEY] = SignedVersions()
+        return self.annotations.get(self.ANNOTATIONS_KEY)

--- a/opengever/sign/tests/test_pending_signer.py
+++ b/opengever/sign/tests/test_pending_signer.py
@@ -13,6 +13,15 @@ class TestPendingSigner(IntegrationTestCase):
                 'userid': 'regular_user'
             }, signer.serialize())
 
+    def test_can_be_converted_to_a_signatory(self):
+        signer = PendingSigner(email='foo@example.com')
+
+        self.assertDictEqual(
+            {
+                'email': 'foo@example.com',
+                'userid': 'regular_user',
+            }, signer.to_signatory().serialize())
+
 
 class TestPendingSigners(IntegrationTestCase):
     def test_can_be_serialized(self):
@@ -26,3 +35,11 @@ class TestPendingSigners(IntegrationTestCase):
         self.assertEqual(2, len(container.serialize()))
         self.assertItemsEqual([signer2.email, signer1.email],
                               [item.get('email') for item in container.serialize()])
+
+    def test_can_be_converted_to_signatories(self):
+        container = PendingSigners()
+
+        container.append(PendingSigner())
+        container.append(PendingSigner())
+
+        self.assertEqual(2, len(container.to_signatories()))

--- a/opengever/sign/tests/test_signatory.py
+++ b/opengever/sign/tests/test_signatory.py
@@ -1,0 +1,37 @@
+from opengever.sign.signatory import Signatories
+from opengever.sign.signatory import Signatory
+from opengever.testing import IntegrationTestCase
+
+
+class TestSignatory(IntegrationTestCase):
+    def test_can_be_serialized(self):
+        signatory = Signatory(email='foo@example.com', userid='regular_user')
+
+        self.assertDictEqual(
+            {
+                'email': 'foo@example.com',
+                'userid': 'regular_user'
+            }, signatory.serialize())
+
+    def test_does_not_auto_lookup_userid(self):
+        signatory = Signatory(email='foo@example.com')
+
+        self.assertDictEqual(
+            {
+                'email': 'foo@example.com',
+                'userid': '',
+            }, signatory.serialize())
+
+
+class TestSignatories(IntegrationTestCase):
+    def test_can_be_serialized(self):
+        container = Signatories()
+        signatory1 = Signatory(email='foo@example.com')
+        signatory2 = Signatory(email='bar@example.com')
+
+        container.append(signatory1)
+        container.append(signatory2)
+
+        self.assertEqual(2, len(container.serialize()))
+        self.assertItemsEqual([signatory2.email, signatory1.email],
+                              [item.get('email') for item in container.serialize()])

--- a/opengever/sign/tests/test_signed_version.py
+++ b/opengever/sign/tests/test_signed_version.py
@@ -1,0 +1,75 @@
+from datetime import datetime
+from ftw.testing import freeze
+from opengever.sign.signatory import Signatories
+from opengever.sign.signatory import Signatory
+from opengever.sign.signed_version import SignedVersion
+from opengever.sign.signed_version import SignedVersions
+from opengever.testing import IntegrationTestCase
+
+
+FROZEN_NOW = datetime(2024, 2, 18, 15, 45)
+
+
+class TestSignedVersion(IntegrationTestCase):
+    def test_constructor_sets_the_creation_date(self):
+        with freeze(FROZEN_NOW):
+            self.assertEqual(FROZEN_NOW, SignedVersion().created)
+
+    def test_constructor_sets_a_new_uuid(self):
+        self.assertNotEqual(SignedVersion().id_, SignedVersion().id_)
+
+    def test_can_be_serialized(self):
+        signatories = Signatories([Signatory(email='foo@example.com')])
+
+        signed_version = SignedVersion(
+            id_="1",
+            created=FROZEN_NOW,
+            signatories=signatories,
+            version=1)
+
+        self.assertDictEqual(
+            {
+                'id': signed_version.id_,
+                'created': u'2024-02-18T15:45:00',
+                'signatories': [
+                    {
+                        'email': 'foo@example.com',
+                        'userid': ''
+                    }
+                ],
+                'version': 1
+            }, signed_version.serialize())
+
+
+class TestSignedVersions(IntegrationTestCase):
+    def test_can_be_serialized(self):
+        signatories = Signatories([Signatory(email='foo@example.com')])
+        signed_version_1 = SignedVersion(
+            id_=u"1",
+            created=FROZEN_NOW,
+            signatories=signatories,
+            version=1)
+
+        signed_version_2 = SignedVersion(
+            id_=u"1",
+            created=FROZEN_NOW,
+            version=2)
+
+        container = SignedVersions()
+        container.add_signed_version(signed_version_1)
+        container.add_signed_version(signed_version_2)
+
+        self.assertDictEqual({
+            1: {
+                u'created': u'2024-02-18T15:45:00',
+                u'id': u'1',
+                u'signatories': [{u'email': u'foo@example.com', u'userid': u''}],
+                u'version': 1
+            },
+            2: {
+                u'created': u'2024-02-18T15:45:00',
+                u'id': u'1',
+                u'signatories': [],
+                u'version': 2
+            }
+        }, container.serialize())

--- a/opengever/sign/tests/test_storage.py
+++ b/opengever/sign/tests/test_storage.py
@@ -1,4 +1,6 @@
+from opengever.sign.signed_version import SignedVersion
 from opengever.sign.storage import PendingSigningJobStorage
+from opengever.sign.storage import SignedVersionsStorage
 from opengever.testing import IntegrationTestCase
 
 
@@ -15,3 +17,14 @@ class TestPendingSigningJobStorage(IntegrationTestCase):
         PendingSigningJobStorage(self.subdocument).store({'userid': 'foo.bar'})
 
         self.assertIsNone(PendingSigningJobStorage(self.document).load())
+
+
+class TestSignedVersionStorage(IntegrationTestCase):
+    def test_can_load_and_persist_data(self):
+        self.login(self.regular_user)
+
+        SignedVersionsStorage(self.document).load().add_signed_version(SignedVersion(id_=1, version=5))
+        SignedVersionsStorage(self.document).load().add_signed_version(SignedVersion(id_=2, version=6))
+
+        signed_versions = SignedVersionsStorage(self.document).load().serialize()
+        self.assertEqual([5, 6], signed_versions.keys())


### PR DESCRIPTION
This PR is a follow-up PR of #8050 

Currently, we only track pending signing jobs on a document. As soon as the document sign process is completed, we do not have any information about the signatories or which versions has been signed.

This PR adds a storage for `signature items` and provides it through the api.

A new signature item will be created and persisted as soon as the signing process will be completed (all the requested signatories have been signed the document). 

In a pending signing job, we're just working with email addresses and will provide actor-ids on the fly when serializing it. This is what we want because the underlying actor could still change. As soon as the signature job is completed, we need to make sure, that the underlying actor does no longer change. We do this by effectively store the actor-ids of internal users instead of their email. But we still keep the email addresses for external users. This guarantees that its not possible to implicitly change the signatory by assigning the email address to another user in the future.

For [TI-661]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-661]: https://4teamwork.atlassian.net/browse/TI-661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ