### PR TITLE
Fixes nested tasktemplates on the first level

### DIFF
--- a/changes/TI-1300.bugfix
+++ b/changes/TI-1300.bugfix
@@ -1,0 +1,1 @@
+Fix creating nested parallel task template containing a sequential template. [elioschmutz]

--- a/opengever/api/tests/test_process.py
+++ b/opengever/api/tests/test_process.py
@@ -1043,7 +1043,7 @@ class TestProcessInitialTaskStates(IntegrationTestCase):
                     'review_state': TASK_STATE_IN_PROGRESS,
                     'items': [
                         {
-                            'review_state': TASK_STATE_OPEN,
+                            'review_state': TASK_STATE_IN_PROGRESS,
                             'items': [
                                 {'review_state': TASK_STATE_OPEN},
                                 {'review_state': TASK_STATE_PLANNED}
@@ -1087,9 +1087,9 @@ class TestProcessInitialTaskStates(IntegrationTestCase):
             'review_state': TASK_STATE_IN_PROGRESS,
             'items': [
                 {
-                    'review_state': TASK_STATE_PLANNED,
+                    'review_state': TASK_STATE_IN_PROGRESS,
                     'items': [
-                        {'review_state': TASK_STATE_PLANNED},
+                        {'review_state': TASK_STATE_OPEN},
                         {'review_state': TASK_STATE_PLANNED}],
                 },
                 {
@@ -1108,9 +1108,9 @@ class TestProcessInitialTaskStates(IntegrationTestCase):
                     ],
                 },
                 {
-                    'review_state': TASK_STATE_PLANNED,
+                    'review_state': TASK_STATE_IN_PROGRESS,
                     'items': [
-                        {'review_state': TASK_STATE_PLANNED},
+                        {'review_state': TASK_STATE_OPEN},
                         {'review_state': TASK_STATE_PLANNED}
                     ],
                 }
@@ -1147,9 +1147,9 @@ class TestProcessInitialTaskStates(IntegrationTestCase):
             'review_state': TASK_STATE_IN_PROGRESS,
             'items': [
                 {
-                    'review_state': TASK_STATE_PLANNED,
+                    'review_state': TASK_STATE_IN_PROGRESS,
                     'items': [
-                        {'review_state': TASK_STATE_PLANNED},
+                        {'review_state': TASK_STATE_OPEN},
                         {'review_state': TASK_STATE_PLANNED}],
                 },
                 {
@@ -1168,9 +1168,9 @@ class TestProcessInitialTaskStates(IntegrationTestCase):
                     ],
                 },
                 {
-                    'review_state': TASK_STATE_PLANNED,
+                    'review_state': TASK_STATE_IN_PROGRESS,
                     'items': [
-                        {'review_state': TASK_STATE_PLANNED},
+                        {'review_state': TASK_STATE_OPEN},
                         {'review_state': TASK_STATE_PLANNED}
                     ],
                 }

--- a/opengever/task/__init__.py
+++ b/opengever/task/__init__.py
@@ -29,6 +29,8 @@ FINISHED_TASK_STATES = [
 
 TASK_STATE_PLANNED = 'task-state-planned'
 
+TASK_STATE_OPEN = 'task-state-open'
+
 TASK_STATE_SKIPPED = 'task-state-skipped'
 
 TASK_STATE_IN_PROGRESS = 'task-state-in-progress'

--- a/opengever/task/handlers.py
+++ b/opengever/task/handlers.py
@@ -99,7 +99,8 @@ def review_state_changed(task, event):
 
     # If we start working on a subtask always means that we're also working
     # on the parent task. We need to ensure, that every parent task is in progress.
-    if event.action not in ['task-transition-planned-open',
+    if event.action not in ['task-transition-open-planned',
+                            'task-transition-planned-open',
                             'task-transition-rejected-skipped',
                             'task-transition-reassign']:
         task.maybe_start_parent_task()

--- a/opengever/task/tests/test_task_from_template.py
+++ b/opengever/task/tests/test_task_from_template.py
@@ -432,7 +432,7 @@ class TestSequentialTaskProcess(IntegrationTestCase):
         self.assertEquals(doc, subprocess_task1.relatedItems[0].to_object)
 
         self.assertEquals(
-            'task-state-open', api.content.get_state(subprocess_task2))
+            'task-state-in-progress', api.content.get_state(subprocess_task2))
         self.assertEquals(doc, subprocess_task2.relatedItems[0].to_object)
 
         self.assertEquals(
@@ -485,7 +485,7 @@ class TestSequentialTaskProcess(IntegrationTestCase):
         )
 
         self.assertEquals(
-            'task-state-open', api.content.get_state(subprocess_task1))
+            'task-state-in-progress', api.content.get_state(subprocess_task1))
         self.assertEquals(doc, subprocess_task1.relatedItems[0].to_object)
 
         self.assertEquals(


### PR DESCRIPTION
This PR fixes the initial state of tasks created from a task template.

To make it clear what really changes through this PR, the first  commit provides a bunch of missing tests of the current implementation which will then be updated with the bugfix.

Here is an example of what changes through this PR: If I start a process with the following structure:

- Parallel Task
  - Task 1
  - Task 2
  - Sequential Task
    - Task 3
    - Task 4

The tasks where started in the following states:

- Parallel Task (in Progress)
  - Task 1 (open)
  - Task 2 (open)
  - Sequential Task (planned)
    - Task 3 (planned)
    - Task 4 (planned)

With the fix, it would create tasks in the following states:

- Parallel Task (in Progress)
  - Task 1 (open)
  - Task 2 (open)
  - Sequential Task (in Progress)
    - Task 3 (open)
    - Task 4 (planned)


## Before
![Bildschirmfoto 2024-10-02 um 08 43 38](https://github.com/user-attachments/assets/ce7bccff-3021-43e9-9801-d887db53e8b9)


## After
![Bildschirmfoto 2024-10-02 um 08 37 39](https://github.com/user-attachments/assets/1730392c-5fea-47f0-9706-7d3814495c88)


For [TI-1300]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[TI-1300]: https://4teamwork.atlassian.net/browse/TI-1300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ