### PR TITLE
Enable searching by meeting title in  meeting listing view

### DIFF
--- a/changes/TI-1747.other
+++ b/changes/TI-1747.other
@@ -1,0 +1,1 @@
+Enable searching for meetings by title in the meeting listing view. [amo]

--- a/opengever/meeting/tabs/meetinglisting.py
+++ b/opengever/meeting/tabs/meetinglisting.py
@@ -123,4 +123,4 @@ class MeetingListingTab(FilteredListingTab):
 @adapter(IMeetingTableSourceConfig, Interface)
 class MeetingTableSource(SqlTableSource):
 
-    searchable_columns = [Meeting.location]
+    searchable_columns = [Meeting.location, Meeting.title]


### PR DESCRIPTION
**This PR:**

The meeting `title` is now also searchable. The current searchable column in the meeting list view is only the meeting `location`.

Users can now search using the meeting `title` along with the `location`

For [TI-1747](https://4teamwork.atlassian.net/browse/TI-1747)

_**Search by meeting title**_

Before :

https://github.com/user-attachments/assets/555364ba-5a29-4d39-8809-b71fec0e6fb2


After:


https://github.com/user-attachments/assets/b9651653-e717-428e-82a3-b87e9faeb672


-----

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[TI-1747]: https://4teamwork.atlassian.net/browse/TI-1747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ