### PR TITLE
Set is_active filter to true for possible participants

### DIFF
--- a/changes/TI-1737.other
+++ b/changes/TI-1737.other
@@ -1,0 +1,1 @@
+Restrict possible participants search from finding inactive users in kub. [ran]

--- a/opengever/dossier/participations.py
+++ b/opengever/dossier/participations.py
@@ -158,7 +158,7 @@ class KuBParticipationHandler(PloneParticipationHandler):
     def __init__(self, context):
         self.context = context
         self.annotations = IAnnotations(self.context)
-        self.participant_source = KuBContactsSourceBinder()(self.context)
+        self.participant_source = KuBContactsSourceBinder(only_active=True)(self.context)
 
 
 class IParticipationData(Interface):


### PR DESCRIPTION
Inactive users in kub shouldn't be able to be found in the "possible participants" search in Gever Dossiers. 

To correct this behaviour, the "only_active" in the KubClient was set to True and the behavior of "is_active" in KuB was corrected in the following PR: https://github.com/4teamwork/kub/pull/356

Before: (Pascal Reiss is an inactive user in KuB):

<img width="688" alt="1737_before" src="https://github.com/user-attachments/assets/65c732a4-49ef-4709-bc50-ce3eee32cda3" />

After:

<img width="651" alt="1737_after" src="https://github.com/user-attachments/assets/3d42b0c2-5717-4b8f-8eb2-42086f9f2291" />

For [TI-1737]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-1737]: https://4teamwork.atlassian.net/browse/TI-1737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ