### PR TITLE
Properly raise http errors when communicating with ogsign

### DIFF
--- a/changes/TI-1931.other
+++ b/changes/TI-1931.other
@@ -1,0 +1,1 @@
+Properly raise http errors when communicating with ogsign. [elioschmutz]

--- a/opengever/sign/client.py
+++ b/opengever/sign/client.py
@@ -13,7 +13,7 @@ class SignServiceClient(object):
     def queue_signing(self, document, token, signers, editors):
         bumblebee_service = IBumblebeeServiceV3(getRequest())
 
-        return requests.post(
+        resp = requests.post(
             '{}/signing-jobs/'.format(self.sign_service_url),
             headers={"Accept": "application/json"},
             json={'access_token': token,
@@ -25,7 +25,10 @@ class SignServiceClient(object):
                   'title': document.title_or_id(),
                   'signers': signers,
                   'editors': editors,
-                  }).json()
+                  })
+
+        resp.raise_for_status()
+        return resp.json()
 
     def abort_signing(self, job_id):
         if job_id is None:


### PR DESCRIPTION
This PR fixes an issue where gever is not properly raising http errors when communicating with ogsign.

For [TI-1931]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-1931]: https://4teamwork.atlassian.net/browse/TI-1931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ