### PR TITLE
OGDS Plugin doesn't return local groups

### DIFF
--- a/changes/TI-3810.bugfix
+++ b/changes/TI-3810.bugfix
@@ -1,0 +1,1 @@
+OGDS Authentication Plugin doesn't return local groups  [ran]

--- a/opengever/ogds/auth/plugin.py
+++ b/opengever/ogds/auth/plugin.py
@@ -21,6 +21,7 @@ from Products.PluggableAuthService.interfaces.plugins import IUserEnumerationPlu
 from Products.PluggableAuthService.plugins.BasePlugin import BasePlugin
 from sqlalchemy import func
 from sqlalchemy.sql import select
+from sqlalchemy.sql.expression import false
 from sqlalchemy.sql.expression import true
 from zope.interface import implements
 
@@ -284,6 +285,7 @@ class OGDSAuthenticationPlugin(BasePlugin, Cacheable):
         query = (
             select([Group.groupid])
             .where(Group.active == true())
+            .where(Group.is_local == false())
             .order_by(Group.groupid)
         )
 
@@ -351,6 +353,7 @@ class OGDSAuthenticationPlugin(BasePlugin, Cacheable):
             .select_from(groups.join(groups_users))
             .where(func.lower(groups_users.c.userid) == principal_id.lower())
             .where(groups.c.active == true())
+            .where(groups.c.is_local == false())
         )
 
         # Omit groups with non-ASCII names
@@ -372,6 +375,7 @@ class OGDSAuthenticationPlugin(BasePlugin, Cacheable):
         query = (
             select([Group.groupname])
             .where(Group.active == true())
+            .where(Group.is_local == false())
             .where(func.lower(Group.groupid) == group_id.lower())
         )
         res = self.query_ogds(query).fetchone()
@@ -421,6 +425,7 @@ class OGDSAuthenticationPlugin(BasePlugin, Cacheable):
         query = (
             select([Group.groupid])
             .where(Group.active == true())
+            .where(Group.is_local == false())
             .order_by(Group.groupid)
         )
         return [self.to_ascii(value) for value, in self.query_ogds(query)]
@@ -468,6 +473,10 @@ class OGDSAuthenticationPlugin(BasePlugin, Cacheable):
             .where(func.lower(id_column) == principal_id.lower())
             .where(active_column == true())
         )
+
+        if is_group:
+            query = query.where(Group.is_local == false())
+
         match = self.query_ogds(query).fetchone()
 
         if match:


### PR DESCRIPTION
Right now, ogds auth plugin returns local groups from OGDS, even though they are already available in source_groups. This PR changes the Auth Plugin group query to filter out local groups.


Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [TI-3810]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value


[TI-3810]: https://4teamwork.atlassian.net/browse/TI-3810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ