### PR TITLE
Fix dossier transfer if the target admin unit does not provide the same dossier_types or document_types.

### DIFF
--- a/changes/TI-1345.bugfix
+++ b/changes/TI-1345.bugfix
@@ -1,0 +1,1 @@
+Fix dossier transfer if the target admin unit does not provide the same dossier or document types. [elioschmutz]


### PR DESCRIPTION
This PR fixes an issue where it is not possible to transfer a dossier if the target admin unit does not provide the same dossier or document types.

We fix the issue by removing the not existing type before deserializing it. Means, we loose this information on the target admin unit. This is the desired behavior.

For [TI-1345]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-1345]: https://4teamwork.atlassian.net/browse/TI-1345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ