### PR TITLE
Fix broken JS registry for new installs

### DIFF
--- a/changes/GH-8077.bugfix
+++ b/changes/GH-8077.bugfix
@@ -1,0 +1,1 @@
+Fix broken JS registry for new installs introduced in 2024.14.0. [buchi]

--- a/opengever/core/profiles/default/jsregistry.xml
+++ b/opengever/core/profiles/default/jsregistry.xml
@@ -424,7 +424,7 @@
       enabled="True"
       id="++resource++opengever.document/startredirect.js"
       inline="False"
-      insert-after="++resource++opengever.base/base.js"
+      insert-after="++resource++ftw.lawgiver-resources/sharing.js"
       />
 
   <javascript


### PR DESCRIPTION
With #8036 the order of the resources was changed so that the cooked javascript was broken.

## Checklist

- [x] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)
