### PR TITLE
Reapplying changes from PR #8117 causes E2E test failures

### DIFF
--- a/changes/TI-1333.feature
+++ b/changes/TI-1333.feature
@@ -1,0 +1,1 @@
+Change task template `text field` from Text field to RichText field. [amo]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -8,7 +8,7 @@ API Changelog
 
 Breaking Changes
 ^^^^^^^^^^^^^^^^
-
+- The task template text field was changed from a Text field to a RichTextField.
 
 Other Changes
 ^^^^^^^^^^^^^

--- a/opengever/api/tests/test_process.py
+++ b/opengever/api/tests/test_process.py
@@ -114,7 +114,7 @@ class TestProcessPost(IntegrationTestCase):
             "start_immediately": False,
             "process": {
                 "title": "New employee",
-                "text": "A new employee arrives.",
+                "text": "<p> A new employee arrives.</p>",
                 "sequence_type": "sequential",
                 "items": [
                     {
@@ -138,6 +138,7 @@ class TestProcessPost(IntegrationTestCase):
         self.assertEqual(1, len(children['added']))
         main_task = children['added'].pop()
 
+        self.assertEqual("<p> A new employee arrives.</p>", main_task.text.output)
         self.assertEqual(browser.json['@id'], main_task.absolute_url())
         self.assertEqual(u'New employee', main_task.title)
         self.assertEqual(self.regular_user.getId(), main_task.issuer)

--- a/opengever/api/tests/test_tasktemplate.py
+++ b/opengever/api/tests/test_tasktemplate.py
@@ -30,3 +30,28 @@ class TestTaskTemplatePost(SolrIntegrationTestCase):
             browser.json.get('responsible'))
         self.assertEquals({u'title': u'Finanz\xe4mt', u'token': u'fa'},
                           browser.json.get('responsible_client'))
+
+    @browsing
+    def test_tasktemplate_with_richt_text_description(self, browser):
+        self.login(self.administrator, browser=browser)
+        data = {
+            '@type': u'opengever.tasktemplates.tasktemplate',
+            'title': 'Testtasktemplate',
+            'task_type': {'token': 'information'},
+            'deadline': 7,
+            'issuer': {'token': INTERACTIVE_ACTOR_RESPONSIBLE_ID},
+            "responsible": {
+                'token': "fa:{}".format(self.secretariat_user.id),
+                'title': u'Finanzamt: K\xe4thi B\xe4rfuss'
+            },
+            "text": "task template description"
+        }
+        browser.open(self.tasktemplatefolder, method="POST",
+                     headers=self.api_headers, data=json.dumps(data))
+        self.assertEquals(
+            {
+                u'data': u'task template description',
+                u'content-type': u'text/html',
+                u'encoding': u'utf8'
+            }, browser.json.get("text")
+        )

--- a/opengever/core/upgrades/20250131155145_update_task_template_text_field_to_rich_text/upgrade.py
+++ b/opengever/core/upgrades/20250131155145_update_task_template_text_field_to_rich_text/upgrade.py
@@ -1,0 +1,20 @@
+from ftw.upgrade import UpgradeStep
+from plone.app.textfield import IRichTextValue
+from plone.app.textfield.value import RichTextValue
+
+
+class UpdateTaskTemplateTextFieldToRichText(UpgradeStep):
+    """Update task template text field to rich text.
+    """
+    def __call__(self):
+        query = {'object_provides': "opengever.tasktemplates.content.tasktemplate.ITaskTemplate"}
+        msg = "Change task template text field from text field to rich text field"
+        for task in self.objects(query, msg):
+            if IRichTextValue.providedBy(task.text):
+                continue
+            task.text = RichTextValue(
+                raw=task.text or "",
+                mimeType='text/html',
+                outputMimeType='text/x-html-safe',
+                encoding='utf-8',
+            )

--- a/opengever/tasktemplates/content/tasktemplate.py
+++ b/opengever/tasktemplates/content/tasktemplate.py
@@ -7,6 +7,7 @@ from opengever.task.util import update_reponsible_field_data
 from opengever.tasktemplates import _
 from opengever.tasktemplates.sources import TaskResponsibleSourceBinder
 from opengever.tasktemplates.sources import TaskTemplateIssuerSourceBinder
+from plone.app.textfield import RichText
 from plone.autoform import directives as form
 from plone.dexterity.browser.add import DefaultAddForm
 from plone.dexterity.browser.add import DefaultAddView
@@ -86,10 +87,12 @@ class ITaskTemplate(model.Schema):
 
     # Bad naming: comments is more appropriated
     model.primary('text')
-    text = schema.Text(
+    text = RichText(
         title=_(u"label_text", default=u"Text"),
         description=_(u"help_text", default=u""),
         required=False,
+        default_mime_type='text/html',
+        output_mime_type='text/x-html-safe'
     )
 
     form.widget(preselected=checkbox.SingleCheckBoxFieldWidget)


### PR DESCRIPTION
Reapply changes from PR [#8177](https://github.com/4teamwork/opengever.core/pull/8117) with fixes for E2E tests.

This PR reapplies the changes originally introduced in PR #8117, which were reverted  to fix broken E2E tests. The following adjustments have been made:
- Touched the upgrade step: `bin/upgrade touch opengever/core/upgrades/20250127123059_update_task_template_text_field_to_rich_text`.

This PR is linked to the Frontend PR: https://github.com/4teamwork/gever-ui/pull/2844 and should be merged only after all tests (backend and frontend) are green and approved.

Reference: PR [#8177](https://github.com/4teamwork/opengever.core/pull/8117) 