### PR TITLE
Add RISProposal as possible type for relation of document

### DIFF
--- a/changes/TI-2959.bugfix
+++ b/changes/TI-2959.bugfix
@@ -1,0 +1,1 @@
+Allow RISProposal to be related to a document. [ran]

--- a/opengever/document/base.py
+++ b/opengever/document/base.py
@@ -14,6 +14,7 @@ from opengever.locking.lock import LOCK_TYPE_COPIED_TO_WORKSPACE_LOCK
 from opengever.meeting.model.generateddocument import GeneratedExcerpt
 from opengever.meeting.proposal import IBaseProposal
 from opengever.meeting.proposal import ISubmittedProposal
+from opengever.ris.proposal import IProposal as IRisProposal
 from opengever.task.task import ITask
 from opengever.trash.trash import ITrashed
 from opengever.workspace.interfaces import IWorkspace
@@ -26,6 +27,7 @@ from Products.CMFCore.utils import getToolByName
 from Products.MimetypesRegistry.common import MimeTypeException
 from Products.MimetypesRegistry.interfaces import IMimetype
 from zc.relation.interfaces import ICatalog
+from zExceptions import BadRequest
 from zope.component import getUtility
 from zope.intid.interfaces import IIntIds
 import logging
@@ -103,7 +105,13 @@ class BaseDocumentMixin(object):
         if relations:
             relation = relations[0]
             submitted_proposal = relation.from_object
-            assert(ISubmittedProposal.providedBy(submitted_proposal))
+            if not (
+                ISubmittedProposal.providedBy(submitted_proposal)
+                or IRisProposal.providedBy(submitted_proposal)
+            ):
+                raise BadRequest(
+                    "Related Proposal must be either ISubmittedProposal or IRisProposal"
+                )
             if check_security:
                 if api.user.has_permission('View', obj=submitted_proposal):
                     return submitted_proposal


### PR DESCRIPTION
Before, everytime a document related to a new RISProposal class tried to be opened, the get_submitted_proposal() function failed, due to a weird assert that only allowed ISubmittedProposal to be related to a document.

This was now expanded with the interface IProposal (of new ris proposal class).


For [TI-2959]

## Checklist


- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[TI-2959]: https://4teamwork.atlassian.net/browse/TI-2959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ