### PR TITLE
Properly extract RichTextValue in object transportation

### DIFF
--- a/opengever/base/tests/test_transport.py
+++ b/opengever/base/tests/test_transport.py
@@ -8,6 +8,7 @@ from opengever.base.transport import Transporter
 from opengever.propertysheets.utils import get_custom_properties
 from opengever.task.reminder import ReminderOnDate
 from opengever.testing import IntegrationTestCase
+from plone.app.textfield.value import RichTextValue
 from zExceptions import Unauthorized
 from zope.component import getAdapters
 import json
@@ -26,6 +27,8 @@ class TestTransporter(IntegrationTestCase):
         self.login(self.regular_user)
 
         self.task.set_reminder(ReminderOnDate({'date': date(2019, 12, 30)}))
+        self.task.text = RichTextValue(u'Lorem ipsum')
+
         objects_to_test = [self.task]
 
         for obj in objects_to_test:

--- a/opengever/base/transport.py
+++ b/opengever/base/transport.py
@@ -8,6 +8,7 @@ from opengever.propertysheets.creation_defaults import initialize_customproperti
 from opengever.propertysheets.field import IPropertySheetField
 from opengever.task.reminder import Reminder
 from opengever.task.task import ITask
+from plone.app.textfield import IRichTextValue
 from plone.dexterity.interfaces import IDexterityContent
 from plone.dexterity.utils import addContentToContainer
 from plone.dexterity.utils import createContent
@@ -290,6 +291,9 @@ class DexterityFieldDataCollector(object):
                 return None
             elif self._provided_by_one_of(field, (IRelationList,)):
                 return []
+
+        elif self._provided_by_one_of(value, (IRichTextValue, )):
+            return value.raw
 
         return value
 


### PR DESCRIPTION
This is a follow-up of #8105 

This PR fixes an issue where extracting task metadata for task transportation from one admin unit to another is no longer possible due the implementation of #8105 

Traceback:

```
2025-01-23T13:57:18 ERROR Zope.SiteErrorLog 1737637038.740.535046553442 https://dev.onegovgever.ch/fd/ordnungssystem/raumplanung-bau-und-verkehr/mobilitaet/velo-und-fussverkehr/dossier-3135/task-2917/@@transporter-extract-object-json
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module opengever.base.transport, line 147, in __call__
  Module json, line 244, in dumps
  Module json.encoder, line 207, in encode
  Module json.encoder, line 270, in iterencode
  Module json.encoder, line 184, in default
TypeError: RichTextValue object. (Did you mean <attribute>.raw or <attribute>.output?) is not JSON serializable
```

Can be reproduced when accessing a task with a rich text value on: `/fd/ordnungssystem/fuehrung/kommunikation/allgemeines/dossier-1/task-49/transporter-extract-object-json`

Internal reference: https://4teamwork.slack.com/archives/C02090HG555/p1737541885530209

For [TI-1333]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry: not required because it's a follow-up PR within the same release
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-1333]: https://4teamwork.atlassian.net/browse/TI-1333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ