### PR TITLE
Make sign service client configurable

### DIFF
--- a/opengever/core/testserver.py
+++ b/opengever/core/testserver.py
@@ -37,7 +37,6 @@ from zope.schema.vocabulary import SimpleTerm
 from zope.schema.vocabulary import SimpleVocabulary
 import atexit
 import imp
-import opengever.sign.client
 import os
 import pytz
 import transaction
@@ -47,8 +46,6 @@ SOLR_HOSTNAME = os.environ.get('SOLR_HOSTNAME', 'localhost')
 SOLR_PORT = os.environ.get('SOLR_PORT', '55003')
 SOLR_CORE = os.environ.get('SOLR_CORE', 'testserver')
 REUSE_RUNNING_SOLR = os.environ.get('TESTSERVER_REUSE_RUNNING_SOLR', None)
-
-opengever.sign.client.sign_service_client = opengever.sign.client.NullSignServiceClient()
 
 
 class SQLiteBackup(object):

--- a/opengever/sign/client.py
+++ b/opengever/sign/client.py
@@ -4,6 +4,7 @@ from ftw.bumblebee.interfaces import IBumblebeeServiceV3
 from os import environ
 from plone import api
 from zope.globalrequest import getRequest
+import os
 import requests
 
 
@@ -69,4 +70,12 @@ class NullSignServiceClient(object):
         pass
 
 
-sign_service_client = SignServiceClient()
+client_registry = {
+    'ogsign_service': SignServiceClient,
+    'null_service': NullSignServiceClient
+}
+
+
+def get_sign_service_client():
+    client_name = os.environ.get('SIGN_SERVICE_CLIENT', 'ogsign_service').strip().lower()
+    return client_registry[client_name]()

--- a/opengever/sign/sign.py
+++ b/opengever/sign/sign.py
@@ -2,7 +2,7 @@ from base64 import urlsafe_b64decode
 from base64 import urlsafe_b64encode
 from opengever.base.security import as_internal_workflow_transition
 from opengever.document.document import Document
-from opengever.sign.client import sign_service_client
+from opengever.sign.client import get_sign_service_client
 from opengever.sign.pending_signing_job import PendingSigningJob
 from opengever.sign.storage import PendingSigningJobStorage
 from opengever.sign.storage import SignedVersionsStorage
@@ -34,7 +34,7 @@ class Signer(object):
 
     def start_signing(self, editors=[]):
         token = self.issue_token()
-        response = sign_service_client.queue_signing(self.context, token, editors)
+        response = get_sign_service_client().queue_signing(self.context, token, editors)
         self.pending_signing_job = PendingSigningJob(
             userid=api.user.get_current().id,
             version=self.context.get_current_version_id(missing_as_zero=True),
@@ -77,7 +77,7 @@ class Signer(object):
             return
 
         try:
-            sign_service_client.abort_signing(pending_signing_job.job_id)
+            get_sign_service_client().abort_signing(pending_signing_job.job_id)
         except ConnectionError:
             # The user should always be able to abort the job
             pass


### PR DESCRIPTION
This PR makes the sign service client configurable. This allows us to use the `NullSignServiceClient` in e2e testing.

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [TI-1931]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)



[TI-1931]: https://4teamwork.atlassian.net/browse/TI-1931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ