### PR TITLE
Make Solr Sync more robust

### DIFF
--- a/changes/TI-2438.bugfix
+++ b/changes/TI-2438.bugfix
@@ -1,0 +1,1 @@
+Fix solr sync by making value extraction more robust in cases where the value contains curly braces. [ran]

--- a/solr-conf/sync-solr.js
+++ b/solr-conf/sync-solr.js
@@ -85,7 +85,7 @@ function valueToString(value) {
  */
 function extractValueFromDoc(doc, key) {
   var value = valueToString(doc.getFieldValue(key));
-  if (value.indexOf("{") === 0 && value.indexOf("}") === value.length - 1) {
+  if (value.indexOf("{") === 0 && value.lastIndexOf("}") === value.length - 1) {
     value = value.substring(1, value.length - 1);
     var modifierSplit = value.split("=");
     var modifier = modifierSplit.shift();


### PR DESCRIPTION
Previously, if a word document had a "}" character, it wouldn't be properly indexed. This issue has been fixed with this PR.


Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [TI-2438]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-2438]: https://4teamwork.atlassian.net/browse/TI-2438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ