### PR TITLE
Ensure crontab file has correct mode

### DIFF
--- a/changes/GH-8121.bugfix
+++ b/changes/GH-8121.bugfix
@@ -1,0 +1,1 @@
+Ensure crontab file has correct mode. [buchi]

--- a/docker/core/Dockerfile
+++ b/docker/core/Dockerfile
@@ -94,6 +94,7 @@ COPY ./docker/core/entrypoint.d /app/entrypoint.d
 COPY ./docker/core/docker-entrypoint.sh ./docker/core/inituser /app/
 COPY ./docker/core/zopectl /app/bin/
 COPY --chown=plone ./docker/core/cron /app/cron
+RUN chmod 644 /app/cron/crontab
 
 RUN mkdir -p /app/var/log /app/var/instance \
  && chown plone:plone /app/var/log \


### PR DESCRIPTION
Depending on the local umask when building the Docker image, the file may have a wrong mode (writeable for group) and will be ignored. This ensure that the crontab has the correct mode.


## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)
