### PR TITLE
Update document state translations

### DIFF
--- a/changes/TI-2471.other
+++ b/changes/TI-2471.other
@@ -1,0 +1,1 @@
+Expand translations for document states. [ran]

--- a/opengever/base/locales/de/LC_MESSAGES/plone.po
+++ b/opengever/base/locales/de/LC_MESSAGES/plone.po
@@ -172,7 +172,10 @@ msgid "disposition-transition-refuse"
 msgstr "Ablehnen"
 
 msgid "document-state-draft"
-msgstr "nicht definiert"
+msgstr "Entwurf"
+
+msgid "document-state-shadow"
+msgstr "Schattenkopie"
 
 msgid "document-state-final"
 msgstr "Final"

--- a/opengever/base/locales/en/LC_MESSAGES/plone.po
+++ b/opengever/base/locales/en/LC_MESSAGES/plone.po
@@ -219,9 +219,12 @@ msgstr "Submit disposition"
 msgid "disposition-transition-refuse"
 msgstr "Refuse"
 
-#. German translation: nicht definiert
+#. German translation: Entwurf
 msgid "document-state-draft"
-msgstr "undefined"
+msgstr "Draft"
+
+msgid "document-state-shadow"
+msgstr "Shadow copy"
 
 msgid "document-state-final"
 msgstr "Final"

--- a/opengever/base/locales/fr/LC_MESSAGES/plone.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/plone.po
@@ -42,13 +42,13 @@ msgid "Document state changed to document-state-draft"
 msgstr "Etat du document modifié: brouillon"
 
 msgid "Document state changed to document-state-final"
-msgstr "Etat du document modifié: final"
+msgstr "Etat du document modifié: Finalisé"
 
 msgid "Document state changed to opengever_workspace_document--STATUS--final"
-msgstr "Etat du document modifié: final"
+msgstr "Etat du document modifié: Finalisé"
 
 msgid "Document state changed to opengever_workspace_document--STATUS--active"
-msgstr "Etat du document modifié: brouillon"
+msgstr "Etat du document modifié: Brouillon"
 
 msgid "Document state changed to document-state-signing"
 msgstr "Etat du document modifié: en cours de signature"
@@ -172,10 +172,13 @@ msgid "disposition-transition-refuse"
 msgstr "Offre refusée"
 
 msgid "document-state-draft"
-msgstr "Non défini"
+msgstr "Brouillon"
+
+msgid "document-state-shadow"
+msgstr "Copie shadow"
 
 msgid "document-state-final"
-msgstr "Final"
+msgstr "Finalisé"
 
 msgid "document-state-pending"
 msgstr "En suspend"

--- a/opengever/base/locales/plone.pot
+++ b/opengever/base/locales/plone.pot
@@ -54,6 +54,9 @@ msgstr ""
 msgid "document-state-draft"
 msgstr ""
 
+msgid "document-state-shadow"
+msgstr ""
+
 msgid "document-state-final"
 msgstr ""
 


### PR DESCRIPTION
In the Status facet of the extended Search, the translations for document-state-shadow, document-state-draft, and others weren't properly translated.

This PR translates these in the backend using the already existing translation from the frontend.

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [TI-2471]


## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- [x] All msg-strings are unicode


[TI-2471]: https://4teamwork.atlassian.net/browse/TI-2471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ