### PR TITLE
Provide signing backoff status in document status endpoint

### DIFF
--- a/changes/TI-2916.feature
+++ b/changes/TI-2916.feature
@@ -1,0 +1,1 @@
+Provide pending signing job and signing backoff status in document status endpoint  [elioschmutz]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -12,7 +12,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
-
+- ``[document-id]/status``: Provide pending signing job and signing backoff status if sign-feature is enabled.
 
 2026.2.0 (2026-03-19)
 ----------------------

--- a/opengever/base/service.py
+++ b/opengever/base/service.py
@@ -1,4 +1,6 @@
 from ftw.bumblebee.interfaces import IBumblebeeDocument
+from opengever.sign.sign import Signer
+from opengever.sign.utils import is_sign_feature_enabled
 from plone import api
 from plone.rest import Service
 from plone.restapi.services.locking.locking import lock_info
@@ -29,6 +31,11 @@ class DocumentStatus(Service):
         payload['file_mtime'] = self.context.get_file_mtime()
 
         payload['review_state'] = api.content.get_state(self.context)
+
+        if is_sign_feature_enabled():
+            signer = Signer(self.context)
+            payload['pending_signing_job'] = signer.serialize_pending_signing_job()
+            payload['signing_backoff_status'] = signer.get_backoff_status()
 
         return json.dumps(payload)
 

--- a/opengever/base/tests/test_api.py
+++ b/opengever/base/tests/test_api.py
@@ -1,13 +1,18 @@
 from datetime import datetime
 from ftw.testbrowser import browsing
 from ftw.testing.freezer import freeze
+from opengever.document.document import Document
 from opengever.document.interfaces import ICheckinCheckoutManager
+from opengever.sign.sign import Signer
 from opengever.testing import IntegrationTestCase
 from opengever.wopi.lock import create_lock as create_wopi_lock
+from plone import api
 from plone.locking.interfaces import ILockable
 from zope.app.intid.interfaces import IIntIds
 from zope.component import getMultiAdapter
 from zope.component import getUtility
+import re
+import requests_mock
 
 
 class TestDocumentStatus(IntegrationTestCase):
@@ -135,3 +140,26 @@ class TestDocumentStatus(IntegrationTestCase):
             u'title': u'Vertr\xe4gsentwurf',
         }
         self.assertEqual(expected, browser.json)
+
+    @browsing
+    @requests_mock.Mocker()
+    def test_document_status_contains_pending_signing_job_when_sign_feature_enabled(self, browser, mocker):
+        self.activate_feature('sign')
+        self.login(self.regular_user, browser=browser)
+
+        mocker.post(re.compile('/signing-jobs'), json={'id': 'job-1'})
+        mocker.get(re.compile('/signing-jobs/job-1/backoff_status'),
+                   json={'scheduled_poll_time': '2024-02-18T16:00:00'})
+
+        browser.open(self.document, view='status', headers=self.api_headers)
+        self.assertEqual({}, browser.json.get('pending_signing_job'))
+        self.assertIsNone(browser.json.get('signing_backoff_status'))
+
+        api.content.transition(obj=self.document,
+                               transition=Document.draft_signing_transition)
+        Signer(self.document).start_signing([])
+
+        browser.open(self.document, view='status', headers=self.api_headers)
+        self.assertEqual('job-1', browser.json.get('pending_signing_job').get('job_id'))
+        self.assertEqual({'scheduled_poll_time': '2024-02-18T16:00:00'},
+                         browser.json.get('signing_backoff_status'))

--- a/opengever/sign/client.py
+++ b/opengever/sign/client.py
@@ -56,6 +56,14 @@ class SignServiceClient(object):
             '{}/signing-jobs/{}'.format(self.sign_service_url, job_id),
             headers={"Accept": "application/json"})
 
+    def get_backoff_status(self, job_id):
+        resp = requests.get(
+            '{}/signing-jobs/{}/backoff_status'.format(self.sign_service_url, job_id),
+            headers={"Accept": "application/json"},
+            timeout=3)
+        resp.raise_for_status()
+        return resp.json()
+
 
 class NullSignServiceClient(object):
 
@@ -68,6 +76,9 @@ class NullSignServiceClient(object):
 
     def abort_signing(self, job_id):
         pass
+
+    def get_backoff_status(self, job_id):
+        return None
 
 
 client_registry = {

--- a/opengever/sign/sign.py
+++ b/opengever/sign/sign.py
@@ -10,6 +10,11 @@ from opengever.sign.token import TokenManager
 from plone import api
 from plone.dexterity.utils import safe_utf8
 from requests.exceptions import ConnectionError
+from requests.exceptions import RequestException
+import logging
+
+
+logger = logging.getLogger('opengever.sign')
 
 
 class Signer(object):
@@ -87,6 +92,20 @@ class Signer(object):
         if not user:
             raise IssuerNotFound()
         return api.env.adopt_user(user=user)
+
+    def get_backoff_status(self):
+        if api.content.get_state(self.context) != Document.signing_state:
+            return None
+
+        job = self.pending_signing_job
+        if not job:
+            return None
+
+        try:
+            return get_sign_service_client().get_backoff_status(job.job_id)
+        except RequestException as e:
+            logger.warning('Failed to fetch backoff status for job %s: %s', job.job_id, e)
+            return None
 
     def update_pending_signing_job(self, **data):
         self.pending_signing_job = self.pending_signing_job.update(**data)

--- a/opengever/sign/tests/test_client.py
+++ b/opengever/sign/tests/test_client.py
@@ -61,6 +61,15 @@ class TestSigningClient(IntegrationTestCase):
 
         self.assertEqual(200, response.status_code)
 
+    def test_get_backoff_status(self, mocker):
+        self.login(self.regular_user)
+        mocker.get(re.compile('/signing-jobs/123/backoff_status'),
+                   json={'scheduled_poll_time': '2024-02-18T16:00:00'})
+
+        backoff_status = SignServiceClient().get_backoff_status('123')
+
+        self.assertEqual({'scheduled_poll_time': '2024-02-18T16:00:00'}, backoff_status)
+
     def test_can_use_a_different_gever_callback_url(self, mocker):
         self.login(self.regular_user)
         os.environ['SIGN_SERVICE_GEVER_URL'] = "http://example.com/mygever"

--- a/opengever/sign/tests/test_sign.py
+++ b/opengever/sign/tests/test_sign.py
@@ -10,6 +10,7 @@ from opengever.testing import IntegrationTestCase
 from plone import api
 import os
 import re
+import requests
 import requests_mock
 
 
@@ -156,6 +157,38 @@ class TestSigning(IntegrationTestCase):
         self.assertItemsEqual(
             [{u'userid': u'', u'email': u'updated@example.com'}],
             signer.pending_signing_job.serialize().get('editors'))
+
+    def test_get_backoff_status(self, mocker):
+        self.login(self.regular_user)
+        mocker.post(re.compile('/signing-jobs'), json=DEFAULT_MOCK_RESPONSE)
+        mocker.get(re.compile('/signing-jobs/1/backoff_status'),
+                   json={'scheduled_poll_time': '2024-02-18T16:00:00'})
+
+        api.content.transition(obj=self.document,
+                               transition=Document.draft_signing_transition)
+        signer = Signer(self.document)
+        signer.start_signing([])
+
+        self.assertEqual({'scheduled_poll_time': '2024-02-18T16:00:00'}, signer.get_backoff_status())
+
+    def test_get_backoff_status_returns_none_when_not_in_signing_state(self, mocker):
+        self.login(self.regular_user)
+
+        signer = Signer(self.document)
+        self.assertIsNone(signer.get_backoff_status())
+
+    def test_get_backoff_status_returns_none_on_service_failure(self, mocker):
+        self.login(self.regular_user)
+        mocker.post(re.compile('/signing-jobs'), json=DEFAULT_MOCK_RESPONSE)
+        mocker.get(re.compile('/signing-jobs/1/backoff_status'),
+                   exc=requests.exceptions.Timeout)
+
+        api.content.transition(obj=self.document,
+                               transition=Document.draft_signing_transition)
+        signer = Signer(self.document)
+        signer.start_signing([])
+
+        self.assertIsNone(signer.get_backoff_status())
 
     def test_signed_versions_are_dropped_after_copy_obj(self, mocker):
         self.login(self.regular_user)


### PR DESCRIPTION
Provide signing backoff status in document status endpoint.

Take a look at the ogsign PR for more information about the status itself: https://github.com/4teamwork/ogsign/pull/22

The frontend will use this new status to show the next poll time to the user.

For [TI-2916]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- [x] API Changelog entry (see [guide]## Post-merge action


[TI-2916]: https://4teamwork.atlassian.net/browse/TI-2916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ