### PR TITLE
Add new solr Field "ID"

### DIFF
--- a/changes/TI-1103.other
+++ b/changes/TI-1103.other
@@ -1,0 +1,1 @@
+Add "Dossier ID" to solr fields. [ran]

--- a/opengever/base/solr/fields.py
+++ b/opengever/base/solr/fields.py
@@ -595,6 +595,11 @@ FIELDS_WITH_MAPPING = [
         title=dossier_mf(u'filing_no_filing'),
     ),
     ListingField(
+        'id',
+        index='id',
+        title=dossier_mf(u'id', default=u'ID'),
+    ),
+    ListingField(
         'issuer',
         index='issuer',
         transform=display_name,


### PR DESCRIPTION
Excel Export for faceted Search was implemented in https://github.com/4teamwork/gever-ui/pull/2809.
It was noticed that header "Dossier ID" didn't exist in fields, and therefore wouldn't be included in the excel export. To fix this, this field was added to solr fields.py.
9 solr tests don't pass due to the problem mentioned by Buchi in the daily

For [TI-1103]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-1103]: https://4teamwork.atlassian.net/browse/TI-1103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ