### PR TITLE
Add support for read-only mode with Docker

### DIFF
--- a/changes/GH-8142.other
+++ b/changes/GH-8142.other
@@ -1,0 +1,1 @@
+Add support for read-only mode with Docker. [buchi]

--- a/docker/core/entrypoint.d/create_zope_conf.py
+++ b/docker/core/entrypoint.d/create_zope_conf.py
@@ -23,7 +23,8 @@ def main():
         'zodb_cache_size': env.get('ZODB_CACHE_SIZE', 100000),
         'zserver_threads': env.get('ZSERVER_THREADS', 1),
         'zeo_address': env.get('ZEO_ADDRESS', 'zeoserver:8100'),
-        'storage': env.get('STORAGE', 'zeoclient')
+        'storage': env.get('STORAGE', 'zeoclient'),
+        'read_only': env.get('READ_ONLY', 'false'),
     }
 
     if options['debug_mode'] == 'on':
@@ -129,7 +130,7 @@ ZEO_STORAGE_TEMPLATE = """\
 <zodb_db main>
     cache-size {zodb_cache_size}
     <zeoclient>
-      read-only false
+      read-only {read_only}
       read-only-fallback false
       blob-dir /data/blobstorage
       shared-blob-dir on


### PR DESCRIPTION
Allows us to run GEVER/teamraum in read-only mode.

## Checklist

- [x] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)
