### PR TITLE
Provide Excel Export for groups membership

### DIFF
--- a/changes/TI-1476.other
+++ b/changes/TI-1476.other
@@ -1,0 +1,1 @@
+Provide groups membership export for admin users. [amo]

--- a/opengever/base/reporter.py
+++ b/opengever/base/reporter.py
@@ -84,7 +84,7 @@ class XLSReporter(object):
 
     def __init__(self, request, attributes, results,
                  sheet_title=u' ', footer=u'', portrait_format=False,
-                 blank_header_rows=0, field_mapper=None):
+                 blank_header_rows=0, field_mapper=None, is_auto_filter_enabled=False):
         """Initalize the XLS reporter
         Arguments:
         attributes -- a list of mappings (with 'id', 'title', 'transform')
@@ -99,6 +99,7 @@ class XLSReporter(object):
         self.portrait_format = portrait_format
         self.blank_header_rows = blank_header_rows
         self.field_mapper = field_mapper
+        self.is_auto_filter_enabled = is_auto_filter_enabled
 
     def __call__(self):
         workbook = self.prepare_workbook()
@@ -124,6 +125,16 @@ class XLSReporter(object):
 
         for index, width in column_widths.iteritems():
             sheet.column_dimensions[index].width = width
+
+        if self.is_auto_filter_enabled:
+            # Determine the range for auto_filter based on attributes length
+            last_column = get_column_letter(len(self.attributes))
+            header_row_index = self.blank_header_rows + 1  # Adjusts for any blank header rows
+            sheet.auto_filter.ref = "{start_col}{header_row}:{end_col}{header_row}".format(
+                start_col=get_column_letter(1),
+                header_row=header_row_index,
+                end_col=last_column
+            )
 
         return workbook
 

--- a/opengever/globalindex/browser/configure.zcml
+++ b/opengever/globalindex/browser/configure.zcml
@@ -18,5 +18,10 @@
       />
 
 
-
+  <browser:page
+      name="groups-membership-report"
+      for="*"
+      class=".report.OGDSGroupsMembershipReporter"
+      permission="zope2.View"
+      />
 </configure>

--- a/opengever/globalindex/locales/de/LC_MESSAGES/opengever.globalindex.po
+++ b/opengever/globalindex/locales/de/LC_MESSAGES/opengever.globalindex.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-04-23 09:41+0000\n"
+"POT-Creation-Date: 2024-11-12 10:32+0000\n"
 "PO-Revision-Date: 2016-07-22 15:25+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-globalindex/de/>\n"
@@ -99,6 +99,19 @@ msgid "label_firstname"
 msgstr "Vorname"
 
 #: ./opengever/globalindex/browser/report.py
+msgid "label_groupid"
+msgstr "Gruppen-ID"
+
+#: ./opengever/globalindex/browser/report.py
+msgid "label_groupname"
+msgstr "Gruppenname"
+
+#. Default: "Groups membership report"
+#: ./opengever/globalindex/browser/report.py
+msgid "label_groups_membership_report"
+msgstr "Gruppenmitgliedschaften"
+
+#: ./opengever/globalindex/browser/report.py
 msgid "label_issuer"
 msgstr "Auftraggeber"
 
@@ -163,6 +176,10 @@ msgstr "Titel"
 #: ./opengever/globalindex/browser/report.py
 msgid "label_url"
 msgstr "URL"
+
+#: ./opengever/globalindex/browser/report.py
+msgid "label_userid"
+msgstr "Benutzer-ID"
 
 #: ./opengever/globalindex/browser/report.py
 msgid "label_username"

--- a/opengever/globalindex/locales/en/LC_MESSAGES/opengever.globalindex.po
+++ b/opengever/globalindex/locales/en/LC_MESSAGES/opengever.globalindex.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-04-23 09:41+0000\n"
+"POT-Creation-Date: 2024-11-12 10:32+0000\n"
 "PO-Revision-Date: 2016-07-22 15:25+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-globalindex/de/>\n"
@@ -104,6 +104,19 @@ msgstr "Secondary E-Mail"
 msgid "label_firstname"
 msgstr "First name"
 
+#: ./opengever/globalindex/browser/report.py
+msgid "label_groupid"
+msgstr "Group-ID"
+
+#: ./opengever/globalindex/browser/report.py
+msgid "label_groupname"
+msgstr "Group name"
+
+#. Default: "Groups membership report"
+#: ./opengever/globalindex/browser/report.py
+msgid "label_groups_membership_report"
+msgstr "Group membership report"
+
 #. German translation: Auftraggeber
 #: ./opengever/globalindex/browser/report.py
 msgid "label_issuer"
@@ -177,6 +190,10 @@ msgstr "Title"
 #: ./opengever/globalindex/browser/report.py
 msgid "label_url"
 msgstr "URL"
+
+#: ./opengever/globalindex/browser/report.py
+msgid "label_userid"
+msgstr "User-ID"
 
 #: ./opengever/globalindex/browser/report.py
 msgid "label_username"

--- a/opengever/globalindex/locales/fr/LC_MESSAGES/opengever.globalindex.po
+++ b/opengever/globalindex/locales/fr/LC_MESSAGES/opengever.globalindex.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-04-23 09:41+0000\n"
+"POT-Creation-Date: 2024-11-12 10:32+0000\n"
 "PO-Revision-Date: 2017-12-03 09:48+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-globalindex/fr/>\n"
@@ -99,6 +99,19 @@ msgid "label_firstname"
 msgstr "Prénom"
 
 #: ./opengever/globalindex/browser/report.py
+msgid "label_groupid"
+msgstr "ID de groupe"
+
+#: ./opengever/globalindex/browser/report.py
+msgid "label_groupname"
+msgstr "Nom du groupe"
+
+#. Default: "Groups membership report"
+#: ./opengever/globalindex/browser/report.py
+msgid "label_groups_membership_report"
+msgstr "Rapport d'appartenance aux groupes"
+
+#: ./opengever/globalindex/browser/report.py
 msgid "label_issuer"
 msgstr "Mandant"
 
@@ -163,6 +176,10 @@ msgstr "Titre"
 #: ./opengever/globalindex/browser/report.py
 msgid "label_url"
 msgstr "URL"
+
+#: ./opengever/globalindex/browser/report.py
+msgid "label_userid"
+msgstr "ID utilisateur"
 
 #: ./opengever/globalindex/browser/report.py
 msgid "label_username"

--- a/opengever/globalindex/locales/opengever.globalindex.pot
+++ b/opengever/globalindex/locales/opengever.globalindex.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-04-23 09:41+0000\n"
+"POT-Creation-Date: 2024-11-12 10:32+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -100,6 +100,19 @@ msgid "label_firstname"
 msgstr ""
 
 #: ./opengever/globalindex/browser/report.py
+msgid "label_groupid"
+msgstr ""
+
+#: ./opengever/globalindex/browser/report.py
+msgid "label_groupname"
+msgstr ""
+
+#. Default: "Groups membership report"
+#: ./opengever/globalindex/browser/report.py
+msgid "label_groups_membership_report"
+msgstr ""
+
+#: ./opengever/globalindex/browser/report.py
 msgid "label_issuer"
 msgstr ""
 
@@ -163,6 +176,10 @@ msgstr ""
 
 #: ./opengever/globalindex/browser/report.py
 msgid "label_url"
+msgstr ""
+
+#: ./opengever/globalindex/browser/report.py
+msgid "label_userid"
 msgstr ""
 
 #: ./opengever/globalindex/browser/report.py

--- a/opengever/globalindex/tests/test_reporter.py
+++ b/opengever/globalindex/tests/test_reporter.py
@@ -299,3 +299,68 @@ class TestUserReporter(IntegrationTestCase):
             ]
         ]
         self.assertSequenceEqual(expected_values, cell_values)
+
+
+class TestOGDSGroupsMembershipReporter(IntegrationTestCase):
+
+    @browsing
+    def test_groups_membership_report(self, browser):
+        # Login as an administrator to access the report
+        self.login(self.administrator, browser=browser)
+
+        browser.open(view='groups-membership-report')
+
+        # Ensure the response status is 200 (OK)
+        self.assertEqual(browser.status_code, 200)
+
+        # Save the returned Excel content to a temporary file
+        with NamedTemporaryFile(delete=False, suffix='.xlsx') as tmpfile:
+            tmpfile.write(browser.contents)
+            tmpfile.flush()
+            workbook = load_workbook(tmpfile.name)
+
+        # Check the headers/columns in the Excel sheet
+        self.assertSequenceEqual(
+            ['Username', 'User-ID', 'Group name', 'Group-ID'],
+            [cell.value for cell in list(workbook.active.rows)[0]]
+        )
+
+        # Get the rows (skip the first row which contains headers)
+        rows = list(workbook.active.rows)[1:]
+        expected_values = [
+            [u'kathi.barfuss', u'regular_user', u'fa_users', u'fa_users'],
+            [u'jurgen.fischer', u'archivist', u'fa_users', u'fa_users'],
+            [u'ramon.flucht', u'records_manager', u'fa_users', u'fa_users'],
+            [u'gunther.frohlich', u'gunther.frohlich', u'fa_users', u'fa_users'],
+            [u'faivel.fruhling', u'dossier_manager', u'fa_users', u'fa_users'],
+            [u'fridolin.hugentobler', u'fridolin.hugentobler', u'fa_users', u'fa_users'],
+            [u'maja.harzig', u'limited_admin', u'fa_users', u'fa_users'],
+            [u'herbert.jager', u'meeting_user', u'fa_users', u'fa_users'],
+            [u'nicole.kohler', u'nicole.kohler', u'fa_users', u'fa_users'],
+            [u'jurgen.konig', u'jurgen.konig', u'fa_users', u'fa_users'],
+            [u'propertysheets.manager', u'propertysheets_manager', u'fa_users', u'fa_users'],
+            [u'webaction.manager', u'webaction_manager', u'fa_users', u'fa_users'],
+            [u'david.meier', u'member_admin', u'fa_users', u'fa_users'],
+            [u'franzi.muller', u'committee_responsible', u'fa_users', u'fa_users'],
+            [u'hans.peter', u'hans.peter', u'fa_users', u'fa_users'],
+            [u'beatrice.schrodinger', u'beatrice.schrodinger', u'fa_users', u'fa_users'],
+            [u'committee.secretary', u'committee.secretary', u'fa_users', u'fa_users'],
+            [u'service.user', u'service_user', u'fa_users', u'fa_users'],
+            [u'robert.ziegler', u'robert.ziegler', u'fa_users', u'fa_users'],
+            [u'kathi.barfuss', u'regular_user', u'projekt_a', u'projekt_a'],
+            [u'robert.ziegler', u'robert.ziegler', u'projekt_a', u'projekt_a'],
+            [u'james.bond', u'james.bond', u'rk_users', u'rk_users'],
+            [u'herbert.jager', u'meeting_user', u'projekt_b', u'projekt_b'],
+            [u'franzi.muller', u'committee_responsible', u'projekt_b', u'projekt_b'],
+            [u'nicole.kohler', u'nicole.kohler', u'committee_rpk_group', u'committee_rpk_group'],
+            [u'franzi.muller', u'committee_responsible', u'committee_rpk_group', u'committee_rpk_group'],
+            [u'nicole.kohler', u'nicole.kohler', u'committee_ver_group', u'committee_ver_group'],
+            [u'franzi.muller', u'committee_responsible', u'committee_ver_group', u'committee_ver_group'],
+            [u'jurgen.konig', u'jurgen.konig', u'fa_inbox_users', u'fa_inbox_users']
+        ]
+
+        for row, expected_row in zip(rows, expected_values):
+            self.assertSequenceEqual(
+                expected_row,
+                [cell.value for cell in row]
+            )


### PR DESCRIPTION
**This PR:**
Implement a new endpoint `groups-membership-report` to export all groups and their related users in an Excel table.

The endpoint is accessible only for admin users


For [TI-1476](https://4teamwork.atlassian.net/browse/TI-1476)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [x] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[TI-1476]: https://4teamwork.atlassian.net/browse/TI-1476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ