### PR TITLE
Allow multiple principals when creating role assignment reports

### DIFF
--- a/changes/TI-1541-2.other
+++ b/changes/TI-1541-2.other
@@ -1,0 +1,1 @@
+Allow to create role assignment reports with multiple participants. [elioschmutz]

--- a/opengever/sharing/local_roles_lookup/reporter.py
+++ b/opengever/sharing/local_roles_lookup/reporter.py
@@ -34,7 +34,7 @@ class RoleAssignmentReporter(object):
         return self.report_for(*args, **kwargs)
 
     def report_for(self,
-                   principal_id=None,
+                   principal_ids=[],
                    include_memberships=False,
                    root=None,
                    start=0,
@@ -62,7 +62,7 @@ class RoleAssignmentReporter(object):
                 "total_items": 1
             }
         """
-        principal_ids = self.expand_principal_ids(principal_id,
+        principal_ids = self.expand_principal_ids(principal_ids,
                                                   include_memberships)
         uids = self.get_distinct_uids(principal_ids)
 
@@ -104,17 +104,20 @@ class RoleAssignmentReporter(object):
                 .with_path(root)
                 .build())
 
-    def expand_principal_ids(self, principal_id, include_memberships=False):
+    def expand_principal_ids(self, principal_ids, include_memberships=False):
         """Returns a list of principal IDs, including memberships if requested.
         """
-        if not principal_id:
-            return []
+        if not principal_ids:
+            return set()
 
-        principal_ids = [principal_id]
+        expanded_principal_ids = set(principal_ids)
+
         if include_memberships:
-            principal_ids.extend(self.resolve_user_memberships(principal_id))
+            for principal_id in principal_ids:
+                expanded_principal_ids.update(
+                    self.resolve_user_memberships(principal_id))
 
-        return principal_ids
+        return expanded_principal_ids
 
     def resolve_user_memberships(self, principal_id):
         ogds_user = User.query.filter_by(userid=principal_id).one_or_none()

--- a/opengever/sharing/tests/test_role_assignment_reporter.py
+++ b/opengever/sharing/tests/test_role_assignment_reporter.py
@@ -106,7 +106,7 @@ class TestRoleAssignmentReporter(SolrIntegrationTestCase):
         self.login(self.administrator)
         reporter = RoleAssignmentReporter()
 
-        self.assertItemsEqual(
+        self.assertEqual(
             {
                 'total_items': 1,
                 'items': [
@@ -133,7 +133,7 @@ class TestRoleAssignmentReporter(SolrIntegrationTestCase):
         self.login(self.administrator)
         reporter = RoleAssignmentReporter()
 
-        self.assertItemsEqual(
+        self.assertEqual(
             {
                 'total_items': 5,
                 'items': [

--- a/opengever/sharing/tests/test_role_assignment_reporter.py
+++ b/opengever/sharing/tests/test_role_assignment_reporter.py
@@ -127,7 +127,68 @@ class TestRoleAssignmentReporter(SolrIntegrationTestCase):
                         }
                     }
                 ],
-            }, reporter('jurgen.konig'))
+            }, reporter(['jurgen.konig']))
+
+    def test_creates_a_report_for_multiple_principals(self):
+        self.login(self.administrator)
+        reporter = RoleAssignmentReporter()
+
+        self.assertEqual(
+            {
+                "total_items": 3,
+                "items": [
+                    {
+                        "item": {
+                            "@id": "http://nohost/plone/ordnungssystem",
+                            "@type": "opengever.repository.repositoryroot",
+                            "UID": "createrepositorytree000000000001",
+                            "description": "",
+                            "is_leafnode": None,
+                            "reference": "Client1",
+                            "review_state": "repositoryroot-state-active",
+                            "title": "Ordnungssystem",
+                        },
+                        "role_assignments": {
+                            "Contributor": ["archivist"],
+                            "Reviewer": ["jurgen.konig"],
+                            "Publisher": ["jurgen.konig"],
+                        },
+                    },
+                    {
+                        "item": {
+                            "@id": "http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/dossier-2/dossier-4",
+                            "@type": "opengever.dossier.businesscasedossier",
+                            "UID": "createtreatydossiers000000000018",
+                            "description": "",
+                            "is_leafnode": None,
+                            "reference": "Client1 1.1 / 1.1.1",
+                            "review_state": "dossier-state-active",
+                            "title": "Subsubdossier",
+                        },
+                        "role_assignments": {
+                            "Reviewer": ["archivist"],
+                            "Editor": ["archivist"],
+                            "Reader": ["archivist"],
+                        },
+                    },
+                    {
+                        "item": {
+                            "@id": "http://nohost/plone/ordnungssystem/rechnungsprufungskommission",
+                            "@type": "opengever.repository.repositoryfolder",
+                            "UID": "createrepositorytree000000000004",
+                            "description": "",
+                            "is_leafnode": True,
+                            "reference": "Client1 2",
+                            "review_state": "repositoryfolder-state-active",
+                            "title": "2. Rechnungspr\xc3\xbcfungskommission",
+                        },
+                        "role_assignments": {
+                            "Contributor": ["archivist"],
+                            "Publisher": ["archivist"],
+                        },
+                    },
+                ],
+            }, reporter(['jurgen.konig', 'archivist']))
 
     def test_creates_a_report_for_a_principal_including_all_group_memberships(self):
         self.login(self.administrator)
@@ -175,7 +236,7 @@ class TestRoleAssignmentReporter(SolrIntegrationTestCase):
                     },
                 ],
             },
-            self.strip_item_metadata(reporter('jurgen.konig', include_memberships=True)))
+            self.strip_item_metadata(reporter(['jurgen.konig'], include_memberships=True)))
 
     def test_creates_a_report_restricted_to_a_specific_branch(self):
         self.login(self.administrator)


### PR DESCRIPTION
This is a follow-up PR of #8088 

It extends the `RoleAssignmentReporter` to allow creating reports of multiple principals instead only of one principal.

In addition, the PR fixes an issue in testing where I used `assertItemsEqual` instead `assertEqual`. Using `assertItemsEqual` for nested dicts will not properly deep assert the values. It will lead to false positives.

For [TI-1541]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-1541]: https://4teamwork.atlassian.net/browse/TI-1541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ