### PR TITLE
2026.2 stable

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,15 @@ Versions are of the form MAJOR.MINOR.PATCH. Each MINOR release (MAJOR.MINOR.0) i
 
 .. towncrier release notes start
 
+2026.2.1 (2026-04-20)
+---------------------
+
+Other changes:
+
+
+- Add translated error message for NoEmailError when starting document signing  [elioschmutz] [TI-3775]
+
+
 2026.2.0 (2026-03-19)
 ---------------------
 

--- a/changes/TI-3775.other
+++ b/changes/TI-3775.other
@@ -1,1 +1,0 @@
-Add translated error message for NoEmailError when starting document signing  [elioschmutz]

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 import os
 
 
-version = '2026.2.1'
+version = '2026.2.2.dev0'
 maintainer = '4teamwork AG'
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 import os
 
 
-version = '2026.2.1.dev0'
+version = '2026.2.1'
 maintainer = '4teamwork AG'
 
 

--- a/versions.cfg
+++ b/versions.cfg
@@ -13,6 +13,8 @@ sablon = 0.3.1
 
 
 [versions]
+opengever.core = 2026.2.1
+
 alabaster = 0.7.10
 alembic = 1.4.3
 amqp = 1.4.7

--- a/versions.cfg
+++ b/versions.cfg
@@ -13,8 +13,6 @@ sablon = 0.3.1
 
 
 [versions]
-opengever.core = 2026.2.1
-
 alabaster = 0.7.10
 alembic = 1.4.3
 amqp = 1.4.7


### PR DESCRIPTION
_PR-Description: should contain all the information necessary for an outsider to understand the change without looking at the code or the issue!_

- _Why the change is necessary_
- _What the goal of the change is_
- _How change is achieved (e.g. design decisions)_
- _The author should advertise and sell the change in the PR body_

_Screenshot: whenever useful, but only as a visual aid._


Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [TI-XXXX]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
