### PR TITLE
Enhance RoleAssignmentReportsGet endpoint with new values

### DIFF
--- a/changes/TI-1477.other
+++ b/changes/TI-1477.other
@@ -1,0 +1,1 @@
+Enhance the returned data from the RoleAssignmentReportsGet endpoint by including new values. [amo]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -25,6 +25,8 @@ Other Changes
 ^^^^^^^^^^^^^
 - Add ``pending_signing_job`` attribute to serialized documents.
 - Add ``signatures_by_version`` attribute to serialized documents.
+- Extend serialized attributes of the role assignment report items
+
 
 
 2024.14.0 (2024-09-24)

--- a/opengever/api/role_assignment_reports.py
+++ b/opengever/api/role_assignment_reports.py
@@ -1,3 +1,4 @@
+from opengever.base.interfaces import IReferenceNumber
 from opengever.base.interfaces import IRoleAssignmentReportsStorage
 from opengever.ogds.base.actor import Actor
 from opengever.sharing.browser.sharing import GEVER_ROLE_MAPPING
@@ -7,8 +8,10 @@ from plone.app.uuid.utils import uuidToObject
 from plone.protect.interfaces import IDisableCSRFProtection
 from plone.restapi.batching import HypermediaBatch
 from plone.restapi.deserializer import json_body
+from plone.restapi.interfaces import ISerializeToJsonSummary
 from plone.restapi.services import Service
 from zExceptions import BadRequest
+from zope.component import getMultiAdapter
 from zope.i18n import translate
 from zope.interface import alsoProvides
 from zope.interface import implements
@@ -59,7 +62,9 @@ class RoleAssignmentReportsGet(RoleAssignmentReportsBase):
                 raise BadRequest("Invalid report_id '{}'".format(report_id))
             for item in result['items']:
                 obj = uuidToObject(item['UID'])
-                item['title'] = obj.Title()
+                item.update(**getMultiAdapter((obj, self.request), ISerializeToJsonSummary)())
+                ref_num = IReferenceNumber(obj)
+                item['reference_number'] = ref_num.get_number()
                 item['url'] = obj.absolute_url()
 
             result['referenced_roles'] = self.get_referenced_roles()

--- a/opengever/api/tests/test_role_assignment_reports.py
+++ b/opengever/api/tests/test_role_assignment_reports.py
@@ -41,36 +41,66 @@ class TestRoleAssignmentReportsGet(IntegrationTestCase):
         browser.open(self.portal.absolute_url() + '/@role-assignment-reports/report_0',
                      method='GET', headers=self.api_headers)
         self.assertEqual(
-            {u'@id': u'http://nohost/plone/@role-assignment-reports/report_0',
-             u'@type': u'virtual.report.roleassignmentreport',
-             u'referenced_roles': [{u'id': u'Reader', u'title': u'Read'},
-                                   {u'id': u'Contributor', u'title': u'Add dossiers'},
-                                   {u'id': u'Editor', u'title': u'Edit dossiers'},
-                                   {u'id': u'Reviewer', u'title': u'Resolve dossiers'},
-                                   {u'id': u'Publisher', u'title': u'Reactivate dossiers'},
-                                   {u'id': u'DossierManager', u'title': u'Manage dossiers'},
-                                   {u'id': u'TaskResponsible', u'title': u'Task responsible'},
-                                   {u'id': u'Role Manager', u'title': u'Role manager'}],
-             u'items': [{u'UID': u'createrepositorytree000000000001',
-                         u'roles': [u'Contributor'],
-                         u'title': u'Ordnungssystem',
-                         u'url': u'http://nohost/plone/ordnungssystem'},
-                        {u'UID': u'createtreatydossiers000000000018',
-                         u'roles': [u'Reader', u'Editor', u'Reviewer'],
-                         u'title': u'Subsubdossier',
-                         u'url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-'
-                         u'vereinbarungen/dossier-1/dossier-2/dossier-4'},
-                        {u'UID': u'createrepositorytree000000000004',
-                         u'roles': [u'Contributor', u'Publisher'],
-                         u'title': u'2. Rechnungspr\xfcfungskommission',
-                         u'url': u'http://nohost/plone/ordnungssystem/rechnungsprufungskommission'}],
-             u'items_total': 3,
-             u'modified': u'2016-08-31T20:01:33+00:00',
-             u'principal_type': u'user',
-             u'principal_label': u'Fischer J\xfcrgen (jurgen.fischer)',
-             u'principal_id': self.archivist.getId(),
-             u'report_id': u'report_0',
-             u'state': u'ready'}, browser.json)
+            {
+                u'@id': u'http://nohost/plone/@role-assignment-reports/report_0',
+                u'@type': u'virtual.report.roleassignmentreport',
+                u'items': [
+                    {
+                        u'@id': u'http://nohost/plone/ordnungssystem',
+                        u'@type': u'opengever.repository.repositoryroot',
+                        u'UID': u'createrepositorytree000000000001',
+                        u'description': u'',
+                        u'is_leafnode': None,
+                        u'reference_number': u'Client1',
+                        u'review_state': u'repositoryroot-state-active',
+                        u'roles': [u'Contributor'],
+                        u'title': u'Ordnungssystem',
+                        u'url': u'http://nohost/plone/ordnungssystem'
+                    },
+                    {
+                        u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/dossier-2/dossier-4', # noqa
+                        u'@type': u'opengever.dossier.businesscasedossier',
+                        u'UID': u'createtreatydossiers000000000018',
+                        u'description': u'',
+                        u'dossier_type': None,
+                        u'is_leafnode': None,
+                        u'is_subdossier': True,
+                        u'reference_number': u'Client1 1.1 / 1.1.1',
+                        u'review_state': u'dossier-state-active',
+                        u'roles': [u'Reader', u'Editor', u'Reviewer'],
+                        u'title': u'Subsubdossier',
+                        u'url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/dossier-2/dossier-4' # noqa
+                    },
+                    {
+                        u'@id': u'http://nohost/plone/ordnungssystem/rechnungsprufungskommission',
+                        u'@type': u'opengever.repository.repositoryfolder',
+                        u'UID': u'createrepositorytree000000000004',
+                        u'description': u'',
+                        u'is_leafnode': True,
+                        u'reference_number': u'Client1 2',
+                        u'review_state': u'repositoryfolder-state-active',
+                        u'roles': [u'Contributor', u'Publisher'],
+                        u'title': u'2. Rechnungspr\xfcfungskommission',
+                        u'url': u'http://nohost/plone/ordnungssystem/rechnungsprufungskommission'
+                    }
+                ],
+                u'items_total': 3,
+                u'modified': u'2016-08-31T20:01:33+00:00',
+                u'principal_id': u'archivist',
+                u'principal_label': u'Fischer J\xfcrgen (jurgen.fischer)',
+                u'principal_type': u'user',
+                u'referenced_roles': [
+                    {u'id': u'Reader', u'title': u'Read'},
+                    {u'id': u'Contributor', u'title': u'Add dossiers'},
+                    {u'id': u'Editor', u'title': u'Edit dossiers'},
+                    {u'id': u'Reviewer', u'title': u'Resolve dossiers'},
+                    {u'id': u'Publisher', u'title': u'Reactivate dossiers'},
+                    {u'id': u'DossierManager', u'title': u'Manage dossiers'},
+                    {u'id': u'TaskResponsible', u'title': u'Task responsible'},
+                    {u'id': u'Role Manager', u'title': u'Role manager'}
+                ],
+                u'report_id': u'report_0',
+                u'state': u'ready'}, browser.json)
 
     @browsing
     def test_get_role_assignment_report_with_invalid_report_id_raises_bad_request(self, browser):


### PR DESCRIPTION
**This PR** 
Updates the returned values from the `RoleAssignmentReportsGet` endpoint with additional data, including `reference_number `and `review_state`. This data will be used in the frontend to add new columns to the `RoleAssignmentReport `table.

For [TI-1477](https://4teamwork.atlassian.net/browse/TI-1477)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-1477]: https://4teamwork.atlassian.net/browse/TI-1477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ