### PR TITLE
Implement RoleAssignmentReporter

### DIFF
--- a/changes/TI-1541.other
+++ b/changes/TI-1541.other
@@ -1,0 +1,1 @@
+Introduce an object to create role assignment reports. [elioschmutz]

--- a/opengever/sharing/local_roles_lookup/reporter.py
+++ b/opengever/sharing/local_roles_lookup/reporter.py
@@ -1,0 +1,193 @@
+from collections import defaultdict
+from ftw.solr.interfaces import ISolrSearch
+from ftw.solr.query import make_filters
+from opengever.base.solr import batched_solr_results
+from opengever.base.solr import OGSolrDocument
+from opengever.ogds.models.user import User
+from opengever.sharing.local_roles_lookup.manager import LocalRolesLookupManager
+from plone.app.uuid.utils import uuidToObject
+from zope.component import getUtility
+
+
+class RoleAssignmentReporter(object):
+    """Responsible for generating role assignment report data.
+    """
+
+    field_list = [
+        'UID',
+        'path',
+        'Title',
+        'Description',
+        'review_state',
+        'portal_type',
+        'reference',
+        'is_leafnode',
+    ]
+
+    sort_order = 'path asc'
+
+    def __init__(self):
+        self.solr_service = SolrQueryService()
+        self.local_roles_manager = LocalRolesLookupManager()
+
+    def __call__(self, *args, **kwargs):
+        return self.report_for(*args, **kwargs)
+
+    def report_for(self,
+                   principal_id=None,
+                   include_memberships=False,
+                   root=None,
+                   start=0,
+                   rows=25):
+        """Generates a report of objects with custom local role assignments.
+
+        The report contains a dictionary with:
+        - `items`: A list of objects, each containing:
+            - A serialized Solr document representing the object.
+            - A dictionary mapping local roles to the list of principals assigned
+                to each role.
+        - `total_items`: The total number of objects included in the report.
+
+        Example:
+            {
+                "items": [
+                    {
+                        "item": {"@id": "..."},
+                        "role_assignments": {
+                            "role1": ["principal1", "principal2"],
+                            "role2": ["principal1"],
+                        }
+                    }
+                ],
+                "total_items": 1
+            }
+        """
+        principal_ids = self.expand_principal_ids(principal_id,
+                                                  include_memberships)
+        uids = self.get_distinct_uids(principal_ids)
+
+        if not uids:
+            return {'total_items': 0, 'items': []}
+
+        filters = self.build_filters(uids, root)
+        role_assignments = self.role_assignments_by_uid(uids, principal_ids)
+
+        items, total_items = self.solr_service.search(
+            filters, self.field_list, self.sort_order, start, rows)
+
+        items = [{
+            'item': self.serialize_solr_doc(item),
+            'role_assignments': role_assignments.get(item.get('UID'), {}),
+        } for item in items]
+
+        return {'total_items': total_items, 'items': items}
+
+    def serialize_solr_doc(self, doc):
+        item = OGSolrDocument(doc)
+        serialized_item = {
+            '@id': item.getURL(),
+            '@type': item.portal_type,
+            'UID': item.UID,
+            'title': item.Title,
+            'description': item.Description,
+            'review_state': item.review_state,
+            'reference': item.reference,
+            'is_leafnode': item.is_leafnode,
+        }
+        return serialized_item
+
+    def build_filters(self, uids, root):
+        """Builds the filters for Solr queries."""
+        return (SolrFilterBuilder()
+                .with_portal_types(self.local_roles_manager.MANAGED_PORTAL_TYPES)
+                .with_uids(uids)
+                .with_path(root)
+                .build())
+
+    def expand_principal_ids(self, principal_id, include_memberships=False):
+        """Returns a list of principal IDs, including memberships if requested.
+        """
+        if not principal_id:
+            return []
+
+        principal_ids = [principal_id]
+        if include_memberships:
+            principal_ids.extend(self.resolve_user_memberships(principal_id))
+
+        return principal_ids
+
+    def resolve_user_memberships(self, principal_id):
+        ogds_user = User.query.filter_by(userid=principal_id).one_or_none()
+        if not ogds_user:
+            return []
+        return [group.groupid for group in ogds_user.groups if group.active]
+
+    def get_distinct_uids(self, principal_ids):
+        if principal_ids:
+            return self.local_roles_manager.get_distinct_uids_by_principals(principal_ids)
+        else:
+            return self.local_roles_manager.get_distinct_uids()
+
+    def role_assignments_by_uid(self, uids_filter=None, principal_ids_filter=None):
+        """Returns a dict of uids containing local role assignments.
+
+        {
+          "uid1": {
+            "role1": ["principal_1", "principal_2]
+            "role2": ["principal_1"]
+          }
+        }
+        """
+        uids = defaultdict(lambda: defaultdict(list))
+        for entry in self.local_roles_manager.get_entries(
+                uids_filter=uids_filter,
+                principal_ids_filter=principal_ids_filter):
+            for role in entry.roles:
+                uids[entry.object_uid][role].append(entry.principal_id)
+        return uids
+
+
+class SolrFilterBuilder:
+    """Builds Solr filters for querying."""
+
+    def __init__(self):
+        self.filters = {}
+
+    def with_portal_types(self, portal_types):
+        self.filters['portal_type'] = portal_types
+        return self
+
+    def with_uids(self, uids):
+        if uids:
+            self.filters['UID'] = uids
+        return self
+
+    def with_path(self, root):
+        if root:
+            self.filters['path'] = {
+                'query': '/'.join(uuidToObject(root).getPhysicalPath()),
+                'depth': -1,
+            }
+        return self
+
+    def build(self):
+        return make_filters(**self.filters)
+
+
+class SolrQueryService:
+    def __init__(self):
+        self.solr = getUtility(ISolrSearch)
+
+    def search(self, filters, fields, sort, start, rows):
+        response = self.solr.search(filters=filters,
+                                    fl=fields,
+                                    sort=sort,
+                                    start=start,
+                                    rows=rows)
+        return response.docs, response.num_found
+
+    def fetch_all(self, filters, fields, sort):
+        items = []
+        for batch in batched_solr_results(filters=filters, fl=fields, sort=sort):
+            items.extend(batch)
+        return items, len(items)

--- a/opengever/sharing/tests/test_role_assignment_reporter.py
+++ b/opengever/sharing/tests/test_role_assignment_reporter.py
@@ -1,0 +1,198 @@
+from copy import deepcopy
+from opengever.sharing.local_roles_lookup.reporter import RoleAssignmentReporter
+from opengever.testing import SolrIntegrationTestCase
+
+
+class TestRoleAssignmentReporter(SolrIntegrationTestCase):
+
+    def strip_item_metadata(self, report):
+        """Formats the report by removing item metadata for easier testing
+        """
+        formatted_report = deepcopy(report)
+        for report_item in formatted_report.get('items'):
+            report_item['item'] = {'@id': report_item['item'].get('@id')}
+
+        return formatted_report
+
+    def test_can_creates_a_report_for_all_principals_and_objects(self):
+        self.login(self.administrator)
+        reporter = RoleAssignmentReporter()
+
+        self.assertEqual(
+            {
+                'total_items': 10,
+                'items': [
+                    {
+                        "item": {"@id": "http://nohost/plone/ordnungssystem"},
+                        "role_assignments": {
+                            "Contributor": ["archivist", "fa_users"],
+                            "Editor": ["fa_users"],
+                            "Publisher": ["jurgen.konig"],
+                            "Reader": ["fa_users"],
+                            "Reviewer": ["jurgen.konig"],
+                        },
+                    },
+                    {
+                        "item": {"@id": "http://nohost/plone/ordnungssystem/fuhrung"},
+                        "role_assignments": {"DossierManager": ["dossier_manager"]},
+                    },
+                    {
+                        "item": {
+                            "@id": "http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1"
+                        },
+                        "role_assignments": {"TaskResponsible": ["fa_inbox_users", "regular_user"]},
+                    },
+                    {
+                        "item": {
+                            "@id": "http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/dossier-2/dossier-4"
+                        },
+                        "role_assignments": {
+                            "Editor": ["archivist"],
+                            "Reader": ["archivist"],
+                            "Reviewer": ["archivist"],
+                        },
+                    },
+                    {
+                        "item": {
+                            "@id": "http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-16"
+                        },
+                        "role_assignments": {
+                            "Contributor": ["robert.ziegler"],
+                            "Editor": ["robert.ziegler"],
+                            "Reader": ["robert.ziegler"],
+                        },
+                    },
+                    {
+                        "item": {
+                            "@id": "http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-17"
+                        },
+                        "role_assignments": {
+                            "Contributor": ["robert.ziegler"],
+                            "Editor": ["robert.ziegler"],
+                            "Reader": ["robert.ziegler"],
+                            "TaskResponsible": ["fa_inbox_users", "regular_user"],
+                        },
+                    },
+                    {
+                        "item": {
+                            "@id": "http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-5"
+                        },
+                        "role_assignments": {"TaskResponsible": ["fa_inbox_users", "regular_user"]},
+                    },
+                    {
+                        "item": {
+                            "@id": "http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-6"
+                        },
+                        "role_assignments": {"TaskResponsible": ["fa_inbox_users", "regular_user"]},
+                    },
+                    {
+                        "item": {
+                            "@id": "http://nohost/plone/ordnungssystem/rechnungsprufungskommission"
+                        },
+                        "role_assignments": {"Contributor": ["archivist"], "Publisher": ["archivist"]},
+                    },
+                    {
+                        "item": {"@id": "http://nohost/plone/workspaces/workspace-1"},
+                        "role_assignments": {
+                            "WorkspaceAdmin": ["fridolin.hugentobler", "gunther.frohlich"],
+                            "WorkspaceGuest": ["hans.peter"],
+                            "WorkspaceMember": ["beatrice.schrodinger"],
+                        },
+                    },
+                ]
+            }, self.strip_item_metadata(reporter()))
+
+    def test_creates_a_report_for_a_single_principal(self):
+        self.login(self.administrator)
+        reporter = RoleAssignmentReporter()
+
+        self.assertItemsEqual(
+            {
+                'total_items': 1,
+                'items': [
+                    {
+                        'item': {
+                            '@id': 'http://nohost/plone/ordnungssystem',
+                            '@type': 'opengever.repository.repositoryroot',
+                            'UID': 'createrepositorytree000000000001',
+                            'description': '',
+                            'is_leafnode': None,
+                            'reference': 'Client1',
+                            'review_state': 'repositoryroot-state-active',
+                            'title': 'Ordnungssystem'
+                        },
+                        'role_assignments': {
+                            'Publisher': ['jurgen.konig'],
+                            'Reviewer': ['jurgen.konig']
+                        }
+                    }
+                ],
+            }, reporter('jurgen.konig'))
+
+    def test_creates_a_report_for_a_principal_including_all_group_memberships(self):
+        self.login(self.administrator)
+        reporter = RoleAssignmentReporter()
+
+        self.assertItemsEqual(
+            {
+                'total_items': 5,
+                'items': [
+                    {
+                        "item": {
+                            "@id": "http://nohost/plone/ordnungssystem",
+                        },
+                        "role_assignments": {
+                            "Contributor": ["fa_users"],
+                            "Editor": ["fa_users"],
+                            "Publisher": ["jurgen.konig"],
+                            "Reader": ["fa_users"],
+                            "Reviewer": ["jurgen.konig"],
+                        },
+                    },
+                    {
+                        "item": {
+                            "@id": "http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1",
+                        },
+                        "role_assignments": {"TaskResponsible": ["fa_inbox_users"]},
+                    },
+                    {
+                        "item": {
+                            "@id": "http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-17",
+                        },
+                        "role_assignments": {"TaskResponsible": ["fa_inbox_users"]},
+                    },
+                    {
+                        "item": {
+                            "@id": "http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-5",
+                        },
+                        "role_assignments": {"TaskResponsible": ["fa_inbox_users"]},
+                    },
+                    {
+                        "item": {
+                            "@id": "http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-6",
+                        },
+                        "role_assignments": {"TaskResponsible": ["fa_inbox_users"]},
+                    },
+                ],
+            },
+            self.strip_item_metadata(reporter('jurgen.konig', include_memberships=True)))
+
+    def test_creates_a_report_restricted_to_a_specific_branch(self):
+        self.login(self.administrator)
+        reporter = RoleAssignmentReporter()
+
+        report = reporter(include_memberships=True, root=self.dossier.UID())
+        self.assertEqual(
+            [
+                'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1',
+                'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/dossier-2/dossier-4',
+            ],
+            [report_item.get('item').get('@id') for report_item in report.get('items')])
+
+    def test_report_for_is_batched(self):
+        self.login(self.administrator)
+        reporter = RoleAssignmentReporter()
+
+        report = reporter(rows=3)
+        self.assertEqual(3, len(report.get('items')))
+        self.assertEqual(10, report.get('total_items'))


### PR DESCRIPTION
This PR implements the `RoleAssignmentReporter` which is able to return a dict of objects having changed local roles.

The reporter creates a dict providing a list of objects, ordered by their paths, that define custom local roles.

Each item in the list contains:
- a serialized Solr item representing the object.
- a dictionary mapping each defined local role to a list of principals assigned that role.

The report can be filtered by a specific `principal_id`, with an option to include or exclude assigned groups for the given principal. Additionally, the report can be limited to a specific branch.

For [TI-1541]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-1541]: https://4teamwork.atlassian.net/browse/TI-1541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ