### PR TITLE
Remove persistent objects in sign module

### DIFF
--- a/opengever/sign/pending_editor.py
+++ b/opengever/sign/pending_editor.py
@@ -1,22 +1,54 @@
 from opengever.sign.utils import email_to_userid
-from persistent import Persistent
-from persistent.list import PersistentList
 from plone.restapi.serializer.converters import json_compatible
 
 
-class PendingEditors(PersistentList):
+class PendingEditors(list):
 
     @classmethod
     def from_emails(cls, emails):
         return cls([PendingEditor(email=email) for email in emails])
 
+    @classmethod
+    def from_json_object(cls, values):
+        if not values:
+            return cls()
+
+        return cls(
+            [PendingEditor.from_json_object(value) for value in values])
+
+    def to_json_object(self):
+        return [pending_editor.to_json_object() for pending_editor in self]
+
+    def __eq__(self, value):
+        return isinstance(value, PendingEditors) and value.to_json_object() == self.to_json_object()
+
+    def __ne__(self, value):
+        return not value == self
+
     def serialize(self):
         return json_compatible([pending_editor.serialize() for pending_editor in self])
 
 
-class PendingEditor(Persistent):
+class PendingEditor(object):
     def __init__(self, email=''):
         self.email = email
+
+    def __eq__(self, value):
+        return isinstance(value, PendingEditor) and value.to_json_object() == self.to_json_object()
+
+    def __ne__(self, value):
+        return not value == self
+
+    @classmethod
+    def from_json_object(cls, value):
+        return cls(
+            email=value.get('email')
+        )
+
+    def to_json_object(self):
+        return {
+            'email': self.email
+        }
 
     def serialize(self):
         return json_compatible({

--- a/opengever/sign/pending_signature.py
+++ b/opengever/sign/pending_signature.py
@@ -1,12 +1,26 @@
 from opengever.sign.signatory import Signatories
 from opengever.sign.signatory import Signatory
 from opengever.sign.utils import email_to_userid
-from persistent import Persistent
-from persistent.list import PersistentList
 from plone.restapi.serializer.converters import json_compatible
 
 
-class PendingSignatures(PersistentList):
+class PendingSignatures(list):
+
+    def __eq__(self, value):
+        return isinstance(value, PendingSignatures) and value.to_json_object() == self.to_json_object()
+
+    def __ne__(self, value):
+        return not value == self
+
+    @classmethod
+    def from_json_object(cls, values):
+        if not values:
+            return cls()
+
+        return cls([PendingSignature.from_json_object(value) for value in values])
+
+    def to_json_object(self):
+        return [signature.to_json_object() for signature in self]
 
     def serialize(self):
         return json_compatible([signature.serialize() for signature in self])
@@ -15,7 +29,7 @@ class PendingSignatures(PersistentList):
         return Signatories([signature.to_signatory() for signature in self])
 
 
-class PendingSignature(Persistent):
+class PendingSignature(object):
 
     def __init__(self,
                  email='',
@@ -26,6 +40,27 @@ class PendingSignature(Persistent):
         self.email = email
         self.status = status
         self.signed_at = signed_at
+
+    def __eq__(self, value):
+        return isinstance(value, PendingSignature) and value.to_json_object() == self.to_json_object()
+
+    def __ne__(self, value):
+        return not value == self
+
+    @classmethod
+    def from_json_object(cls, value):
+        return cls(
+            email=value.get('email'),
+            status=value.get('status'),
+            signed_at=value.get('signed_at')
+        )
+
+    def to_json_object(self):
+        return {
+            'email': self.email,
+            'status': self.status,
+            'signed_at': self.signed_at,
+        }
 
     def serialize(self):
         return json_compatible({

--- a/opengever/sign/sign.py
+++ b/opengever/sign/sign.py
@@ -54,7 +54,9 @@ class Signer(object):
 
     def finish_signing(self):
         signed_version = self.pending_signing_job.to_signed_version()
-        self.signed_versions_storage.load().add_signed_version(signed_version)
+        signed_versions = self.signed_versions_storage.load()
+        signed_versions.add_signed_version(signed_version)
+        self.signed_versions_storage.store(signed_versions)
         self.pending_signing_job_storage.clear()
 
     @property

--- a/opengever/sign/sign.py
+++ b/opengever/sign/sign.py
@@ -87,7 +87,7 @@ class Signer(object):
         return api.env.adopt_user(user=user)
 
     def update_pending_signing_job(self, **data):
-        self.pending_signing_job.update(**data)
+        self.pending_signing_job = self.pending_signing_job.update(**data)
 
     def serialize_pending_signing_job(self):
         return self.pending_signing_job.serialize() if self.pending_signing_job else {}

--- a/opengever/sign/signatory.py
+++ b/opengever/sign/signatory.py
@@ -1,18 +1,54 @@
-from persistent import Persistent
-from persistent.list import PersistentList
 from plone.restapi.serializer.converters import json_compatible
 
 
-class Signatories(PersistentList):
+class Signatories(list):
+
+    def __eq__(self, value):
+        return isinstance(value, Signatories) and value.to_json_object() == self.to_json_object()
+
+    def __ne__(self, value):
+        return not value == self
+
+    @classmethod
+    def from_json_object(cls, values):
+        if not values:
+            return cls()
+
+        return cls([Signatory.from_json_object(value) for value in values])
+
+    def to_json_object(self):
+        return [signatory.to_json_object() for signatory in self]
+
     def serialize(self):
         return json_compatible([signatory.serialize() for signatory in self])
 
 
-class Signatory(Persistent):
+class Signatory(object):
     def __init__(self, userid='', email='', signed_at=None):
         self.userid = userid
         self.email = email
         self.signed_at = signed_at
+
+    def __eq__(self, value):
+        return isinstance(value, Signatory) and value.to_json_object() == self.to_json_object()
+
+    def __ne__(self, value):
+        return not value == self
+
+    @classmethod
+    def from_json_object(cls, value):
+        return cls(
+            userid=value.get('userid'),
+            email=value.get('email'),
+            signed_at=value.get('signed_at')
+        )
+
+    def to_json_object(self):
+        return {
+            'userid': self.userid,
+            'email': self.email,
+            'signed_at': self.signed_at,
+        }
 
     def serialize(self):
         return json_compatible({

--- a/opengever/sign/signed_version.py
+++ b/opengever/sign/signed_version.py
@@ -1,12 +1,31 @@
 from datetime import datetime
 from opengever.sign.signatory import Signatories
-from persistent import Persistent
-from persistent.dict import PersistentDict
 from plone.restapi.serializer.converters import json_compatible
 from uuid import uuid4
 
 
-class SignedVersions(PersistentDict):
+class SignedVersions(dict):
+
+    def __eq__(self, value):
+        return isinstance(value, SignedVersions) and value.to_json_object() == self.to_json_object()
+
+    def __ne__(self, value):
+        return not value == self
+
+    @classmethod
+    def from_json_object(cls, values):
+        if not values:
+            return cls()
+
+        return cls({
+            key: SignedVersion.from_json_object(value) for key, value in values.items()
+        })
+
+    def to_json_object(self):
+        return {
+            version_id: version_item.to_json_object() for version_id, version_item in self.items()
+        }
+
     def add_signed_version(self, signed_version):
         if signed_version.version in self:
             raise Exception("Signed version %s already exists" % signed_version.version)
@@ -20,7 +39,7 @@ class SignedVersions(PersistentDict):
             })
 
 
-class SignedVersion(Persistent):
+class SignedVersion(object):
     def __init__(self,
                  id_=None,
                  created=None,
@@ -37,6 +56,29 @@ class SignedVersion(Persistent):
         self.created = created or datetime.now()
         self.version = version
         self.signatories = signatories
+
+    def __eq__(self, value):
+        return isinstance(value, SignedVersion) and value.to_json_object() == self.to_json_object()
+
+    def __ne__(self, value):
+        return not value == self
+
+    @classmethod
+    def from_json_object(cls, value):
+        return cls(
+            id_=value.get('id'),
+            created=value.get('created'),
+            signatories=Signatories.from_json_object(value.get('signatories')),
+            version=value.get('version')
+        )
+
+    def to_json_object(self):
+        return {
+            'id': self.id_,
+            'created': self.created,
+            'signatories': self.signatories.to_json_object(),
+            'version': self.version,
+        }
 
     def serialize(self):
         return json_compatible({

--- a/opengever/sign/storage.py
+++ b/opengever/sign/storage.py
@@ -1,3 +1,4 @@
+from opengever.sign.pending_signing_job import PendingSigningJob
 from opengever.sign.signed_version import SignedVersions
 from zope.annotation import IAnnotations
 
@@ -13,10 +14,10 @@ class PendingSigningJobStorage(object):
         self.annotations = IAnnotations(self.context)
 
     def store(self, pending_signing_job):
-        self.annotations[self.ANNOTATIONS_KEY] = pending_signing_job
+        self.annotations[self.ANNOTATIONS_KEY] = pending_signing_job.to_json_object()
 
     def load(self):
-        return self.annotations.get(self.ANNOTATIONS_KEY)
+        return PendingSigningJob.from_json_object(self.annotations.get(self.ANNOTATIONS_KEY))
 
     def clear(self):
         if self.ANNOTATIONS_KEY in self.annotations:

--- a/opengever/sign/storage.py
+++ b/opengever/sign/storage.py
@@ -36,5 +36,8 @@ class SignedVersionsStorage(object):
 
     def load(self, auto_init=True):
         if auto_init and self.ANNOTATIONS_KEY not in self.annotations:
-            self.annotations[self.ANNOTATIONS_KEY] = SignedVersions()
-        return self.annotations.get(self.ANNOTATIONS_KEY)
+            self.store(SignedVersions())
+        return SignedVersions.from_json_object(self.annotations.get(self.ANNOTATIONS_KEY))
+
+    def store(self, signed_versions):
+        self.annotations[self.ANNOTATIONS_KEY] = signed_versions.to_json_object()

--- a/opengever/sign/tests/test_pending_editors.py
+++ b/opengever/sign/tests/test_pending_editors.py
@@ -13,6 +13,12 @@ class TestPendingEditor(IntegrationTestCase):
                 'userid': 'regular_user'
             }, signer.serialize())
 
+    def test_can_be_converted_from_json_object_to_json_object(self):
+        pending_editor = PendingEditor(email='foo@example.com')
+
+        self.assertTrue(
+            pending_editor == PendingEditor.from_json_object(pending_editor.to_json_object()))
+
 
 class TestPendingEditors(IntegrationTestCase):
     def test_can_be_serialized(self):
@@ -25,7 +31,16 @@ class TestPendingEditors(IntegrationTestCase):
 
         self.assertEqual(2, len(container.serialize()))
         self.assertItemsEqual([signer2.email, signer1.email],
-                              [item.get('email') for item in container.serialize()])
+                              [item.get('email') for item in container.serialize()] )
+
+    def test_can_be_converted_from_json_object_to_json_object(self):
+        container = PendingEditors([
+            PendingEditor(email='foo@example.com'),
+            PendingEditor(email='foo@example.com')
+        ])
+
+        self.assertTrue(
+            container == PendingEditors.from_json_object(container.to_json_object()))
 
     def test_can_be_created_from_a_list_of_emails(self):
         container = PendingEditors.from_emails(['foo@example.com', 'bar@example.com'])

--- a/opengever/sign/tests/test_pending_signatures.py
+++ b/opengever/sign/tests/test_pending_signatures.py
@@ -17,6 +17,14 @@ class TestPendingSignature(IntegrationTestCase):
                 'userid': 'regular_user'
             }, signature.serialize())
 
+    def test_can_be_converted_from_json_object_to_json_object(self):
+        signature = PendingSignature(email='foo@example.com',
+                                     status="signed",
+                                     signed_at='2025-01-28T15:00:00.000Z')
+
+        self.assertTrue(
+            signature == PendingSignature.from_json_object(signature.to_json_object()))
+
     def test_can_be_converted_to_a_signatory(self):
         signature = PendingSignature(email='foo@example.com',
                                      status="signed",
@@ -42,6 +50,15 @@ class TestPendingSignatures(IntegrationTestCase):
         self.assertEqual(2, len(container.serialize()))
         self.assertItemsEqual([signature2.email, signature1.email],
                               [item.get('email') for item in container.serialize()])
+
+    def test_can_be_converted_from_json_object_to_json_object(self):
+        container = PendingSignatures([
+            PendingSignature(email='foo@example.com'),
+            PendingSignature(email='bar@example.com')
+        ])
+
+        self.assertTrue(
+            container == PendingSignatures.from_json_object(container.to_json_object()))
 
     def test_can_be_converted_to_signatories(self):
         container = PendingSignatures()

--- a/opengever/sign/tests/test_pending_signing_job.py
+++ b/opengever/sign/tests/test_pending_signing_job.py
@@ -57,6 +57,22 @@ class TestPendingSigningJob(IntegrationTestCase):
                 'invite_url': 'redirect@example.com/invite',
             }, metadata.serialize())
 
+    def test_can_be_converted_from_json_object_to_json_object(self):
+        self.login(self.regular_user)
+
+        pending_signing_job = PendingSigningJob(
+            created=FROZEN_NOW,
+            userid='foo.bar',
+            version=1,
+            editors=['bar.foo@example.com'],
+            signatures=PendingSignatures([PendingSignature(email="foo@example.com")]),
+            job_id='1',
+            redirect_url='redirect@example.com',
+            invite_url='redirect@example.com/invite')
+
+        self.assertTrue(
+            pending_signing_job == PendingSigningJob.from_json_object(pending_signing_job.to_json_object()))
+
     def test_can_be_converted_to_a_signed_version(self):
         self.login(self.regular_user)
 

--- a/opengever/sign/tests/test_sign.py
+++ b/opengever/sign/tests/test_sign.py
@@ -125,9 +125,10 @@ class TestSigning(IntegrationTestCase):
         self.login(self.regular_user)
 
         signer = Signer(self.document)
-        storage = signer.signed_versions_storage.load()
-        storage.add_signed_version(SignedVersion(version=1))
-        storage.add_signed_version(SignedVersion(version=2))
+        signed_versions = signer.signed_versions_storage.load()
+        signed_versions.add_signed_version(SignedVersion(version=1))
+        signed_versions.add_signed_version(SignedVersion(version=2))
+        signer.signed_versions_storage.store(signed_versions)
 
         self.assertEqual([1, 2], signer.serialize_signed_versions().keys())
 

--- a/opengever/sign/tests/test_signatory.py
+++ b/opengever/sign/tests/test_signatory.py
@@ -16,6 +16,14 @@ class TestSignatory(IntegrationTestCase):
                 'signed_at': '2025-01-28T15:00:00.000Z',
             }, signatory.serialize())
 
+    def test_can_be_converted_from_json_object_to_json_object(self):
+        signatory = Signatory(email='foo@example.com',
+                              userid='regular_user',
+                              signed_at='2025-01-28T15:00:00.000Z')
+
+        self.assertTrue(
+            signatory == Signatory.from_json_object(signatory.to_json_object()))
+
     def test_does_not_auto_lookup_userid(self):
         signatory = Signatory(email='foo@example.com')
 
@@ -39,3 +47,12 @@ class TestSignatories(IntegrationTestCase):
         self.assertEqual(2, len(container.serialize()))
         self.assertItemsEqual([signatory2.email, signatory1.email],
                               [item.get('email') for item in container.serialize()])
+
+    def test_can_be_converted_from_json_object_to_json_object(self):
+        container = Signatories([
+            Signatory(email='foo@example.com'),
+            Signatory(email='foo@example.com')
+        ])
+
+        self.assertTrue(
+            container == Signatories.from_json_object(container.to_json_object()))

--- a/opengever/sign/tests/test_signed_version.py
+++ b/opengever/sign/tests/test_signed_version.py
@@ -42,6 +42,19 @@ class TestSignedVersion(IntegrationTestCase):
                 'version': 1
             }, signed_version.serialize())
 
+    def test_can_be_converted_from_json_object_to_json_object(self):
+        signatories = Signatories([Signatory(email='foo@example.com',
+                                             signed_at='2025-01-28T15:00:00.000Z')])
+
+        signed_version = SignedVersion(
+            id_="1",
+            created=FROZEN_NOW,
+            signatories=signatories,
+            version=1)
+
+        self.assertTrue(
+            signed_version == SignedVersion.from_json_object(signed_version.to_json_object()))
+
 
 class TestSignedVersions(IntegrationTestCase):
     def test_can_be_serialized(self):
@@ -83,3 +96,25 @@ class TestSignedVersions(IntegrationTestCase):
                 u'version': 2
             }
         }, container.serialize())
+
+    def test_can_be_converted_from_json_object_to_json_object(self):
+        signatories = Signatories([Signatory(email='foo@example.com',
+                                             signed_at='2025-01-28T15:00:00.000Z')])
+
+        signed_version_1 = SignedVersion(
+            id_=u"1",
+            created=FROZEN_NOW,
+            signatories=signatories,
+            version=1)
+
+        signed_version_2 = SignedVersion(
+            id_=u"1",
+            created=FROZEN_NOW,
+            version=2)
+
+        container = SignedVersions()
+        container.add_signed_version(signed_version_1)
+        container.add_signed_version(signed_version_2)
+
+        self.assertTrue(
+            container == SignedVersions.from_json_object((container.to_json_object())))

--- a/opengever/sign/tests/test_storage.py
+++ b/opengever/sign/tests/test_storage.py
@@ -1,3 +1,4 @@
+from opengever.sign.pending_signing_job import PendingSigningJob
 from opengever.sign.signed_version import SignedVersion
 from opengever.sign.storage import PendingSigningJobStorage
 from opengever.sign.storage import SignedVersionsStorage
@@ -8,13 +9,15 @@ class TestPendingSigningJobStorage(IntegrationTestCase):
     def test_can_store_and_load_data(self):
         self.login(self.regular_user)
         storage = PendingSigningJobStorage(self.document)
-        storage.store({'userid': 'foo.bar'})
 
-        self.assertDictEqual({'userid': 'foo.bar'}, storage.load())
+        pending_signing_job = PendingSigningJob(userid='foo.bar',)
+        storage.store(pending_signing_job)
+
+        self.assertTrue(pending_signing_job == storage.load())
 
     def test_data_is_stored_on_the_context(self):
         self.login(self.regular_user)
-        PendingSigningJobStorage(self.subdocument).store({'userid': 'foo.bar'})
+        PendingSigningJobStorage(self.subdocument).store(PendingSigningJob())
 
         self.assertIsNone(PendingSigningJobStorage(self.document).load())
 

--- a/opengever/sign/tests/test_storage.py
+++ b/opengever/sign/tests/test_storage.py
@@ -26,8 +26,11 @@ class TestSignedVersionStorage(IntegrationTestCase):
     def test_can_load_and_persist_data(self):
         self.login(self.regular_user)
 
-        SignedVersionsStorage(self.document).load().add_signed_version(SignedVersion(id_=1, version=5))
-        SignedVersionsStorage(self.document).load().add_signed_version(SignedVersion(id_=2, version=6))
+        signed_versions = SignedVersionsStorage(self.document).load()
+        signed_versions.add_signed_version(SignedVersion(id_=1, version=5))
+        signed_versions.add_signed_version(SignedVersion(id_=2, version=6))
+
+        SignedVersionsStorage(self.document).store(signed_versions)
 
         signed_versions = SignedVersionsStorage(self.document).load().serialize()
         self.assertEqual([5, 6], signed_versions.keys())


### PR DESCRIPTION
This PR refactors the sign module to no longer use persistent objects when dealing with signature data. See https://github.com/4teamwork/opengever.core/pull/8120#discussion_r1950529343 for more information.

To store the values, we now use json strings and we deserialize it back to objects when loading it from the annotations.

This should make future development easier and less error prone. 

For [TI-1495]

## Checklist

- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-1495]: https://4teamwork.atlassian.net/browse/TI-1495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ