### PR TITLE
Provide actions to change dossier and sub-dossiers responsible

### DIFF
--- a/changes/TI-2135.other
+++ b/changes/TI-2135.other
@@ -1,0 +1,1 @@
+Provide actions to transfer responsibility for dossiers and sub-dossiers via context actions and listing actions. [amo]

--- a/opengever/api/tests/test_transfer_dossier.py
+++ b/opengever/api/tests/test_transfer_dossier.py
@@ -205,3 +205,22 @@ class TestTransferDossierPost(SolrIntegrationTestCase):
 
         self.assertEqual(self.meeting_user.getId(), IDossier(self.dossier).responsible)
         self.assertEqual(self.dossier_responsible.getId(), IDossier(self.subdossier).responsible)
+
+    @browsing
+    def test_transfer_dossier_changes_responsible_extract_token_from_old_user(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        self.assertEqual(self.dossier_responsible.getId(),
+                         IDossier(self.dossier).responsible)
+
+        old_userid = {
+            u'token': self.dossier_responsible.getId(),
+            u'title': self.dossier_responsible.getUserName()
+        }
+
+        browser.open(self.dossier.absolute_url() + '/@transfer-dossier', method='POST',
+                     headers=self.api_headers, data=json.dumps(
+                         {"old_userid": old_userid,
+                          "new_userid": self.meeting_user.getId()}))
+
+        self.assertEqual(self.meeting_user.getId(), IDossier(self.dossier).responsible)

--- a/opengever/api/tests/test_ui_actions.py
+++ b/opengever/api/tests/test_ui_actions.py
@@ -35,7 +35,8 @@ class TestUIActionsGET(IntegrationTestCase):
                 {u'id': u'edit'},
                 {u'id': u'export_pdf'},
                 {u'id': u'pdf_dossierdetails'},
-                {u'id': u'zipexport'}]}, browser.json)
+                {u'id': u'zipexport'},
+                {u'id': u'transfer_dossier_responsible'}]}, browser.json)
 
     @browsing
     def test_ui_actions_includes_listing_actions(self, browser):
@@ -61,7 +62,7 @@ class TestUIActionsGET(IntegrationTestCase):
         browser.open(dossier_url, method='GET', headers=self.api_headers)
         self.assertEqual([u'edit_items', u'change_items_state', u'copy_items',
                           u'move_items', u'export_dossiers', u'export_dossiers_with_subdossiers',
-                          u'pdf_dossierlisting'],
+                          u'pdf_dossierlisting', u'transfer_dossier_responsible'],
                          [action['id'] for action in browser.json['listing_actions']])
         combined_url = u'{}/@ui-actions?categories:list=listing_actions'\
                        u'&listings:list=tasks&listings:list=dossiers'.format(

--- a/opengever/api/transfer.py
+++ b/opengever/api/transfer.py
@@ -40,6 +40,14 @@ class ExtractOldNewUserMixin(Service):
         old_userid = data.get("old_userid")
         new_userid = data.get("new_userid")
 
+        # In case of a context action, we receive a dict for the old_userid,
+        # from which we need to extract the token.
+
+        # example:
+        # 'old_userid': {u'token': u'ben.utzer', u'title': u'Utzer Ben (ben.utzer)'}
+        if isinstance(old_userid, dict):
+            old_userid = old_userid.get('token')
+
         if not old_userid:
             raise BadRequest("Property 'old_userid' is required")
         if not new_userid:

--- a/opengever/base/context_actions.py
+++ b/opengever/base/context_actions.py
@@ -70,6 +70,7 @@ class BaseContextActions(object):
         self.maybe_add_zipexport()
         self.maybe_add_save_minutes_as_pdf()
         self.maybe_export_workspace_users()
+        self.maybe_add_transfer_dossier_responsible()
         return self.actions
 
     def add_action(self, action):
@@ -247,6 +248,9 @@ class BaseContextActions(object):
         return False
 
     def is_export_workspace_users_available(self):
+        return False
+
+    def is_transfer_dossier_responsible_available(self):
         return False
 
     def maybe_add_add_invitation(self):
@@ -476,3 +480,7 @@ class BaseContextActions(object):
     def maybe_export_workspace_users(self):
         if self.is_export_workspace_users_available():
             self.add_action(u'export_workspace_participators')
+
+    def maybe_add_transfer_dossier_responsible(self):
+        if self.is_transfer_dossier_responsible_available():
+            self.add_action(u'transfer_dossier_responsible')

--- a/opengever/base/listing_actions.py
+++ b/opengever/base/listing_actions.py
@@ -36,6 +36,7 @@ class BaseListingActions(object):
         self.maybe_add_delete_workspace_content()
         self.maybe_add_delete()
         self.maybe_add_export_users()
+        self.maybe_add_transfer_dossier_responsible()
         return self.actions
 
     def add_action(self, action):
@@ -114,6 +115,9 @@ class BaseListingActions(object):
         return False
 
     def is_export_users_available(self):
+        return False
+
+    def is_transfer_dossier_responsible_available(self):
         return False
 
     def maybe_add_attach_documents(self):
@@ -215,3 +219,7 @@ class BaseListingActions(object):
     def maybe_add_export_users(self):
         if self.is_export_users_available():
             self.add_action(u'export_users')
+
+    def maybe_add_transfer_dossier_responsible(self):
+        if self.is_transfer_dossier_responsible_available():
+            self.add_action(u'transfer_dossier_responsible')

--- a/opengever/dossier/actions.py
+++ b/opengever/dossier/actions.py
@@ -40,6 +40,9 @@ class DossierListingActions(BaseListingActions):
     def is_pdf_dossierlisting_available(self):
         return True
 
+    def is_transfer_dossier_responsible_available(self):
+        return True
+
 
 class PrivateDossierListingActions(BaseListingActions):
 
@@ -53,6 +56,9 @@ class PrivateDossierListingActions(BaseListingActions):
         return True
 
     def is_pdf_dossierlisting_available(self):
+        return True
+
+    def is_transfer_dossier_responsible_available(self):
         return True
 
 
@@ -180,6 +186,9 @@ class DossierContextActions(BaseContextActions):
 
     def is_zipexport_available(self):
         return True
+
+    def is_transfer_dossier_responsible_available(self):
+        return api.user.has_permission('Modify portal content', obj=self.context)
 
 
 @adapter(IDossierTemplateMarker, IOpengeverBaseLayer)

--- a/opengever/dossier/tests/test_actions.py
+++ b/opengever/dossier/tests/test_actions.py
@@ -23,7 +23,7 @@ class TestDossierListingActions(IntegrationTestCase):
         self.login(self.regular_user)
         expected_actions = [u'edit_items', u'change_items_state', u'copy_items',
                             u'move_items', u'export_dossiers', u'export_dossiers_with_subdossiers',
-                            u'pdf_dossierlisting']
+                            u'pdf_dossierlisting', u'transfer_dossier_responsible']
         self.assertEqual(expected_actions, self.get_actions(self.repository_root))
         self.assertEqual(expected_actions, self.get_actions(self.branch_repofolder))
 
@@ -31,14 +31,14 @@ class TestDossierListingActions(IntegrationTestCase):
         self.login(self.regular_user)
         expected_actions = [u'edit_items', u'change_items_state', u'copy_items',
                             u'move_items', u'export_dossiers', u'export_dossiers_with_subdossiers',
-                            u'pdf_dossierlisting']
+                            u'pdf_dossierlisting', u'transfer_dossier_responsible']
         self.assertEqual(expected_actions, self.get_actions(self.portal))
 
     def test_dossier_actions_for_dossier(self):
         self.login(self.regular_user)
         expected_actions = [u'edit_items', u'change_items_state', u'copy_items',
                             u'move_items', u'export_dossiers', u'export_dossiers_with_subdossiers',
-                            u'pdf_dossierlisting']
+                            u'pdf_dossierlisting', u'transfer_dossier_responsible']
         self.assertEqual(expected_actions, self.get_actions(self.dossier))
         self.assertEqual(expected_actions, self.get_actions(self.meeting_dossier))
 
@@ -56,8 +56,9 @@ class TestDossierListingActions(IntegrationTestCase):
 
     def test_dossier_actions_for_private_dossier_and_private_folder(self):
         self.login(self.regular_user)
-        expected_actions = [u'edit_items', u'change_items_state', u'export_dossiers',
-                            u'pdf_dossierlisting', u'delete']
+        expected_actions = [
+            u'edit_items', u'change_items_state', u'export_dossiers',
+            u'pdf_dossierlisting', u'delete', u'transfer_dossier_responsible']
         self.assertEqual(expected_actions, self.get_actions(self.private_dossier))
         self.assertEqual(expected_actions, self.get_actions(self.private_folder))
 
@@ -111,8 +112,11 @@ class TestDossierContextActions(IntegrationTestCase):
 
     def test_dossier_context_actions(self):
         self.login(self.regular_user)
-        expected_actions = [u'document_with_template', u'edit', u'export_pdf',
-                            u'pdf_dossierdetails', u'zipexport']
+        expected_actions = [
+            u'document_with_template',
+            u'edit', u'export_pdf',
+            u'pdf_dossierdetails', u'zipexport',
+            u'transfer_dossier_responsible']
         self.assertEqual(expected_actions, self.get_actions(self.dossier))
 
     def test_document_from_docugate_available_if_feature_enabled(self):
@@ -170,7 +174,8 @@ class TestWorkspaceClientDossierContextActions(FunctionalWorkspaceClientTestCase
             expected_actions = [u'copy_documents_from_workspace', u'copy_documents_to_workspace',
                                 u'create_linked_workspace', u'document_with_template', u'edit',
                                 u'export_pdf', u'link_to_workspace', u'list_workspaces',
-                                u'pdf_dossierdetails', u'unlink_workspace', u'zipexport']
+                                u'pdf_dossierdetails', u'unlink_workspace', u'zipexport',
+                                u'transfer_dossier_responsible']
 
             self.assertEqual(expected_actions, self.get_actions(self.dossier))
 
@@ -180,7 +185,7 @@ class TestWorkspaceClientDossierContextActions(FunctionalWorkspaceClientTestCase
             subdossier = create(Builder('dossier').within(self.dossier))
             expected_actions = [u'copy_documents_to_workspace', u'delete', u'document_with_template', u'edit',
                                 u'export_pdf', u'list_workspaces', u'pdf_dossierdetails',
-                                u'zipexport']
+                                u'zipexport', u'transfer_dossier_responsible']
 
             self.assertEqual(expected_actions, self.get_actions(subdossier))
 
@@ -221,8 +226,10 @@ class TestWorkspaceClientDossierContextActions(FunctionalWorkspaceClientTestCase
             api.content.transition(obj=self.dossier,
                                    transition='dossier-transition-deactivate')
             transaction.commit()
-            expected_actions = [u'export_pdf', u'list_workspaces', u'pdf_dossierdetails',
-                                u'unlink_workspace', u'zipexport']
+            expected_actions = [
+                u'export_pdf', u'list_workspaces', u'pdf_dossierdetails',
+                u'unlink_workspace', u'zipexport',
+            ]
             self.assertEqual(expected_actions, self.get_actions(self.dossier))
 
 


### PR DESCRIPTION
This PR:

Provides a context and listing action to change the responsibility for the dossier and its related sub-dossiers.

For [TI-2135](https://4teamwork.atlassian.net/browse/TI-2135)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-2135]: https://4teamwork.atlassian.net/browse/TI-2135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ