### PR TITLE
Add Dossier creator column to dossier report

### DIFF
--- a/changes/TI-1472.other
+++ b/changes/TI-1472.other
@@ -1,0 +1,1 @@
+Add an optional Creator column to the dossier report. [amo]

--- a/opengever/dossier/browser/report.py
+++ b/opengever/dossier/browser/report.py
@@ -66,6 +66,13 @@ class DossierReporter(SolrReporterView):
             'is_default': True,
             'tabbedview_column': 'reference',
         },
+        {
+            'id': 'creator',
+            'is_default': False,
+            'alias': 'creator_fullname',
+            'transform': readable_actor,
+            'title': _(u'dossier_report_creator', default=u'Creator')
+        },
     )
 
     def __call__(self):

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2024-02-07 13:02+0000\n"
+"POT-Creation-Date: 2024-11-05 13:46+0000\n"
 "PO-Revision-Date: 2017-05-23 04:53+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -358,6 +358,11 @@ msgstr "Dokumente"
 #: ./opengever/dossier/browser/protect_dossier.py
 msgid "dossier_protection_inconsistency_warning"
 msgstr "Die lokalen Berechtigungen stimmen nicht mit den Dossier-Schutz Einstellungen überein. Wenn Sie dieses Formular speichern, werden die aktuellen lokalen Berechtigungen mit den Dossier-Schutz Einstellungen überschrieben."
+
+#. Default: "Creator"
+#: ./opengever/dossier/browser/report.py
+msgid "dossier_report_creator"
+msgstr "Ersteller"
 
 #. Default: "Responsible"
 #: ./opengever/dossier/browser/report.py
@@ -836,11 +841,6 @@ msgstr "Standardabläufe"
 #: ./opengever/dossier/templatefolder/form.py
 msgid "label_template"
 msgstr "Vorlage"
-
-#. Default: "Template group"
-#: ./opengever/dossier/templatefolder/tabs.py
-msgid "label_template_group"
-msgstr "Vorlagengruppe"
 
 #. Default: "Title"
 #: ./opengever/dossier/dossiertemplate/form.py

--- a/opengever/dossier/locales/en/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/en/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2024-02-07 13:02+0000\n"
+"POT-Creation-Date: 2024-11-05 13:46+0000\n"
 "PO-Revision-Date: 2017-05-23 04:53+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -443,6 +443,11 @@ msgstr "Documents"
 #: ./opengever/dossier/browser/protect_dossier.py
 msgid "dossier_protection_inconsistency_warning"
 msgstr "Local roles do not match with current dossier protection settings. If you save this form, local roles will be overridden with the roles specified in protection settings."
+
+#. Default: "Creator"
+#: ./opengever/dossier/browser/report.py
+msgid "dossier_report_creator"
+msgstr "Creator"
 
 #. Default: "Responsible"
 #: ./opengever/dossier/browser/report.py
@@ -1010,12 +1015,6 @@ msgstr "Task template folders"
 #: ./opengever/dossier/templatefolder/form.py
 msgid "label_template"
 msgstr "Template"
-
-#. German translation: Vorlagengruppe
-#. Default: "Template group"
-#: ./opengever/dossier/templatefolder/tabs.py
-msgid "label_template_group"
-msgstr "Template group"
 
 #. German translation: Titel
 #. Default: "Title"

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-02-07 13:02+0000\n"
+"POT-Creation-Date: 2024-11-05 13:46+0000\n"
 "PO-Revision-Date: 2017-12-03 11:16+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/fr/>\n"
@@ -356,6 +356,11 @@ msgstr "Documents"
 #: ./opengever/dossier/browser/protect_dossier.py
 msgid "dossier_protection_inconsistency_warning"
 msgstr "Les autorisations actuelles ne correspondent pas aux paramètres de protection du dossier. En enregistrant ce formulaire, les autorisations locales actuelles seront écrasées par les paramètres de protection du dossier."
+
+#. Default: "Creator"
+#: ./opengever/dossier/browser/report.py
+msgid "dossier_report_creator"
+msgstr "Créateur"
 
 #. Default: "Responsible"
 #: ./opengever/dossier/browser/report.py
@@ -834,11 +839,6 @@ msgstr "Déroulements standard"
 #: ./opengever/dossier/templatefolder/form.py
 msgid "label_template"
 msgstr "Modèle"
-
-#. Default: "Template group"
-#: ./opengever/dossier/templatefolder/tabs.py
-msgid "label_template_group"
-msgstr "Groupe de modèles"
 
 #. Default: "Title"
 #: ./opengever/dossier/dossiertemplate/form.py

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-02-07 13:02+0000\n"
+"POT-Creation-Date: 2024-11-05 13:46+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -356,6 +356,11 @@ msgstr ""
 #. Default: "The local roles do not match with the current dossier protection settings. If you save this form, the local roles will be overridden."
 #: ./opengever/dossier/browser/protect_dossier.py
 msgid "dossier_protection_inconsistency_warning"
+msgstr ""
+
+#. Default: "Creator"
+#: ./opengever/dossier/browser/report.py
+msgid "dossier_report_creator"
 msgstr ""
 
 #. Default: "Responsible"
@@ -832,11 +837,6 @@ msgstr ""
 #: ./opengever/dossier/dossiertemplate/form.py
 #: ./opengever/dossier/templatefolder/form.py
 msgid "label_template"
-msgstr ""
-
-#. Default: "Template group"
-#: ./opengever/dossier/templatefolder/tabs.py
-msgid "label_template_group"
 msgstr ""
 
 #. Default: "Title"

--- a/opengever/dossier/tests/test_reporter.py
+++ b/opengever/dossier/tests/test_reporter.py
@@ -107,6 +107,7 @@ class TestDossierReporter(SolrIntegrationTestCase):
             'touched',
             'keywords',
             'description',
+            'creator'
         ]})
         browser.open(view='dossier_report', data=params)
 
@@ -123,7 +124,8 @@ class TestDossierReporter(SolrIntegrationTestCase):
             u'Reference number',
             u'Last modified',
             u'Keywords',
-            u'Description'
+            u'Description',
+            u'Creator'
         ]
         self.assertEqual(expected_titles, [cell.value for cell in rows[0]])
 
@@ -137,7 +139,8 @@ class TestDossierReporter(SolrIntegrationTestCase):
             u'Client1 1.1 / 1',
             datetime(2016, 8, 31, 0, 0),
             u'Finanzverwaltung, Vertr\xe4ge',
-            self.dossier.description
+            self.dossier.description,
+            u'Ziegler Robert (robert.ziegler)'
         ]
         self.assertEqual(expected_values, [cell.value for cell in rows[1]])
 


### PR DESCRIPTION
**This PR**:
Adds the dossier creator to the dossier report if the creator column is sent from the front end

For [TI-1472](https://4teamwork.atlassian.net/browse/TI-1472)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [x] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[TI-1472]: https://4teamwork.atlassian.net/browse/TI-1472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ