### PR TITLE
Only users with 'Transfer Assignment' can see transfer responsible ac…

### DIFF
--- a/changes/TI-2961.bugfix
+++ b/changes/TI-2961.bugfix
@@ -1,0 +1,1 @@
+Only users with 'Transfer Assignment' can see transfer responsible action. [ran]

--- a/opengever/api/tests/test_ui_actions.py
+++ b/opengever/api/tests/test_ui_actions.py
@@ -35,8 +35,7 @@ class TestUIActionsGET(IntegrationTestCase):
                 {u'id': u'edit'},
                 {u'id': u'export_pdf'},
                 {u'id': u'pdf_dossierdetails'},
-                {u'id': u'zipexport'},
-                {u'id': u'transfer_dossier_responsible'}]}, browser.json)
+                {u'id': u'zipexport'}]}, browser.json)
 
     @browsing
     def test_ui_actions_includes_listing_actions(self, browser):

--- a/opengever/dossier/actions.py
+++ b/opengever/dossier/actions.py
@@ -2,6 +2,7 @@ from opengever.base.context_actions import BaseContextActions
 from opengever.base.interfaces import IOpengeverBaseLayer
 from opengever.base.listing_actions import BaseListingActions
 from opengever.docugate import is_docugate_feature_enabled
+from opengever.dossier import is_grant_dossier_manager_to_responsible_enabled
 from opengever.dossier.base import DOSSIER_STATE_RESOLVED
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.dossiertemplate.behaviors import IDossierTemplateMarker
@@ -188,7 +189,15 @@ class DossierContextActions(BaseContextActions):
         return True
 
     def is_transfer_dossier_responsible_available(self):
-        return api.user.has_permission('Modify portal content', obj=self.context)
+
+        # Fribourg wants everyone to see the action and get an Error if they don't
+        # have the correct permissions.
+        # Everyone else should only be able to see it if they have the correct permissions.
+
+        if is_grant_dossier_manager_to_responsible_enabled():
+            return api.user.has_permission('Modify portal content', obj=self.context)
+
+        return api.user.has_permission('opengever.api: Transfer Assignment', obj=self.context)
 
 
 @adapter(IDossierTemplateMarker, IOpengeverBaseLayer)

--- a/opengever/dossier/tests/test_actions.py
+++ b/opengever/dossier/tests/test_actions.py
@@ -115,6 +115,23 @@ class TestDossierContextActions(IntegrationTestCase):
         expected_actions = [
             u'document_with_template',
             u'edit', u'export_pdf',
+            u'pdf_dossierdetails', u'zipexport']
+        self.assertEqual(expected_actions, self.get_actions(self.dossier))
+
+    def test_dossier_context_actions_with_manager(self):
+        self.login(self.manager)
+        expected_actions = [
+            u'document_with_template',
+            u'edit', u'export_pdf', u'local_roles',
+            u'pdf_dossierdetails', u'protect_dossier', u'zipexport',
+            u'transfer_dossier_responsible']
+        self.assertEqual(expected_actions, self.get_actions(self.dossier))
+
+    def test_dossier_context_actions_with_limited_admin(self):
+        self.login(self.limited_admin)
+        expected_actions = [
+            u'document_with_template',
+            u'edit', u'export_pdf',
             u'pdf_dossierdetails', u'zipexport',
             u'transfer_dossier_responsible']
         self.assertEqual(expected_actions, self.get_actions(self.dossier))
@@ -174,8 +191,7 @@ class TestWorkspaceClientDossierContextActions(FunctionalWorkspaceClientTestCase
             expected_actions = [u'copy_documents_from_workspace', u'copy_documents_to_workspace',
                                 u'create_linked_workspace', u'document_with_template', u'edit',
                                 u'export_pdf', u'link_to_workspace', u'list_workspaces',
-                                u'pdf_dossierdetails', u'unlink_workspace', u'zipexport',
-                                u'transfer_dossier_responsible']
+                                u'pdf_dossierdetails', u'unlink_workspace', u'zipexport']
 
             self.assertEqual(expected_actions, self.get_actions(self.dossier))
 
@@ -185,7 +201,7 @@ class TestWorkspaceClientDossierContextActions(FunctionalWorkspaceClientTestCase
             subdossier = create(Builder('dossier').within(self.dossier))
             expected_actions = [u'copy_documents_to_workspace', u'delete', u'document_with_template', u'edit',
                                 u'export_pdf', u'list_workspaces', u'pdf_dossierdetails',
-                                u'zipexport', u'transfer_dossier_responsible']
+                                u'zipexport']
 
             self.assertEqual(expected_actions, self.get_actions(subdossier))
 


### PR DESCRIPTION
Fribourg, which grants the dossier responsible the dossier manager role and wants explicitly that every user sees the "transfer responsible action". All other users from other customers should only be able to see the action if they have the permission to enact it.

For [TI-1604]

## Checklist

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

[TI-1604]: https://4teamwork.atlassian.net/browse/TI-1604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ