### PR TITLE
Build docker images with bake

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -13,7 +13,10 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Create src directory
         run: mkdir src
@@ -39,56 +42,33 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Extract metadata from Git reference
-        id: meta_ogcore
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            4teamwork/ogcore
-          flavor: |
-            latest=false
-          tags: |
-            type=pep440,pattern={{version}}
-            type=raw,value=latest,enable=${{ github.ref_type == 'tag' && github.event.base_ref == 'refs/heads/master' }}
-            type=edge,branch=master
+      - name: Set Git commit env variables
+        run: |
+          echo "GIT_TAG=$(git describe --tags --candidates=0)" >> $GITHUB_ENV
+          echo "GIT_SHA_TAG=$(git describe --tags)" >> $GITHUB_ENV
+          echo "LATEST_TAG=$(git describe --tags --abbrev=0 origin/master)" >> $GITHUB_ENV
+          echo "BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_ENV
 
       - name: Build and push ogcore
-        uses: docker/build-push-action@v6
+        uses: docker/bake-action@v6
+        env:
+          GITLAB_DEPLOY_TOKEN: ${{ secrets.GITLAB_DEPLOY_TOKEN }}
         with:
-          context: .
-          file: ./docker/core/Dockerfile
-          platforms: ${{ github.ref_type == 'tag' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          source: .
+          files: docker-bake.hcl
+          targets: ogcore
           push: true
-          tags: ${{ steps.meta_ogcore.outputs.tags }}
-          labels: ${{ steps.meta_ogcore.outputs.labels }}
-          cache-from: type=gha,scope=ogcore
-          cache-to: type=gha,mode=max,scope=ogcore
-          secrets: |
-            "gldt=${{ secrets.GITLAB_DEPLOY_TOKEN }}"
-
-      - name: Extract metadata from Git reference for ogtestserver
-        id: meta_ogtestserver
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            4teamwork/ogtestserver
-          flavor: |
-            latest=false
-          tags: |
-            type=pep440,pattern={{version}}
-            type=raw,value=latest,enable=${{ github.ref_type == 'tag' && github.event.base_ref == 'refs/heads/master' }}
-            type=edge,branch=master
+          set: |
+            *.secrets=id=gldt,env=GITLAB_DEPLOY_TOKEN
 
       - name: Build and push ogtestserver
-        uses: docker/build-push-action@v6
+        uses: docker/bake-action@v6
+        env:
+          GITLAB_DEPLOY_TOKEN: ${{ secrets.GITLAB_DEPLOY_TOKEN }}
         with:
-          context: .
-          file: ./docker/testserver/Dockerfile
-          platforms: ${{ github.ref_type == 'tag' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          source: .
+          files: docker-bake.hcl
+          targets: ogtestserver
           push: true
-          tags: ${{ steps.meta_ogtestserver.outputs.tags }}
-          labels: ${{ steps.meta_ogtestserver.outputs.labels }}
-          cache-from: type=gha,scope=ogtestserver
-          cache-to: type=gha,mode=max,scope=ogtestserver
-          secrets: |
-            "gldt=${{ secrets.GITLAB_DEPLOY_TOKEN }}"
+          set: |
+            *.secrets=id=gldt,env=GITLAB_DEPLOY_TOKEN

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,78 @@
+/*
+# To build locally use:
+GIT_SHA_TAG=$(git describe --tags) \
+GIT_TAG=$(git describe --tags --candidates=0) \
+LATEST_TAG=$(git describe --tags --abbrev=0 master) \
+BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD) \
+docker buildx bake -f docker-bake.hcl --load
+*/
+
+variable "OGCORE_IMAGE" {
+  default = "docker.io/4teamwork/ogcore"
+}
+variable "OGTESTSERVER_IMAGE" {
+  default = "docker.io/4teamwork/ogtestserver"
+}
+variable "GIT_TAG" {
+  default = ""
+}
+variable "GIT_SHA_TAG" {
+  default = ""
+}
+variable "LATEST_TAG" {
+  default = ""
+}
+variable "BRANCH_NAME" {
+  default = ""
+}
+
+group "default" {
+  targets = ["ogcore"]
+}
+
+target "ogcore" {
+  dockerfile = "./docker/core/Dockerfile"
+  context = "."
+  tags = [
+    strlen(GIT_TAG) > 0 ? "${OGCORE_IMAGE}:${GIT_TAG}" : "",
+    equal(GIT_TAG, LATEST_TAG) ? "${OGCORE_IMAGE}:latest" : "",
+    equal(GIT_TAG, "") && equal(BRANCH_NAME, "master") ? "${OGCORE_IMAGE}:edge" : "",
+    notequal(BRANCH_NAME, "master") && strlen(GIT_TAG) < 1 ? "${OGCORE_IMAGE}:${GIT_SHA_TAG}" : "",
+  ]
+  platforms = [
+    "linux/amd64",
+    strlen(GIT_TAG) > 0 ? "linux/arm64" : "",
+  ]
+  secret = [
+    {
+      type = "env"
+      id = "gldt"
+      env = "GITLAB_DEPLOY_TOKEN"
+    }
+  ]
+}
+
+target "ogtestserver" {
+  args = {
+    OGCORE_VERSION = strlen(GIT_TAG) > 0 ? "${GIT_TAG}" : equal(BRANCH_NAME, "master") ? "edge" : "${GIT_SHA_TAG}",
+  }
+  dockerfile = "./docker/testserver/Dockerfile"
+  context = "."
+  tags = [
+    strlen(GIT_TAG) > 0 ? "${OGTESTSERVER_IMAGE}:${GIT_TAG}" : "",
+    equal(GIT_TAG, LATEST_TAG) ? "${OGTESTSERVER_IMAGE}:latest" : "",
+    equal(GIT_TAG, "") && equal(BRANCH_NAME, "master") ? "${OGTESTSERVER_IMAGE}:edge" : "",
+    notequal(BRANCH_NAME, "master") && strlen(GIT_TAG) < 1 ? "${OGTESTSERVER_IMAGE}:${GIT_SHA_TAG}" : "",
+  ]
+  platforms = [
+    "linux/amd64",
+    strlen(GIT_TAG) > 0 ? "linux/arm64" : "",
+  ]
+  secret = [
+    {
+      type = "env"
+      id = "gldt"
+      env = "GITLAB_DEPLOY_TOKEN"
+    }
+  ]
+}

--- a/docker/testserver/Dockerfile
+++ b/docker/testserver/Dockerfile
@@ -1,4 +1,5 @@
-FROM 4teamwork/ogcore:latest
+ARG OGCORE_VERSION=latest
+FROM 4teamwork/ogcore:${OGCORE_VERSION}
 
 USER root
 WORKDIR /app


### PR DESCRIPTION
With the old approach, building the latest tag didn't work reliably. Further the ogtestserver image was always built from the latest ogcore image, even for backport releases.

Now, the bake file determines which tags to build from Git:
- Git tag => tag (e.g. `2025.7.0`)
- Git tag is latest on master branch => `latest`
- No tag on master => `edge`
- No tag on any other branch => previous tag + number of commits + sha (e.g. `2025.7.0-7-gc79899e76`)

For [TI-2050](https://4teamwork.atlassian.net/browse/TI-2050)

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
