### PR TITLE
Fix the document_version_count index to index the actual number of ve…

### DIFF
--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -1835,7 +1835,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
         self.assertEqual(
             {u'@id': self.document.absolute_url(),
              u'UID': IUUID(self.document),
-             u'document_version_count': 1},
+             u'document_version_count': 2},
             browser.json['items'][0])
 
 

--- a/opengever/document/indexers.py
+++ b/opengever/document/indexers.py
@@ -284,4 +284,6 @@ def is_locked_by_copy_to_workspace(obj):
 
 @indexer(IBaseDocument)
 def document_version_count(obj):
-    return obj.get_current_version_id(missing_as_zero=True)
+    # We track the total number of versions, not the current version number.
+    # Since versioning starts at 0, we add 1 to get the actual count of versions.
+    return obj.get_current_version_id(missing_as_zero=True) + 1

--- a/opengever/document/tests/test_indexers.py
+++ b/opengever/document/tests/test_indexers.py
@@ -559,8 +559,8 @@ class SolrDocumentIndexer(SolrIntegrationTestCase):
         self.commit_solr()
 
         indexed_value = solr_data_for(self.document, 'document_version_count')
-        self.assertEqual(indexed_value, 1)
-        self.assertEqual(indexed_value, self.document.get_current_version_id())
+        self.assertEqual(indexed_value, 2)
+        self.assertEqual(indexed_value, self.document.get_current_version_id() + 1)
 
     def test_mail_version_count_indexed(self):
         """mails are read only (no Edit) therefor the version should never changes
@@ -576,7 +576,7 @@ class SolrDocumentIndexer(SolrIntegrationTestCase):
         indexed_value = solr_data_for(self.mail_eml, 'document_version_count')
 
         # Explicit assertion to confirm indexing matches method return value
-        self.assertEqual(indexed_value, self.mail_eml.get_current_version_id())
+        self.assertEqual(indexed_value, self.mail_eml.get_current_version_id() + 1)
 
         # Mails are always on version 0
-        self.assertEqual(indexed_value, 0)
+        self.assertEqual(indexed_value, 1)


### PR DESCRIPTION
This is a follow-up PR of #8170 

Currently, we do index the current version id for the `document_version_count` index. Since versioning starts at 0, we add 1 to get the actual count of versions.

For [TI-2442]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry :information_source: no changelog required because it is within the same release.
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-2442]: https://4teamwork.atlassian.net/browse/TI-2442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ