### PR TITLE
Add new document types

### DIFF
--- a/changes/TI-1640.other
+++ b/changes/TI-1640.other
@@ -1,0 +1,1 @@
+Add new document types. [amo]

--- a/docs/schema-dumps/ftw.mail.mail.schema.json
+++ b/docs/schema-dumps/ftw.mail.mail.schema.json
@@ -108,13 +108,16 @@
             "_zope_schema_type": "Choice",
             "enum": [
                 "contract",
+                "costs-statement",
+                "credit-note",
                 "directive",
                 "offer",
                 "protocol",
                 "question",
                 "regulations",
                 "report",
-                "request"
+                "request",
+                "supplementary-agreement"
             ]
         },
         "document_author": {

--- a/docs/schema-dumps/opengever.document.document.schema.json
+++ b/docs/schema-dumps/opengever.document.document.schema.json
@@ -121,13 +121,16 @@
             "_zope_schema_type": "Choice",
             "enum": [
                 "contract",
+                "costs-statement",
+                "credit-note",
                 "directive",
                 "offer",
                 "protocol",
                 "question",
                 "regulations",
                 "report",
-                "request"
+                "request",
+                "supplementary-agreement"
             ]
         },
         "document_author": {

--- a/opengever/api/tests/test_vocabularies.py
+++ b/opengever/api/tests/test_vocabularies.py
@@ -214,9 +214,10 @@ class TestGetVocabularies(IntegrationTestCase):
             headers=self.api_headers,
         ).json
         self.assertEqual(url, response.get('@id'))
-        self.assertEqual(8, response.get('items_total'))
+        self.assertEqual(11, response.get('items_total'))
         expected_tokens = [u'contract', u'directive', u'offer', u'protocol',
-                           u'question', u'regulations', u'report', u'request']
+                           u'question', u'regulations', u'report', u'request',
+                           u'costs-statement', 'credit-note', 'supplementary-agreement']
         self.assertItemsEqual(expected_tokens,
                               [item['token'] for item in response.get('items')])
 
@@ -230,9 +231,10 @@ class TestGetVocabularies(IntegrationTestCase):
             headers=self.api_headers,
         ).json
         self.assertEqual(url, response.get('@id'))
-        self.assertEqual(8, response.get('items_total'))
+        self.assertEqual(11, response.get('items_total'))
         expected_tokens = [u'contract', u'directive', u'offer', u'protocol',
-                           u'question', u'regulations', u'report', u'request']
+                           u'question', u'regulations', u'report', u'request',
+                           u'costs-statement', 'credit-note', 'supplementary-agreement']
         self.assertItemsEqual(expected_tokens,
                               [item['token'] for item in response.get('items')])
 
@@ -465,9 +467,10 @@ class TestGetSources(IntegrationTestCase):
         ).json
 
         self.assertEqual(url, response.get('@id'))
-        self.assertEqual(8, response.get('items_total'))
+        self.assertEqual(11, response.get('items_total'))
         expected_tokens = [u'contract', u'directive', u'offer', u'protocol',
-                           u'question', u'regulations', u'report', u'request']
+                           u'question', u'regulations', u'report', u'request',
+                           u'costs-statement', 'credit-note', 'supplementary-agreement']
         self.assertItemsEqual(expected_tokens,
                               [item['token'] for item in response.get('items')])
 
@@ -482,9 +485,10 @@ class TestGetSources(IntegrationTestCase):
         ).json
 
         self.assertEqual(url, response.get('@id'))
-        self.assertEqual(8, response.get('items_total'))
+        self.assertEqual(11, response.get('items_total'))
         expected_tokens = [u'contract', u'directive', u'offer', u'protocol',
-                           u'question', u'regulations', u'report', u'request']
+                           u'question', u'regulations', u'report', u'request',
+                           u'costs-statement', 'credit-note', 'supplementary-agreement']
         self.assertItemsEqual(expected_tokens,
                               [item['token'] for item in response.get('items')])
 

--- a/opengever/bundle/schemas/documents.schema.json
+++ b/opengever/bundle/schemas/documents.schema.json
@@ -164,13 +164,16 @@
                     "enum": [
                         null,
                         "contract",
+                        "costs-statement",
+                        "credit-note",
                         "directive",
                         "offer",
                         "protocol",
                         "question",
                         "regulations",
                         "report",
-                        "request"
+                        "request",
+                        "supplementary-agreement"
                     ]
                 },
                 "document_author": {

--- a/opengever/document/vdexvocabs/document_types.vdex
+++ b/opengever/document/vdexvocabs/document_types.vdex
@@ -91,4 +91,38 @@
             <langstring language="fr-ch">Règlement</langstring>
         </caption>
     </term>
+    <term>
+        <termIdentifier>costs-statement</termIdentifier>
+        <caption>
+            <langstring language="en">Costs Statement</langstring>
+            <langstring language="en-us">Costs Statement</langstring>
+            <langstring language="de-ch">Kostenabrechnung</langstring>
+            <langstring language="de">Kostenabrechnung</langstring>
+            <langstring language="fr">Décompte de frais</langstring>
+            <langstring language="fr-ch">Décompte de frais</langstring>
+        </caption>
+    </term>
+    <term>
+        <termIdentifier>credit-note</termIdentifier>
+        <caption>
+            <langstring language="en">Credit Note</langstring>
+            <langstring language="en-us">Credit Note</langstring>
+            <langstring language="de-ch">Gutschrift</langstring>
+            <langstring language="de">Gutschrift</langstring>
+            <langstring language="fr">Note de crédit</langstring>
+            <langstring language="fr-ch">Note de crédit</langstring>
+        </caption>
+    </term>
+    <term>
+        <termIdentifier>supplementary-agreement</termIdentifier>
+        <caption>
+            <langstring language="en">Supplementary Agreement</langstring>
+            <langstring language="en-us">Supplementary Agreement</langstring>
+            <langstring language="de-ch">Zusatzvertrag</langstring>
+            <langstring language="de">Zusatzvertrag</langstring>
+            <langstring language="fr">Avenant</langstring>
+            <langstring language="fr-ch">Avenant</langstring>
+        </caption>
+    </term>
+
 </vdex>

--- a/opengever/propertysheets/tests/test_assignment.py
+++ b/opengever/propertysheets/tests/test_assignment.py
@@ -14,6 +14,10 @@ EXPECTED_DOCUMENT_ASSIGNMENT_SLOTS = [
     u"IDocumentMetadata.document_type.regulations",
     u"IDocumentMetadata.document_type.report",
     u"IDocumentMetadata.document_type.request",
+    u"IDocumentMetadata.document_type.costs-statement",
+    u"IDocumentMetadata.document_type.credit-note",
+    u"IDocumentMetadata.document_type.supplementary-agreement",
+
 ]
 
 EXPECTED_DOCUMENT_DEFAULT_SLOT = [

--- a/opengever/propertysheets/tests/test_propertysheet_metaschema.py
+++ b/opengever/propertysheets/tests/test_propertysheet_metaschema.py
@@ -145,6 +145,14 @@ class TestPropertysheetMetaschemaEndpoint(IntegrationTestCase):
                         u"Document (Type: Contract)",
                     ],
                     [
+                        u"IDocumentMetadata.document_type.costs-statement",
+                        u"Document (Type: Costs Statement)",
+                    ],
+                    [
+                        u"IDocumentMetadata.document_type.credit-note",
+                        u"Document (Type: Credit Note)",
+                    ],
+                    [
                         u"IDocumentMetadata.document_type.directive",
                         u"Document (Type: Directive)",
                     ],
@@ -172,6 +180,11 @@ class TestPropertysheetMetaschemaEndpoint(IntegrationTestCase):
                         u"IDocumentMetadata.document_type.request",
                         u"Document (Type: Request)",
                     ],
+
+                    [
+                        u"IDocumentMetadata.document_type.supplementary-agreement",
+                        u"Document (Type: Supplementary Agreement)",
+                    ],
                     [u"IDossier.default", u"Dossier"],
                     [
                         u"IDossier.dossier_type.businesscase",
@@ -181,6 +194,8 @@ class TestPropertysheetMetaschemaEndpoint(IntegrationTestCase):
                 u"enum": [
                     u"IDocument.default",
                     u"IDocumentMetadata.document_type.contract",
+                    u"IDocumentMetadata.document_type.costs-statement",
+                    u"IDocumentMetadata.document_type.credit-note",
                     u"IDocumentMetadata.document_type.directive",
                     u"IDocumentMetadata.document_type.question",
                     u"IDocumentMetadata.document_type.offer",
@@ -188,12 +203,16 @@ class TestPropertysheetMetaschemaEndpoint(IntegrationTestCase):
                     u"IDocumentMetadata.document_type.regulations",
                     u"IDocumentMetadata.document_type.report",
                     u"IDocumentMetadata.document_type.request",
+
+                    u"IDocumentMetadata.document_type.supplementary-agreement",
                     u"IDossier.default",
                     u"IDossier.dossier_type.businesscase",
                 ],
                 u"enumNames": [
                     u"Document",
                     u"Document (Type: Contract)",
+                    u"Document (Type: Costs Statement)",
+                    u"Document (Type: Credit Note)",
                     u"Document (Type: Directive)",
                     u"Document (Type: Inquiry)",
                     u"Document (Type: Offer)",
@@ -201,6 +220,7 @@ class TestPropertysheetMetaschemaEndpoint(IntegrationTestCase):
                     u"Document (Type: Regulations)",
                     u"Document (Type: Report)",
                     u"Document (Type: Request)",
+                    u"Document (Type: Supplementary Agreement)",
                     u"Dossier",
                     u"Dossier (Type: Business case)",
                 ],
@@ -325,11 +345,14 @@ class TestPropertysheetMetaschemaEndpoint(IntegrationTestCase):
                 u'Dokument (Typ: Anfrage)',
                 u'Dokument (Typ: Antrag)',
                 u'Dokument (Typ: Bericht)',
+                u'Dokument (Typ: Gutschrift)',
+                u'Dokument (Typ: Kostenabrechnung)',
                 u'Dokument (Typ: Offerte)',
                 u'Dokument (Typ: Protokoll)',
                 u'Dokument (Typ: Reglement)',
                 u'Dokument (Typ: Vertrag)',
                 u'Dokument (Typ: Weisung)',
+                u'Dokument (Typ: Zusatzvertrag)',
                 u'Dossier',
                 u'Dossier (Typ: Gesch\xe4ftsfall)',
             ],
@@ -434,10 +457,13 @@ class TestWorkSpacePropertysheetMetaschemaEndpoint(IntegrationTestCase):
                 u'Dokument (Typ: Anfrage)',
                 u'Dokument (Typ: Antrag)',
                 u'Dokument (Typ: Bericht)',
+                u'Dokument (Typ: Gutschrift)',
+                u'Dokument (Typ: Kostenabrechnung)',
                 u'Dokument (Typ: Offerte)',
                 u'Dokument (Typ: Protokoll)',
                 u'Dokument (Typ: Reglement)',
                 u'Dokument (Typ: Vertrag)',
                 u'Dokument (Typ: Weisung)',
+                u'Dokument (Typ: Zusatzvertrag)'
             ],
             properties['assignments']['items']['enumNames'])


### PR DESCRIPTION
This PR:
Adds new Document type in `document_types` vocabulary

For [TI-1640](https://4teamwork.atlassian.net/browse/TI-1640)

**Before:**
<img width="569" alt="before_docu_type" src="https://github.com/user-attachments/assets/4a410bb6-25f7-4fa4-a438-c999bd5d7195" />

**After:**

<img width="569" alt="after_docu_types" src="https://github.com/user-attachments/assets/e6184737-d55e-4528-844d-f32d6e140fd4" />

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-1640]: https://4teamwork.atlassian.net/browse/TI-1640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ