### PR TITLE
Add folder_contents listing in the @listing-custom-fields endpoint

### DIFF
--- a/changes/TI-1895.feature
+++ b/changes/TI-1895.feature
@@ -1,0 +1,1 @@
+Add folder_content listing to the @listing-custom-fields endpoint. [amo]

--- a/changes/TI-1895.other
+++ b/changes/TI-1895.other
@@ -1,0 +1,1 @@
+Exclude the dossier assignment slot from propertysheets for teamraum deployments. [amo]

--- a/docs/public/dev-manual/api/listings.rst
+++ b/docs/public/dev-manual/api/listings.rst
@@ -319,7 +319,17 @@ Endpoints verwendet werden.
                     "widget": "date"
                 }
             }
-        }
+        },
+        "folder_contents": {
+            "properties": {
+                 "hasmeetingaccess_custom_field_boolean": {
+                 "name": "hasmeetingaccess_custom_field_boolean",
+                 "title": "can access meetings",
+                 "type": "boolean",
+                 "widget": null
+              }
+            }
+          }
     }
 
 

--- a/opengever/api/listing_custom_fields.py
+++ b/opengever/api/listing_custom_fields.py
@@ -7,6 +7,7 @@ from plone.restapi.services import Service
 LISTING_TO_SLOTS = {
     u'dossiers': get_dossier_assignment_slots,
     u'documents': get_document_assignment_slots,
+    u'folder_contents': get_document_assignment_slots,
 }
 
 

--- a/opengever/api/tests/test_listing_custom_fields.py
+++ b/opengever/api/tests/test_listing_custom_fields.py
@@ -118,9 +118,54 @@ class TestListingCustomFieldsGet(IntegrationTestCase):
                             u'widget': None
                         }
                     }
+                },
+                u'folder_contents': {
+                    u'properties': {
+                        u'choose_custom_field_string': {
+                            u'name': u'choose_custom_field_string',
+                            u'title': u'Choose',
+                            u'type': u'string',
+                            u'widget': None
+                        },
+                        u'choosemulti_custom_field_strings': {
+                            u'name': u'choosemulti_custom_field_strings',
+                            u'title': u'Choose multi',
+                            u'type': u'array',
+                            u'widget': None
+                        },
+                        u'date_custom_field_date': {
+                            u'name': u'date_custom_field_date',
+                            u'title': u'Choose a date',
+                            u'type': u'string',
+                            u'widget': u'date'
+                        },
+                        u'f1_custom_field_string': {
+                            u'name': u'f1_custom_field_string',
+                            u'title': u'Field 1',
+                            u'type': u'string',
+                            u'widget': None
+                        },
+                        u'num_custom_field_int': {
+                            u'name': u'num_custom_field_int',
+                            u'title': u'Number',
+                            u'type': u'integer',
+                            u'widget': None
+                        },
+                        u'textline_custom_field_string': {
+                            u'name': u'textline_custom_field_string',
+                            u'title': u'A line of text',
+                            u'type': u'string',
+                            u'widget': None
+                        },
+                        u'yesorno_custom_field_boolean': {
+                            u'name': u'yesorno_custom_field_boolean',
+                            u'title': u'Yes or no',
+                            u'type': u'boolean',
+                            u'widget': None
+                        }
+                    }
                 }
-            },
-            browser.json
+            }, browser.json
         )
 
     @browsing
@@ -148,6 +193,16 @@ class TestListingCustomFieldsGet(IntegrationTestCase):
         self.assertEqual(
             {
                 u"documents": {
+                    u"properties": {
+                        u"yesorno_custom_field_boolean": {
+                            u"name": u"yesorno_custom_field_boolean",
+                            u"title": u"Y/N (regulations)",
+                            u"type": u"boolean",
+                            u"widget": None
+                        }
+                    }
+                },
+                u"folder_contents": {
                     u"properties": {
                         u"yesorno_custom_field_boolean": {
                             u"name": u"yesorno_custom_field_boolean",

--- a/opengever/propertysheets/assignment.py
+++ b/opengever/propertysheets/assignment.py
@@ -1,4 +1,5 @@
 from opengever.propertysheets import _
+from opengever.workspace import is_workspace_feature_enabled
 from zope.component import getUtility
 from zope.interface import implementer
 from zope.schema.interfaces import IVocabularyFactory
@@ -21,8 +22,9 @@ class PropertySheetAssignmentVocabulary(object):
         for term in get_document_assignment_slots_vocab():
             assignment_terms.append(term)
 
-        for term in get_dossier_assignment_slots_vocab():
-            assignment_terms.append(term)
+        if not is_workspace_feature_enabled():
+            for term in get_dossier_assignment_slots_vocab():
+                assignment_terms.append(term)
 
         return SimpleVocabulary(assignment_terms)
 

--- a/opengever/propertysheets/definition.py
+++ b/opengever/propertysheets/definition.py
@@ -4,7 +4,6 @@ from opengever.propertysheets.default_expression import attach_expression_defaul
 from opengever.propertysheets.default_from_member import attach_member_property_default_factory
 from opengever.propertysheets.exceptions import InvalidFieldType
 from opengever.propertysheets.exceptions import InvalidFieldTypeDefinition
-from opengever.propertysheets.exceptions import InvalidSchemaAssignment
 from opengever.propertysheets.helpers import add_current_value_to_allowed_terms
 from opengever.propertysheets.helpers import is_choice_field
 from opengever.propertysheets.helpers import is_multiple_choice_field
@@ -198,9 +197,11 @@ class PropertySheetSchemaDefinition(object):
                 term = assignment_slots.getTermByToken(token)
                 assignments.append(term.value)
             except LookupError:
-                raise InvalidSchemaAssignment(
-                    "The assignment '{}' is invalid.".format(token)
-                )
+                # Missing slots should be ignored without raising an error.
+                # This allows custom properties to remain usable even if the corresponding slots no longer exist.
+                # Currently, this mainly occurs during testing or local development
+                # when switching between Gever and Teamraum.
+                continue
 
         self._assignments = tuple(assignments)
 

--- a/opengever/propertysheets/tests/test_propertysheet_metaschema.py
+++ b/opengever/propertysheets/tests/test_propertysheet_metaschema.py
@@ -410,3 +410,34 @@ class TestPropertysheetMetaschemaEndpoint(IntegrationTestCase):
             ],
             [prop['description'] for prop in field_properties.values()]
         )
+
+
+class TestWorkSpacePropertysheetMetaschemaEndpoint(IntegrationTestCase):
+    features = ('workspace',)
+
+    @browsing
+    def test_assignment_vocabularies_excluded_dossier_type(self, browser):
+        self.login(self.propertysheets_manager, browser)
+
+        headers = self.api_headers.copy()
+        headers.update({'Accept-Language': 'de-ch'})
+
+        browser.open(
+            view="@propertysheet-metaschema",
+            headers=headers,
+        )
+
+        properties = browser.json['properties']
+        self.assertEqual(
+            [
+                u'Dokument',
+                u'Dokument (Typ: Anfrage)',
+                u'Dokument (Typ: Antrag)',
+                u'Dokument (Typ: Bericht)',
+                u'Dokument (Typ: Offerte)',
+                u'Dokument (Typ: Protokoll)',
+                u'Dokument (Typ: Reglement)',
+                u'Dokument (Typ: Vertrag)',
+                u'Dokument (Typ: Weisung)',
+            ],
+            properties['assignments']['items']['enumNames'])


### PR DESCRIPTION
**This PR:**

- Provides a new slot in the ListingCustomFieldsGet endpoint for folder_contents.
- Excludes dossier assignment from the property sheet when the workspace is active."

For [TI-1895](https://4teamwork.atlassian.net/browse/TI-1895)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [x] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[TI-1895]: https://4teamwork.atlassian.net/browse/TI-1895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ