### PR TITLE
Extend listing endpoint to filter by custom field type (date)

### DIFF
--- a/changes/TI-1539.other
+++ b/changes/TI-1539.other
@@ -1,0 +1,1 @@
+Fix filtering by custom fields in the @listing-endpoint. [amo]

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -4,6 +4,8 @@ from opengever.api.solr_query_service import SolrFieldMapper
 from opengever.api.solr_query_service import SolrQueryBaseService
 from opengever.base.interfaces import ISearchSettings
 from opengever.base.solr.fields import REQUIRED_RESPONSE_FIELDS
+from opengever.document.behaviors.customproperties import IDocumentCustomProperties
+from opengever.dossier.behaviors.customproperties import IDossierCustomProperties
 from opengever.dossier.indexers import ParticipationIndexHelper
 from plone.registry.interfaces import IRegistry
 from plone.uuid.interfaces import IUUID
@@ -318,7 +320,7 @@ class ListingGet(LiveSearchQueryPreprocessingMixin, SolrQueryBaseService):
             raise BadRequest(
                 "Unknown listing {}. Available listings are: {}".format(
                     self.name, ",".join(FILTERS.keys())))
-
+        self.configure_custom_property_field(self.listing_name)
         query, filters, start, rows, sort, field_list, params = \
             self.prepare_solr_query(self.request_payload)
 
@@ -334,3 +336,9 @@ class ListingGet(LiveSearchQueryPreprocessingMixin, SolrQueryBaseService):
         res['facets'] = self.extract_facets_from_response(resp)
 
         return res
+
+    def configure_custom_property_field(self, listing_name):
+        if listing_name == "dossiers":
+            self.field_mapper.propertysheet_field = IDossierCustomProperties['custom_properties']
+        if listing_name == "documents":
+            self.field_mapper.propertysheet_field = IDocumentCustomProperties['custom_properties']

--- a/opengever/api/tests/test_listing_custom_fields.py
+++ b/opengever/api/tests/test_listing_custom_fields.py
@@ -73,18 +73,50 @@ class TestListingCustomFieldsGet(IntegrationTestCase):
                 },
                 u"dossiers": {
                     u"properties": {
-                        u"additional_title_custom_field_string": {
-                            u"name": u"additional_title_custom_field_string",
-                            u"title": u"Additional dossier title",
-                            u'widget': None,
-                            u"type": u"string"
+                        u'additional_title_custom_field_string': {
+                            u'name': u'additional_title_custom_field_string',
+                            u'title': u'Additional dossier title',
+                            u'type': u'string',
+                            u'widget': None
+                        },
+                        u'choose_dossier_custom_field_string': {
+                            u'name': u'choose_dossier_custom_field_string',
+                            u'title': u'Choose',
+                            u'type': u'string',
+                            u'widget': None
+                        },
+                        u'choosemulti_dossier_custom_field_strings': {
+                            u'name': u'choosemulti_dossier_custom_field_strings',
+                            u'title': u'Choose multi',
+                            u'type': u'array',
+                            u'widget': None
+                        },
+
+                        u'date_dossier_custom_field_date': {
+                            u'name': u'date_dossier_custom_field_date',
+                            u'title': u'Choose a date',
+                            u'type': u'string',
+                            u'widget': u'date'
                         },
                         u'location_custom_field_string': {
                             u'name': u'location_custom_field_string',
                             u'title': u'Location',
-                            u'widget': None,
-                            u'type': u'string'
+                            u'type': u'string',
+                            u'widget': None
                         },
+                        u'num_dossier_custom_field_int': {
+                            u'name': u'num_dossier_custom_field_int',
+                            u'title': u'Number',
+                            u'type': u'integer',
+                            u'widget': None
+                        },
+
+                        u'yesorno_dossier_custom_field_boolean': {
+                            u'name': u'yesorno_dossier_custom_field_boolean',
+                            u'title': u'Yes or no',
+                            u'type': u'boolean',
+                            u'widget': None
+                        }
                     }
                 }
             },

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -820,6 +820,12 @@ class TestDossierDefaults(TestDefaultsBase):
 
         # Add customproperties form missing values
         expected['custom_properties']['IDossier.default']['additional_title'] = None
+        expected['custom_properties']['IDossier.default']['yesorno_dossier'] = False
+        expected['custom_properties']['IDossier.default']['choose_dossier'] = None
+        expected['custom_properties']['IDossier.default']['num_dossier'] = None
+        expected['custom_properties']['IDossier.default']['choosemulti_dossier'] = set()
+        expected['custom_properties']['IDossier.default']['text_dossier'] = None
+        expected['custom_properties']['IDossier.default']['date_dossier'] = None
 
         self.assert_default_values_equal(expected, persisted_values)
 
@@ -877,7 +883,12 @@ class TestDossierDefaults(TestDefaultsBase):
 
         # Add customproperties form missing values
         expected['custom_properties']['IDossier.default']['additional_title'] = None
-
+        expected['custom_properties']['IDossier.default']['yesorno_dossier'] = False
+        expected['custom_properties']['IDossier.default']['choose_dossier'] = None
+        expected['custom_properties']['IDossier.default']['num_dossier'] = None
+        expected['custom_properties']['IDossier.default']['choosemulti_dossier'] = set()
+        expected['custom_properties']['IDossier.default']['text_dossier'] = None
+        expected['custom_properties']['IDossier.default']['date_dossier'] = None
         self.assert_default_values_equal(expected, persisted_values)
 
     @browsing

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -557,6 +557,15 @@ class OpengeverContentFixture(object):
                         u"Additional dossier title", u"", False)
             .with_field("textline", u"location", u"Location", u"", False,
                         default=u"B\xfcren an der Aare")
+            .with_field("bool", u"yesorno_dossier", u"Yes or no", u"", False)
+            .with_field("choice", u"choose_dossier", u"Choose", u"", False,
+                        values=["one", "two", "three"])
+            .with_field("multiple_choice", u"choosemulti_dossier", u"Choose multi", u"", False,
+                        values=["one", "two", "three"])
+            .with_field("int", u"num_dossier", u"Number", u"", False)
+            .with_field("text", u"text_dossier", u"Some lines of text", u"", False)
+            .with_field("date", u"date_dossier", u"Choose a date", u"", False)
+
         )
 
     @staticuid()


### PR DESCRIPTION
**This PR:** 

Provide the Custom fileds on the `ListingGet` endpoint based on the listing name `dossiers` or `documents`.
It also update the test fixture schema so we add  more custom fields to the dossier schema.

Currently, the `@listing-endpoint` does not support filtering by custom fields of type `date` because the field mapper lacks knowledge of these fields. This PR addresses the issue by updating the `field mapper` to handle `date custom fields` for filtering.

For [TI-1539](https://4teamwork.atlassian.net/browse/TI-1539)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[TI-1539]: https://4teamwork.atlassian.net/browse/TI-1539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ