### PR TITLE
Link title/path of dossiers and repository folders exported as excel.

### DIFF
--- a/changes/TI-2089.feature
+++ b/changes/TI-2089.feature
@@ -1,0 +1,1 @@
+Link title/path of dossiers and repository folders exported as excel. [elioschmutz]

--- a/opengever/dossier/browser/report.py
+++ b/opengever/dossier/browser/report.py
@@ -21,6 +21,10 @@ class DossierReporterFieldMapper(SolrFieldMapper):
         )
 
 
+def get_link(value, dossier):
+    return dossier.getURL()
+
+
 class DossierReporter(SolrReporterView):
     """View that generate an excel spreadsheet with the XLSReporter,
     which list the selected dossier (paths in request)
@@ -37,6 +41,7 @@ class DossierReporter(SolrReporterView):
         {
             'id': 'title',
             'is_default': True,
+            'hyperlink': get_link,
         },
         {
             'id': 'start',

--- a/opengever/repository/browser/excel_export.py
+++ b/opengever/repository/browser/excel_export.py
@@ -29,6 +29,10 @@ def bool_label(value):
     )
 
 
+def get_link(value, context):
+    return context.absolute_url()
+
+
 class RepositoryRootExcelExport(BrowserView):
     """Export a repository tree as an Excel document."""
 
@@ -155,7 +159,7 @@ def generate_report(request, context):
     column_map = (
         {'id': 'get_repository_number', 'title': label_repository_number, 'fold_by_method': repository_number_to_outine_level, 'callable': True},  # noqa
         {'id': 'get_folder_uid', 'title': label_repositoryfolder_uid, 'callable': True},
-        {'id': 'get_folder_path', 'title': label_repositoryfolder_path, 'callable': True},
+        {'id': 'get_folder_path', 'title': label_repositoryfolder_path, 'callable': True, 'hyperlink': get_link,},  # noqa
         {'id': 'title_de', 'title': label_repositoryfolder_title_de},
         {'id': 'title_fr', 'title': label_repositoryfolder_title_fr},
         {'id': 'title_en', 'title': label_repositoryfolder_title_en},


### PR DESCRIPTION
This PR links the repository-folder path and the dossier titles of the corresponding exports.

## Repo-Export
![5](https://github.com/user-attachments/assets/94484227-7c6f-48ad-af21-1be6e47f071d)


## Dossier-Export
![4](https://github.com/user-attachments/assets/4bd70b92-3858-4da5-813e-de66def8a040)


For [TI-2089]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-2089]: https://4teamwork.atlassian.net/browse/TI-2089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ