### PR TITLE
Remove relatedItems from request

### DIFF
--- a/changes/TI-1796.other
+++ b/changes/TI-1796.other
@@ -1,0 +1,1 @@
+Remove 'relatedItems' field from copy_from_workspace post request. [ran]

--- a/opengever/workspaceclient/linked_workspaces.py
+++ b/opengever/workspaceclient/linked_workspaces.py
@@ -453,6 +453,7 @@ class LinkedWorkspaces(object):
         proxy_post = ProxyPost(document_repr)
         proxy_post.context = self.context
         proxy_post.request = getRequest()
+        proxy_post.request_data.pop('relatedItems', None)
         gever_doc = proxy_post.reply()
 
         # Dossier


### PR DESCRIPTION
Since copying from workspace to dossier doesnt copy the related document, the 'relatedItems' field can be removed from the request.


For [TI-1796]


- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-1796]: https://4teamwork.atlassian.net/browse/TI-1796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ