### PR TITLE
Implement salutation visibility based on the hide_salutation flag

### DIFF
--- a/changes/TI-1570.other
+++ b/changes/TI-1570.other
@@ -1,0 +1,1 @@
+Add salutation visibility control based on feature flag setting. [amo]

--- a/opengever/base/addressblock/addressblock.py
+++ b/opengever/base/addressblock/addressblock.py
@@ -1,4 +1,6 @@
 from opengever.base.addressblock.interfaces import IAddressBlockData
+from opengever.base.addressblock.interfaces import IAddressBlockDataSettings
+from plone import api
 from zope.interface import implementer
 
 
@@ -61,6 +63,18 @@ class AddressBlockData(object):
     def is_po_box_address(self):
         return bool(self.po_box)
 
+    def is_salutation_hidden(self):
+        """Check wether the salutation flag is enabled or not"""
+        return api.portal.get_registry_record(
+            'hide_salutation', interface=IAddressBlockDataSettings
+        )
+
+    def get_salutation(self):
+        """Return the salutation if it's not hidden."""
+        if self.salutation and not self.is_salutation_hidden():
+            return self.salutation
+        return ''
+
     def format(self):
         lines = []
 
@@ -68,7 +82,7 @@ class AddressBlockData(object):
             # Private address:
             # Line 1 is salutation
             # Line 2 is person's full name, possibly preceeded by academic title
-            if self.salutation:
+            if self.get_salutation():
                 lines.append(self.salutation)
             lines.append(self.join_tokens(
                 self.academic_title,
@@ -84,7 +98,7 @@ class AddressBlockData(object):
                 # Business address, addressed to a specific person:
                 # Line 2 is the person's salutation, title, and full name
                 lines.append(self.join_tokens(
-                    self.salutation,
+                    self.get_salutation(),
                     self.academic_title,
                     self.first_name,
                     self.last_name,

--- a/opengever/base/addressblock/interfaces.py
+++ b/opengever/base/addressblock/interfaces.py
@@ -1,4 +1,5 @@
 from zope.interface import Interface
+from zope.schema import Bool
 from zope.schema import TextLine
 
 
@@ -16,3 +17,11 @@ class IAddressBlockData(Interface):
 
     postal_code = TextLine()
     city = TextLine()
+
+
+class IAddressBlockDataSettings(Interface):
+    hide_salutation = Bool(
+        title=u'Hide / show salutation',
+        description=u'Whether hide salutation feature is enabled',
+        default=False
+    )

--- a/opengever/base/addressblock/tests/test_address_formatting.py
+++ b/opengever/base/addressblock/tests/test_address_formatting.py
@@ -1,13 +1,13 @@
 from opengever.base.addressblock import AddressBlockData
+from opengever.testing import IntegrationTestCase
 from textwrap import dedent
-from unittest import TestCase
 
 
 def addr(text):
     return dedent(text.lstrip('\n')).strip()
 
 
-class TestAddressFormatting(TestCase):
+class TestAddressFormatting(IntegrationTestCase):
 
     def test_private_address(self):
         block = AddressBlockData(
@@ -284,5 +284,28 @@ class TestAddressFormatting(TestCase):
 
         expected = addr(u"""
         Bill Gates
+        """)
+        self.assertEqual(expected, block.format())
+
+    def test_private_address_when_hide_salutation_is_active(self):
+        from opengever.base.addressblock.interfaces import IAddressBlockDataSettings
+        from plone import api
+        api.portal.set_registry_record('hide_salutation', True,
+                                       interface=IAddressBlockDataSettings)
+        block = AddressBlockData(
+            salutation=u'Herr',
+            academic_title=u'Dr.',
+            first_name=u'Fridolin',
+            last_name=u'M\xfcller',
+
+            street_and_no=u'Murtenstrasse 42',
+            postal_code=u'3008',
+            city=u'Bern',
+        )
+
+        expected = addr(u"""
+        Dr. Fridolin M\xfcller
+        Murtenstrasse 42
+        3008 Bern
         """)
         self.assertEqual(expected, block.format())

--- a/opengever/core/profiles/default/registry.xml
+++ b/opengever/core/profiles/default/registry.xml
@@ -225,4 +225,7 @@
   <!-- Sign -->
   <records interface="opengever.sign.interfaces.ISignSettings" />
 
+  <!-- doc props -->
+  <records interface="opengever.base.addressblock.interfaces.IAddressBlockDataSettings" />
+
 </registry>

--- a/opengever/core/upgrades/20250114101908_add_hide_salutation_feature_flag/registry.xml
+++ b/opengever/core/upgrades/20250114101908_add_hide_salutation_feature_flag/registry.xml
@@ -1,0 +1,5 @@
+<registry>
+    <records interface="opengever.base.addressblock.interfaces.IAddressBlockDataSettings">
+        <value key="hide_salutation">False</value>
+    </records>
+</registry>

--- a/opengever/core/upgrades/20250114101908_add_hide_salutation_feature_flag/upgrade.py
+++ b/opengever/core/upgrades/20250114101908_add_hide_salutation_feature_flag/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddHideSalutationFeatureFlag(UpgradeStep):
+    """Add hide salutation feature flag.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
**This PR:**
Adds functionality to control the visibility of the salutation in address blocks based on a feature flag. The `hide_salutation` setting from the registry determines whether the salutation should be included in the formatted address. If the flag is enabled, the salutation is hidden; otherwise, it is shown as part of the address block.


For [TI-1570](https://4teamwork.atlassian.net/browse/TI-1570)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[TI-1570]: https://4teamwork.atlassian.net/browse/TI-1570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ