### PR TITLE
Implement auto-open of next task after closing the previous one

### DIFF
--- a/changes/TI-1331.other
+++ b/changes/TI-1331.other
@@ -1,0 +1,1 @@
+The next task in the sequence of the standard process can only be automatically opened after the responsible person closes the previous task. [amo]

--- a/opengever/api/tests/test_task_from_template.py
+++ b/opengever/api/tests/test_task_from_template.py
@@ -33,46 +33,10 @@ class TestSequentialTaskPassDocumentsToNextTask(IntegrationTestCase):
         self.assertItemsEqual([], self.seq_subtask_2.task_documents())
 
     @browsing
-    def test_can_pass_documents_to_next_task_with_open_resolved_transition(self, browser):
-        self.login(self.secretariat_user, browser=browser)
-
-        ITask(self.seq_subtask_1).task_type = 'correction'
-        url = '{}/@workflow/task-transition-open-resolved'.format(
-            self.seq_subtask_1.absolute_url())
-        data = {'pass_documents_to_next_task': True}
-
-        browser.open(url, method='POST', data=json.dumps(data),
-                     headers=self.api_headers)
-
-        self.assertEqual(200, browser.status_code)
-        self.assertItemsEqual(
-            [self.document, self.seq_subtask_1_document],
-            [item.to_object for item in ITask(self.seq_subtask_2).relatedItems])
-
-    @browsing
     def test_can_pass_documents_to_next_task_with_open_tested_and_closed_transition(self, browser):
         self.login(self.secretariat_user, browser=browser)
 
         url = '{}/@workflow/task-transition-open-tested-and-closed'.format(
-            self.seq_subtask_1.absolute_url())
-        data = {'pass_documents_to_next_task': True}
-
-        browser.open(url, method='POST', data=json.dumps(data),
-                     headers=self.api_headers)
-
-        self.assertEqual(200, browser.status_code)
-        self.assertItemsEqual(
-            [self.document, self.seq_subtask_1_document],
-            [item.to_object for item in ITask(self.seq_subtask_2).relatedItems])
-
-    @browsing
-    def test_can_pass_documents_to_next_task_with_in_progress_resolved_transition(self, browser):
-        self.login(self.secretariat_user, browser=browser)
-
-        ITask(self.seq_subtask_1).task_type = 'correction'
-        api.content.transition(obj=self.seq_subtask_1, transition='task-transition-open-in-progress')
-
-        url = '{}/@workflow/task-transition-in-progress-resolved'.format(
             self.seq_subtask_1.absolute_url())
         data = {'pass_documents_to_next_task': True}
 

--- a/opengever/task/handlers.py
+++ b/opengever/task/handlers.py
@@ -101,8 +101,8 @@ def review_state_changed(task, event):
     # on the parent task. We need to ensure, that every parent task is in progress.
     if event.action not in ['task-transition-open-planned',
                             'task-transition-planned-open',
-                            'task-transition-rejected-skipped',
-                            'task-transition-reassign']:
+                            'task-transition-reassign',
+                            'task-transition-rejected-skipped']:
         task.maybe_start_parent_task()
 
     if event.action in FINAL_TRANSITIONS:
@@ -111,11 +111,11 @@ def review_state_changed(task, event):
             task.close_main_task()
             return
 
-    if event.action not in ['task-transition-open-resolved',
-                            'task-transition-open-tested-and-closed',
-                            'task-transition-in-progress-resolved',
+    if event.action not in ['task-transition-open-tested-and-closed',
+                            'task-transition-resolved-tested-and-closed',
                             'task-transition-in-progress-tested-and-closed',
-                            'task-transition-rejected-skipped']:
+                            'task-transition-rejected-skipped'
+                            ]:
         return
 
     if task.is_part_of_sequential_process:


### PR DESCRIPTION
**This PR:**

If we have a standard process for tasks, the current situation is that once a task is marked as erledigt, the next task will open automatically. This behavior is not ideal. With our new implementation, the next task will only open if the previous task is closed.


For [TI-1331](https://4teamwork.atlassian.net/browse/TI-1331)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[TI-1331]: https://4teamwork.atlassian.net/browse/TI-1331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ