### PR TITLE
Provides bumblebee connection information to the ogsign service to enable multiple bumblebee apps.

### DIFF
--- a/changes/TI-1931-3.other
+++ b/changes/TI-1931-3.other
@@ -1,0 +1,1 @@
+Provides bumblebee app id to the ogsign service to enable multiple bumblebee apps. Requires ogsign 2025.2.0 or higher [elioschmutz]

--- a/opengever/sign/client.py
+++ b/opengever/sign/client.py
@@ -1,3 +1,5 @@
+from ftw.bumblebee.config import bumblebee_config
+from ftw.bumblebee.hashing import get_conversion_access_token
 from ftw.bumblebee.interfaces import IBumblebeeServiceV3
 from os import environ
 from plone import api
@@ -37,6 +39,9 @@ class SignServiceClient(object):
                   'document_uid': document.UID(),
                   'title': document.title_or_id(),
                   'editors': editors,
+                  'bumblebee_convert_url': bumblebee_service.get_convert_url(),
+                  'bumblebee_app_id': bumblebee_config.app_id,
+                  'bumblebee_access_token': get_conversion_access_token(),
                   })
 
         resp.raise_for_status()

--- a/opengever/sign/tests/test_client.py
+++ b/opengever/sign/tests/test_client.py
@@ -17,6 +17,7 @@ TOKEN = '<access-token>'
 @requests_mock.Mocker()
 class TestSigningClient(IntegrationTestCase):
     def tearDown(self):
+        os.environ['BUMBLEBEE_PUBLIC_URL'] = 'http://bumblebee.local/'
         if 'SIGN_SERVICE_GEVER_URL' in os.environ:
             del os.environ['SIGN_SERVICE_GEVER_URL']
 
@@ -29,9 +30,16 @@ class TestSigningClient(IntegrationTestCase):
         response = SignServiceClient().queue_signing(
             self.document, TOKEN, editors)
 
+        request_json = mocker.last_request.json()
+        request_json['bumblebee_access_token'] = '<bumblebee_access_token>'
+        request_json['bumblebee_convert_url'] = request_json['bumblebee_convert_url'].split('?')[0]
+
         self.assertDictEqual(
             {
                 u'access_token': u'<access-token>',
+                u'bumblebee_access_token': u'<bumblebee_access_token>',
+                u'bumblebee_app_id': u'local',
+                u'bumblebee_convert_url': u'http://bumblebee.local/YnVtYmxlYmVl/api/v3/convert',
                 u'document_uid': u'createtreatydossiers000000000002',
                 u'document_url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-14', # noqa
                 u'download_url': u'http://nohost/plone/bumblebee_download?checksum={}&uuid=createtreatydossiers000000000002'.format(DOCX_CHECKSUM), # noqa
@@ -40,7 +48,7 @@ class TestSigningClient(IntegrationTestCase):
                 u'upload_url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-14/@upload-signed-pdf', # noqa
                 u'update_url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-14/@update-pending-signing-job', # noqa
             },
-            mocker.last_request.json())
+            request_json)
 
         self.assertDictEqual(DEFAULT_MOCK_RESPONSE, response)
 
@@ -62,9 +70,16 @@ class TestSigningClient(IntegrationTestCase):
         response = SignServiceClient().queue_signing(
             self.document, TOKEN, [])
 
+        request_json = mocker.last_request.json()
+        request_json['bumblebee_access_token'] = '<bumblebee_access_token>'
+        request_json['bumblebee_convert_url'] = request_json['bumblebee_convert_url'].split('?')[0]
+
         self.assertDictEqual(
             {
                 u'access_token': u'<access-token>',
+                u'bumblebee_access_token': u'<bumblebee_access_token>',
+                u'bumblebee_app_id': u'local',
+                u'bumblebee_convert_url': u'http://bumblebee.local/YnVtYmxlYmVl/api/v3/convert',
                 u'document_uid': u'createtreatydossiers000000000002',
                 u'document_url': u'http://example.com/mygever/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-14', # noqa
                 u'download_url': u'http://nohost/plone/bumblebee_download?checksum={}&uuid=createtreatydossiers000000000002'.format(DOCX_CHECKSUM), # noqa
@@ -73,6 +88,6 @@ class TestSigningClient(IntegrationTestCase):
                 u'upload_url': u'http://example.com/mygever/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-14/@upload-signed-pdf', # noqa
                 u'update_url': u'http://example.com/mygever/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-14/@update-pending-signing-job', # noqa
             },
-            mocker.last_request.json())
+            request_json)
 
         self.assertDictEqual(DEFAULT_MOCK_RESPONSE, response)

--- a/opengever/sign/tests/test_sign.py
+++ b/opengever/sign/tests/test_sign.py
@@ -8,6 +8,7 @@ from opengever.sign.signed_version import SignedVersion
 from opengever.sign.token import InvalidToken
 from opengever.testing import IntegrationTestCase
 from plone import api
+import os
 import re
 import requests_mock
 
@@ -27,6 +28,8 @@ class TestSigning(IntegrationTestCase):
     features = ['sign']
 
     def test_store_signing_document_metadata_when_starting_sign_process(self, mocker):
+        os.environ['BUMBLEBEE_PUBLIC_URL'] = 'http://bumblebee.local/'
+
         self.login(self.regular_user)
 
         mocker.post(re.compile('/signing-jobs'), json=DEFAULT_MOCK_RESPONSE)
@@ -39,10 +42,15 @@ class TestSigning(IntegrationTestCase):
         request = mocker.last_request.json()
         request['access_token'] = '<token>'
         request['download_url'] = '<download-url>'
+        request['bumblebee_access_token'] = '<bumblebee_access_token>'
+        request['bumblebee_convert_url'] = request['bumblebee_convert_url'].split('?')[0]
 
         self.assertDictEqual(
             {
                 u'access_token': u'<token>',
+                u'bumblebee_access_token': u'<bumblebee_access_token>',
+                u'bumblebee_app_id': u'local',
+                u'bumblebee_convert_url': u'http://bumblebee.local/YnVtYmxlYmVl/api/v3/convert',
                 u'document_uid': u'createtreatydossiers000000000002',
                 u'document_url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-14',
                 u'download_url': u'<download-url>',


### PR DESCRIPTION
Multiple gever installations of the same gever admin unit network usually point to the same bumblebee server but uses a different app_id for each admin unit. Currently, `ogsign` configured its own bumblebee which makes it impossible to use one ogsign service for multiple gever admin units with different bumblebee apps.

Since ogsign-Version: `v2025.2.0`, we need to pass the bumblebee related configuration as part of the signing job creation. `ogsign` will then use these information to do the bumblebee requests.

This PR passes the the required bumblebee specific information to the ogsign service when creating the job.

This feature requres `ogsign >= 2025.2.0`. 

Related `ogsign`-PR: https://github.com/4teamwork/ogsign/pull/17

For [TI-1931]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-1931]: https://4teamwork.atlassian.net/browse/TI-1931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ