### PR TITLE
Fix broken build of cryptography in Docker image

### DIFF
--- a/changes/GH-8076.bugfix
+++ b/changes/GH-8076.bugfix
@@ -1,0 +1,1 @@
+Fix broken build of cryptography in Docker image introduced in 2024.15.0. [buchi]

--- a/docker/core/Dockerfile
+++ b/docker/core/Dockerfile
@@ -58,6 +58,8 @@ COPY ./docker/core/requirements-core.txt ./docker/core/requirements-deployment.t
 RUN --mount=type=cache,target=/root/.cache \
     --mount=type=secret,id=gldt \
     export GITLAB_DEPLOY_TOKEN=$(cat /run/secrets/gldt) && \
+    CFLAGS="-I/usr/include/openssl1.1" \
+    LDFLAGS="-L/usr/lib/openssl1.1" \
     pip install \
     --prefix /app \
     --extra-index-url https://__token__:$GITLAB_DEPLOY_TOKEN@git.4teamwork.ch/api/v4/projects/486/packages/pypi/simple \


### PR DESCRIPTION
Cryptography was accidentally linked against OpenSSL 3.

## Checklist

- [x] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)
