### PR TITLE
Fix dossier report translations for archival_value column

### DIFF
--- a/changes/TI-1604.bugfix
+++ b/changes/TI-1604.bugfix
@@ -1,0 +1,1 @@
+Fix dossier report translations for archival_value column. [ran]

--- a/opengever/dossier/browser/report.py
+++ b/opengever/dossier/browser/report.py
@@ -1,4 +1,5 @@
 from opengever.api.solr_query_service import SolrFieldMapper
+from opengever.base import _ as base_mf
 from opengever.base.browser.reporting_view import SolrReporterView
 from opengever.base.reporter import DATE_NUMBER_FORMAT
 from opengever.base.reporter import readable_actor
@@ -77,6 +78,12 @@ class DossierReporter(SolrReporterView):
             'alias': 'creator_fullname',
             'transform': readable_actor,
             'title': _(u'dossier_report_creator', default=u'Creator')
+        },
+        {
+            'id': 'archival_value',
+            'is_default': False,
+            'transform': StringTranslater(None, 'plone').translate,
+            'title': base_mf(u'label_archival_value', default=u'Archival Value')
         },
     )
 


### PR DESCRIPTION
Archival value column title and values were not properly translated in the Dossier Export. This problem is now fixed with this PR.

Before:

<img width="156" height="119" alt="1608_before" src="https://github.com/user-attachments/assets/4f090b3f-a443-4f0d-b6aa-abe35e845f41" />

After:

<img width="144" height="134" alt="1608_after2" src="https://github.com/user-attachments/assets/3c7589c9-68ce-4c2e-91d7-7a2b67099df4" />



For [TI-1608]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-1608]: https://4teamwork.atlassian.net/browse/TI-1608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ