### PR TITLE
Prevent zest.releaser from building wheels.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,4 @@
 [zest.releaser]
 prereleaser.middle = opengever.core.releaser.on_prerelease_middle
 postreleaser.middle = opengever.core.releaser.on_postrelease_middle
+create-wheel = false


### PR DESCRIPTION
Prevent `zest.releaser` from building wheels.

Since version `8.0.0a2` zest.releaser will always build wheels, which we don't want for `opengever.core`. 

For [TI-1447](https://4teamwork.atlassian.net/browse/TI-1447)


[TI-1447]: https://4teamwork.atlassian.net/browse/TI-1447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ