### PR TITLE
Disallow to cancel tasks which are synced between multiple admin units.

### DIFF
--- a/changes/TI-2432.bugfix
+++ b/changes/TI-2432.bugfix
@@ -1,0 +1,1 @@
+Disallow to cancel tasks which are synced between multiple admin units. [elioschmutz]

--- a/opengever/task/browser/transitioncontroller.py
+++ b/opengever/task/browser/transitioncontroller.py
@@ -303,10 +303,14 @@ class TaskTransitionController(BrowserView):
     def progress_to_cancelled_guard(self, c, include_agency):
         """Checks if:
         - The task is generated from tasktemplate and its the main task
+        - Task is not a predecessor or a successor
         - The current user is the issuer
         """
         if self.context.is_from_tasktemplate:
             return not ITask.providedBy(aq_parent(self.context))
+
+        if c.task.has_successors or (c.task.is_successor and not c.task.is_forwarding_successor):
+            return False
 
         if include_agency:
             return (c.current_user.is_issuer


### PR DESCRIPTION
This fix reapplies a dropped commit (https://github.com/4teamwork/opengever.core/compare/7aea2c6d6078de117d4a0b8795deee737dd91d7b..def5b0cd054d76190c6bb5a274f74c79c6e198a0) which was inteded to merge when the cancel-feature has been implemented. 

According to the story specs: https://4teamwork.atlassian.net/browse/CA-4666, this should have never been possible.

Here is the original PR: https://github.com/4teamwork/opengever.core/pull/7575 which implemented the abort-feature.

For [TI-2432]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-2432]: https://4teamwork.atlassian.net/browse/TI-2432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ