### PR TITLE
Fix login for newly registered teamraum users when using OGDS authentication

### DIFF
--- a/changes/TI-932.bugfix
+++ b/changes/TI-932.bugfix
@@ -1,0 +1,1 @@
+Fix login for newly registered teamraum users when using OGDS authentication. [buchi]


### PR DESCRIPTION
An OGDS sync is required after a new user has been created by the invitation process when using the OGDS auth plugin.
The OGDS sync is triggered after the user created a new account and gets redirected back to the `@@my-invitations` endpoint and before the regular authentication flow is triggered.

The sync could be optimized by just syncing the new user, but for now syncing all users seems to be fast enough.

For [TI-932](https://4teamwork.atlassian.net/browse/TI-932)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)




[TI-932]: https://4teamwork.atlassian.net/browse/TI-932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ