### PR TITLE
Allow 'text' in MetaDataSchema to be None

### DIFF
--- a/changes/TI-2109.bugfix
+++ b/changes/TI-2109.bugfix
@@ -1,0 +1,1 @@
+Fix error when delegating a task and description is None. [ran]

--- a/opengever/task/browser/delegate/metadata.py
+++ b/opengever/task/browser/delegate/metadata.py
@@ -57,6 +57,7 @@ class IUpdateMetadata(Schema):
         title=_(u"label_text", default=u"Text"),
         description=_(u"help_text", default=u""),
         required=False,
+        missing_value=None,
         defaultFactory=text_default,
         default_mime_type='text/html',
         output_mime_type='text/x-html-safe')

--- a/opengever/task/transition.py
+++ b/opengever/task/transition.py
@@ -451,6 +451,13 @@ class DelegateTransitionExtender(DefaultTransitionExtender):
                         transition_params.pop('documents', []),
                         transition_params)
 
+    def _deserialize_schema(self, schema, transition_params, collect_errors=False):
+        if "text" in transition_params and transition_params["text"] is None:
+            del transition_params["text"]
+
+        return super(DelegateTransitionExtender, self)._deserialize_schema(
+            schema, transition_params, collect_errors=collect_errors)
+
 
 @implementer(ITransitionExtender)
 @adapter(ITask, IBrowserRequest)


### PR DESCRIPTION
Due to making the "Beschreibung" field in tasks into a RichText field, the backend schema for tasks was changed to accept Richtext. The RichTextDeserializer doesnt cannot deserialize null values which leads to 500 Error.

For [TI-2109]

## Checklist


- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-2109]: https://4teamwork.atlassian.net/browse/TI-2109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ