### PR TITLE
Correct permission for "transfer responsible"

### DIFF
--- a/changes/TI-2961.other
+++ b/changes/TI-2961.other
@@ -1,0 +1,1 @@
+Correct the permission required for the action "transfer responsible". [ran]

--- a/opengever/dossier/actions.py
+++ b/opengever/dossier/actions.py
@@ -188,7 +188,7 @@ class DossierContextActions(BaseContextActions):
         return True
 
     def is_transfer_dossier_responsible_available(self):
-        return api.user.has_permission('Modify portal content', obj=self.context)
+        return api.user.has_permission('opengever.api: Transfer Assignment', obj=self.context)
 
 
 @adapter(IDossierTemplateMarker, IOpengeverBaseLayer)


### PR DESCRIPTION
Before anyone who had "Modify Portal Content" could attempt "transfer responsible" action for a dossier. Now only the users with the required permission may even see the action.

For [TI-2961]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[TI-2961]: https://4teamwork.atlassian.net/browse/TI-2961?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ