### PR TITLE
Fix logging in upgrade command

### DIFF
--- a/changes/GH-8056.bugfix
+++ b/changes/GH-8056.bugfix
@@ -1,0 +1,1 @@
+Fix logging when installing upgrades with upgrade command. [buchi]

--- a/opengever/setup/zopectl.py
+++ b/opengever/setup/zopectl.py
@@ -238,4 +238,4 @@ def setup_logging():
     # to make sure output gets logged on console
     stream_handler = logging.root.handlers[0]
     stream_handler.setLevel(logging.INFO)
-    logger.setLevel(logging.INFO)
+    logging.root.setLevel(logging.INFO)


### PR DESCRIPTION
Set log level for root logger instead of "opengever.setup" logger only. This way we also get the logs from ftw.upgrade at INFO level.

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)
