### PR TITLE
Update Solr to version 9.9.0

### DIFF
--- a/changes/TI-2274.other
+++ b/changes/TI-2274.other
@@ -1,0 +1,1 @@
+Update Solr to version 9.9.0. [buchi]

--- a/docker/solr/Dockerfile
+++ b/docker/solr/Dockerfile
@@ -1,4 +1,4 @@
-FROM solr:9.8.1
+FROM solr:9.9.0
 
 ENV SOLR_OPTS="-Dlog4j2.formatMsgNoLookups=true" \
     SOLR_CORES="ogsite" \

--- a/opengever/core/solr_testing.py
+++ b/opengever/core/solr_testing.py
@@ -52,7 +52,7 @@ class SolrServer(object):
             'SOLR_CORES=testing functionaltesting testserver',
             '--name',
             self.container_name,
-            '4teamwork/ogsolr:9.8.1',
+            '4teamwork/ogsolr:9.9.0',
             'solr-foreground',
         ]
 

--- a/solr-conf/solrconfig.xml
+++ b/solr-conf/solrconfig.xml
@@ -35,7 +35,7 @@
        that you fully re-index after changing this setting as it can
        affect both how text is indexed and queried.
   -->
-  <luceneMatchVersion>9.11</luceneMatchVersion>
+  <luceneMatchVersion>9.12</luceneMatchVersion>
 
   <!-- Data Directory
 


### PR DESCRIPTION
_PR-Description: should contain all the information necessary for an outsider to understand the change without looking at the code or the issue!_

- _Why the change is necessary_
- _What the goal of the change is_
- _How change is achieved (e.g. design decisions)_
- _The author should advertise and sell the change in the PR body_

_Screenshot: whenever useful, but only as a visual aid._


Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [TI-XXXX]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
