### PR TITLE
Change the task text field from Text field to RichText

### DIFF
--- a/changes/TI-1333.other
+++ b/changes/TI-1333.other
@@ -1,0 +1,1 @@
+Change task `text field` from Text field to RichText field. [amo]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -8,11 +8,10 @@ API Changelog
 
 Breaking Changes
 ^^^^^^^^^^^^^^^^
-
+- The task text field was changed from a Text field to a RichTextField.
 
 Other Changes
 ^^^^^^^^^^^^^
-
 
 2025.1.0 (2024-01-14)
 ----------------------

--- a/docs/schema-dumps/opengever.task.task.schema.json
+++ b/docs/schema-dumps/opengever.task.task.schema.json
@@ -84,10 +84,10 @@
             "_zope_schema_type": "Date"
         },
         "text": {
-            "type": "string",
+            "type": "object",
             "title": "Beschreibung",
             "description": "Geben Sie eine detaillierte Arbeitsanweisung oder einen Kommentar ein",
-            "_zope_schema_type": "Text"
+            "_zope_schema_type": "RichText"
         },
         "relatedItems": {
             "type": "array",

--- a/opengever/activity/tests/test_mail.py
+++ b/opengever/activity/tests/test_mail.py
@@ -95,7 +95,7 @@ class TestEmailNotification(IntegrationTestCase):
         self.assertIn('<p>comment</p>', raw_mail)
 
     @browsing
-    def test_notification_add_task_summary_is_split_into_lines(self, browser):
+    def test_notification_add_task_summary_is_richtext(self, browser):
         self.login(self.dossier_responsible, browser)
         self.create_task_via_browser(browser, description='Multi\nline\ncomment')
         process_mail_queue()
@@ -105,9 +105,9 @@ class TestEmailNotification(IntegrationTestCase):
         raw_mail = mails[0]
         mail = raw_mail.decode("quopri")
 
-        self.assertIn('<td>Multi<br />', mail)
-        self.assertIn('line<br />', mail)
-        self.assertIn('comment</td>', mail)
+        self.assertIn('<td>Multi</p>', mail)
+        self.assertIn('<p>line</p>', mail)
+        self.assertIn('<p>comment</td>', mail)
 
     @browsing
     def test_add_task_notification_mail_includes_info_at(self, browser):

--- a/opengever/api/forwarding.py
+++ b/opengever/api/forwarding.py
@@ -30,8 +30,10 @@ class AssignToDossier(Service):
             if responsible:
                 task_payload.update(responsible)
 
-            transition_params['task'] = task_payload
+            if task_payload.get("text") is None:
+                task_payload["text"] = ""
 
+            transition_params['task'] = task_payload
         try:
             task = api.portal.get_tool('portal_workflow').doActionFor(
                 self.context,

--- a/opengever/api/tests/test_task.py
+++ b/opengever/api/tests/test_task.py
@@ -661,7 +661,10 @@ class TestTaskPatch(IntegrationTestCase):
         # returned by the PATCH request.
         self.assertEqual(3, len(browser.json['responses']))
         self.assertEqual(
-            [{u'after': u'New description',
+            [{u'after': {
+                u'data': u'New description',
+                u'content-type': u'text/html',
+                u'encoding': u'utf8'},
               u'before': None,
               u'field_id': u'text',
               u'field_title': u''}],
@@ -671,7 +674,10 @@ class TestTaskPatch(IntegrationTestCase):
         responses = browser.json['responses']
         self.assertEquals(3, len(responses))
         self.assertEquals(
-            [{u'after': u'New description',
+            [{u'after': {
+                u'data': u'New description',
+                u'content-type': u'text/html',
+                u'encoding': u'utf8'},
               u'before': None,
               u'field_id': u'text',
               u'field_title': u''}],

--- a/opengever/api/tests/test_templatefolder.py
+++ b/opengever/api/tests/test_templatefolder.py
@@ -945,7 +945,7 @@ class TestTriggerTaskTemplatePost(IntegrationTestCase):
         main_task = children['added'].pop()
 
         self.assertEqual(u'Neuanstellung Hugo B\xf6ss', main_task.title)
-        self.assertEqual(u'Bla bla', main_task.text)
+        self.assertEqual(u'Bla bla', main_task.text.output)
         self.assertEqual(date(2021, 12, 12), main_task.deadline)
 
     @browsing
@@ -962,12 +962,11 @@ class TestTriggerTaskTemplatePost(IntegrationTestCase):
                     '@id': self.tasktemplate.absolute_url(),
                     'deadline': u'2021-12-12',
                     'title': u'Arbeitsplatz Hugo B\xf6ss',
-                    'text': None,
+                    'text': u'',
                 }
             ],
             'start_immediately': True
         }
-
         with self.observe_children(self.dossier) as children:
             browser.open('{}/@trigger-task-template'.format(
                          self.dossier.absolute_url()),
@@ -981,7 +980,7 @@ class TestTriggerTaskTemplatePost(IntegrationTestCase):
         subtask = subtasks.pop()
 
         self.assertEqual(u'Arbeitsplatz Hugo B\xf6ss', subtask.title)
-        self.assertIsNone(subtask.text)
+        self.assertEqual(subtask.text.output, u'')
         self.assertEqual(date(2021, 12, 12), subtask.deadline)
 
     @browsing

--- a/opengever/core/upgrades/20250113110216_update_task_text_field_to_rich_text/upgrade.py
+++ b/opengever/core/upgrades/20250113110216_update_task_text_field_to_rich_text/upgrade.py
@@ -1,0 +1,23 @@
+from ftw.upgrade import UpgradeStep
+from plone.app.textfield import IRichTextValue
+from plone.app.textfield.value import RichTextValue
+
+
+class UpdateTaskTextFieldToRichText(UpgradeStep):
+    """Update task text field to rich text.
+    """
+
+    def __call__(self):
+        query = {'object_provides': "opengever.task.task.ITask"}
+        msg = "Change Task text field from Text field to Richtext field"
+
+        for task in self.objects(query, msg):
+            if IRichTextValue.providedBy(task.text):
+                continue
+
+            task.text = RichTextValue(
+                raw=task.text or "",
+                mimeType='text/html',
+                outputMimeType='text/x-html-safe',
+                encoding='utf-8',
+            )

--- a/opengever/globalindex/model/task.py
+++ b/opengever/globalindex/model/task.py
@@ -208,8 +208,12 @@ class Task(Base):
     def sync_with(self, plone_task, graceful=False):
         """Sync this task instace with its corresponding plone taks."""
         self.title = plone_task.safe_title
-        self.text = plone_task.text
-
+        self.text = ""
+        if plone_task.text:
+            if isinstance(plone_task.text, unicode):
+                self.text = plone_task.text
+            else:
+                self.text = plone_task.text.output
         self.breadcrumb_title = plone_task.get_breadcrumb_title(
             self.MAX_BREADCRUMB_LENGTH,
         )

--- a/opengever/globalindex/tests/test_task_sql_syncer.py
+++ b/opengever/globalindex/tests/test_task_sql_syncer.py
@@ -98,7 +98,7 @@ class TestTaskSQLSyncer(IntegrationTestCase):
             u'Vertr\xe4ge mit der kantonalen Finanzverwaltung', task.containing_dossier)
         self.assertEqual('', task.containing_subdossier)
         self.assertEqual(1, task.dossier_sequence_number)
-        self.assertIsNone(task.text)
+        self.assertEqual(task.text, "")
         expected_principals = [
             get_current_org_unit().users_group.id(), self.regular_user.getId(),
             get_current_org_unit().inbox_group.id(), u'rk_inbox_users']

--- a/opengever/task/activities.py
+++ b/opengever/task/activities.py
@@ -14,6 +14,7 @@ from opengever.task import _
 from opengever.task import FINISHED_TASK_STATES
 from opengever.task.response_description import ResponseDescription
 from plone import api
+from plone.app.textfield import IRichTextValue
 from Products.CMFPlone import PloneMessageFactory
 from Products.CMFPlone.utils import safe_unicode
 
@@ -91,7 +92,10 @@ class TaskAddedActivity(BaseTaskActivity):
                 msg, self.translate(label, language))
             # Break lines correctly in the table rows
             if value:
-                msg += u"<br />".join(value.splitlines())
+                if IRichTextValue.providedBy(value):
+                    msg += value.output
+                else:
+                    msg += u"<br />".join(value.splitlines())
             msg += u"</td></tr>"
         return u'{}</tbody></table>'.format(msg)
 

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -46,6 +46,7 @@ from opengever.tasktemplates.interfaces import IPartOfSequentialProcess
 from persistent.dict import PersistentDict
 from persistent.list import PersistentList
 from plone import api
+from plone.app.textfield import RichText
 from plone.autoform import directives as form
 from plone.dexterity.content import Container
 from plone.indexer.interfaces import IIndexer
@@ -235,11 +236,12 @@ class ITask(model.Schema):
     )
 
     dexteritytextindexer.searchable('text')
-    text = schema.Text(
-        title=_(u"label_text", default=u"Text"),
+    text = RichText(
+        title=_(u'label_text', default='Text'),
         description=_(u"help_text", default=u""),
         required=False,
-    )
+        default_mime_type='text/html',
+        output_mime_type='text/x-html-safe')
 
     relatedItems = RelationList(
         title=_(u'label_related_items', default=u'Related Items'),

--- a/opengever/task/tests/test_indexer.py
+++ b/opengever/task/tests/test_indexer.py
@@ -8,6 +8,7 @@ from opengever.testing import solr_data_for
 from opengever.testing import SolrIntegrationTestCase
 from plone import api
 from plone.app.relationfield.event import update_behavior_relations
+from plone.app.textfield.value import RichTextValue
 from z3c.relationfield.relation import RelationValue
 from zope.component import getUtility
 from zope.intid import IIntIds
@@ -28,7 +29,7 @@ class TestTaskSolrIndexer(SolrIntegrationTestCase):
         self.login(self.regular_user)
 
         self.task.title = u'Test Aufgabe'
-        self.task.text = u'Lorem ipsum'
+        self.task.text = RichTextValue(u'Lorem ipsum')
         self.task.task_type = u'comment'
         self.task.responsible = self.regular_user.getId()
 


### PR DESCRIPTION
**This PR:**
Changes `Task`  text field from a TextField to a RichTextField.


For [TI-1333](https://4teamwork.atlassian.net/browse/TI-1333)

**The UI related PR**=> [Provide WysiwgyEditor field for task](https://github.com/4teamwork/gever-ui/pull/2837) 
## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))

[TI-1333]: https://4teamwork.atlassian.net/browse/TI-1333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ