### PR TITLE
Show committee instead of responsible in Proposal Listing

### DIFF
--- a/changes/TI-2272.feature
+++ b/changes/TI-2272.feature
@@ -1,0 +1,1 @@
+Extend solr and add RisCommittee actor. [ran]

--- a/opengever/api/actors.py
+++ b/opengever/api/actors.py
@@ -44,9 +44,14 @@ class SerializeActorToJson(object):
                 represents = serializer()
                 represents['@id'] = represents_url
 
+        if self.context.actor_type == 'riscommittee':
+            id = self.context.get_profile_url()
+        else:
+            id = '{}/@actors/{}'.format(
+                api.portal.get().absolute_url(), self.context.identifier)
+
         result = {
-            '@id': '{}/@actors/{}'.format(
-                api.portal.get().absolute_url(), self.context.identifier),
+            '@id': id,
             '@type': 'virtual.ogds.actor',
             'active': self.context.is_active,
             'actor_type': self.context.actor_type,

--- a/opengever/base/solr/fields.py
+++ b/opengever/base/solr/fields.py
@@ -476,6 +476,11 @@ FIELDS_WITH_MAPPING = [
         accessor='checked_out_fullname',
     ),
     ListingField(
+        'committee',
+        index='committee',
+        title=document_mf('label_committee', default='Committee'),
+    ),
+    ListingField(
         'containing_dossier',
         index='containing_dossier',
         title=document_mf(u'label_dossier_title'),

--- a/opengever/core/upgrades/20250327125737_reindex_committee_title_url/upgrade.py
+++ b/opengever/core/upgrades/20250327125737_reindex_committee_title_url/upgrade.py
@@ -1,0 +1,23 @@
+from ftw.upgrade import UpgradeStep
+from opengever.core.upgrade import NightlyIndexer
+from opengever.meeting.proposal import IProposal
+from opengever.ris.proposal import IProposal as IRisProposal
+
+
+class ReindexCommittee(UpgradeStep):
+    """
+    Reindex committee
+    """
+
+    deferrable = True
+
+    def __call__(self):
+        query = {'object_provides': [
+            IRisProposal.__identifier__,
+            IProposal.__identifier__,
+        ]}
+
+        with NightlyIndexer(idxs=["committee"],
+                            index_in_solr_only=True) as indexer:
+            for brain in self.brains(query, 'Index committee in Solr'):
+                indexer.add_by_brain(brain)

--- a/opengever/meeting/configure.zcml
+++ b/opengever/meeting/configure.zcml
@@ -243,6 +243,11 @@
       name="responsible"
       />
 
+  <adapter
+      factory=".indexers.committeeIndexer"
+      name="committee"
+      />
+
   <adapter factory=".period.PeriodValidator" />
 
 </configure>

--- a/opengever/ogds/base/tests/test_actor.py
+++ b/opengever/ogds/base/tests/test_actor.py
@@ -16,6 +16,7 @@ from opengever.ogds.base.actor import KuBContactActor
 from opengever.ogds.base.actor import NullActor
 from opengever.ogds.base.actor import OGDSGroupActor
 from opengever.ogds.base.actor import OGDSUserActor
+from opengever.ogds.base.actor import RISCommitteeActor
 from opengever.ogds.base.actor import TeamActor
 from opengever.ogds.models.user import User
 from opengever.testing import FunctionalTestCase
@@ -28,6 +29,13 @@ import requests_mock
 
 
 class TestActorLookup(IntegrationTestCase):
+    def setUp(self):
+        super(TestActorLookup, self).setUp()
+        with self.login(self.manager):
+            self.ris_proposal = create(
+                Builder('ris_proposal').within(self.dossier).having(document=self.document)
+                .with_committee_title('Kantonsrat')
+                .with_committee_url('https:://spv.onegovgever.ch'))
 
     def test_null_actor(self):
         actor = Actor.lookup('not-existing')
@@ -91,6 +99,14 @@ class TestActorLookup(IntegrationTestCase):
             actor.get_link(with_icon=False))
 
         self.assertEqual(None, actor.login_name)
+
+    def test_riscommittee_actor_lookup(self):
+        self.login(self.meeting_user)
+        actor = Actor.lookup('riscommittee:proposal-5')
+
+        self.assertIsInstance(actor, RISCommitteeActor)
+        self.assertEqual('Kantonsrat', actor.get_label())
+        self.assertEqual('https:://spv.onegovgever.ch', actor.get_profile_url())
 
     def test_team_actor_lookup(self):
         self.login(self.regular_user)

--- a/opengever/ris/configure.zcml
+++ b/opengever/ris/configure.zcml
@@ -16,4 +16,9 @@
 
   <adapter factory=".sequence.ProposalSequenceNumberGenerator" />
 
+  <adapter
+      factory=".indexers.committee"
+      name="committee"
+      />
+
 </configure>

--- a/opengever/ris/indexers.py
+++ b/opengever/ris/indexers.py
@@ -1,0 +1,8 @@
+from opengever.ris.proposal import IProposal
+from plone.indexer import indexer
+
+
+@indexer(IProposal)
+def committee(obj):
+    """String indexer for the SPV committee name"""
+    return "riscommittee:{}".format(obj.id)

--- a/opengever/testing/builders/dx.py
+++ b/opengever/testing/builders/dx.py
@@ -588,7 +588,20 @@ class RisProposalBuilder(GeverDexterityBuilder):
             'committee_title': "Finanzkommission",
             'committee_url': "https://example.com/fin/",
             'issuer': TEST_USER_ID,
+            'portal_type': 'opengever.ris.proposal',
         }
+
+    def with_committee_title(self, content):
+        self.arguments["committee_title"] = content
+        return self
+
+    def with_committee_url(self, content):
+        self.arguments["committee_url"] = content
+        return self
+
+    def with_id(self, content):
+        self.arguments["id"] = content
+        return self
 
 
 builder_registry.register('ris_proposal', RisProposalBuilder)

--- a/solr-conf/managed-schema
+++ b/solr-conf/managed-schema
@@ -134,6 +134,7 @@
     <field name="checked_out" type="string" indexed="true" stored="false" />
     <field name="is_locked_by_copy_to_workspace" type="boolean" indexed="true" stored="false" />
     <field name="is_completed" type="boolean" indexed="true" stored="false" />
+    <field name="committee" type="string" indexed="true" stored="false" />
     <field name="containing_dossier" type="string" indexed="false" stored="false" />
     <field name="containing_subdossier" type="string" indexed="false" stored="false" />
     <field name="deadline" type="pdate" indexed="true" stored="false" />


### PR DESCRIPTION
Although the Header in the Proposal Listing was marked as "Committee"/"Gremium", what was actually displayed was the responsible field. Changes have been made to display the actual "committee". For the new actor-type "riscommittee" which is in the new SPV, the details and info was modified to show no-members and correct link in the SPV.

Before:

After:
<img width="1541" alt="after2272" src="https://github.com/user-attachments/assets/f6272de8-5c8b-4f30-81ce-bbc4f75837c7" />


For [TI-2272](https://4teamwork.atlassian.net/browse/TI-2272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)


## Checklist


- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


- Upgrade-Steps:
  - [x] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [x] Make it deferrable if possible
  - [x] Execute as much as possible conditionally




[TI-2272]: https://4teamwork.atlassian.net/browse/TI-2272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ