### PR TITLE
Use Alpine 3.20 as base image

### DIFF
--- a/docker/core/Dockerfile
+++ b/docker/core/Dockerfile
@@ -1,9 +1,37 @@
+# pkg builder
+# -----------------------------------------------------------------------------
+FROM alpine:3.20 AS pkg-builder
+
+RUN apk -U add \
+    sudo \
+    alpine-sdk \
+    apkbuild-pypi
+
+RUN mkdir -p /var/cache/distfiles && \
+    adduser -D packager && \
+    addgroup packager abuild && \
+    chgrp abuild /var/cache/distfiles && \
+    chmod g+w /var/cache/distfiles && \
+    echo "packager ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+WORKDIR /work
+USER packager
+
+RUN abuild-keygen -a -i -n
+
+COPY --chown=packager:packager ./docker/core/packages/ ./
+
+RUN cd openssl1.1-compat && \
+    abuild -r
+
 # ogcore builder
 # -----------------------------------------------------------------------------
-FROM 4teamwork/plone:4.3.20-alpine3.18 AS builder
+FROM 4teamwork/plone:4.3.20-alpine3.20 AS builder
 USER root
 
-RUN apk add \
+RUN --mount=from=pkg-builder,source=/home/packager/packages/work,target=/packages \
+    --mount=from=pkg-builder,source=/etc/apk/keys,target=/etc/apk/keys \
+    apk --repository /packages add \
     gcc \
     musl-dev \
     libc-dev \
@@ -16,6 +44,7 @@ RUN apk add \
     openssl1.1-compat-dev \
     libffi-dev \
     libpq \
+    libpq-dev \
     gettext
 
 # Fix support for python-ldap<3.4.2 with OpenLDAP 2.6
@@ -24,20 +53,6 @@ RUN echo "INPUT ( libldap.so )" > /usr/lib/libldap_r.so
 WORKDIR /app
 
 ENV PATH="/app/bin:$PATH"
-
-# libpq-dev requires OpenSSL 3 headers. Currently it's not possible to install
-# versions 1.1 and 3 at the same time. For building psycopg2 we temporarily
-# uninstall the 1.1 headers and reinstall them after having built psycopg2.
-RUN --mount=type=cache,target=/root/.cache \
-    apk del \
-    openssl1.1-compat-dev \
- && apk add --virtual .postgresql-dev \
-    libpq-dev \
- && pip install \
-    --prefix /app \
-    psycopg2==2.8.6 \
- && apk del .postgresql-dev \
- && apk add openssl1.1-compat-dev
 
 COPY ./docker/core/requirements-core.txt ./docker/core/requirements-deployment.txt /app/
 RUN --mount=type=cache,target=/root/.cache \
@@ -102,7 +117,7 @@ RUN python2.7 -m compileall /app/lib/python2.7/site-packages/ftw/bumblebee/hashi
 
 # go-crond builder
 # -----------------------------------------------------------------------------
-FROM golang:1.21-alpine3.18 AS go-crond-builder
+FROM golang:1.23-alpine3.20 AS go-crond-builder
 
 RUN apk upgrade --no-cache --force
 RUN apk add --update build-base make git
@@ -122,7 +137,7 @@ RUN make build
 
 # ogcore production image
 # -----------------------------------------------------------------------------
-FROM 4teamwork/plone:4.3.20-alpine3.18 AS prod
+FROM 4teamwork/plone:4.3.20-alpine3.20 AS prod
 
 USER root
 RUN apk add \

--- a/docker/core/packages/openssl1.1-compat/APKBUILD
+++ b/docker/core/packages/openssl1.1-compat/APKBUILD
@@ -1,0 +1,145 @@
+# Contributor: Ariadne Conill <ariadne@dereferenced.org>
+# Maintainer: Timo Teras <timo.teras@iki.fi>
+pkgname=openssl1.1-compat
+pkgver=1.1.1w
+_abiver=${pkgver%.*}
+pkgrel=1
+pkgdesc="toolkit for transport layer security (TLS) - version 1.1"
+url="https://www.openssl.org/"
+arch="all"
+license="OpenSSL"
+replaces="libressl"
+depends_dev="libcrypto1.1 libssl1.1 pkgconf"
+makedepends_build="perl"
+makedepends_host="linux-headers"
+makedepends="$makedepends_host $makedepends_build"
+subpackages="$pkgname-dbg $pkgname-libs-static:_static $pkgname-dev:_dev
+	libcrypto$_abiver:_libcrypto libssl$_abiver:_libssl"
+source="https://www.openssl.org/source/openssl-$pkgver.tar.gz
+	man-section.patch
+	ppc64.patch
+	"
+builddir="$srcdir/openssl-$pkgver"
+pcprefix="openssl$_abiver:pc:"
+
+build() {
+	local _target _optflags
+
+	# openssl will prepend crosscompile always core CC et al
+	CC=${CC#${CROSS_COMPILE}}
+	CXX=${CXX#${CROSS_COMPILE}}
+	CPP=${CPP#${CROSS_COMPILE}}
+
+	# determine target OS for openssl
+	case "$CARCH" in
+		aarch64*)	_target="linux-aarch64" ;;
+		arm*)		_target="linux-armv4" ;;
+		mips64*)	_target="linux64-mips64" ;;
+		# explicit _optflags is needed to prevent automatic -mips3 addition
+		mips*)		_target="linux-mips32"; _optflags="-mips32" ;;
+		ppc)		_target="linux-ppc" ;;
+		ppc64)		_target="linux-ppc64" ;;
+		ppc64le)	_target="linux-ppc64le" ;;
+		x86)		_target="linux-elf" ;;
+		x86_64)		_target="linux-x86_64"; _optflags="enable-ec_nistp_64_gcc_128" ;;
+		s390x)		_target="linux64-s390x";;
+		riscv64)	_target="linux-generic64";;
+		*)		msg "Unable to determine architecture from (CARCH=$CARCH)" ; return 1 ;;
+	esac
+
+	# Configure assumes --options are for it, so can't use
+	# gcc's --sysroot fake this by overriding CC
+	[ -n "$CBUILDROOT" ] && CC="$CC --sysroot=$CBUILDROOT"
+
+	# when cross building do not enable threads as libatomic is not avaiable
+	if [ "$CBUILD" != "$CHOST" ]; then
+		case $CARCH in
+			riscv64) _optflags="$_optflags no-threads";;
+		esac
+	fi
+
+	perl ./Configure \
+		$_target \
+		--prefix=/usr \
+		--libdir=lib \
+		--openssldir=/etc/ssl1.1 \
+		shared \
+		no-zlib \
+		no-async \
+		no-comp \
+		no-idea \
+		no-mdc2 \
+		no-rc5 \
+		no-ec2m \
+		no-sm2 \
+		no-sm4 \
+		no-ssl2 \
+		no-ssl3 \
+		no-seed \
+		no-weak-ssl-ciphers \
+		$_optflags \
+		$CPPFLAGS \
+		$CFLAGS \
+		$LDFLAGS -Wa,--noexecstack
+	make
+}
+
+check() {
+	# AFALG tests have a sporadic test failure, just delete the broken
+	# test for now.
+	rm -f test/recipes/30-test_afalg.t
+
+	make test
+}
+
+package() {
+	make DESTDIR="$pkgdir" install_sw install_ssldirs
+	# remove the script c_rehash
+	rm "$pkgdir"/usr/bin/c_rehash
+	mv -f "$pkgdir"/usr/bin/openssl "$pkgdir"/usr/bin/openssl$_abiver
+}
+
+_dev() {
+	pkgdesc="$pkgdesc (development files)"
+	depends="$depends_dev"
+	mkdir -p "$subpkgdir"/usr/include/openssl1.1 "$subpkgdir"/usr/lib/openssl1.1
+	mv "$pkgdir"/usr/include/* "$subpkgdir"/usr/include/openssl1.1
+	mv "$pkgdir"/usr/lib/pkgconfig "$subpkgdir"/usr/lib/openssl1.1/pkgconfig
+	ln -s ../../../lib/libcrypto.so.1.1 "$subpkgdir"/usr/lib/openssl1.1/libcrypto.so
+	ln -s ../../../lib/libssl.so.1.1 "$subpkgdir"/usr/lib/openssl1.1/libssl.so
+	rm -f "$pkgdir"/usr/lib/*.so
+}
+
+_libcrypto() {
+	pkgdesc="Crypto library from openssl"
+	replaces="libressl2.7-libcrypto"
+	mkdir -p "$subpkgdir"/lib "$subpkgdir"/usr/lib
+	mv "$pkgdir"/etc "$subpkgdir"/
+	for i in "$pkgdir"/usr/lib/libcrypto*; do
+		mv $i "$subpkgdir"/lib/
+		ln -s ../../lib/${i##*/} "$subpkgdir"/usr/lib/${i##*/}
+	done
+	mv "$pkgdir"/usr/lib/engines-$_abiver "$subpkgdir"/usr/lib/
+}
+
+_libssl() {
+	pkgdesc="SSL shared libraries"
+
+	mkdir -p "$subpkgdir"/lib "$subpkgdir"/usr/lib
+	for i in "$pkgdir"/usr/lib/libssl*; do
+		mv $i "$subpkgdir"/lib/
+		ln -s ../../lib/${i##*/} "$subpkgdir"/usr/lib/${i##*/}
+	done
+}
+
+_static() {
+	pkgdesc="$pkgdesc (static library)"
+	mkdir -p "$subpkgdir"/usr/lib/openssl1.1
+	mv "$pkgdir"/usr/lib/*.a "$subpkgdir"/usr/lib/openssl1.1/
+}
+
+sha512sums="
+b4c625fe56a4e690b57b6a011a225ad0cb3af54bd8fb67af77b5eceac55cc7191291d96a660c5b568a08a2fbf62b4612818e7cca1bb95b2b6b4fc649b0552b6d  openssl-1.1.1w.tar.gz
+43c3255118db6f5f340dc865c0f25ccbcafe5bf7507585244ca59b4d27daf533d6c3171aa32a8685cbb6200104bec535894b633de13feaadff87ab86739a445a  man-section.patch
+e040f23770d52b988578f7ff84d77563340f37c026db7643db8e4ef18e795e27d10cb42cb8656da4d9c57a28283a2828729d70f940edc950c3422a54fea55509  ppc64.patch
+"

--- a/docker/core/packages/openssl1.1-compat/man-section.patch
+++ b/docker/core/packages/openssl1.1-compat/man-section.patch
@@ -1,0 +1,54 @@
+From: Debian OpenSSL Team <pkg-openssl-devel@lists.alioth.debian.org>
+Date: Sun, 5 Nov 2017 15:09:09 +0100
+Subject: man-section
+
+---
+ Configurations/unix-Makefile.tmpl | 6 ++++--
+ util/process_docs.pl              | 3 ++-
+ 2 files changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/Configurations/unix-Makefile.tmpl b/Configurations/unix-Makefile.tmpl
+index 1292053546f5..c034d21884d8 100644
+--- a/Configurations/unix-Makefile.tmpl
++++ b/Configurations/unix-Makefile.tmpl
+@@ -183,7 +183,8 @@ HTMLDIR=$(DOCDIR)/html
+ # MANSUFFIX is for the benefit of anyone who may want to have a suffix
+ # appended after the manpage file section number.  "ssl" is popular,
+ # resulting in files such as config.5ssl rather than config.5.
+-MANSUFFIX=
++MANSUFFIX=ssl
++MANSECTION=SSL
+ HTMLSUFFIX=html
+ 
+ # For "optional" echo messages, to get "real" silence
+@@ -726,7 +727,8 @@ uninstall_runtime: uninstall_programs uninstall_runtime_libs
+ 	@[ -n "$(INSTALLTOP)" ] || (echo INSTALLTOP should not be empty; exit 1)
+ 	@$(ECHO) "*** Installing manpages"
+ 	$(PERL) $(SRCDIR)/util/process_docs.pl \
+-		"--destdir=$(DESTDIR)$(MANDIR)" --type=man --suffix=$(MANSUFFIX)
++		"--destdir=$(DESTDIR)$(MANDIR)" --type=man --suffix=$(MANSUFFIX) \
++		--mansection=$(MANSECTION)
+ 
+ uninstall_man_docs:
+ 	@$(ECHO) "*** Uninstalling manpages"
+diff --git a/util/process_docs.pl b/util/process_docs.pl
+index 30b149eb8fcc..424155ea808e 100755
+--- a/util/process_docs.pl
++++ b/util/process_docs.pl
+@@ -37,6 +37,7 @@ GetOptions(\%options,
+            'type=s',            # The result type, 'man' or 'html'
+            'suffix:s',          # Suffix to add to the extension.
+                                 # Only used with type=man
++           'mansection:s',      # Section to put to manpage in
+            'remove',            # To remove files rather than writing them
+            'dry-run|n',         # Only output file names on STDOUT
+            'debug|D+',
+@@ -97,7 +98,7 @@ foreach my $section (sort @{$options{section}}) {
+         my $name = uc $podname;
+         my $suffix = { man  => ".$podinfo{section}".($options{suffix} // ""),
+                        html => ".html" } -> {$options{type}};
+-        my $generate = { man  => "pod2man --name=$name --section=$podinfo{section} --center=OpenSSL --release=$config{version} \"$podpath\"",
++        my $generate = { man  => "pod2man --name=$name --section=$podinfo{section}$options{mansection} --center=OpenSSL --release=$config{version} \"$podpath\"",
+                          html => "pod2html \"--podroot=$options{sourcedir}\" --htmldir=$updir --podpath=man1:man3:man5:man7 \"--infile=$podpath\" \"--title=$podname\" --quiet"
+                          } -> {$options{type}};
+         my $output_dir = catdir($options{destdir}, "man$podinfo{section}");

--- a/docker/core/packages/openssl1.1-compat/ppc64.patch
+++ b/docker/core/packages/openssl1.1-compat/ppc64.patch
@@ -1,0 +1,96 @@
+From 34ab13b7d8e3e723adb60be8142e38b7c9cd382a Mon Sep 17 00:00:00 2001
+From: Andy Polyakov <appro@openssl.org>
+Date: Sun, 5 May 2019 18:25:50 +0200
+Subject: [PATCH] crypto/perlasm/ppc-xlate.pl: add linux64v2 flavour
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This is a big endian ELFv2 configuration. ELFv2 was already being
+used for little endian, and big endian was traditionally ELFv1
+but there are practical configurations that use ELFv2 with big
+endian nowadays (Adélie Linux, Void Linux, possibly Gentoo, etc.)
+
+Reviewed-by: Paul Dale <paul.dale@oracle.com>
+Reviewed-by: Richard Levitte <levitte@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/8883)
+---
+ crypto/perlasm/ppc-xlate.pl | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/crypto/perlasm/ppc-xlate.pl b/crypto/perlasm/ppc-xlate.pl
+index e52f2f6ea62..5fcd0526dff 100755
+--- a/crypto/perlasm/ppc-xlate.pl
++++ b/crypto/perlasm/ppc-xlate.pl
+@@ -49,7 +49,7 @@
+ 	/osx/		&& do { $name = "_$name";
+ 				last;
+ 			      };
+-	/linux.*(32|64le)/
++	/linux.*(32|64(le|v2))/
+ 			&& do {	$ret .= ".globl	$name";
+ 				if (!$$type) {
+ 				    $ret .= "\n.type	$name,\@function";
+@@ -80,7 +80,7 @@
+ };
+ my $text = sub {
+     my $ret = ($flavour =~ /aix/) ? ".csect\t.text[PR],7" : ".text";
+-    $ret = ".abiversion	2\n".$ret	if ($flavour =~ /linux.*64le/);
++    $ret = ".abiversion	2\n".$ret	if ($flavour =~ /linux.*64(le|v2)/);
+     $ret;
+ };
+ my $machine = sub {
+@@ -186,7 +186,7 @@
+ 
+ # Some ABIs specify vrsave, special-purpose register #256, as reserved
+ # for system use.
+-my $no_vrsave = ($flavour =~ /aix|linux64le/);
++my $no_vrsave = ($flavour =~ /aix|linux64(le|v2)/);
+ my $mtspr = sub {
+     my ($f,$idx,$ra) = @_;
+     if ($idx == 256 && $no_vrsave) {
+@@ -318,7 +318,7 @@ sub vfour {
+ 	if ($label) {
+ 	    my $xlated = ($GLOBALS{$label} or $label);
+ 	    print "$xlated:";
+-	    if ($flavour =~ /linux.*64le/) {
++	    if ($flavour =~ /linux.*64(le|v2)/) {
+ 		if ($TYPES{$label} =~ /function/) {
+ 		    printf "\n.localentry	%s,0\n",$xlated;
+ 		}
+
+From 098404128383ded87ba390dd74ecd9e2ffa6f530 Mon Sep 17 00:00:00 2001
+From: Andy Polyakov <appro@openssl.org>
+Date: Sun, 5 May 2019 18:30:55 +0200
+Subject: [PATCH] Configure: use ELFv2 ABI on some ppc64 big endian systems
+
+If _CALL_ELF is defined to be 2, it's an ELFv2 system.
+Conditionally switch to the v2 perlasm scheme.
+
+Reviewed-by: Paul Dale <paul.dale@oracle.com>
+Reviewed-by: Richard Levitte <levitte@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/8883)
+---
+ Configure | 10 +++++++---
+ 1 file changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/Configure b/Configure
+index 22082deb4c7..e303d98deb3 100755
+--- a/Configure
++++ b/Configure
+@@ -1402,8 +1402,15 @@
+ my %predefined_C = compiler_predefined($config{CROSS_COMPILE}.$config{CC});
+ my %predefined_CXX = $config{CXX}
+     ? compiler_predefined($config{CROSS_COMPILE}.$config{CXX})
+     : ();
+ 
++unless ($disabled{asm}) {
++    # big endian systems can use ELFv2 ABI
++    if ($target eq "linux-ppc64") {
++        $target{perlasm_scheme} = "linux64v2" if ($predefined_C{_CALL_ELF} == 2);
++    }
++}
++
+ # Check for makedepend capabilities.
+ if (!$disabled{makedepend}) {
+     if ($config{target} =~ /^(VC|vms)-/) {


### PR DESCRIPTION
Update to latest Alpine version (3.20)

Base images `4teamwork/plone` and `4teamwork/python` are already updated.

Alpine 3.20 no longer provides openssl 1.1, therefore we have to build it ourselves.
It's no longer necessary to uninstall openssl 1.1 for building psycopg2 as we put the 1.1 headers in a different location 😉 .


## Checklist

- [x] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)

