### PR TITLE
Allow admins to delete any watcher

### DIFF
--- a/changes/TI-1935.feature
+++ b/changes/TI-1935.feature
@@ -1,0 +1,1 @@
+A limited admin, an administrator and a manager can always remove a watcher from an object. [elioschmutz]

--- a/changes/TI-1935.other
+++ b/changes/TI-1935.other
@@ -1,0 +1,1 @@
+Extends the @watchers response with `watcher_properties` which tells the frontend if a specific watcher is deleteable by the current user. [elioschmutz]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -24,6 +24,7 @@ Breaking Changes
 Other Changes
 ^^^^^^^^^^^^^
 ``@listing``: Filtering by inactive dossier responsible is now available.
+``@watchers``: Extends the @watchers response with ``watcher_properties``.
 
 2025.6.0 (2025-04-07)
 ---------------------

--- a/docs/public/dev-manual/api/watchers.rst
+++ b/docs/public/dev-manual/api/watchers.rst
@@ -30,11 +30,11 @@ Ein Beobachter kann verschiedene Rollen haben, beispielsweise die Rollen Auftrag
         "referenced_actors": [
           {
             "@id": "https://example.org/@actors/peter.mueller",
-            "identifier": "peter.mueller",
+            "identifier": "peter.mueller"
           },
           {
             "@id": "https://example.org/@actors/rolf.ziegler",
-            "identifier": "rolf.ziegler",
+            "identifier": "rolf.ziegler"
           }
         ],
         "referenced_watcher_roles": [
@@ -49,7 +49,7 @@ Ein Beobachter kann verschiedene Rollen haben, beispielsweise die Rollen Auftrag
           {
             "id": "task_responsible",
             "title": "Auftragnehmer"
-          },
+          }
         ],
         "watchers_and_roles": {
           "peter.mueller": [
@@ -59,6 +59,14 @@ Ein Beobachter kann verschiedene Rollen haben, beispielsweise die Rollen Auftrag
             "regular_watcher",
             "task_responsible"
           ]
+        },
+        "watcher_properties": {
+          "peter.mueller": {
+            "can_delete_watcher": true
+          },
+          "rolf.ziegler": {
+            "can_delete_watcher": false
+          }
         }
       }
 
@@ -89,7 +97,8 @@ Die Beobachter können als Komponente eines Inhalts direkt über den ``expand``-
           "@id": "https://example.org/ordnungssystem/fuehrung/dossier-23/task-1/@listing-stats",
           "referenced_actors": ["..."],
           "referenced_watcher_roles": ["..."],
-          "watchers_and_roles": { "...": "..." }
+          "watchers_and_roles": { "...": "..." },
+          "watcher_properties": { "...": "..." }
         }
       },
       "...": "..."

--- a/opengever/api/permissions.zcml
+++ b/opengever/api/permissions.zcml
@@ -8,5 +8,6 @@
   <permission id="opengever.api.ManageGroups" title="opengever.api: Manage Groups" />
   <permission id="opengever.api.NotifyArbitraryUsers" title="opengever.api: Notify Arbitrary Users" />
   <permission id="opengever.api.AccessErrorLog" title="opengever.api: Access error log" />
+  <permission id="opengever.api.RemoveAnyWatcher" title="opengever.api: Remove any watcher" />
 
 </configure>

--- a/opengever/api/tests/test_watchers.py
+++ b/opengever/api/tests/test_watchers.py
@@ -54,6 +54,10 @@ class TestWatchersGet(SolrIntegrationTestCase):
             u'watchers_and_roles': {
                 self.regular_user.id: [u'regular_watcher', u'task_responsible'],
                 self.dossier_responsible.id: [u'task_issuer']
+            },
+            u'watcher_properties': {
+                self.regular_user.id: {'can_delete_watcher': True },
+                self.dossier_responsible.id: {'can_delete_watcher': False },
             }
         }
 
@@ -106,6 +110,10 @@ class TestWatchersGet(SolrIntegrationTestCase):
             u'watchers_and_roles': {
                 self.regular_user.id: [u'regular_watcher', u'task_responsible'],
                 self.dossier_responsible.id: [u'task_issuer']
+            },
+            u'watcher_properties': {
+                self.regular_user.id: {'can_delete_watcher': False },
+                self.dossier_responsible.id: {'can_delete_watcher': False },
             }
         }
 
@@ -143,6 +151,9 @@ class TestWatchersGet(SolrIntegrationTestCase):
             ],
             u'watchers_and_roles': {
                 self.dossier_responsible.id: [u'regular_watcher']
+            },
+            u'watcher_properties': {
+                self.dossier_responsible.id: {'can_delete_watcher': False },
             }
         }
 
@@ -179,6 +190,9 @@ class TestWatchersGet(SolrIntegrationTestCase):
             ],
             u'watchers_and_roles': {
                 self.dossier_responsible.id: [u'regular_watcher']
+            },
+            u'watcher_properties': {
+                self.dossier_responsible.id: {'can_delete_watcher': False },
             }
         }
 
@@ -219,6 +233,9 @@ class TestWatchersGet(SolrIntegrationTestCase):
             ],
             u'watchers_and_roles': {
                 u'team:1': [u'task_responsible'],
+            },
+            u'watcher_properties': {
+                u'team:1': {'can_delete_watcher': False },
             }
         }
 
@@ -257,9 +274,11 @@ class TestWatchersGet(SolrIntegrationTestCase):
             ],
             u'watchers_and_roles': {
                 u'inbox:fa': [u'task_responsible'],
+            },
+            u'watcher_properties': {
+                u'inbox:fa': {'can_delete_watcher': False },
             }
         }
-
         self.assertEqual(expected_json, browser.json)
 
         browser.open(self.task.absolute_url() + '?expand=watchers',
@@ -289,7 +308,8 @@ class TestWatchersGet(SolrIntegrationTestCase):
         expected_json = {u'@id': self.document.absolute_url() + '/@watchers',
                          u'referenced_actors': [],
                          u'referenced_watcher_roles': [],
-                         u'watchers_and_roles': {}}
+                         u'watchers_and_roles': {},
+                         u'watcher_properties': {}}
         self.assertEqual(expected_json, browser.json['@components']['watchers'])
 
 

--- a/opengever/api/watchers.py
+++ b/opengever/api/watchers.py
@@ -98,9 +98,20 @@ class WatcherDeleter(object):
 
     def __init__(self, context):
         self.context = context
+        self.center = notification_center()
 
     def can_delete(self, actor_id):
-        # The user can always remove itslef
+        watchers = self.center.get_watchers(self.context, WATCHER_ROLE)
+
+        # Delete watcher is only possible for the WATCHER_ROLE
+        if actor_id not in [watcher.actorid for watcher in watchers]:
+            return False
+
+        # Always allow depending on a permission
+        if api.user.has_permission('opengever.api: Remove any watcher', obj=self.context):
+            return True
+
+        # The user can always remove itself
         if actor_id == api.user.get_current().getId():
             return True
 

--- a/opengever/api/watchers.py
+++ b/opengever/api/watchers.py
@@ -59,9 +59,15 @@ class Watchers(object):
             }
             for role in roles]
 
+        watcher_properties = defaultdict(dict)
+        deleter = WatcherDeleter(self.context)
+        for actor_id in watchers_and_roles:
+            watcher_properties[actor_id]['can_delete_watcher'] = deleter.can_delete(actor_id)
+
         result['watchers']['watchers_and_roles'] = watchers_and_roles
         result['watchers']['referenced_watcher_roles'] = referenced_watcher_roles
         result['watchers']['referenced_actors'] = referenced_actors
+        result['watchers']['watcher_properties'] = watcher_properties
         return result
 
 

--- a/opengever/base/monkey/patches/readonly.py
+++ b/opengever/base/monkey/patches/readonly.py
@@ -230,6 +230,7 @@ WRITE_PERMISSIONS = [
     'opengever.api: Manage Role Assignment Reports',
     'opengever.api: Notify Arbitrary Users',
     'opengever.api: Transfer Assignment',
+    'opengever.api: Remove any watcher',
     'opengever.contact: Edit team',
     'opengever.disposition: Edit transfer number',
     'opengever.document: Cancel',

--- a/opengever/core/lawgiver.zcml
+++ b/opengever/core/lawgiver.zcml
@@ -233,6 +233,7 @@
                    opengever.api: Manage Groups,
                    opengever.api: Manage Role Assignment Reports,
                    opengever.api: Notify Arbitrary Users,
+                   opengever.api: Remove any watcher,
                    opengever.api: Transfer Assignment,
                    opengever.api: View AllowedRolesAndPrincipals,
                    opengever.bumblebee: Revive Preview,

--- a/opengever/core/profiles/default/rolemap.xml
+++ b/opengever/core/profiles/default/rolemap.xml
@@ -454,6 +454,12 @@
       <role name="Reviewer" />
     </permission>
 
+    <permission name="opengever.api: Remove any watcher" acquire="True">
+      <role name="Manager" />
+      <role name="Administrator" />
+      <role name="LimitedAdmin" />
+    </permission>
+
   </permissions>
 
 </rolemap>

--- a/opengever/core/upgrades/20250605111905_add_remove_any_watcher_permission/rolemap.xml
+++ b/opengever/core/upgrades/20250605111905_add_remove_any_watcher_permission/rolemap.xml
@@ -1,0 +1,9 @@
+<rolemap>
+  <permissions>
+    <permission name="opengever.api: Remove any watcher" acquire="True">
+      <role name="Manager" />
+      <role name="Administrator" />
+      <role name="LimitedAdmin" />
+    </permission>
+  </permissions>
+</rolemap>

--- a/opengever/core/upgrades/20250605111905_add_remove_any_watcher_permission/upgrade.py
+++ b/opengever/core/upgrades/20250605111905_add_remove_any_watcher_permission/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddRemoveAnyWatcherPermission(UpgradeStep):
+    """Add remove any watcher permission.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
An admin, limited admin, or manager can now remove any watcher from an object via the @watchers endpoint. Previously, it was only possible to remove yourself, groups, or teams associated with the current user.

Since determining whether a specific watcher can be removed has become more complex, this PR introduces a new property in the @watchers response. This property indicates whether the current user is allowed to remove each watcher. The frontend can now rely on this property to determine whether to display a delete icon.

For [TI-1935]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide]

[TI-1935]: https://4teamwork.atlassian.net/browse/TI-1935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ