### PR TITLE
Properly resolve principals in the role assignment excel export

### DIFF
--- a/changes/TI-2673.bugfix
+++ b/changes/TI-2673.bugfix
@@ -1,0 +1,1 @@
+Fix empty excel sheet if exporting the role assignment report filtered by a group. [elioschmutz]

--- a/opengever/sharing/local_roles_lookup/exporter.py
+++ b/opengever/sharing/local_roles_lookup/exporter.py
@@ -18,7 +18,7 @@ class RoleAssignmentReportExcelDownload(BaseReporterView):
         principal_ids, include_memberships, root = self.extract_query_params()
 
         report = RoleAssignmentReporter().excel_report_for(
-            principal_ids=principal_ids,
+            principal_ids=self.resolve_principals(principal_ids),
             include_memberships=include_memberships,
             root=root)
 
@@ -35,6 +35,9 @@ class RoleAssignmentReportExcelDownload(BaseReporterView):
         root = filters.get("root")
 
         return principal_ids, include_memberships, root
+
+    def resolve_principals(self, principal_ids):
+        return [principal_id.split(':')[-1] for principal_id in principal_ids]
 
     @property
     def filename(self):

--- a/opengever/sharing/tests/test_role_assignment_excel_export.py
+++ b/opengever/sharing/tests/test_role_assignment_excel_export.py
@@ -58,6 +58,71 @@ class TestExcelRoleAssignmentReport(SolrIntegrationTestCase):
             [[cell.value for cell in row] for row in rows])
 
     @browsing
+    def test_role_assignment_report_group_filter(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        url = u'{}/download-role-assignment-report'.format(
+            self.portal.absolute_url())
+
+        with freeze(datetime(2017, 10, 16, 0, 0, tzinfo=pytz.utc)):
+            browser.open(url, view="?filters.principal_ids:record:list=group:fa_inbox_users")
+
+        self.assertEquals(
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            browser.headers['content-type'])
+
+        data = browser.contents
+        with NamedTemporaryFile(delete=False, suffix='.xlsx') as tmpfile:
+            tmpfile.write(data)
+            tmpfile.flush()
+            workbook = load_workbook(tmpfile.name)
+            os.remove(tmpfile.name)
+
+        rows = list(workbook.active.rows)
+
+        self.assertSequenceEqual(
+            [
+                ["Title", "URL", "Portal type", "Principal id", "User name", "Group name", "Role"],
+                [
+                    u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
+                    u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1',
+                    u'Business Case Dossier',
+                    u'fa_inbox_users',
+                    None,
+                    u'fa_inbox_users',
+                    u'Task responsible'
+                ],
+                [
+                    u'Zu allem \xdcbel',
+                    u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-17',
+                    u'Business Case Dossier',
+                    u'fa_inbox_users',
+                    None,
+                    u'fa_inbox_users',
+                    u'Task responsible'
+                ],
+                [
+                    u'Abgeschlossene Vertr\xe4ge',
+                    u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-5',
+                    u'Business Case Dossier',
+                    u'fa_inbox_users',
+                    None,
+                    u'fa_inbox_users',
+                    u'Task responsible'
+                ],
+                [
+                    u'Inaktive Vertr\xe4ge',
+                    u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-6',
+                    u'Business Case Dossier',
+                    u'fa_inbox_users',
+                    None,
+                    u'fa_inbox_users',
+                    u'Task responsible'
+                ]
+            ],
+            [[cell.value for cell in row] for row in rows])
+
+    @browsing
     def test_filename_includes_date_time(self, browser):
         self.login(self.administrator, browser=browser)
 


### PR DESCRIPTION
This PR resolves an issue where exporting the role assignment report filtered by group results in an empty excel sheet.

For [TI-2673]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-2673]: https://4teamwork.atlassian.net/browse/TI-2673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ