### PR TITLE
Add document version count to listing and index it

### DIFF
--- a/changes/TI-2442.other
+++ b/changes/TI-2442.other
@@ -1,0 +1,1 @@
+Add new listing field: "document_version_count". [amo]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -13,6 +13,7 @@ Breaking Changes
 Other Changes
 ^^^^^^^^^^^^^
 - ``@possible-watchers``: endpoint only returns users having view permission on the given context.
+- ``@listing``: New field `document_version_count` is now available.
 
 2025.7.0 (2025-06-06)
 ---------------------

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -37,6 +37,7 @@ OTHER_ALLOWED_FIELDS = set([
     'location',
     'related_items',
     'is_locked_by_copy_to_workspace',
+    'document_version_count',
     'progress',
 ])
 

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -1822,6 +1822,22 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
             [('Testdossier B', 1.0), ('Testdossier A', 0.5), ('Testdossier C', None)],
             [(item['title'], item['progress']) for item in browser.json['items']])
 
+    @browsing
+    def test_document_version_count(self, browser):
+        self.login(self.regular_user, browser=browser)
+        versioner = Versioner(self.document)
+        versioner.create_version('Initial version')
+        versioner.create_version('Second version')
+        self.commit_solr()
+
+        view = '@listing?name=documents&columns:list=document_version_count'
+        browser.open(self.dossier, view=view, headers=self.api_headers)
+        self.assertEqual(
+            {u'@id': self.document.absolute_url(),
+             u'UID': IUUID(self.document),
+             u'document_version_count': 1},
+            browser.json['items'][0])
+
 
 class TestPloneDossierParticipationsInListingWithRealSolr(SolrIntegrationTestCase):
 

--- a/opengever/base/solr/fields.py
+++ b/opengever/base/solr/fields.py
@@ -733,6 +733,11 @@ FIELDS_WITH_MAPPING = [
         additional_required_fields=['portal_type', 'Title'],
         title=dossier_mf(u'label_title', default=u'Title'),
     ),
+    ListingField(
+        'document_version_count',
+        index='document_version_count',
+        title=document_mf(u'label_document_version_count'),
+    ),
     DateListingField(
         'touched',
         title=base_mf(u'label_last_modified', default=u'Last modified'),

--- a/opengever/core/upgrades/20250613143257_add_document_version_count_index/upgrade.py
+++ b/opengever/core/upgrades/20250613143257_add_document_version_count_index/upgrade.py
@@ -1,0 +1,18 @@
+from ftw.upgrade import UpgradeStep
+from opengever.core.upgrade import NightlyIndexer
+from opengever.document.behaviors import IBaseDocument
+
+
+class AddDocumentVersionCountIndex(UpgradeStep):
+    """Add document version count index.
+    """
+
+    def __call__(self):
+        query = {'object_provides': [
+            IBaseDocument.__identifier__,
+        ]}
+
+        with NightlyIndexer(idxs=["document_version_count"],
+                            index_in_solr_only=True) as indexer:
+            for brain in self.brains(query, 'Index document version count in Solr'):
+                indexer.add_by_brain(brain)

--- a/opengever/document/configure.zcml
+++ b/opengever/document/configure.zcml
@@ -384,6 +384,11 @@
       name="is_locked_by_copy_to_workspace"
       />
 
+  <adapter
+      factory=".indexers.document_version_count"
+      name="document_version_count"
+      />
+
   <adapter factory=".document.UploadValidator" />
 
   <adapter factory=".fileactions.BaseDocumentFileActions" />

--- a/opengever/document/indexers.py
+++ b/opengever/document/indexers.py
@@ -280,3 +280,8 @@ def is_locked_by_copy_to_workspace(obj):
         return False
 
     return obj.is_locked_by_copy_to_workspace()
+
+
+@indexer(IBaseDocument)
+def document_version_count(obj):
+    return obj.get_current_version_id(missing_as_zero=True)

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2024-09-12 08:50+0000\n"
+"POT-Creation-Date: 2025-06-13 12:43+0000\n"
 "PO-Revision-Date: 2017-10-13 14:27+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -500,6 +500,9 @@ msgstr "Dokument signiert"
 #: ./opengever/document/behaviors/metadata.py
 msgid "label_document_type"
 msgstr "Dokumenttyp"
+
+msgid "label_document_version_count"
+msgstr "Anzahl Versionen"
 
 #. Default: "Added as watcher of the document"
 #: ./opengever/document/activities.py

--- a/opengever/document/locales/en/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/en/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2024-09-12 08:50+0000\n"
+"POT-Creation-Date: 2025-06-13 12:43+0000\n"
 "PO-Revision-Date: 2017-10-13 14:27+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -594,6 +594,9 @@ msgstr "Document signed"
 #: ./opengever/document/behaviors/metadata.py
 msgid "label_document_type"
 msgstr "Document type"
+
+msgid "label_document_version_count"
+msgstr "Version count"
 
 #. Default: "Added as watcher of the document"
 #: ./opengever/document/activities.py

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-09-12 08:50+0000\n"
+"POT-Creation-Date: 2025-06-13 12:43+0000\n"
 "PO-Revision-Date: 2017-09-03 08:50+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-document/fr/>\n"
@@ -497,6 +497,9 @@ msgstr "Document signé"
 #: ./opengever/document/behaviors/metadata.py
 msgid "label_document_type"
 msgstr "Type de document"
+
+msgid "label_document_version_count"
+msgstr "Nombre de versions"
 
 #. Default: "Added as watcher of the document"
 #: ./opengever/document/activities.py

--- a/opengever/document/locales/opengever.document-manual.pot
+++ b/opengever/document/locales/opengever.document-manual.pot
@@ -21,3 +21,6 @@ msgstr ""
 
 msgid "label_filesize"
 msgstr ""
+
+msgid "label_document_version_count"
+msgstr ""

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-09-12 08:50+0000\n"
+"POT-Creation-Date: 2025-06-13 12:43+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -494,6 +494,9 @@ msgstr ""
 #. Default: "Document Type"
 #: ./opengever/document/behaviors/metadata.py
 msgid "label_document_type"
+msgstr ""
+
+msgid "label_document_version_count"
 msgstr ""
 
 #. Default: "Added as watcher of the document"

--- a/opengever/document/versioner.py
+++ b/opengever/document/versioner.py
@@ -62,6 +62,7 @@ class Versioner(object):
                 'approval_state',
                 'filename',
                 'file_extension',
+                'document_version_count'
             ]
         )
 

--- a/opengever/dossier/tests/test_move_items.py
+++ b/opengever/dossier/tests/test_move_items.py
@@ -470,6 +470,7 @@ class TestMoveItemsUpdatesIndexAndMetadata(SolrIntegrationTestCase, MoveItemsHel
             u'related_items',
             u'Subject',
             u'is_locked_by_copy_to_workspace',
+            u'document_version_count'
         ]
 
         unchanged_solrdata += self.common_unchanged_solrdata
@@ -701,6 +702,7 @@ class TestMoveItemsUpdatesIndexAndMetadata(SolrIntegrationTestCase, MoveItemsHel
             u'filesize',
             u'receipt_date',
             u'is_locked_by_copy_to_workspace',
+            u'document_version_count'
         ]
 
         unchanged_solrdata += self.common_unchanged_solrdata

--- a/solr-conf/managed-schema.xml
+++ b/solr-conf/managed-schema.xml
@@ -154,6 +154,7 @@
     <field name="document_author" type="string" indexed="true" stored="false" />
     <field name="document_date" type="pdate" indexed="true" stored="false" />
     <field name="document_type" type="string" indexed="true" stored="false" />
+    <field name="document_version_count" type="pint" indexed="true" stored="false" />
     <field name="dossier_review_state" type="string" indexed="true" stored="false" />
     <field name="dossier_type" type="string" indexed="true" stored="false" />
     <field name="touched" type="pdate" indexed="true" stored="false" />


### PR DESCRIPTION
This PR:
- Indexes the document_version_count field in Solr.
- Include the field in the `@listing`

For [TI-2442](https://4teamwork.atlassian.net/browse/TI-2442)

## Checklist



_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-2442]: https://4teamwork.atlassian.net/browse/TI-2442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ