### PR TITLE
Escape html for solr listing document snippets.

### DIFF
--- a/changes/TI-3167.other
+++ b/changes/TI-3167.other
@@ -1,0 +1,1 @@
+- XSS: Escape html for solr listing document snippets. [elioschmutz]

--- a/opengever/base/solr/contentlisting.py
+++ b/opengever/base/solr/contentlisting.py
@@ -5,6 +5,7 @@ from opengever.base.brain import supports_translated_title
 from opengever.base.contentlisting import OpengeverCatalogContentListingObject
 from opengever.base.interfaces import IOGSolrDocument
 from opengever.base.utils import get_preferred_language_code
+from opengever.base.utils import to_safe_html
 from Products.CMFPlone.utils import safe_unicode
 from zope.globalrequest import getRequest
 from zope.interface import implementer
@@ -71,6 +72,10 @@ class OGSolrDocument(SolrDocument):
 class OGSolrContentListing(SolrContentListing):
 
     doc_type = OGSolrDocument
+
+    def _add_snippets(self, doc):
+        super(OGSolrContentListing, self)._add_snippets(doc)
+        doc['_snippets_'] = to_safe_html(doc.get('_snippets_', ''))
 
 
 class OGSolrContentListingObject(


### PR DESCRIPTION
This PR properly removes dangerous html tags from the solr listing document snippets.

We can't just search and replace reserved html characters and convert them into html entities (i.e. replacing < to &gt;) because the `snippets` includes text highlighting which is made with html.

We use the plone internal `safe_html` portal transform to fix it. This will remove dangerous tags which is what we want here.

For [TI-3167]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-3167]: https://4teamwork.atlassian.net/browse/TI-3167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ