### PR TITLE
Add translated error message for NoEmailError when starting document signing

### DIFF
--- a/changes/TI-3775.other
+++ b/changes/TI-3775.other
@@ -1,0 +1,1 @@
+Add translated error message for NoEmailError when starting document signing  [elioschmutz]

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2025-06-13 12:43+0000\n"
+"POT-Creation-Date: 2026-04-15 07:45+0000\n"
 "PO-Revision-Date: 2017-10-13 14:27+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -122,6 +122,10 @@ msgstr "Das Dokument ${title} enthält keine Datei."
 #: ./opengever/document/browser/edit.py
 msgid "The Document is already checked out by: ${userid}"
 msgstr "Das Dokument ist bereits von ${userid} ausgecheckt."
+
+#: ./opengever/document/transition.py
+msgid "This user does not have a valid email address defined."
+msgstr "Dieser Benutzer hat keine gültige E-Mail-Adresse hinterlegt."
 
 #: ./opengever/document/browser/templates/submitted_with.pt
 msgid "Update document in proposal"

--- a/opengever/document/locales/en/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/en/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2025-06-13 12:43+0000\n"
+"POT-Creation-Date: 2026-04-15 07:45+0000\n"
 "PO-Revision-Date: 2017-10-13 14:27+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -145,6 +145,10 @@ msgstr "Document ${title} has no file."
 #: ./opengever/document/browser/edit.py
 msgid "The Document is already checked out by: ${userid}"
 msgstr "Document is already checked out by: ${userid}"
+
+#: ./opengever/document/transition.py
+msgid "This user does not have a valid email address defined."
+msgstr "This user does not have a valid email address defined."
 
 #. German translation: Eingereichte Version aktualisieren
 #: ./opengever/document/browser/templates/submitted_with.pt

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2025-06-13 12:43+0000\n"
+"POT-Creation-Date: 2026-04-15 07:45+0000\n"
 "PO-Revision-Date: 2017-09-03 08:50+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-document/fr/>\n"
@@ -124,6 +124,10 @@ msgstr "Le dodument  ${title} ne contient pas de fichier."
 #: ./opengever/document/browser/edit.py
 msgid "The Document is already checked out by: ${userid}"
 msgstr "Le document a déjà un checkout par ${userid}."
+
+#: ./opengever/document/transition.py
+msgid "This user does not have a valid email address defined."
+msgstr "Cet utilisateur n’a pas d’adresse e-mail valide définie."
 
 #: ./opengever/document/browser/templates/submitted_with.pt
 msgid "Update document in proposal"

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2025-06-13 12:43+0000\n"
+"POT-Creation-Date: 2026-04-15 07:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -123,6 +123,10 @@ msgstr ""
 
 #: ./opengever/document/browser/edit.py
 msgid "The Document is already checked out by: ${userid}"
+msgstr ""
+
+#: ./opengever/document/transition.py
+msgid "This user does not have a valid email address defined."
 msgstr ""
 
 #: ./opengever/document/browser/templates/submitted_with.pt

--- a/opengever/document/transition.py
+++ b/opengever/document/transition.py
@@ -36,7 +36,7 @@ class DocumentFinalSigningTransitionExtender(TransitionExtender):
         """
         actor = ogds_service().fetch_user(api.user.get_current().id)
         if not actor or not actor.email:
-            raise NoEmailError()
+            raise NoEmailError(_(u'This user does not have a valid email address defined.'))
 
         Signer(self.context).start_signing(editors=[actor.email])
 


### PR DESCRIPTION
This PR provides a translated error message for the `NoEmailError` which will be raised on sign-transitions.

Currently, the UI will only show an "Unknown error happened".

For [TI-3775]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


[TI-3775]: https://4teamwork.atlassian.net/browse/TI-3775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ