### PR TITLE
Support setting local roles by groupname when importing repositories from Excel

### DIFF
--- a/changes/TI-1116.other
+++ b/changes/TI-1116.other
@@ -1,0 +1,1 @@
+Add support for setting local roles by groupname in additon to group ids when importing repositories from Excel. [buchi]


### PR DESCRIPTION
This is required when using a non-legacy profile with ogds-sync (group names and ids are not equal).

For [TI-1116](https://4teamwork.atlassian.net/browse/TI-1116)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-1116]: https://4teamwork.atlassian.net/browse/TI-1116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ