### PR TITLE
Fix error caused by differing titles in custom fields with the same ID

### DIFF
--- a/changes/TI-1363.bugfix
+++ b/changes/TI-1363.bugfix
@@ -1,0 +1,1 @@
+Fix error when custom fields with the same ID have different titles by allowing title differences without raising an error. [elioschmutz]


### PR DESCRIPTION
This PR addresses an issue where custom fields with the same ID but different titles would raise an error when trying to export a list of such objects (excel-export) or by just fetching the `@listing` of such objects.

The fix removes the title from the equality comparison, allowing custom fields with the same ID to have different titles without causing errors. As a result, if multiple matches are found, the first match will be returned, and its title will be used in listings and exports.

The provided solution is a quick-fix. A more comprehensive solution would require a deeper refactoring. It should not be possible to have such fields in general. Means, there should be a field definition which can be assigned to slots. Currently, we add a field definition for each slot.

For [TI-1363]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-1363]: https://4teamwork.atlassian.net/browse/TI-1363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ