### PR TITLE
Allow downloading checked-out documents with no modifications

### DIFF
--- a/changes/TI-675.bugfix
+++ b/changes/TI-675.bugfix
@@ -1,0 +1,1 @@
+Allow downloading checked-out documents with no modifications and only an initial version. [buchi]

--- a/opengever/document/browser/download.py
+++ b/opengever/document/browser/download.py
@@ -50,11 +50,8 @@ class DocumentishDownload(Download):
 
         if self.is_checked_out_by_another_user():
             current_version_id = self.context.get_current_version_id()
-            if current_version_id is None:
-                raise BadRequest('The document is checked out by another user '
-                                 'and there is no current version to download.')
-
-            self.request['version_id'] = current_version_id
+            if current_version_id is not None:
+                self.request['version_id'] = current_version_id
             return DocumentDownloadFileVersion(self.context, self.request)()
 
         DownloadConfirmationHelper(self.context).process_request_form()


### PR DESCRIPTION
Until now we prevented downloading documents with no versions that are checked out by another user. This doesn't make sense as this is only the case when the document hasn't been modified yet. As soon as the document is modified, the initial version is created and used for downloads.

For [TI-675](https://4teamwork.atlassian.net/browse/TI-675)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)



[TI-675]: https://4teamwork.atlassian.net/browse/TI-675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ