### PR TITLE
Cron time window

### DIFF
--- a/changes/GH-8058.other
+++ b/changes/GH-8058.other
@@ -1,0 +1,1 @@
+Run cron jobs in Docker deployments within a time window to avoid high load peaks on servers with multiple deployments. [buchi]

--- a/docker/core/Dockerfile
+++ b/docker/core/Dockerfile
@@ -76,7 +76,7 @@ RUN chown -R plone:plone /app/etc
 COPY ./docker/core/entrypoint.d /app/entrypoint.d
 COPY ./docker/core/docker-entrypoint.sh ./docker/core/inituser /app/
 COPY ./docker/core/zopectl /app/bin/
-COPY ./docker/core/cron /app/cron
+COPY --chown=plone ./docker/core/cron /app/cron
 
 RUN mkdir -p /app/var/log /app/var/instance \
  && chown plone:plone /app/var/log \

--- a/docker/core/cron/crontab
+++ b/docker/core/cron/crontab
@@ -3,3 +3,4 @@
 30 4 * * * /app/bin/zopectl -C /app/etc/zope.conf generate_overdue_notifications
 0 1 * * * /app/bin/zopectl -C /app/etc/zope.conf run_nightly_jobs
 0 22 * * * /app/bin/zopectl -C /app/etc/zope.conf dump_content_stats --python-du -d /data --filestorage-path filestorage/Data.fs --blobstorage-path blobstorage
+0 23 * * * /app/bin/zeopack -d 7 zeoserver:8100

--- a/docker/core/docker-entrypoint.sh
+++ b/docker/core/docker-entrypoint.sh
@@ -11,6 +11,7 @@ python /app/entrypoint.d/create_zope_conf.py "$CONFIG_FILE"
 python /app/entrypoint.d/create_ogds_zcml.py
 python /app/entrypoint.d/create_solr_zcml.py
 python /app/entrypoint.d/create_package_includes.py
+python /app/entrypoint.d/create_crontab.py
 
 if [ $# -eq 0 ]
 then

--- a/docker/core/entrypoint.d/create_crontab.py
+++ b/docker/core/entrypoint.d/create_crontab.py
@@ -1,0 +1,53 @@
+# Create crontab file with start times depending on deployment number to avoid
+# starting cron jobs at the same time.
+from os import environ
+
+
+# Cron jobs: tuples of (from, until, cmd)
+CRON_JOBS = [
+    ('22', '22:30', '/app/bin/zopectl -C /app/etc/zope.conf dump_content_stats --python-du -d /data --filestorage-path filestorage/Data.fs --blobstorage-path blobstorage'),
+    ('23', '24', '/app/bin/zeopack -d 7 zeoserver:8100'),
+    ('1', '2', '/app/bin/zopectl -C /app/etc/zope.conf run_nightly_jobs'),
+    ('4', '4:20', '/app/bin/zopectl -C /app/etc/zope.conf generate_remind_notifications'),
+    ('4:30', '4:50', '/app/bin/zopectl -C /app/etc/zope.conf generate_overdue_notifications'),
+    ('6', '6:15', '/app/bin/zopectl -C /app/etc/zope.conf send_digest'),
+]
+
+
+def safe_int(value, default=1):
+    try:
+        return int(value)
+    except (ValueError, TypeError):
+        return default
+
+
+def parse_minutes(value):
+    hours = int(value.split(':')[0])
+    minutes = 0
+    if ':' in value:
+        minutes = int(value.split(':')[1])
+    return hours * 60 + minutes
+
+
+def main():
+    if environ.get('CRON_SKIP_GENERATION', '').lower() in ['1', 'true', 'yes']:
+        return
+
+    start_slot = safe_int(environ.get('CRON_START_SLOT', environ.get('DEPLOYMENT_NUMBER', '01')))
+    max_start_slots = safe_int(environ.get('CRON_MAX_START_SLOTS', '12'), default=12)
+    start_slot = (start_slot - 1) % max_start_slots + 1
+
+    with open('/app/cron/crontab', 'w') as cronfile:
+        for job in CRON_JOBS:
+            from_minutes = parse_minutes(job[0])
+            until_minutes = parse_minutes(job[1])
+            window_minutes = until_minutes - from_minutes
+            delta = window_minutes / float(max_start_slots)
+            start_minutes = from_minutes + delta * (start_slot - 1)
+            hours = int(start_minutes // 60)
+            minutes = int(start_minutes % 60)
+            cronfile.write('{} {} * * * {}\n'.format(minutes, hours, job[2]))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Create cron jobs in Docker deployments within a time window.

Cron jobs are now started within a time window to avoid starting them at the same time for each deployment.
By default the deployment number is used to spread the cron jobs equaly in 12 slots. This can be customized by setting the `CRON_START_SLOT` and `CRON_MAX_START_SLOTS` environment variables explicitly.
The time window is defined by start and end time and is currently not configurable.

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)
