### PR TITLE
Make reindex local roles lookup table more failsafe

### DIFF
--- a/opengever/sharing/local_roles_lookup/manager.py
+++ b/opengever/sharing/local_roles_lookup/manager.py
@@ -69,6 +69,11 @@ class LocalRolesLookupManager(object):
         self.delete_all_by_uid(context.UID())
 
         for principal, roles in context.get_local_roles():
+            if not principal:
+                # It's possible that some local roles are assigned to 'None'.
+                # We should skip those principals.
+                continue
+
             managed_roles = list(set(roles).intersection(self.MANAGED_ROLES))
             if not managed_roles:
                 continue


### PR DESCRIPTION
This is a follow-up PR of https://github.com/4teamwork/opengever.core/pull/8086

It's possible that we get `None` principals in `local_roles`:

```
>>> obj.__ac_local_roles__
{'principal1': ['Owner'], None: ['Role Manager'], 'principal2': ['Owner']}
```

Here is an example object: https://4teamwork.slack.com/archives/C06US2QSCD8/p1732699211158489

We fix the lookup table update function to skip those principals.

For [TI-1540]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-1540]: https://4teamwork.atlassian.net/browse/TI-1540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ