### PR TITLE
Fix OGDS sync for multi-tenant setups:

### DIFF
--- a/changes/TI-1456.bugfix
+++ b/changes/TI-1456.bugfix
@@ -1,0 +1,1 @@
+- Fix OGDS sync for multi-tenant setups. [lgraf]

--- a/opengever/ogds/base/__init__.py
+++ b/opengever/ogds/base/__init__.py
@@ -1,3 +1,4 @@
+from AccessControl.SecurityManagement import newSecurityManager
 from opengever.core.debughelpers import get_first_plone_site
 from opengever.core.debughelpers import setup_plone
 from opengever.ogds.base.sync.ogds_updater import sync_ogds
@@ -18,5 +19,15 @@ def sync_ogds_zopectl_handler(app, args):
     stream_handler.setLevel(logging.INFO)
 
     plone = setup_plone(get_first_plone_site(app))
+
+    # Switch security context to 'zopemaster' instead of SpecialUsers.system.
+    # This is required because in multi-tenant setups, the OGDS sync will
+    # dispatch a remote request to update the sync timestamp. This request
+    # will need to be authenticated and therefore needs a user which has an
+    # actual userid - which the SpecialUsers.system doesn't.
+    user = app.acl_users.getUser('zopemaster')
+    user = user.__of__(app.acl_users)
+    newSecurityManager(app, user)
+
     sync_ogds(plone, local_groups=is_workspace_feature_enabled())
     transaction.commit()


### PR DESCRIPTION
OGDS sync was broken for multi-tenant setups, because dispatching the remote request to update the sync timestamp failed when attempting to create an authentication token for a userid of `None`.

⚠️ Needs backport to `2024.9.x` (probably)

A while back we switched the user that is used for zopectl commands from the `zopemaster` user to `SpecialUsers.system`.

Once the remote requests dispatched from OGDS sync were [changed to use the admin unit auth PAS plugin](https://github.com/4teamwork/opengever.core/commit/bcd997defcf3eb3b95a12d7aceec119a37b13546), they required the userid to generate the authentication token. This failed, because the `SpecialUsers.system` does not have a userid:

```
2024-10-25 10:52:53 INFO opengever.ogds.base Issued remote request to update sync_stamp on fd to 2024-10-25T10:52:53.295722
Traceback (most recent call last):
  File "opengever.core/parts/instance/bin/interpreter", line 425, in <module>
    exec(_val)
  File "<string>", line 1, in <module>
  File "opengever.core/opengever/ogds/base/__init__.py", line 21, in sync_ogds_zopectl_handler
    sync_ogds(plone, local_groups=is_workspace_feature_enabled())
  File "opengever.core/opengever/ogds/base/sync/ogds_updater.py", line 138, in sync_ogds
    set_remote_import_stamp(plone)
  File "opengever.core/opengever/ogds/base/sync/import_stamp.py", line 74, in set_remote_import_stamp
    data={REQUEST_SYNC_KEY: timestamp})
  File "opengever.core/opengever/base/request.py", line 83, in dispatch_request
    data, headers)
  File "opengever.core/opengever/base/request.py", line 143, in _remote_request
    get_current_admin_unit().id(), member.getId())
  File "opengever.core/opengever/ogds/auth/admin_unit.py", line 120, in create_auth_token
    userid = six.ensure_binary(userid)
  File "Plone/eggs/six-1.16.0-py2.7.egg/six.py", line 913, in ensure_binary
    raise TypeError("not expecting type '%s'" % type(s))
TypeError: not expecting type '<type 'NoneType'>
```


This fix therefore explicitly changes the user used for the sync_ogds zopectl handler to `zopemaster`.

(TTW ogds sync was not affected, because those already were using an actual user, e.g. an administrator account or `zopemaster`).

---

This issue was introduced in `2024.9.0`. From what I can tell, this means that affected deployments are SG and any multi-tenant SaaS deployments. ZG is already on `2024.9.0` as well, but because of the docker setup the `ogds-sync` service is used there, which doesn't have this issue.

I would therefore recommend to:
- Fix it in `master`, backport to `2024.9.0` (and any other non-current versions we plan to update to)
- Egg-patch SG (already done), because deploying a hotfix across ~70 deployments, several servers, and restarting all the instances, just to fix a file that is invoked by a cron-job on one deployment seems quite absurd.


For [TI-1456](https://4teamwork.atlassian.net/browse/TI-1456)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
