### PR TITLE
Fix pdf-dossier-tasks endpoint

### DIFF
--- a/changes/TI-2113.other
+++ b/changes/TI-2113.other
@@ -1,0 +1,1 @@
+Fix pdf-dossier-tasks endpoint after provide Richtext for text (description) field. [amo]

--- a/opengever/latex/dossiertasks.py
+++ b/opengever/latex/dossiertasks.py
@@ -79,9 +79,11 @@ class DossierTasksLaTeXView(MakoLaTeXView):
             if deadline:
                 deadline = deadline.strftime(self.strftimestring)
 
+            task_description = task.text.output if task.text else u''
+
             task_data_list.append({
                 'title': self.convert_plain(task.title),
-                'description': self.convert_plain(task.text or ""),
+                'description': self.convert(task_description),
                 'sequence_number': task.get_sequence_number(),
                 'type': self.convert_plain(task.get_task_type_label()),
                 'completion_date': completion_date,

--- a/opengever/latex/listing.py
+++ b/opengever/latex/listing.py
@@ -17,6 +17,10 @@ from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.component import adapter
 from zope.interface import implementer
 from zope.interface import Interface
+import re
+
+
+STRIP_HTML_RE = re.compile('<[^<]+?>')
 
 
 class Column(object):
@@ -326,7 +330,8 @@ class TaskHistoryLaTeXListing(LaTexListing):
 
             Column('text',
                    _('label_description', default='Description'),
-                   '50%'),
+                   '50%',
+                   lambda item: STRIP_HTML_RE.sub('', item.text if item.text else "")),
         ]
 
 

--- a/opengever/latex/tests/test_dossiertasks.py
+++ b/opengever/latex/tests/test_dossiertasks.py
@@ -13,6 +13,7 @@ from opengever.testing import FunctionalTestCase
 from plone import api
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import TEST_USER_ID
+from plone.app.textfield.value import RichTextValue
 from zope.component import getMultiAdapter
 
 
@@ -47,15 +48,18 @@ class TestDossierTasksLaTeXView(FunctionalTestCase):
         with freeze(datetime(2016, 4, 12, 10, 35)):
             task1 = create(Builder('task')
                            .within(dossier)
-                           .having(responsible=self.user.userid,
-                                   issuer=SITE_OWNER_NAME,
-                                   title="task 1"))
+                           .having(
+                               responsible=self.user.userid,
+                               issuer=SITE_OWNER_NAME,
+                               title="task 1",
+                               text=RichTextValue(u'task 1 description')))
 
             task2 = create(Builder('task')
                            .within(subdossier)
                            .having(responsible=self.user.userid,
                                    issuer=self.user.userid,
-                                   title="task 2"))
+                                   title="task 2",
+                                   text=RichTextValue(u'task 2 description')))
 
         expected_deadline = datetime(2016, 4, 19, 0, 0)
 
@@ -72,7 +76,7 @@ class TestDossierTasksLaTeXView(FunctionalTestCase):
             expected = {'label': 'Task list for dossier "`Anfr\xc3\xb6gen 2015 (Client1 / 1)"\'',
                         'task_data_list': [{'completion_date': completion_date.strftime('%d.%m.%Y'),
                                             'deadline': expected_deadline.strftime('%d.%m.%Y'),
-                                            'description': '',
+                                            'description': 'task 1 description',
                                             'responsible': 'Test User (test\\_user\\_1\\_)',
                                             'issuer': 'admin (admin)',
                                             'sequence_number': 1,
@@ -80,7 +84,7 @@ class TestDossierTasksLaTeXView(FunctionalTestCase):
                                             'type': ''},
                                            {'completion_date': None,
                                             'deadline': expected_deadline.strftime('%d.%m.%Y'),
-                                            'description': '',
+                                            'description': 'task 2 description',
                                             'responsible': 'Test User (test\\_user\\_1\\_)',
                                             'issuer': 'Test User (test\\_user\\_1\\_)',
                                             'sequence_number': 2,


### PR DESCRIPTION
After providing the RichText field for the task, we encountered an issue with the `pdf-dossier-tasks` endpoint returning a `500 `error when accessing the description directly via `task.text`, which will no longer work with the rich text. We should be able to get the text (description) via `task.text.output`.

Since the `task history` also uses the same field `RichText`, we have an issue where, if the user has, for example, tables or other HTML tags in the history, the PDF is not displaying as expected—some fields get wrapped or disappear. After some debugging with @buchi , we fixed this problem by stripping the HTML from the history and displaying it as plain text.

For [TI-2113](https://4teamwork.atlassian.net/browse/TI-2113)

**After:**

[dossier-17.pdf](https://github.com/user-attachments/files/18988360/dossier-17.pdf)



## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[TI-2113]: https://4teamwork.atlassian.net/browse/TI-2113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ