### PR TITLE
Fix sort order for children dossier when exporting dossiers including subdossiers

### DIFF
--- a/opengever/base/browser/reporting_view.py
+++ b/opengever/base/browser/reporting_view.py
@@ -149,7 +149,11 @@ class SolrReporterView(BaseReporterView):
             sort = 'modified desc'
 
         filter_queries.extend(FILTERS.get(listing.listing_name, []))
-        solr_query['sort'] = sort
+
+        if include_children:
+            sort = 'path asc'
+
+        solr_query["sort"] = sort
 
         path_filters = []
         path_filters.append('path:({})'.format(' OR '.join([escape(path) for path in paths])))


### PR DESCRIPTION
**This PR:**
Follow-Up: Add Hierarchical Path Filtering and Sorting for Include-Children Feature

The hierarchy of the exported Excel file was disorganized. When exporting dossiers with subdossiers, the subdossiers were not listed under their main positions, which was not ideal for users. With these changes, we now have a proper hierarchy in the exported Excel table.

For [TI-1471](https://4teamwork.atlassian.net/browse/TI-1471)


[TI-1471]: https://4teamwork.atlassian.net/browse/TI-1471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ