### PR TITLE
Fix PDF save callback issue with document_version_count Index

### DIFF
--- a/changes/TI-3142.bugfix
+++ b/changes/TI-3142.bugfix
@@ -1,0 +1,1 @@
+Fix error when storing a document as PDF. [elioschmutz]

--- a/opengever/document/tests/test_indexers.py
+++ b/opengever/document/tests/test_indexers.py
@@ -580,3 +580,15 @@ class SolrDocumentIndexer(SolrIntegrationTestCase):
 
         # Mails are always on version 0
         self.assertEqual(indexed_value, 1)
+
+    def test_reindex_object_is_possible_as_anonymous(self):
+        """A document should be reindexable as an anonymous user because no
+        user specific data is indexed.
+
+        Reindexing as an anonymous user is required by the
+        save_pdf_under_callback view which is called by bumblebee."""
+        self.login(self.regular_user)
+        document = self.document
+
+        self.logout()
+        self.assertIsNone(document.reindexObject())


### PR DESCRIPTION
GEVER provides a feature to store a document as a PDF directly into a dossier:

<img width="754" height="434" alt="Bildschirmfoto 2025-09-23 um 12 07 09" src="https://github.com/user-attachments/assets/b321bd3a-02b7-4a27-be15-396238c3ca03" />

This action sends a request to `bumblebee` to generate a PDF representation of the current document. Once ready, bumblebee uploads the PDF back to GEVER using a callback URL: [save_pdf_under_callback](https://github.com/4teamwork/opengever.core/blob/f43d66f955a23884e8998bd9b86f9eecc86fcb37/opengever/bumblebee/browser/configure.zcml#L62)

This callback is called anonymously by bumblebee. After storing the PDF, we trigger an `ObjectModifiedEvent` to reindex the document metadata.

**Why This Fails in Production**
In tests, this works fine due to the patching of `collective.indexing`:
- [Patch to immediately process the indexing queue](https://github.com/4teamwork/opengever.core/blob/master/opengever/testing/patch.py#L41)
- Callback runs inside a user context manager: [Link](https://github.com/4teamwork/opengever.core/blob/f43d66f955a23884e8998bd9b86f9eecc86fcb37/opengever/bumblebee/browser/callback.py#L53)

However, in production environments:
- Indexing happens after the transaction is committed
- At this point, the context is anonymous
- This becomes a problem because of the [document_version_count](https://github.com/4teamwork/opengever.core/pull/8168) index

This new index requires access to the document's revision history, which is protected and requires an authenticated user.

**The Fix**
We now index the `document_version_count` index with elevated privileges, ensuring that even when the callback runs anonymously, the reindexing can access the revision history.

The provided test ensures that full object reindexing works again from an anonymous context.

For [TI-3142]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-3142]: https://4teamwork.atlassian.net/browse/TI-3142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ