### PR TITLE
Fix upgradestep for grant dossier manager to responsible

### DIFF
--- a/changes/TI-2137.other
+++ b/changes/TI-2137.other
@@ -1,0 +1,1 @@
+Fix upgradestep to grant dossier manager to responsible feature if the userid is not the same as the username. [elioschmutz]

--- a/opengever/core/upgrades/20250324140844_migrate_grant_role_manager_to_responsible_to_grant_dossier_manager_to_responsible_feature/upgrade.py
+++ b/opengever/core/upgrades/20250324140844_migrate_grant_role_manager_to_responsible_to_grant_dossier_manager_to_responsible_feature/upgrade.py
@@ -53,7 +53,8 @@ class MigrateGrantRoleManagerToResponsibleToGrantDossierManagerToResponsibleFeat
             # or dossiers with a non existing responsible.
             # Both should not happen, but is possible. We skip such dossiers.
             responsible = IDossier(obj).responsible
-            if not responsible or not api.user.get(responsible):
+            responsible_user = api.user.get(responsible or '')
+            if not responsible_user:
                 continue
 
             # Assign the new assignment dossier manager roles.
@@ -64,7 +65,7 @@ class MigrateGrantRoleManagerToResponsibleToGrantDossierManagerToResponsibleFeat
             # We use this information later on to decide if we need to reindex
             # the object security of the object.
             need_reindex = not api.user.has_permission(
-                'View', dossier_protection.dossier_manager, obj=obj)
+                'View', user=responsible_user, obj=obj)
 
             # Grant the dossier manager role to the dossier responsible
             dossier_protection.grant_dossier_manager_roles()


### PR DESCRIPTION
This is a follow-up PR of #8141 and fixes an issue in the upgradestep where we try to check the permission of the current dossier responsible.

There are users where the userid is not the username. `has_permission` will not find users by the username. This will fail for such users. We have to first get the user and the pass the user object to make it more failsafe.

For [TI-2137]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-2137]: https://4teamwork.atlassian.net/browse/TI-2137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ