### PR TITLE
Restrict possible watchers source

### DIFF
--- a/changes/TI-1935-2.other
+++ b/changes/TI-1935-2.other
@@ -1,0 +1,1 @@
+A limited admin, an administrator and a manager can always remove a watcher from an object. [elioschmutz]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -12,7 +12,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
-
+- ``@possible-watchers``: endpoint only returns users having view permission on the given context.
 
 2025.7.0 (2025-06-06)
 ---------------------

--- a/docs/public/dev-manual/api/watchers.rst
+++ b/docs/public/dev-manual/api/watchers.rst
@@ -154,6 +154,8 @@ Der ``@possible-watchers``-Endpoint liefert eine Liste von Actors welche als Beo
 
 Weil es üblich ist, dass man sich selbst als Beobachter hinzufügen möchte, wird der eigene Benutzer in der Sortierreihenfolge immer zuoberst dargestellt. Alle restlichen Actors werden Typ (Benutzer, Gruppen, Teams) und nach Name und Vorname oder Titel sortiert.
 
+Es werden nur Benutzer angezeigt, welche mindestens Lese-Rechte für den aktuellen Kontext besitzen.
+
 **Beispiel-Request:**
 
 

--- a/opengever/activity/sources.py
+++ b/opengever/activity/sources.py
@@ -3,10 +3,15 @@ from opengever.ogds.base.sources import AllFilteredGroupsSourcePrefixed
 from opengever.ogds.base.sources import AllTeamsSource
 from opengever.ogds.base.sources import AssignedUsersSource
 from opengever.ogds.base.sources import BaseMultipleSourcesQuerySource
+from opengever.ogds.models.group import groups_users
+from opengever.ogds.models.service import ogds_service
 from opengever.ogds.models.user import User
 from opengever.workspace import is_workspace_feature_enabled
 from plone import api
+from Products.CMFCore.interfaces import IIndexableObject
 from sqlalchemy import case
+from sqlalchemy.sql import select
+from zope.component import queryMultiAdapter
 import re
 
 
@@ -29,6 +34,7 @@ class PossibleWatchersSourceUsers(AssignedUsersSource):
     @property
     def search_query(self):
         query = super(PossibleWatchersSourceUsers, self).search_query
+        query = self.restrict_whitelisted_principals(query)
         return self._extend_query(query)
 
     def _extend_query(self, query):
@@ -45,6 +51,49 @@ class PossibleWatchersSourceUsers(AssignedUsersSource):
         return query.order_by(case(
             ((User.userid == current_user.getId(), 1), ),
             else_=2))
+
+    def restrict_whitelisted_principals(self, query):
+        """Only principals having View permission on the context are meant as
+        possible watchers.
+        """
+        return query.filter(User.userid.in_(self.get_whitelisted_principals()))
+
+    def get_whitelisted_principals(self):
+        """Returns a set of user-ids having direct or indirect (through groups)
+        View-permission on the current context.
+        """
+        allowed_users_and_groups = self.extract_allowed_users_and_groups()
+        allowed_users_and_groups.update(
+            self.extract_group_members(allowed_users_and_groups))
+        return allowed_users_and_groups
+
+    def extract_allowed_users_and_groups(self):
+        """Extracts all userids with View-permission on the given context
+        """
+        indexable_object = queryMultiAdapter(
+            (self.context, api.portal.get_tool('portal_catalog')),
+            IIndexableObject)
+
+        if not indexable_object:
+            return set()
+
+        return {
+            index_value.split('user:')[-1]
+            for index_value in indexable_object.allowedRolesAndUsers
+            if index_value.startswith('user:')
+        }
+
+    def extract_group_members(self, groupids):
+        """Returns all group members (userids) of the given groupids.
+        """
+        return {
+            userid
+            for userid, in ogds_service()
+            .session.execute(
+                select([groups_users.c.userid], groups_users.c.groupid.in_(groupids))
+            )
+            .fetchall()
+        }
 
 
 class PossibleWatchersGroupsSource(AllFilteredGroupsSourcePrefixed):

--- a/opengever/api/tests/test_watchers.py
+++ b/opengever/api/tests/test_watchers.py
@@ -806,7 +806,7 @@ class TestPossibleWatchers(IntegrationTestCase):
         browser.open(url, method='GET', headers=self.api_headers)
 
         self.assertEqual(5, len(browser.json.get('items')))
-        self.assertEqual(32, browser.json.get('items_total'))
+        self.assertEqual(31, browser.json.get('items_total'))
         self.assertIn('batching', browser.json)
 
     @browsing


### PR DESCRIPTION
This PR restricts the `@possible-watchers` source by removing every possible watcher user which does not have at least view permission on the context. 

I overtook some of the implementation of the `VisibleUsersAndGroupsFilter` (https://github.com/4teamwork/opengever.core/blob/master/opengever/base/visible_users_and_groups_filter.py) to build the query.

For [TI-1935]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide]

[TI-1935]: https://4teamwork.atlassian.net/browse/TI-1935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ