### PR TITLE
Fix for redis in testserver

### DIFF
--- a/opengever/core/testserver.py
+++ b/opengever/core/testserver.py
@@ -237,8 +237,9 @@ class TestserverLayer(OpengeverFixture):
             sablon.setUp()
             atexit.register(sablon.tearDown)
 
-        redis_service_layer.setUp()
-        atexit.register(redis_service_layer.tearDown)
+        if not os.environ.get('REDIS_URL'):
+            redis_service_layer.setUp()
+            atexit.register(redis_service_layer.tearDown)
 
         # Install a Virtual Host Monster
         if "virtual_hosting" not in app.objectIds():


### PR DESCRIPTION
Currently using the ogtestserver container fails after some time because there is no option to configure the redis_url of an already existing container. With this change we can use the testserver docker setup in ris as we used to before.


