### PR TITLE
Add archival_value index

### DIFF
--- a/changes/TI-2730.feature
+++ b/changes/TI-2730.feature
@@ -1,0 +1,1 @@
+Add 'archival_value' as a new '@listing'-endpoint field [elioschmutz]

--- a/changes/TI-2730.other
+++ b/changes/TI-2730.other
@@ -1,0 +1,1 @@
+Add 'archival_value' index to solr. [elioschmutz]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -16,6 +16,7 @@ Other Changes
 - The ``auto_close_tasks`` transition parameter for ``dossier-transition-resolve`` enables automatic closure of open tasks before resolving the dossier.
 - ``@possible-watchers``: endpoint only returns users having view permission on the given context.
 - ``@listing``: New field `document_version_count` is now available.
+- ``@solrsearch`` and ``@listing``: ``archival_value`` is added as a new solr index and whitelisted in the ``@listing`` endpoint.
 
 2025.7.0 (2025-06-06)
 ---------------------

--- a/docs/public/dev-manual/api/listings.rst
+++ b/docs/public/dev-manual/api/listings.rst
@@ -70,6 +70,7 @@ werden. Folgende Felder stehen zur Verfügung:
 
 - ``@type``: Inhaltstyp
 - ``approval_state``: Genehmigungs-Status
+- ``archival_value``: Archivwürdigkeit
 - ``blocked_local_roles``: Ob Berechtigungen von übergeordneten Ordnern übernommen werden.
 - ``bumblebee_checksum``: SHA-256 Checksumme
 - ``changed``: Änderungsdatum
@@ -149,6 +150,8 @@ siehe Tabelle:
     | Feld                     | Document | Dossier | Arbeitsraume | Arbeitsraum Ordner | Aufgabe |  ToDo   | Anträge | Kontakte | Standardabläufe | Aufgabenvorlagen | Dossiervorlagen | Meetings | Ordnungsposition | RIS-Anträge | Vorlagenordner | Angebote |
     +==========================+==========+=========+==============+====================+=========+=========+=========+==========+=================+==================+=================+==========+==================+=============+================+==========+
     |``@type``                 |    ja    |    ja   |      ja      |         ja         |   ja    |   ja    |   ja    |    ja    |        ja       |        ja        |       ja        |    ja    |        ja        |      ja     |       ja       |   ja     |
+    +--------------------------+----------+---------+--------------+--------------------+---------+---------+---------+----------+-----------------+------------------+-----------------+----------+------------------+-------------+----------------+----------+
+    |``archival_value``        |   nein   |    ja   |     nein     |        nein        |  nein   |  nein   |  nein   |   nein   |       nein      |       nein       |       nein      |   nein   |        nein      |     nein    |      nein      |   nein   |
     +--------------------------+----------+---------+--------------+--------------------+---------+---------+---------+----------+-----------------+------------------+-----------------+----------+------------------+-------------+----------------+----------+
     |``blocked_local_roles``   |   nein   |    ja   |     nein     |        nein        |  nein   |  nein   |  nein   |   nein   |       nein      |       nein       |       nein      |   nein   |        ja        |     nein    |      nein      |   nein   |
     +--------------------------+----------+---------+--------------+--------------------+---------+---------+---------+----------+-----------------+------------------+-----------------+----------+------------------+-------------+----------------+----------+

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -262,6 +262,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
             'columns=relative_path',
             'columns=UID',
             'columns=trashed',
+            'columns=archival_value',
             'sort_on=created',
         ))
         view = '?'.join(('@listing', query_string))
@@ -283,6 +284,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
             {u'review_state': u'dossier-state-active',
              u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1',
              u'UID': IUUID(self.dossier),
+             u'archival_value': u'Nicht gepr\xfcft',
              u'blocked_local_roles': False,
              u'dossier_type_label':u'Gesch\xe4ftsfall',
              u'external_reference': u'qpr-900-9001-\xf7',

--- a/opengever/base/configure.zcml
+++ b/opengever/base/configure.zcml
@@ -517,6 +517,11 @@
       name="touched"
       />
 
+  <adapter
+      factory=".indexes.archival_value_indexer"
+      name="archival_value"
+      />
+
   <utility factory=".sequence.SequenceNumber" />
 
   <adapter factory=".quickupload.OGQuickUploadCapableFileFactory" />

--- a/opengever/base/indexes.py
+++ b/opengever/base/indexes.py
@@ -4,6 +4,8 @@ from Acquisition import aq_parent
 from ftw.mail.mail import IMail
 from opengever.base.behaviors.changed import IChanged
 from opengever.base.behaviors.changed import IChangedMarker
+from opengever.base.behaviors.lifecycle import ILifeCycle
+from opengever.base.behaviors.lifecycle import ILifeCycleMarker
 from opengever.base.behaviors.touched import ITouched
 from opengever.base.behaviors.translated_title import ITranslatedTitle
 from opengever.base.behaviors.translated_title import ITranslatedTitleSupport
@@ -170,3 +172,8 @@ def getObjPositionInParent(obj):
 @indexer(ITouched)
 def touched_indexer(obj):
     return ITouched(obj).touched
+
+
+@indexer(ILifeCycleMarker)
+def archival_value_indexer(obj):
+    return ILifeCycle(obj).archival_value

--- a/opengever/base/solr/fields.py
+++ b/opengever/base/solr/fields.py
@@ -25,9 +25,11 @@ from plone.memoize.instance import memoize
 from plone.rfc822.interfaces import IPrimaryFieldInfo
 from Products.CMFPlone.utils import safe_unicode
 from zExceptions import BadRequest
+from zope.component import getUtility
 from zope.component.hooks import getSite
 from zope.globalrequest import getRequest
 from zope.i18n import translate
+from zope.schema.interfaces import IVocabularyFactory
 import Missing
 
 
@@ -72,6 +74,17 @@ def translate_dossier_type(dossier_type):
         term = voc.getTerm(dossier_type)
     except LookupError:
         return dossier_type
+    else:
+        return term.title
+
+
+def translated_archival_value(obj):
+    portal = getSite()
+    voc = getUtility(IVocabularyFactory, name="lifecycle_archival_value_vocabulary")(portal)
+    try:
+        term = voc.getTerm(obj.get("archival_value"))
+    except LookupError:
+        return obj.get("archival_value")
     else:
         return term.title
 
@@ -454,6 +467,11 @@ FIELDS_WITH_MAPPING = [
         'type',
         index='portal_type',
         accessor='PortalType',
+    ),
+    ListingField(
+        'archival_value',
+        index='archival_value',
+        accessor=translated_archival_value,
     ),
     ListingField(
         'bumblebee_checksum',

--- a/opengever/core/upgrades/20250707134458_add_archival_value_index/upgrade.py
+++ b/opengever/core/upgrades/20250707134458_add_archival_value_index/upgrade.py
@@ -1,0 +1,22 @@
+from ftw.upgrade import UpgradeStep
+from opengever.base.behaviors.lifecycle import ILifeCycleMarker
+from opengever.core.upgrade import NightlyIndexer
+
+
+class AddArchivalValueIndex(UpgradeStep):
+    """Add archival value index.
+    """
+
+    deferrable = True
+
+    def __call__(self):
+        self.install_upgrade_profile()
+
+        query = {'object_provides': [
+            ILifeCycleMarker.__identifier__,
+        ]}
+
+        with NightlyIndexer(idxs=["archival_value"],
+                            index_in_solr_only=True) as indexer:
+            for brain in self.brains(query, 'Index archival_value in Solr'):
+                indexer.add_by_brain(brain)

--- a/opengever/dossier/tests/test_move_items.py
+++ b/opengever/dossier/tests/test_move_items.py
@@ -932,6 +932,7 @@ class TestMoveItemsUpdatesIndexAndMetadata(SolrIntegrationTestCase, MoveItemsHel
         }
 
         unchanged_solrdata = [
+            u'archival_value',
             u'blocked_local_roles',
             u'containing_subdossier',
             u'has_sametype_children',

--- a/solr-conf/managed-schema.xml
+++ b/solr-conf/managed-schema.xml
@@ -139,6 +139,7 @@
 
     <!-- GEVER specific fields -->
     <field name="approval_state" type="string" indexed="true" stored="false" />
+    <field name="archival_value" type="string" indexed="true" stored="false" />
     <field name="attendees" type="string" indexed="true" stored="false" multiValued="true"/>
     <field name="blocked_local_roles" type="boolean" indexed="true" stored="false" />
     <field name="bumblebee_checksum" type="string" indexed="false" stored="false" />


### PR DESCRIPTION
This PR adds a new solr index `archival_value`.

The `archival_value` is also added as a `ListingFiled` for the `@listing`-endpoint.

For [TI-2730]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-2730]: https://4teamwork.atlassian.net/browse/TI-2730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ