### PR TITLE
Properly close tasks in progress with the auto close task feature

### DIFF
--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -919,6 +919,25 @@ class Task(Container, TaskReminderSupport):
         Rather than preventing the dossier from closing, we force each task into a
         valid terminal state based on its current state.
 
+        Transitions applied:
+
+        - task-state-rejected:
+            -> task-transition-rejected-open
+            -> task-transition-open-cancelled
+            => Final state: task-state-cancelled
+
+        - task-state-open:
+            -> task-transition-open-cancelled
+            => Final state: task-state-cancelled
+
+        - task-state-in-progress:
+            -> task-transition-in-progress-tested-and-closed
+            => Final state: task-state-tested-and-closed
+
+        - task-state-resolved:
+            -> task-transition-resolved-tested-and-closed
+            => Final state: task-state-tested-and-closed
+
         This method is recursive, ensuring that all subtasks are also finished in the same way,
         """
         if api.content.get_state(self) == TASK_STATE_REJECTED:
@@ -939,7 +958,7 @@ class Task(Container, TaskReminderSupport):
             # the expected transitions.
             try:
                 # We first try to directly close it.
-                api.content.transition(obj=self, transition='task-transition-resolved-tested-and-closed')
+                api.content.transition(obj=self, transition='task-transition-in-progress-tested-and-closed')
             except InvalidParameterError:
                 # If it does not work, we try to resolve it first.
                 api.content.transition(obj=self, transition='task-transition-in-progress-resolved')

--- a/opengever/task/tests/test_task.py
+++ b/opengever/task/tests/test_task.py
@@ -942,3 +942,141 @@ class TestForceCloseTask(IntegrationTestCase):
         self.assertEqual('task-state-tested-and-closed', api.content.get_state(subtask2))
         self.assertEqual('task-state-cancelled', api.content.get_state(subtask3))
         self.assertEqual('task-state-cancelled', api.content.get_state(subtask4))
+
+    @browsing
+    def test_close_task_variations(self, browser):
+        self.login(self.dossier_responsible, browser)
+
+        # Task type information
+        task_information_open = create(
+            Builder("task")
+            .within(self.dossier)
+            .titled("Subtask 1")
+            .in_state('task-state-open')
+            .having(task_type='information',
+                    issuer=self.dossier_responsible.getId(),
+                    responsible=self.dossier_responsible.getId(),
+                    responsible_client='fa')
+        )
+        task_information_open.close_task()
+
+        task_information_in_progress = create(
+            Builder("task")
+            .within(self.dossier)
+            .in_state('task-state-in-progress')
+            .titled("Subtask 2")
+            .having(task_type='information',
+                    issuer=self.dossier_responsible.getId(),
+                    responsible=self.dossier_responsible.getId(),
+                    responsible_client='fa')
+        )
+        task_information_in_progress.close_task()
+
+        # Task type approval
+        task_approval_open = create(
+            Builder("task")
+            .within(self.dossier)
+            .in_state('task-state-open')
+            .titled("Subtask 3")
+            .having(task_type='approval',
+                    issuer=self.dossier_responsible.getId(),
+                    responsible=self.dossier_responsible.getId(),
+                    responsible_client='fa')
+        )
+        task_approval_open.close_task()
+
+        task_approval_in_progress = create(
+            Builder("task")
+            .within(self.dossier)
+            .in_state('task-state-in-progress')
+            .titled("Subtask 3")
+            .having(task_type='approval',
+                    issuer=self.dossier_responsible.getId(),
+                    responsible=self.dossier_responsible.getId(),
+                    responsible_client='fa')
+        )
+        task_approval_in_progress.close_task()
+
+        task_approval_resolved = create(
+            Builder("task")
+            .within(self.dossier)
+            .in_state('task-state-resolved')
+            .having(task_type='direct-execution',
+                    issuer=self.dossier_responsible.getId(),
+                    responsible=self.dossier_responsible.getId(),
+                    responsible_client='fa')
+        )
+        task_approval_resolved.close_task()
+
+        # Task type direct execution
+        task_direct_execution_open = create(
+            Builder("task")
+            .within(self.dossier)
+            .in_state('task-state-open')
+            .titled("Subtask 5")
+            .having(task_type='direct-execution',
+                    issuer=self.dossier_responsible.getId(),
+                    responsible=self.dossier_responsible.getId(),
+                    responsible_client='fa')
+        )
+        task_direct_execution_open.close_task()
+
+        task_direct_execution_in_progress = create(
+            Builder("task")
+            .within(self.dossier)
+            .in_state('task-state-in-progress')
+            .having(task_type='direct-execution',
+                    issuer=self.dossier_responsible.getId(),
+                    responsible=self.dossier_responsible.getId(),
+                    responsible_client='fa')
+        )
+        task_direct_execution_in_progress.close_task()
+
+        task_direct_execution_rejected = create(
+            Builder("task")
+            .within(self.dossier)
+            .in_state('task-state-rejected')
+            .having(task_type='direct-execution',
+                    issuer=self.dossier_responsible.getId(),
+                    responsible=self.dossier_responsible.getId(),
+                    responsible_client='fa')
+        )
+        task_direct_execution_rejected.close_task()
+
+        task_direct_execution_resolved = create(
+            Builder("task")
+            .within(self.dossier)
+            .in_state('task-state-resolved')
+            .having(task_type='direct-execution',
+                    issuer=self.dossier_responsible.getId(),
+                    responsible=self.dossier_responsible.getId(),
+                    responsible_client='fa')
+        )
+        task_direct_execution_resolved.close_task()
+
+        self.assertDictEqual(
+            {
+                'task_information_open': 'task-state-cancelled',
+                'task_information_in_progress': 'task-state-tested-and-closed',
+
+                'task_approval_open': 'task-state-cancelled',
+                'task_approval_in_progress': 'task-state-tested-and-closed',
+                'task_approval_resolved': 'task-state-tested-and-closed',
+
+                'task_direct_execution_open': 'task-state-cancelled',
+                'task_direct_execution_in_progress': 'task-state-tested-and-closed',
+                'task_direct_execution_rejected': 'task-state-cancelled',
+                'task_direct_execution_resolved': 'task-state-tested-and-closed',
+            },
+            {
+                'task_information_open': api.content.get_state(task_information_open),
+                'task_information_in_progress': api.content.get_state(task_information_in_progress),
+                'task_approval_open': api.content.get_state(task_approval_open),
+                'task_approval_in_progress': api.content.get_state(task_approval_in_progress),
+                'task_approval_resolved': api.content.get_state(task_approval_resolved),
+                'task_direct_execution_open': api.content.get_state(task_direct_execution_open),
+                'task_direct_execution_in_progress': api.content.get_state(task_direct_execution_in_progress),
+                'task_direct_execution_rejected': api.content.get_state(task_direct_execution_rejected),
+                'task_direct_execution_resolved': api.content.get_state(task_direct_execution_resolved),
+            },
+        )


### PR DESCRIPTION
This is a follow up PR for #8162 

It fixes an issue where it was not possible to close a task for direct execution in the "in progress"-state.

Traceback if you treied to close such a task:
```
  File "/home/esc/projects/opengever.core/opengever/task/task.py", line 945, in close_task
    api.content.transition(obj=self, transition='task-transition-in-progress-resolved')
  File "<string>", line 2, in transition
  File "/home/esc/.buildout/eggs/plone.api-1.10.2-py2.7.egg/plone/api/validation.py", line 81, in wrapped
    return function(*args, **kwargs)
  File "<string>", line 2, in transition
  File "/home/esc/.buildout/eggs/plone.api-1.10.2-py2.7.egg/plone/api/validation.py", line 153, in wrapped
    return function(*args, **kwargs)
  File "<string>", line 2, in transition
  File "/home/esc/.buildout/eggs/plone.api-1.10.2-py2.7.egg/plone/api/validation.py", line 116, in wrapped
    return function(*args, **kwargs)
  File "/home/esc/.buildout/eggs/plone.api-1.10.2-py2.7.egg/plone/api/content.py", line 494, in transition
    '{1}'.format(transition, '\n'.join(sorted(transitions))),
InvalidParameterError: Invalid transition 'task-transition-in-progress-resolved'.
Valid transitions are:
task-transition-delegate
task-transition-in-progress-cancelled
task-transition-in-progress-tested-and-closed
task-transition-modify-deadline
task-transition-reassign
```

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [TI-2301]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry ℹ️ not required because the fix is in the same release as the feature
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
