### PR TITLE
Fix isolation issue with tests using a mocked solr.

### DIFF
--- a/opengever/base/tests/test_solr_livesearch.py
+++ b/opengever/base/tests/test_solr_livesearch.py
@@ -60,14 +60,14 @@ class TestSolrLivesearchReply(IntegrationTestCase):
     @browsing
     def test_testing_solr_livesearch(self, browser):
         """Make sure we are testing the solr livesearch reply"""
-        self.solr = self.mock_solr(response_json=self.solr_search_response)
-        browser.open_html(self.livesearch())
+        with self.mock_solr(response_json=self.solr_search_response):
+            browser.open_html(self.livesearch())
         self.assertIn("solr", browser.css(".livesearchContainer").first.classes)
 
     @browsing
     def test_livesearch_reply_listing(self, browser):
-        self.solr = self.mock_solr(response_json=self.solr_search_response)
-        browser.open_html(self.livesearch())
+        with self.mock_solr(response_json=self.solr_search_response):
+            browser.open_html(self.livesearch())
 
         link_nodes = browser.css('.dropdown-list-item')
         self.assertEqual(4, len(link_nodes))
@@ -79,8 +79,8 @@ class TestSolrLivesearchReply(IntegrationTestCase):
     @browsing
     def test_livesearch_reply_escapes_title(self, browser):
         self.solr_search_response["response"]["docs"][0]["Title"] = u"<script>alert('evil');</script>"
-        self.solr = self.mock_solr(response_json=self.solr_search_response)
-        browser.open_html(self.livesearch())
+        with self.mock_solr(response_json=self.solr_search_response):
+            browser.open_html(self.livesearch())
 
         link_node = browser.css('.dropdown-list-item').first
         # lxml unescapes attributes for us. we want to test that the title
@@ -95,8 +95,8 @@ class TestSolrLivesearchReply(IntegrationTestCase):
     def test_livesearch_reply_show_more(self, browser):
         self.solr_search_response["response"]["numFound"] = 4
         self.request.form.update({'limit': '3'})
-        self.solr = self.mock_solr(response_json=self.solr_search_response)
-        browser.open_html(self.livesearch())
+        with self.mock_solr(response_json=self.solr_search_response):
+            browser.open_html(self.livesearch())
 
         link_nodes = browser.css('.dropdown-list-item')
         self.assertEqual(5, len(link_nodes))
@@ -112,8 +112,8 @@ class TestSolrLivesearchReply(IntegrationTestCase):
     def test_livesearch_reply_empty_result(self, browser):
         self.solr_search_response["response"]["docs"] = []
         self.solr_search_response["response"]["numFound"] = 0
-        self.solr = self.mock_solr(response_json=self.solr_search_response)
-        browser.open_html(self.livesearch())
+        with self.mock_solr(response_json=self.solr_search_response):
+            browser.open_html(self.livesearch())
 
         link_nodes = browser.css('.dropdown-list-item')
         self.assertEqual(2, len(link_nodes))

--- a/opengever/base/tests/test_source_binder.py
+++ b/opengever/base/tests/test_source_binder.py
@@ -164,46 +164,44 @@ class TestRelatedDossierAutocomplete(IntegrationTestCase):
 
     @browsing
     def test_related_dossier_autocomplete_uses_solr(self, browser):
-        self.solr = self.mock_solr('solr_autocomplete_dossier.json')
-
         self.login(self.dossier_responsible, browser)
-        browser.open(
-            self.dossier,
-            view='@@edit/++widget++form.widgets.IDossier.relatedDossier/@@autocomplete-search?q=empty'
-        )
-        self.assertEqual(
-            '/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-7|An empty dossier',
-            browser.contents
-        )
-        self.assert_solr_called(
-            self.solr, 'empty', rows=20, fl=['path'],
-            filters=[u'object_provides:opengever.dossier.behaviors.dossier.IDossierMarker',
-                     u'path_parent:\\/plone\\/ordnungssystem']
-        )
+        with self.mock_solr('solr_autocomplete_dossier.json') as solr:
+            browser.open(
+                self.dossier,
+                view='@@edit/++widget++form.widgets.IDossier.relatedDossier/@@autocomplete-search?q=empty'
+            )
+            self.assertEqual(
+                '/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-7|An empty dossier',
+                browser.contents
+            )
+            self.assert_solr_called(
+                solr, 'empty', rows=20, fl=['path'],
+                filters=[u'object_provides:opengever.dossier.behaviors.dossier.IDossierMarker',
+                        u'path_parent:\\/plone\\/ordnungssystem']
+            )
 
 
 class TestAddableDossierTemplatesAutocomplete(IntegrationTestCase):
 
     @browsing
     def test_addable_dossier_autocomplete_uses_solr_when_feature_enabled(self, browser):
-        self.solr = self.mock_solr('solr_autocomplete_dossiertemplate.json')
-
         self.login(self.administrator, browser)
-        browser.open(
-            self.empty_repofolder,
-            view=''
-            '@@edit/++widget++form.widgets.IRestrictAddableDossierTemplates.addable_dossier_templates/'
-            '@@autocomplete-search?q=Bauvorhaben'
-        )
-        self.assertEqual(
-            '/plone/vorlagen/dossiertemplate-1|Bauvorhaben klein',
-            browser.contents
-        )
-        self.assert_solr_called(
-            self.solr, 'Bauvorhaben', rows=20, fl=['path'],
-            filters=[u'portal_type:opengever.dossier.dossiertemplate',
-                     u'is_subdossier:false']
-        )
+        with self.mock_solr('solr_autocomplete_dossiertemplate.json') as solr:
+            browser.open(
+                self.empty_repofolder,
+                view=''
+                '@@edit/++widget++form.widgets.IRestrictAddableDossierTemplates.addable_dossier_templates/'
+                '@@autocomplete-search?q=Bauvorhaben'
+            )
+            self.assertEqual(
+                '/plone/vorlagen/dossiertemplate-1|Bauvorhaben klein',
+                browser.contents
+            )
+            self.assert_solr_called(
+                solr, 'Bauvorhaben', rows=20, fl=['path'],
+                filters=[u'portal_type:opengever.dossier.dossiertemplate',
+                        u'is_subdossier:false']
+            )
 
     @browsing
     def test_addable_dossier_autocomplete_uses_catalog_when_solr_disabled(self, browser):

--- a/opengever/tabbedview/tests/test_catalog_source.py
+++ b/opengever/tabbedview/tests/test_catalog_source.py
@@ -15,158 +15,169 @@ class TestSolrSearch(IntegrationTestCase):
 
     def setUp(self):
         super(TestSolrSearch, self).setUp()
-
-        self.solr = self.mock_solr('solr_search.json')
         self.source = GeverCatalogTableSource(
             BaseCatalogListingTab(self.portal, self.request), self.request)
 
     def test_solr_query_contains_searchable_text(self):
-        self.source.solr_results({'SearchableText': 'foo bar'})
-        self.assertEqual(
-            self.solr.search.call_args[1]['query'],
-            u'foo bar'
-        )
+        with self.mock_solr('solr_search.json') as solr:
+            self.source.solr_results({'SearchableText': 'foo bar'})
+            self.assertEqual(
+                solr.search.call_args[1]['query'],
+                u'foo bar'
+            )
 
     def test_solr_filters_contain_trashed(self):
-        self.source.solr_results(
-            {'SearchableText': 'foo'})
-        self.assertEqual(
-            self.solr.search.call_args[1]['filters'],
-            [u'trashed:false'])
+        with self.mock_solr('solr_search.json') as solr:
+            self.source.solr_results(
+                {'SearchableText': 'foo'})
+            self.assertEqual(
+                solr.search.call_args[1]['filters'],
+                [u'trashed:false'])
 
     def test_solr_filters_contain_path_parent(self):
-        self.source.solr_results(
-            {'SearchableText': 'foo', 'path': {'query': '/my/path'}})
-        self.assertEqual(
-            self.solr.search.call_args[1]['filters'],
-            [u'trashed:false', u'path_parent:\\/my\\/path'])
+        with self.mock_solr('solr_search.json') as solr:
+            self.source.solr_results(
+                {'SearchableText': 'foo', 'path': {'query': '/my/path'}})
+            self.assertEqual(
+                solr.search.call_args[1]['filters'],
+                [u'trashed:false', u'path_parent:\\/my\\/path'])
 
     def test_solr_filters_contain_path_depth(self):
-        self.source.solr_results(
-            {'SearchableText': 'foo', 'path': {'query': '/my/path', 'depth': '1'}})
-        self.assertEqual(
-            self.solr.search.call_args[1]['filters'],
-            [u'trashed:false',
-             u'path_parent:\\/my\\/path',
-             u'path_depth:[* TO 3]'])
+        with self.mock_solr('solr_search.json') as solr:
+            self.source.solr_results(
+                {'SearchableText': 'foo', 'path': {'query': '/my/path', 'depth': '1'}})
+            self.assertEqual(
+                solr.search.call_args[1]['filters'],
+                [u'trashed:false',
+                 u'path_parent:\\/my\\/path',
+                 u'path_depth:[* TO 3]'])
 
     def test_solr_filters_handle_booleans(self):
-        self.source.solr_results(
-            {'SearchableText': 'foo', 'is_subdossier': True})
-        self.assertEqual(
-            self.solr.search.call_args[1]['filters'],
-            [u'trashed:false', u'is_subdossier:true'])
+        with self.mock_solr('solr_search.json') as solr:
+            self.source.solr_results(
+                {'SearchableText': 'foo', 'is_subdossier': True})
+            self.assertEqual(
+                solr.search.call_args[1]['filters'],
+                [u'trashed:false', u'is_subdossier:true'])
 
     def test_solr_filters_handle_strings(self):
-        self.source.solr_results(
-            {'SearchableText': 'foo', 'metadata': 'FD 1 / 1'})
-        self.assertEqual(
-            self.solr.search.call_args[1]['filters'],
-            [u'trashed:false', u'metadata:FD 1 \\/ 1'])
+        with self.mock_solr('solr_search.json') as solr:
+            self.source.solr_results(
+                {'SearchableText': 'foo', 'metadata': 'FD 1 / 1'})
+            self.assertEqual(
+                solr.search.call_args[1]['filters'],
+                [u'trashed:false', u'metadata:FD 1 \\/ 1'])
 
     def test_solr_filters_ignore_unknown_fields(self):
-        self.source.solr_results(
-            {'SearchableText': 'foo', 'reference_number': 'FD 1 / 1'})
-        self.assertEqual(
-            self.solr.search.call_args[1]['filters'],
-            [u'trashed:false'])
+        with self.mock_solr('solr_search.json') as solr:
+            self.source.solr_results(
+                {'SearchableText': 'foo', 'reference_number': 'FD 1 / 1'})
+            self.assertEqual(
+                solr.search.call_args[1]['filters'],
+                [u'trashed:false'])
 
     def test_solr_filters_do_not_contain_sort_parameters(self):
-        self.source.solr_results({
-            'SearchableText': 'foo',
-            'sort_on': 'modified',
-            'sort_order': 'descending',
+        with self.mock_solr('solr_search.json') as solr:
+            self.source.solr_results({
+                'SearchableText': 'foo',
+                'sort_on': 'modified',
+                'sort_order': 'descending',
             })
-        self.assertEqual(
-            self.solr.search.call_args[1]['filters'],
-            [u'trashed:false'])
+            self.assertEqual(
+                solr.search.call_args[1]['filters'],
+                [u'trashed:false'])
 
     def test_solr_sort(self):
-        self.source.solr_results(
-            {'SearchableText': 'foo', 'sort_on': 'sortable_title'})
-        self.assertEqual(
-            self.solr.search.call_args[1]['sort'],
-            u'sortable_title asc')
+        with self.mock_solr('solr_search.json') as solr:
+            self.source.solr_results(
+                {'SearchableText': 'foo', 'sort_on': 'sortable_title'})
+            self.assertEqual(
+                solr.search.call_args[1]['sort'],
+                u'sortable_title asc')
 
     def test_solr_sort_ignores_unknown_fields(self):
-        self.source.solr_results(
-            {'SearchableText': 'foo', 'sort_on': 'getObjPositionInParent'})
-        self.assertEqual(
-            self.solr.search.call_args[1]['sort'],
-            None)
+        with self.mock_solr('solr_search.json') as solr:
+            self.source.solr_results(
+                {'SearchableText': 'foo', 'sort_on': 'getObjPositionInParent'})
+            self.assertEqual(
+                solr.search.call_args[1]['sort'],
+                None)
 
     def test_solr_fieldlist_contains_columns(self):
-        self.source.config.columns = (
-            {'column': 'reference'},
-            {'column': 'Title'},
-        )
-        self.source.solr_results({'SearchableText': 'foo'})
-        self.assertEqual(
-            self.solr.search.call_args[1]['fl'],
-            ['UID', 'getIcon', 'portal_type', 'path', 'id',
-             'bumblebee_checksum', 'reference', 'Title']
+        with self.mock_solr('solr_search.json') as solr:
+            self.source.config.columns = (
+                {'column': 'reference'},
+                {'column': 'Title'},
+            )
+            self.source.solr_results({'SearchableText': 'foo'})
+            self.assertEqual(
+                solr.search.call_args[1]['fl'],
+                ['UID', 'getIcon', 'portal_type', 'path', 'id',
+                 'bumblebee_checksum', 'reference', 'Title']
             )
 
     def test_solr_start_is_calculated_from_batching_current_page_and_pagesize(self):
-        self.source.solr_results(
-            {'SearchableText': 'foo'})
-        self.assertEqual(
-            self.solr.search.call_args[1]['start'],
-            0)
+        with self.mock_solr('solr_search.json') as solr:
+            self.source.solr_results(
+                {'SearchableText': 'foo'})
+            self.assertEqual(
+                solr.search.call_args[1]['start'],
+                0)
 
-        self.source.config.batching_current_page = 3
-        self.source.config.pagesize = 15
-        self.source.solr_results(
-            {'SearchableText': 'foo'})
-        self.assertEqual(
-            self.solr.search.call_args[1]['start'],
-            30)
+            self.source.config.batching_current_page = 3
+            self.source.config.pagesize = 15
+            self.source.solr_results(
+                {'SearchableText': 'foo'})
+            self.assertEqual(
+                solr.search.call_args[1]['start'],
+                30)
 
     def test_solr_rows_equals_pagesize(self):
-        self.source.solr_results(
-            {'SearchableText': 'foo'})
-        self.assertEqual(
-            self.solr.search.call_args[1]['rows'],
-            50)
+        with self.mock_solr('solr_search.json') as solr:
+            self.source.solr_results(
+                {'SearchableText': 'foo'})
+            self.assertEqual(
+                solr.search.call_args[1]['rows'],
+                50)
 
-        self.source.config.pagenumber = 3
-        self.source.config.pagesize = 15
-        self.source.solr_results(
-            {'SearchableText': 'foo'})
-        self.assertEqual(
-            self.solr.search.call_args[1]['rows'],
-            15)
+            self.source.config.pagenumber = 3
+            self.source.config.pagesize = 15
+            self.source.solr_results(
+                {'SearchableText': 'foo'})
+            self.assertEqual(
+                solr.search.call_args[1]['rows'],
+                15)
 
     def test_solr_is_used_if_enabled_and_searchable_text(self):
-        registry = getUtility(IRegistry)
-        settings = registry.forInterface(ISearchSettings)
-        settings.use_solr = True
-        self.source.search_results({'SearchableText': 'foo'})
-        self.assertTrue(self.solr.search.called)
+        with self.mock_solr('solr_search.json') as solr:
+            registry = getUtility(IRegistry)
+            settings = registry.forInterface(ISearchSettings)
+            settings.use_solr = True
+            self.source.search_results({'SearchableText': 'foo'})
+            self.assertTrue(solr.search.called)
 
     def test_solr_is_not_used_if_disabled(self):
-        registry = getUtility(IRegistry)
-        settings = registry.forInterface(ISearchSettings)
-        settings.use_solr = False
-        self.source.search_results({'SearchableText': 'foo'})
-        self.assertFalse(self.solr.search.called)
+        with self.mock_solr('solr_search.json') as solr:
+            registry = getUtility(IRegistry)
+            settings = registry.forInterface(ISearchSettings)
+            settings.use_solr = False
+            self.source.search_results({'SearchableText': 'foo'})
+            self.assertFalse(solr.search.called)
 
     def test_solr_is_used_if_enabled_and_without_searchable_text(self):
-        registry = getUtility(IRegistry)
-        settings = registry.forInterface(ISearchSettings)
-        settings.use_solr = True
-        self.source.search_results({})
-        self.assertTrue(self.solr.search.called)
+        with self.mock_solr('solr_search.json') as solr:
+            registry = getUtility(IRegistry)
+            settings = registry.forInterface(ISearchSettings)
+            settings.use_solr = True
+            self.source.search_results({})
+            self.assertTrue(solr.search.called)
 
 
 class TestBatchableSolrResults(IntegrationTestCase):
 
-    def setUp(self):
-        super(TestBatchableSolrResults, self).setUp()
-        self.solr = self.mock_solr('solr_search.json')
-
     def test_solr_results_for_first_batch(self):
-        resp = self.solr.search()
+        with self.mock_solr('solr_search.json') as solr:
+            resp = solr.search()
         results = BatchableSolrResults(resp)
         self.assertEqual(len(results), 3)
         self.assertEqual(results[0].id, 'my-folder-1')
@@ -174,7 +185,8 @@ class TestBatchableSolrResults(IntegrationTestCase):
         self.assertEqual(results[2].id, 'my-document')
 
     def test_solr_results_for_subsequent_batch(self):
-        resp = self.solr.search()
+        with self.mock_solr('solr_search.json') as solr:
+            resp = solr.search()
         resp.num_found = 53
         resp.start = 50
         results = BatchableSolrResults(resp)
@@ -184,7 +196,8 @@ class TestBatchableSolrResults(IntegrationTestCase):
         self.assertEqual(results[52].id, 'my-document')
 
     def test_solr_results_are_sliceable(self):
-        resp = self.solr.search()
+        with self.mock_solr('solr_search.json') as solr:
+            resp = solr.search()
         resp.num_found = 53
         resp.start = 50
         results = BatchableSolrResults(resp)


### PR DESCRIPTION
The `mock_solr`-method of `opengever/testing/integration_test_case.py` is not isolated at all. If used once, the solr connection is mocked for every upcoming test.

We have another solr-mock implementation within the disposition builder introduced in https://github.com/4teamwork/opengever.core/pull/7939 (https://github.com/4teamwork/opengever.core/pull/7939/commits/b38f4d82779b33fe19e68f5ba39af55294651ca3) which checks for an already running solr and mocks the response if there is no solr connection yet. 

Until now, there was no test using the `mock_solr` method before the disposition activity-tests which relies on these mocked results: https://github.com/4teamwork/opengever.core/blob/master/opengever/disposition/tests/test_activities.py#L36

Under some circumstances, the execution order changes and when running the disposition-tests, the solr was already mocked and have not returned the right results.

This PR fixes this issue by using a context-manager for the `mock_solr` method to properly isolate it between tests.

I run into this issue through the linked story below. But it is unrelated to the story and could have been happen after every other test change.

For [TI-661]

## Checklist

- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-661]: https://4teamwork.atlassian.net/browse/TI-661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ