### PR TITLE
Fix overriding portal types provider for content stats

### DIFF
--- a/changes/GH-8239.bugfix
+++ b/changes/GH-8239.bugfix
@@ -1,0 +1,1 @@
+Fix overriding portal types provider for content stats. [buchi]

--- a/docker/core/etc/site.zcml
+++ b/docker/core/etc/site.zcml
@@ -177,6 +177,7 @@
   <includeOverrides package="opengever.base" file="overrides.zcml" />
   <includeOverrides package="opengever.bumblebee" file="overrides.zcml" />
   <includeOverrides package="opengever.core" file="overrides.zcml" />
+  <includeOverrides package="opengever.contentstats" file="overrides.zcml" />
   <includeOverrides package="opengever.latex" file="overrides.zcml" />
   <includeOverrides package="opengever.mail" file="overrides.zcml" />
   <includeOverrides package="opengever.readonly" file="overrides.zcml" />

--- a/opengever/contentstats/configure.zcml
+++ b/opengever/contentstats/configure.zcml
@@ -13,11 +13,6 @@
       />
 
   <adapter
-      factory=".providers.GEVERPortalTypesProvider"
-      name="portal_types"
-      />
-
-  <adapter
       factory=".providers.CheckedOutDocsProvider"
       name="checked_out_docs"
       />

--- a/opengever/contentstats/overrides.zcml
+++ b/opengever/contentstats/overrides.zcml
@@ -1,0 +1,8 @@
+<configure xmlns="http://namespaces.zope.org/zope">
+
+  <adapter
+      factory=".providers.GEVERPortalTypesProvider"
+      name="portal_types"
+      />
+
+</configure>

--- a/opengever/contentstats/providers.py
+++ b/opengever/contentstats/providers.py
@@ -1,7 +1,6 @@
 from collections import Counter
 from ftw.contentstats.interfaces import IStatsProvider
 from ftw.contentstats.providers.portal_types import PortalTypesProvider
-from opengever.base.interfaces import IOpengeverBaseLayer
 from opengever.contentstats.active_user_stats import UserStatsCalculator
 from opengever.document.document import Document
 from opengever.mail.mail import OGMail
@@ -13,7 +12,7 @@ from zope.interface import Interface
 
 
 @implementer(IStatsProvider)
-@adapter(IPloneSiteRoot, IOpengeverBaseLayer)
+@adapter(IPloneSiteRoot, Interface)
 class GEVERPortalTypesProvider(PortalTypesProvider):
     """Customization of the default ftw.contentstats `portal_types` provider
     that sums up (Documents + Mails) as a separate, fake portal_type


### PR DESCRIPTION
So far the portal types provider wasn't registered correctly and we didn't get the main dossiers counts.
Worked before with buildout because of z3c.autoinclude "magic".


## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Post-merge action

> [!IMPORTANT]
> After this PR is merged, Dev on Kubernetes must be updated.
