### PR TITLE
Fx task transportation unpack

### DIFF
--- a/opengever/base/tests/test_transport.py
+++ b/opengever/base/tests/test_transport.py
@@ -89,9 +89,9 @@ class TestTransporter(IntegrationTestCase):
 
         new_task, = self.empty_dossier.objectValues()
 
-        self.assertEquals(self.task.title, self.task.title)
-        self.assertEquals(self.task.responsible, new_task.responsible)
-        self.assertEquals(self.task.issuer, new_task.issuer)
+        self.assertEquals(self.subtask.title, new_task.title)
+        self.assertEquals(self.subtask.responsible, new_task.responsible)
+        self.assertEquals(self.subtask.issuer, new_task.issuer)
 
     def test_transport_to_with_elevated_privileges(self):
         self.login(self.administrator)

--- a/opengever/base/tests/test_transport.py
+++ b/opengever/base/tests/test_transport.py
@@ -84,6 +84,8 @@ class TestTransporter(IntegrationTestCase):
     def test_transports_tasks_correctly(self):
         self.login(self.regular_user)
 
+        self.subtask.text = RichTextValue(u'Lorem ipsum')
+
         Transporter().transport_from(
             self.empty_dossier, 'plone', '/'.join(self.subtask.getPhysicalPath()))
 
@@ -92,6 +94,7 @@ class TestTransporter(IntegrationTestCase):
         self.assertEquals(self.subtask.title, new_task.title)
         self.assertEquals(self.subtask.responsible, new_task.responsible)
         self.assertEquals(self.subtask.issuer, new_task.issuer)
+        self.assertEquals(self.subtask.text.raw, new_task.text.raw)
 
     def test_transport_to_with_elevated_privileges(self):
         self.login(self.administrator)

--- a/opengever/base/transport.py
+++ b/opengever/base/transport.py
@@ -8,7 +8,9 @@ from opengever.propertysheets.creation_defaults import initialize_customproperti
 from opengever.propertysheets.field import IPropertySheetField
 from opengever.task.reminder import Reminder
 from opengever.task.task import ITask
+from plone.app.textfield import IRichText
 from plone.app.textfield import IRichTextValue
+from plone.app.textfield.value import RichTextValue
 from plone.dexterity.interfaces import IDexterityContent
 from plone.dexterity.utils import addContentToContainer
 from plone.dexterity.utils import createContent
@@ -317,6 +319,13 @@ class DexterityFieldDataCollector(object):
                 filename = value['filename']
                 data = base64.decodestring(value['data'])
                 return field._type(data=data, filename=filename)
+
+        if self._provided_by_one_of(field, (IRichText, )):
+            return RichTextValue(
+                raw=value,
+                mimeType='text/html',
+                outputMimeType='text/x-html-safe')
+
         return value
 
     def _provided_by_one_of(self, obj, ifaces):


### PR DESCRIPTION
Follow-Up of #8114 and #8105 

This PR properly unpacks rich text values after task transportation from one admin unit to another.

For [TI-1333]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry: not required, same release
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-1333]: https://4teamwork.atlassian.net/browse/TI-1333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ