### PR TITLE
Restrict team watchers source to the current org unit

### DIFF
--- a/changes/TI-1735.other
+++ b/changes/TI-1735.other
@@ -1,0 +1,1 @@
+Restrict team watchers source to the current org-unit. [elioschmutz]

--- a/opengever/activity/sources.py
+++ b/opengever/activity/sources.py
@@ -69,4 +69,5 @@ class PossibleWatchersSource(BaseMultipleSourcesQuerySource):
                                  PossibleWatchersGroupsSource(context)]
 
         if not is_workspace_feature_enabled():
-            self.source_instances.append(AllTeamsSource(context))
+            self.source_instances.append(AllTeamsSource(context,
+                                                        only_current_orgunit=True))

--- a/opengever/ogds/base/sources.py
+++ b/opengever/ogds/base/sources.py
@@ -1094,6 +1094,10 @@ class AllTeamsSource(AllUsersInboxesAndTeamsSource):
     def search_query(self):
         query = Team.query.filter(Team.active == True)  # noqa
         query = query.order_by(desc(func.lower(Team.title)))
+
+        if self.only_current_orgunit:
+            query = query.filter(Team.org_unit_id == self.client_id)
+
         return query
 
     def getTerm(self, value):

--- a/opengever/ogds/base/tests/test_sources.py
+++ b/opengever/ogds/base/tests/test_sources.py
@@ -17,6 +17,7 @@ from opengever.ogds.base.sources import ContactsSource
 from opengever.ogds.base.sources import CurrentAdminUnitOrgUnitsSource
 from opengever.ogds.base.sources import UsersContactsInboxesSource
 from opengever.ogds.models.group import Group
+from opengever.ogds.models.team import Team
 from opengever.sharing.interfaces import ISharingConfiguration
 from opengever.testing import FunctionalTestCase
 from opengever.testing import IntegrationTestCase
@@ -1279,4 +1280,19 @@ class TestAllTeamsSource(IntegrationTestCase):
         self.assertItemsEqual(
             [u'Sekretariat Abteilung XY (Finanz\xe4mt)',
              u'Sekretariat Abteilung Null (Finanz\xe4mt)'],
+            [term.title for term in source.search('Sek')])
+
+    def test_can_restrict_teams_to_current_or_unit(self):
+        self.login(self.administrator)
+        source = AllTeamsSource(self.portal, only_current_orgunit=True)
+
+        self.assertItemsEqual(
+            [u'Sekretariat Abteilung XY (Finanz\xe4mt)',
+             u'Sekretariat Abteilung Null (Finanz\xe4mt)'],
+            [term.title for term in source.search('Sek')])
+
+        Team.get_one(groupid='projekt_b').org_unit_id = 'rk'
+
+        self.assertItemsEqual(
+            [u'Sekretariat Abteilung Null (Finanz\xe4mt)'],
             [term.title for term in source.search('Sek')])


### PR DESCRIPTION
We introduced group and teams watchers in a previous PR: #7986  which allows the user to select a group or a team as a watcher. Currently, all teams within the OGDS are queried which is not the desired behavior. Each team is assigned to a specific Org-Unit. The watchers-source should respect this setting to only list teams of the current users org unit.

So this PR updates the sources to only list those teams instead of all teams across all admin units.

For [TI-1735]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-1735]: https://4teamwork.atlassian.net/browse/TI-1735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ