### PR TITLE
Implement non signers sign request

### DIFF
--- a/changes/TI-1494.feature
+++ b/changes/TI-1494.feature
@@ -1,0 +1,1 @@
+Delegate signers management to the external sign service. [elioschmutz]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -23,7 +23,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
-
+- ``pending_signing_job``: Additionally provides ``editors`` and ``invite_url``
 
 2024.17.0 (2024-12-03)
 ----------------------

--- a/docs/public/dev-manual/api/documents_sign.rst
+++ b/docs/public/dev-manual/api/documents_sign.rst
@@ -79,6 +79,12 @@ Ein GET-Request auf ein Dokument stellt verschiedene Informationen zu einem aktu
                     "userid": ""
                 }
             ],
+            "editors": [
+                {
+                    "email": "bar.foo@example.com",
+                    "userid": "bar.foo"
+                }
+            ],
             "job_id": "1",
             "redirect_url": "redirect@example.com"
         },

--- a/opengever/api/tests/test_serializer.py
+++ b/opengever/api/tests/test_serializer.py
@@ -7,6 +7,7 @@ from opengever.document.document import Document
 from opengever.locking.lock import COPIED_TO_WORKSPACE_LOCK
 from opengever.private import get_private_folder
 from opengever.repository.behaviors.responsibleorg import IResponsibleOrgUnit
+from opengever.sign.pending_signer import PendingSigner
 from opengever.sign.sign import Signer
 from opengever.testing import IntegrationTestCase
 from plone import api
@@ -289,6 +290,11 @@ class TestDocumentSerializer(IntegrationTestCase):
         mocker.post(re.compile('/signing-jobs'), json={'id': 'job-1'})
         api.content.transition(obj=self.document,
                                transition=Document.draft_signing_transition)
+
+        # The sign-service will set the signers when syncing between the
+        # external sign-object and the gever pending singing job.
+        # Here in the test, we just set it by hand.
+        Signer(self.document).start_signing(signers=['foo@example.com'])
 
         Signer(self.document).complete_signing('<data>')
         browser.open(self.document, headers=self.api_headers)

--- a/opengever/api/transition.py
+++ b/opengever/api/transition.py
@@ -385,8 +385,10 @@ class GEVERDocumentWorkflowTransition(GEVERWorkflowTransition):
     def reply(self):
         response = super(GEVERDocumentWorkflowTransition, self).reply()
         if self.transition in self.SIGNING_TRANSITIONS:
-            response['redirect_url'] = Signer(
-                self.context).serialize_pending_signing_job().get('redirect_url')
+            pending_signing_job = Signer(
+                self.context).serialize_pending_signing_job()
+            response['redirect_url'] = pending_signing_job.get('redirect_url')
+            response['invite_url'] = pending_signing_job.get('invite_url')
         return response
 
 

--- a/opengever/document/tests/test_document_workflow.py
+++ b/opengever/document/tests/test_document_workflow.py
@@ -228,7 +228,8 @@ class TestDocumentWorkflow(IntegrationTestCase):
                 'created': u'2024-02-18T15:45:00',
                 'job_id': '1',
                 'redirect_url': 'http://external.example.org/signing-requests/123',
-                'signers': [
+                'signers': [],
+                'editors': [
                     {
                         'email': 'foo@example.com',
                         'userid': 'regular_user',
@@ -260,7 +261,8 @@ class TestDocumentWorkflow(IntegrationTestCase):
                 'created': u'2024-02-18T15:45:00',
                 'job_id': '1',
                 'redirect_url': 'http://external.example.org/signing-requests/123',
-                'signers': [
+                'signers': [],
+                'editors': [
                     {
                         'email': 'foo@example.com',
                         'userid': 'regular_user',

--- a/opengever/document/tests/test_document_workflow.py
+++ b/opengever/document/tests/test_document_workflow.py
@@ -228,6 +228,7 @@ class TestDocumentWorkflow(IntegrationTestCase):
                 'created': u'2024-02-18T15:45:00',
                 'job_id': '1',
                 'redirect_url': 'http://external.example.org/signing-requests/123',
+                'invite_url': 'http://external.example.org/invite/signing-requests/123',
                 'signers': [],
                 'editors': [
                     {
@@ -261,6 +262,7 @@ class TestDocumentWorkflow(IntegrationTestCase):
                 'created': u'2024-02-18T15:45:00',
                 'job_id': '1',
                 'redirect_url': 'http://external.example.org/signing-requests/123',
+                'invite_url': 'http://external.example.org/invite/signing-requests/123',
                 'signers': [],
                 'editors': [
                     {

--- a/opengever/document/transition.py
+++ b/opengever/document/transition.py
@@ -38,7 +38,7 @@ class DocumentFinalSigningTransitionExtender(TransitionExtender):
         if not actor or not actor.email:
             raise NoEmailError()
 
-        Signer(self.context).start_signing(signers=[actor.email])
+        Signer(self.context).start_signing(editors=[actor.email])
 
 
 @implementer(ITransitionExtender)

--- a/opengever/sign/client.py
+++ b/opengever/sign/client.py
@@ -10,7 +10,7 @@ class SignServiceClient(object):
     def sign_service_url(self):
         return environ.get('SIGN_SERVICE_URL', '').strip('/')
 
-    def queue_signing(self, document, token, signers):
+    def queue_signing(self, document, token, signers, editors):
         bumblebee_service = IBumblebeeServiceV3(getRequest())
 
         return requests.post(
@@ -23,6 +23,7 @@ class SignServiceClient(object):
                   'document_uid': document.UID(),
                   'title': document.title_or_id(),
                   'signers': signers,
+                  'editors': editors,
                   }).json()
 
     def abort_signing(self, job_id):
@@ -40,7 +41,7 @@ class NullSignServiceClient(object):
     def sign_service_url(self):
         return environ.get('SIGN_SERVICE_URL', '').strip('/')
 
-    def queue_signing(self, document, token, signers):
+    def queue_signing(self, document, token, signers, editors):
         return {}
 
     def abort_signing(self, job_id):

--- a/opengever/sign/pending_editor.py
+++ b/opengever/sign/pending_editor.py
@@ -1,0 +1,20 @@
+from opengever.sign.utils import email_to_userid
+from persistent import Persistent
+from persistent.list import PersistentList
+from plone.restapi.serializer.converters import json_compatible
+
+
+class PendingEditors(PersistentList):
+    def serialize(self):
+        return json_compatible([pending_editor.serialize() for pending_editor in self])
+
+
+class PendingEditor(Persistent):
+    def __init__(self, email=''):
+        self.email = email
+
+    def serialize(self):
+        return json_compatible({
+            'userid': email_to_userid(self.email),
+            'email': self.email,
+        })

--- a/opengever/sign/pending_signing_job.py
+++ b/opengever/sign/pending_signing_job.py
@@ -1,4 +1,6 @@
 from datetime import datetime
+from opengever.sign.pending_editor import PendingEditor
+from opengever.sign.pending_editor import PendingEditors
 from opengever.sign.pending_signer import PendingSigner
 from opengever.sign.pending_signer import PendingSigners
 from opengever.sign.signed_version import SignedVersion
@@ -7,11 +9,13 @@ from plone.restapi.serializer.converters import json_compatible
 
 
 class PendingSigningJob(Persistent):
+
     def __init__(self,
                  created=None,
                  userid='',
                  version=0,
                  signers=list(),
+                 editors=list(),
                  job_id='',
                  redirect_url='',
                  ):
@@ -20,6 +24,7 @@ class PendingSigningJob(Persistent):
         self.userid = userid
         self.version = version
         self.signers = PendingSigners([PendingSigner(email=signer) for signer in signers])
+        self.editors = PendingEditors([PendingEditor(email=editor) for editor in editors])
         self.job_id = job_id
         self.redirect_url = redirect_url
 
@@ -30,6 +35,7 @@ class PendingSigningJob(Persistent):
             'job_id': self.job_id,
             'redirect_url': self.redirect_url,
             'signers': self.signers.serialize(),
+            'editors': self.editors.serialize(),
             'version': self.version,
         })
 

--- a/opengever/sign/pending_signing_job.py
+++ b/opengever/sign/pending_signing_job.py
@@ -18,6 +18,7 @@ class PendingSigningJob(Persistent):
                  editors=list(),
                  job_id='',
                  redirect_url='',
+                 invite_url='',
                  ):
 
         self.created = created or datetime.now()
@@ -27,6 +28,7 @@ class PendingSigningJob(Persistent):
         self.editors = PendingEditors([PendingEditor(email=editor) for editor in editors])
         self.job_id = job_id
         self.redirect_url = redirect_url
+        self.invite_url = invite_url
 
     def serialize(self):
         return json_compatible({
@@ -34,6 +36,7 @@ class PendingSigningJob(Persistent):
             'userid': self.userid,
             'job_id': self.job_id,
             'redirect_url': self.redirect_url,
+            'invite_url': self.invite_url,
             'signers': self.signers.serialize(),
             'editors': self.editors.serialize(),
             'version': self.version,

--- a/opengever/sign/sign.py
+++ b/opengever/sign/sign.py
@@ -32,14 +32,15 @@ class Signer(object):
     def invalidate_token(self):
         self.token_manager.invalidate_token()
 
-    def start_signing(self, signers):
+    def start_signing(self, signers=[], editors=[]):
         token = self.issue_token()
-        response = sign_service_client.queue_signing(self.context, token, signers)
-
+        response = sign_service_client.queue_signing(self.context, token,
+                                                     signers, editors)
         self.pending_signing_job = PendingSigningJob(
             userid=api.user.get_current().id,
             version=self.context.get_current_version_id(missing_as_zero=True),
             signers=signers,
+            editors=editors,
             job_id=response.get('id'),
             redirect_url=response.get('redirect_url'),
         )

--- a/opengever/sign/sign.py
+++ b/opengever/sign/sign.py
@@ -43,6 +43,7 @@ class Signer(object):
             editors=editors,
             job_id=response.get('id'),
             redirect_url=response.get('redirect_url'),
+            invite_url=response.get('invite_url'),
         )
         return token
 

--- a/opengever/sign/tests/test_client.py
+++ b/opengever/sign/tests/test_client.py
@@ -21,7 +21,10 @@ class TestSigningClient(IntegrationTestCase):
 
         mocker.post(re.compile('/signing-jobs'), json=DEFAULT_MOCK_RESPONSE)
 
-        response = SignServiceClient().queue_signing(self.document, TOKEN, ['foo.bar@example.com'])
+        editors = ['foo@example.com']
+        signatories = ['bar@example.com']
+        response = SignServiceClient().queue_signing(
+            self.document, TOKEN, signatories, editors)
 
         self.assertDictEqual(
             {
@@ -29,7 +32,8 @@ class TestSigningClient(IntegrationTestCase):
                 u'document_uid': u'createtreatydossiers000000000002',
                 u'document_url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-14', # noqa
                 u'download_url': u'http://nohost/plone/bumblebee_download?checksum={}&uuid=createtreatydossiers000000000002'.format(DOCX_CHECKSUM), # noqa
-                u'signers': ['foo.bar@example.com'],
+                u'signers': ['bar@example.com'],
+                u'editors': ['foo@example.com'],
                 u'title': u'Vertr\xe4gsentwurf',
                 u'upload_url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-14/@upload-signed-pdf', # noqa
             },

--- a/opengever/sign/tests/test_pending_editors.py
+++ b/opengever/sign/tests/test_pending_editors.py
@@ -1,0 +1,28 @@
+from opengever.sign.pending_editor import PendingEditor
+from opengever.sign.pending_editor import PendingEditors
+from opengever.testing import IntegrationTestCase
+
+
+class TestPendingEditor(IntegrationTestCase):
+    def test_can_be_serialized(self):
+        signer = PendingEditor(email='foo@example.com')
+
+        self.assertDictEqual(
+            {
+                'email': 'foo@example.com',
+                'userid': 'regular_user'
+            }, signer.serialize())
+
+
+class TestPendingEditors(IntegrationTestCase):
+    def test_can_be_serialized(self):
+        container = PendingEditors()
+        signer1 = PendingEditor(email='foo@example.com')
+        signer2 = PendingEditor(email='bar@example.com')
+
+        container.append(signer1)
+        container.append(signer2)
+
+        self.assertEqual(2, len(container.serialize()))
+        self.assertItemsEqual([signer2.email, signer1.email],
+                              [item.get('email') for item in container.serialize()])

--- a/opengever/sign/tests/test_pending_signing_job.py
+++ b/opengever/sign/tests/test_pending_signing_job.py
@@ -27,6 +27,7 @@ class TestPendingSigningJob(IntegrationTestCase):
             userid='foo.bar',
             version=1,
             signers=['foo.bar@example.com'],
+            editors=['bar.foo@example.com'],
             job_id='1',
             redirect_url='redirect@example.com')
 
@@ -38,6 +39,12 @@ class TestPendingSigningJob(IntegrationTestCase):
                 'signers': [
                     {
                         'email': 'foo.bar@example.com',
+                        'userid': '',
+                    }
+                ],
+                'editors': [
+                    {
+                        'email': 'bar.foo@example.com',
                         'userid': '',
                     }
                 ],

--- a/opengever/sign/tests/test_pending_signing_job.py
+++ b/opengever/sign/tests/test_pending_signing_job.py
@@ -29,7 +29,8 @@ class TestPendingSigningJob(IntegrationTestCase):
             signers=['foo.bar@example.com'],
             editors=['bar.foo@example.com'],
             job_id='1',
-            redirect_url='redirect@example.com')
+            redirect_url='redirect@example.com',
+            invite_url='redirect@example.com/invite')
 
         self.assertDictEqual(
             {
@@ -49,7 +50,8 @@ class TestPendingSigningJob(IntegrationTestCase):
                     }
                 ],
                 'job_id': '1',
-                'redirect_url': 'redirect@example.com'
+                'redirect_url': 'redirect@example.com',
+                'invite_url': 'redirect@example.com/invite',
             }, metadata.serialize())
 
     def test_can_be_converted_to_a_signed_version(self):

--- a/opengever/sign/tests/test_sign.py
+++ b/opengever/sign/tests/test_sign.py
@@ -17,6 +17,7 @@ FROZEN_NOW = datetime(2024, 2, 18, 15, 45)
 DEFAULT_MOCK_RESPONSE = {
     'id': '1',
     'redirect_url': 'http://external.example.org/signing-requests/123',
+    'invite_url': 'http://external.example.org/invite/signing-requests/123',
 }
 
 
@@ -59,6 +60,7 @@ class TestSigning(IntegrationTestCase):
                 'created': u'2024-02-18T15:45:00',
                 'job_id': '1',
                 'redirect_url': 'http://external.example.org/signing-requests/123',
+                'invite_url': 'http://external.example.org/invite/signing-requests/123',
                 'signers': [{u'email': u'foo.bar@example.com', u'userid': u''}],
                 'editors': [{u'email': u'bar.foo@example.com', u'userid': u''}],
                 'userid': 'regular_user',


### PR DESCRIPTION
This PR implements non signers sign requests.

With this PR it will be possible to pass `editors` which will later be able to manage signatories directly in the `skribble` UI.

We mainly address the Skribble feature: Create a signature request without initial signers: https://api-doc.skribble.com/#b6100136-63b3-4fd6-a703-3a0848a89c04

See for the ogsign implementation: https://github.com/4teamwork/ogsign/pull/12

For [TI-1494]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-1494]: https://4teamwork.atlassian.net/browse/TI-1494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ