### PR TITLE
Provide dossier Excel export including subdossier

### DIFF
--- a/changes/TI-1471.other
+++ b/changes/TI-1471.other
@@ -1,0 +1,1 @@
+- Provide dossier Excel export, including subdossiers. [amo]

--- a/opengever/api/tests/test_ui_actions.py
+++ b/opengever/api/tests/test_ui_actions.py
@@ -60,7 +60,7 @@ class TestUIActionsGET(IntegrationTestCase):
                       u'&listings:list=dossiers'.format(self.dossier.absolute_url())
         browser.open(dossier_url, method='GET', headers=self.api_headers)
         self.assertEqual([u'edit_items', u'copy_items', u'move_items', u'export_dossiers',
-                          u'pdf_dossierlisting'],
+                          u'export_dossiers_with_subdossiers', u'pdf_dossierlisting'],
                          [action['id'] for action in browser.json['listing_actions']])
         combined_url = u'{}/@ui-actions?categories:list=listing_actions'\
                        u'&listings:list=tasks&listings:list=dossiers'.format(

--- a/opengever/base/listing_actions.py
+++ b/opengever/base/listing_actions.py
@@ -21,6 +21,7 @@ class BaseListingActions(object):
         self.maybe_add_zip_selected()
         self.maybe_add_export_documents()
         self.maybe_add_export_dossiers()
+        self.maybe_add_export_dossiers_with_subdossiers()
         self.maybe_add_export_tasks()
         self.maybe_add_export_proposals()
         self.maybe_add_pdf_dossierlisting()
@@ -76,6 +77,9 @@ class BaseListingActions(object):
         return False
 
     def is_export_dossiers_available(self):
+        return False
+
+    def is_export_dossiers_with_subdossiers_available(self):
         return False
 
     def is_export_proposals_available(self):
@@ -159,6 +163,10 @@ class BaseListingActions(object):
     def maybe_add_export_dossiers(self):
         if self.is_export_dossiers_available():
             self.add_action(u'export_dossiers')
+
+    def maybe_add_export_dossiers_with_subdossiers(self):
+        if self.is_export_dossiers_with_subdossiers_available():
+            self.add_action(u'export_dossiers_with_subdossiers')
 
     def maybe_add_export_proposals(self):
         if self.is_export_proposals_available():

--- a/opengever/document/browser/report.py
+++ b/opengever/document/browser/report.py
@@ -32,7 +32,7 @@ class DocumentReporter(SolrReporterView):
 
     field_mapper = DocumentReporterFieldMapper
 
-    corresponding_listing_name = 'dossiers'
+    corresponding_listing_name = 'documents'
 
     column_settings = [
         {

--- a/opengever/dossier/actions.py
+++ b/opengever/dossier/actions.py
@@ -28,6 +28,9 @@ class DossierListingActions(BaseListingActions):
     def is_export_dossiers_available(self):
         return True
 
+    def is_export_dossiers_with_subdossiers_available(self):
+        return True
+
     def is_move_items_available(self):
         return True
 

--- a/opengever/dossier/tests/test_actions.py
+++ b/opengever/dossier/tests/test_actions.py
@@ -22,20 +22,20 @@ class TestDossierListingActions(IntegrationTestCase):
     def test_dossier_actions_for_reporoot_and_repofolder(self):
         self.login(self.regular_user)
         expected_actions = [u'edit_items', u'copy_items', u'move_items', u'export_dossiers',
-                            u'pdf_dossierlisting']
+                            u'export_dossiers_with_subdossiers', u'pdf_dossierlisting']
         self.assertEqual(expected_actions, self.get_actions(self.repository_root))
         self.assertEqual(expected_actions, self.get_actions(self.branch_repofolder))
 
     def test_dossier_actions_for_plone_site(self):
         self.login(self.regular_user)
         expected_actions = [u'edit_items', u'copy_items', u'move_items', u'export_dossiers',
-                            u'pdf_dossierlisting']
+                            u'export_dossiers_with_subdossiers', u'pdf_dossierlisting']
         self.assertEqual(expected_actions, self.get_actions(self.portal))
 
     def test_dossier_actions_for_dossier(self):
         self.login(self.regular_user)
         expected_actions = [u'edit_items', u'copy_items', u'move_items', u'export_dossiers',
-                            u'pdf_dossierlisting']
+                            u'export_dossiers_with_subdossiers', u'pdf_dossierlisting']
         self.assertEqual(expected_actions, self.get_actions(self.dossier))
         self.assertEqual(expected_actions, self.get_actions(self.meeting_dossier))
 

--- a/opengever/dossier/tests/test_reporter.py
+++ b/opengever/dossier/tests/test_reporter.py
@@ -510,3 +510,40 @@ class TestDossierReporter(SolrIntegrationTestCase):
 
         self.assertEqual(listing_titles_descending, report_titles)
         self.assertNotEqual(listing_titles_ascending, report_titles)
+
+    @browsing
+    def test_dossier_report_with_subdossiers(self, browser):
+        self.login(self.regular_user, browser=browser)
+        data = self.make_path_param(self.dossier)
+        data["include_children"] = True
+
+        browser.open(view='dossier_report', data=data)
+
+        workbook = self.load_workbook(browser.contents)
+        rows = list(workbook.active.rows)
+
+        # Main dossier
+        self.assertSequenceEqual(
+            [self.dossier.title,
+             datetime(2016, 1, 1),
+             None,
+             u'Ziegler Robert (robert.ziegler)',
+             u'Active',
+             u'Client1 1.1 / 1'],
+            [cell.value for cell in rows[1]])
+
+        # Subdossiers
+        self.assertSequenceEqual(
+            [u'2016', datetime(2016, 8, 31, 0, 0), None, None, u'Active', u'Client1 1.1 / 1.1'],
+            [cell.value for cell in rows[2]]
+        )
+
+        self.assertSequenceEqual(
+            [u'Subsubdossier', datetime(2016, 8, 31, 0, 0), None, None, u'Active', u'Client1 1.1 / 1.1.1'],
+            [cell.value for cell in rows[3]]
+        )
+
+        self.assertSequenceEqual(
+            [u'2015', datetime(2016, 8, 31, 0, 0), None, None, u'Active', u'Client1 1.1 / 1.2'],
+            [cell.value for cell in rows[4]]
+        )


### PR DESCRIPTION
**This PR:**

Implements a new action to export dossiers with subdossiers. We use the same endpoint, `dossier_report`, and its related class `DossierReporter`. 

The export is controlled via a parameter flag, `include_children`. If the flag is set to true, the subdossiers will be included in the export; otherwise, only the selected dossiers will be exported.


For [TI-1471](https://4teamwork.atlassian.net/browse/TI-1471)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)



[TI-1471]: https://4teamwork.atlassian.net/browse/TI-1471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ