### PR TITLE
Use self-hosted action runner

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,6 +5,8 @@ on:
   push:
     tags:
       - '*.*.*'
+    branches:
+      - master
 
 jobs:
   build:
@@ -45,6 +47,7 @@ jobs:
             4teamwork/ogcore
           tags: |
             type=pep440,pattern={{version}}
+            type=edge,branch=master
 
       - name: Build and push ogcore
         uses: docker/build-push-action@v6
@@ -68,6 +71,7 @@ jobs:
             4teamwork/ogtestserver
           tags: |
             type=pep440,pattern={{version}}
+            type=edge,branch=master
 
       - name: Build and push ogtestserver
         uses: docker/build-push-action@v6

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -45,8 +45,11 @@ jobs:
         with:
           images: |
             4teamwork/ogcore
+          flavor: |
+            latest=false
           tags: |
             type=pep440,pattern={{version}}
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' && github.event.base_ref == 'refs/heads/master' }}
             type=edge,branch=master
 
       - name: Build and push ogcore
@@ -69,8 +72,11 @@ jobs:
         with:
           images: |
             4teamwork/ogtestserver
+          flavor: |
+            latest=false
           tags: |
             type=pep440,pattern={{version}}
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' && github.event.base_ref == 'refs/heads/master' }}
             type=edge,branch=master
 
       - name: Build and push ogtestserver

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -16,26 +16,26 @@ jobs:
         run: mkdir src
 
       - name: Checkout opengever.maintenance
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 4teamwork/opengever.maintenance
           path: src/opengever.maintenance
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata from Git reference
         id: meta_ogcore
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             4teamwork/ogcore
@@ -43,7 +43,7 @@ jobs:
             type=pep440,pattern={{version}}
 
       - name: Build and push ogcore
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./docker/core/Dockerfile
@@ -58,7 +58,7 @@ jobs:
 
       - name: Extract metadata from Git reference for ogtestserver
         id: meta_ogtestserver
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             4teamwork/ogtestserver
@@ -66,7 +66,7 @@ jobs:
             type=pep440,pattern={{version}}
 
       - name: Build and push ogtestserver
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./docker/testserver/Dockerfile

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           context: .
           file: ./docker/core/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ github.ref_type == 'tag' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           push: true
           tags: ${{ steps.meta_ogcore.outputs.tags }}
           labels: ${{ steps.meta_ogcore.outputs.labels }}
@@ -84,7 +84,7 @@ jobs:
         with:
           context: .
           file: ./docker/testserver/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ github.ref_type == 'tag' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           push: true
           tags: ${{ steps.meta_ogtestserver.outputs.tags }}
           labels: ${{ steps.meta_ogtestserver.outputs.labels }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,6 +1,7 @@
 name: Build Docker image
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - '*.*.*'

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -26,6 +26,9 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver: remote
+          endpoint: tcp://buildkitd.buildx:1234
 
       - name: Login to DockerHub
         uses: docker/login-action@v3


### PR DESCRIPTION
Improve building of Docker image:

- Use our self-hosted action runner which should be faster
- Use newer versions of Docker actions
- Allow running the action manually
- Build image for `master` branch with tag `edge` which can be used for deployment on dev systems.
- Only build ARM image for releases (tags) to have faster builds for `master` branch.
- Only build `lastest` tag if it's on the `master` branch. Should avoid overwriting `latest` with backport releases.

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)
