### PR TITLE
Remove the linked teamraum from target dossier after copy

### DIFF
--- a/changes/TI-1263.other
+++ b/changes/TI-1263.other
@@ -1,0 +1,1 @@
+Remove the linked workspace from the target dossier when copying. [amo]

--- a/opengever/api/copy_.py
+++ b/opengever/api/copy_.py
@@ -14,6 +14,7 @@ from plone.locking.interfaces import ILockable
 from plone.restapi.deserializer import json_body
 from plone.restapi.services.copymove.copymove import Copy
 from zExceptions import Forbidden
+from zope.annotation.interfaces import IAnnotations
 from zope.container.interfaces import INameChooser
 from zope.i18n import translate
 import six
@@ -35,6 +36,11 @@ class Copy(Copy):
         for result in results:
             target_id = result["target"].split("/")[-1]
             obj = self.context[target_id]
+            annotations = IAnnotations(obj)
+
+            if 'opengever.workspaceclient.linked_workspaces' in annotations:
+                del annotations["opengever.workspaceclient.linked_workspaces"]
+
             self.recursive_rename_and_fix_creator(obj, docs_to_update)
             result["target"] = obj.absolute_url()
 


### PR DESCRIPTION
**Current situation :** 

When copying a dossier that is already linked to a workspace causes the target dossier to remain connected to that workspace. This should not happen.

**This PR :**

With the changes made in this PR, the copied dossier will not be connected to any workspace, even if the source dossier is linked to one.

For [TI-1263](https://4teamwork.atlassian.net/browse/TI-1263)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)



[TI-1263]: https://4teamwork.atlassian.net/browse/TI-1263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ