### PR TITLE
Fix Sentry integeration for container deployments

### DIFF
--- a/changes/GH-8185.bugfix
+++ b/changes/GH-8185.bugfix
@@ -1,0 +1,1 @@
+Fix Sentry integeration for container deployments. [buchi]

--- a/docker/core/etc/site.zcml
+++ b/docker/core/etc/site.zcml
@@ -169,6 +169,7 @@
   <include package="ftw.monitor" file="configure.zcml" />
   <include package="ftw.zopemaster" file="configure.zcml" />
   <include package="ftw.slacker" file="configure.zcml" />
+  <include package="ftw.raven" file="configure.zcml" />
   <includeOverrides package="opengever.base" file="overrides.zcml" />
   <includeOverrides package="opengever.bumblebee" file="overrides.zcml" />
   <includeOverrides package="opengever.core" file="overrides.zcml" />


### PR DESCRIPTION
_PR-Description: should contain all the information necessary for an outsider to understand the change without looking at the code or the issue!_

- _Why the change is necessary_
- _What the goal of the change is_
- _How change is achieved (e.g. design decisions)_
- _The author should advertise and sell the change in the PR body_

_Screenshot: whenever useful, but only as a visual aid._


Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [TI-XXXX]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
