### PR TITLE
Filter out inactive groups and users in the group membership report

### DIFF
--- a/changes/TI-2116.feature
+++ b/changes/TI-2116.feature
@@ -1,0 +1,1 @@
+Filter out inactive groups and users in the group membership report. [ran]

--- a/opengever/globalindex/browser/report.py
+++ b/opengever/globalindex/browser/report.py
@@ -14,6 +14,7 @@ from opengever.ogds.models.service import ogds_service
 from opengever.task.helper import task_type_value_helper
 from Products.statusmessages.interfaces import IStatusMessage
 from sqlalchemy.orm import joinedload
+from sqlalchemy.sql.expression import true
 from zExceptions import Unauthorized
 from zope.i18n import translate
 
@@ -186,11 +187,13 @@ class OGDSGroupsMembershipReporter(BaseReporterView):
 
     def __call__(self):
         session = create_session()
-        query = session.query(Group).options(joinedload(Group.users))
+        query = session.query(Group).options(joinedload(Group.users)).filter(Group.active == true())
         groups_with_users = []
 
         for group in query.all():
             for user in group.users:
+                if not user.active:
+                    continue
                 group_info = {
                     'group_name': group.groupname,
                     'group_title': group.title,


### PR DESCRIPTION
St. Gallen still has inactive groups with memberships (both active and inactive users). These should be filtered out for the group membership export.


Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [TI-2116]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)



[TI-2116]: https://4teamwork.atlassian.net/browse/TI-2116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ