### PR TITLE
Fix revocation of temporary dossier permissions when a task is cancelled from the "in progress" state.

### DIFF
--- a/changes/TI-2422.bugfix
+++ b/changes/TI-2422.bugfix
@@ -1,0 +1,1 @@
+Ensure that temporary dossier permissions are correctly revoked when a task is cancelled from the "in progress" state. [elioschmutz]

--- a/opengever/task/__init__.py
+++ b/opengever/task/__init__.py
@@ -43,6 +43,7 @@ FINAL_TASK_STATES = [
 
 FINAL_TRANSITIONS = [
     'task-transition-open-cancelled',
+    'task-transition-in-progress-cancelled',
     'task-transition-open-tested-and-closed',
     'task-transition-in-progress-tested-and-closed',
     'task-transition-resolved-tested-and-closed',


### PR DESCRIPTION
This PR fixes an issue where temporary dossier permissions were not revoked if a task was cancelled while in the "in progress" state. The 'task-transition-in-progress-cancelled' transition is now treated as a final state, which ensures the proper cleanup of temporary permissions associated with the task.

For [TI-2422]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-2422]: https://4teamwork.atlassian.net/browse/TI-2422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ