### PR TITLE
Fix upgradestep for grant dossier manager to responsible if the respo…

### DIFF
--- a/opengever/core/upgrades/20250324140844_migrate_grant_role_manager_to_responsible_to_grant_dossier_manager_to_responsible_feature/upgrade.py
+++ b/opengever/core/upgrades/20250324140844_migrate_grant_role_manager_to_responsible_to_grant_dossier_manager_to_responsible_feature/upgrade.py
@@ -49,10 +49,11 @@ class MigrateGrantRoleManagerToResponsibleToGrantDossierManagerToResponsibleFeat
             manager.clear_by_causes([ASSIGNMENT_VIA_DOSSIER_RESPONSIBLE])
 
             # Get the current responsible. Even if the responsible is required
-            # on a dossier, it's possible to have dossiers without any responsible.
-            # This should not happen, but is possible. We skip such dossiers.
+            # on a dossier, it's possible to have dossiers without any responsible
+            # or dossiers with a non existing responsible.
+            # Both should not happen, but is possible. We skip such dossiers.
             responsible = IDossier(obj).responsible
-            if not responsible:
+            if not responsible or not api.user.get(responsible):
                 continue
 
             # Assign the new assignment dossier manager roles.


### PR DESCRIPTION
This is a follow-up PR of #8141 and fixes an issue in the upgradestep where we try to check the permission of the current dossier responsible. Every dossier should have an *existing* responsible. But it seems, that we have dossier without existing responsible, maybe creaded manually by code.

For [TI-2137]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-2137]: https://4teamwork.atlassian.net/browse/TI-2137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ