### PR TITLE
Sign service uses SIGN_SERVICE_GEVER_URL environment variable to construct the callback links.

### DIFF
--- a/changes/TI-1931-2.other
+++ b/changes/TI-1931-2.other
@@ -1,0 +1,1 @@
+Sign service uses SIGN_SERVICE_GEVER_URL environment variable to construct the callback links. [elioschmutz]

--- a/opengever/sign/client.py
+++ b/opengever/sign/client.py
@@ -1,5 +1,6 @@
 from ftw.bumblebee.interfaces import IBumblebeeServiceV3
 from os import environ
+from plone import api
 from zope.globalrequest import getRequest
 import requests
 
@@ -10,17 +11,29 @@ class SignServiceClient(object):
     def sign_service_url(self):
         return environ.get('SIGN_SERVICE_URL', '').strip('/')
 
+    @property
+    def sign_service_gever_url(self):
+        """An URL which point to gever and is accessible by the sign service.
+        """
+        sign_gever_url = environ.get('SIGN_SERVICE_GEVER_URL', '').strip('/')
+        return sign_gever_url or api.portal.get().absolute_url()
+
+    def construct_callback_url(self, url):
+        return url.replace(api.portal.get().absolute_url(),
+                           self.sign_service_gever_url)
+
     def queue_signing(self, document, token, editors):
         bumblebee_service = IBumblebeeServiceV3(getRequest())
+        document_url = self.construct_callback_url(document.absolute_url())
 
         resp = requests.post(
             '{}/signing-jobs/'.format(self.sign_service_url),
             headers={"Accept": "application/json"},
             json={'access_token': token,
-                  'document_url': document.absolute_url(),
+                  'document_url': document_url,
                   'download_url': bumblebee_service.get_download_url(document),
-                  'upload_url': '{}/@upload-signed-pdf'.format(document.absolute_url()),
-                  'update_url': '{}/@update-pending-signing-job'.format(document.absolute_url()),
+                  'upload_url': '{}/@upload-signed-pdf'.format(document_url),
+                  'update_url': '{}/@update-pending-signing-job'.format(document_url),
                   'document_uid': document.UID(),
                   'title': document.title_or_id(),
                   'editors': editors,


### PR DESCRIPTION
Currently, the sign client implementation uses the current url to generate the callback urls of the sign service.

This only works if the sign service has access to this url. In case of local development or advanced production deployments, we need a static url which is available for the sign-service.

Currently, we have this issue in development. The sign service runs within a docker container but the gever backend is not. The `ogsign` service can't access gever by `localhost`. The URL should point to the host ip address:

``` 
SIGN_SERVICE_GEVER_URL http://172.16.0.1:8080/fd
```  

For [TI-1931]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-1931]: https://4teamwork.atlassian.net/browse/TI-1931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ