### PR TITLE
Only create task reminders for tasks in current admin unit

### DIFF
--- a/changes/TI-2854.bugfix
+++ b/changes/TI-2854.bugfix
@@ -1,0 +1,1 @@
+Only create task reminders for tasks in current admin unit. [buchi]

--- a/opengever/task/reminder/cronjobs.py
+++ b/opengever/task/reminder/cronjobs.py
@@ -2,6 +2,7 @@ from datetime import date
 from opengever.core.debughelpers import get_first_plone_site
 from opengever.core.debughelpers import setup_plone
 from opengever.globalindex.model.reminder_settings import ReminderSetting
+from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.task.activities import TaskReminderActivity
 from opengever.task.reminder import logger
 from plone import api
@@ -38,7 +39,9 @@ def create_reminder_notifications():
     query = ReminderSetting.query.filter(
         ReminderSetting.remind_day == date.today())
 
+    current_admin_unit_id = get_current_admin_unit().unit_id
     for reminder in query.all():
-        TaskReminderActivity(reminder.task, getRequest()).record(reminder.actor_id)
+        if reminder.task.admin_unit_id == current_admin_unit_id:
+            TaskReminderActivity(reminder.task, getRequest()).record(reminder.actor_id)
 
     return query.count()


### PR DESCRIPTION
Currently the `create_reminder_notifications` cronjob creates reminders for all admin units. In multi-tenant setups this is not what we want, as we have to make sure the cron job is only executed once for all tenants. With this change, reminders are only created for tasks of the current tenant (admin unit) and we can run the same cronjob for each tenant.

Fixes creating/sending multiple reminder notifications in multi-tenant setups.

For [TI-2854](https://4teamwork.atlassian.net/browse/TI-2854)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[TI-2854]: https://4teamwork.atlassian.net/browse/TI-2854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ