### PR TITLE
Fix HISTORY.rst

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,15 +6,15 @@ Versions are of the form MAJOR.MINOR.PATCH. Each MINOR release (MAJOR.MINOR.0) i
 .. You should *NOT* be adding new change log entries to this file.
    Create a file in the changes directory instead. Use the issue/ticket number
    as filename and add one of .feature, .bugfix, .other as extension to signify
-2024.16.0 (unreleased)
-----------------------
-
-- Nothing changed yet.
-
-
-2024.15.0 (2024-10-22)
+   the change type (e.g. 6968.feature).
 
 .. towncrier release notes start
+
+2024.15.0 (2024-10-22)
+----------------------
+
+- Brown bag release
+
 
 2024.14.0 (2024-09-24)
 ----------------------


### PR DESCRIPTION
Release `2024.15.0` was a brown bag release that was made without the `zestreleaser.towncrier` plugin. Therefore  HISTORY.rst got messed up by zest.releaser, since it processed it in the traditional style.

Updated [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/35652746/Python+Paket+releasen+mit+zest.releaser) with instructions to also install `zestreleaser.towncrier`.


For [TI-1422](https://4teamwork.atlassian.net/browse/TI-1422)


[TI-1422]: https://4teamwork.atlassian.net/browse/TI-1422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ