### PR TITLE
Fix getting context member ids in workspace

### DIFF
--- a/changes/TI-2078.bugfix
+++ b/changes/TI-2078.bugfix
@@ -1,0 +1,1 @@
+Fix getting context member ids in workspace: get userid instead of username. [buchi]

--- a/opengever/workspace/utils.py
+++ b/opengever/workspace/utils.py
@@ -76,7 +76,7 @@ def get_context_members_ids(context, actor_type, disregard_block=False):
             break
         actorroles = portal.acl_users._getLocalRolesForDisplay(content)
         actor_ids = actor_ids.union(set(
-            map(itemgetter(0),
+            map(itemgetter(3),
                 filter(lambda args: is_valid_actorid(actor_type, *args), actorroles))))
 
         if getattr(aq_base(content), '__ac_local_roles_block__', None) \


### PR DESCRIPTION
Currently the username is returned. With this fix the userid will be returned which matters when using a non-legacy OGDS sync profile.

See also:
https://github.com/plone/Products.PlonePAS/blob/5.1.1/src/Products/PlonePAS/pas.py#L283

For [TI-2078](https://4teamwork.atlassian.net/browse/TI-2078)


- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)



[TI-2078]: https://4teamwork.atlassian.net/browse/TI-2078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ