### PR TITLE
Remove no longer available kgs and plone sources

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -1,7 +1,4 @@
 [buildout]
-extends =
-    http://kgs.4teamwork.ch/sources.cfg
-
 extensions += mr.developer
 
 development-packages =
@@ -16,3 +13,7 @@ auto-checkout = ${buildout:development-packages}
 [branches]
 Products.LDAPUserFolder = ftw
 Products.LDAPMultiPlugins = ftw
+
+[sources]
+opengever.maintenance = git git@github.com:4teamwork/opengever.maintenance.git
+opengever.hatchery = git git@github.com:4teamwork/opengever.hatchery.git


### PR DESCRIPTION
Fix master tests: https://jenkins.4teamwork.ch/job/opengever.core-test-solr.cfg/3374/console

Slack-Discussion: https://4teamwork.slack.com/archives/C06US2QSCD8/p1779111149017089

```
15:27:56 Generic Cause
15:27:56 Running as SYSTEM
15:27:56 [EnvInject] - Loading node environment variables.
15:27:56 Building remotely on [slave3 (mclaren)](https://jenkins.4teamwork.ch/computer/slave3%20(mclaren)/) (slave3) in workspace /var/lib/jenkins/workspace/opengever.core-test-solr.cfg
15:27:56 [WS-CLEANUP] Deleting project workspace...
15:27:56 [WS-CLEANUP] Deferred wipeout is used...
15:27:56 [WS-CLEANUP] Done
15:27:56 The recommended git tool is: NONE
15:27:57 using credential github-app-4teamwork
15:27:57 Cloning the remote Git repository
15:27:57 Cloning repository git@github.com:4teamwork/opengever.core.git
15:27:57  > git init /var/lib/jenkins/workspace/opengever.core-test-solr.cfg # timeout=10
15:27:57 Fetching upstream changes from git@github.com:4teamwork/opengever.core.git
15:27:57  > git --version # timeout=10
15:27:57  > git --version # 'git version 2.47.3'
15:27:57 using GIT_ASKPASS to set credentials 
15:27:57  > git fetch --tags --force --progress -- git@github.com:4teamwork/opengever.core.git +refs/heads/*:refs/remotes/origin/* # timeout=10
15:28:11  > git config remote.origin.url git@github.com:4teamwork/opengever.core.git # timeout=10
15:28:11  > git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/* # timeout=10
15:28:11 Avoid second fetch
15:28:11  > git rev-parse refs/remotes/origin/es/poc^{commit} # timeout=10
15:28:11 JENKINS-19022: warning: possible memory leak due to Git plugin usage; see: https://plugins.jenkins.io/git/#plugin-content-remove-git-plugin-buildsbybranch-builddata-script
15:28:11 Checking out Revision 0668532649ed5b1a1716f753043aaac9aaa48dcd (refs/remotes/origin/es/poc)
15:28:11  > git config core.sparsecheckout # timeout=10
15:28:11  > git checkout -f 0668532649ed5b1a1716f753043aaac9aaa48dcd # timeout=10
15:28:11 Commit message: "wip"
15:28:11 First time build. Skipping changelog.
15:28:12 [GitHub Checks] GitHub check (name: test-solr.cfg, status: in_progress) has been published.
15:28:12 Allocating TCP port ZSERVER_PORT
15:28:12   -> Assigned 33261
15:28:12 Allocating TCP port PORT1
15:28:12   -> Assigned 34645
15:28:12 Allocating TCP port PORT2
15:28:12   -> Assigned 40510
15:28:12 Allocating TCP port PORT3
15:28:12   -> Assigned 35621
15:28:12 Allocating TCP port PORT4
15:28:12   -> Assigned 36258
15:28:12 Allocating TCP port PORT5
15:28:12   -> Assigned 39889
15:28:12 Allocating TCP port PORT6
15:28:12   -> Assigned 43021
15:28:12 Allocating TCP port PORT7
15:28:12   -> Assigned 45415
15:28:12 Allocating TCP port PORT8
15:28:12   -> Assigned 34366
15:28:12 TCP port allocation complete
15:28:12 [opengever.core-test-solr.cfg] $ /bin/sh -xe /tmp/jenkins8339310063724348324.sh
15:28:12 + export CI=true
15:28:12 + CI=true
15:28:12 + /var/lib/jenkins/bin/jenkins-run.py test-solr.cfg
15:28:12 
15:28:12 + ln -s test-solr.cfg buildout.cfg
15:28:12 Traceback (most recent call last):
15:28:12   File "/var/lib/jenkins/bin/jenkins-run.py", line 417, in <module>
15:28:12     Main(sys.argv[1:])()
15:28:12   File "/var/lib/jenkins/bin/jenkins-run.py", line 42, in __call__
15:28:12     self.run_bootstrap()
15:28:12   File "/var/lib/jenkins/bin/jenkins-run.py", line 69, in run_bootstrap
15:28:12     python_path = self.get_python_path()
15:28:12   File "/var/lib/jenkins/bin/jenkins-run.py", line 157, in get_python_path
15:28:12     buildout = BuildoutConfigReader(self.configfile).get_config()
15:28:12   File "/var/lib/jenkins/bin/jenkins-run.py", line 180, in get_config
15:28:12     files = self.get_ordered_extend_files()
15:28:12   File "/var/lib/jenkins/bin/jenkins-run.py", line 192, in get_ordered_extend_files
15:28:12     self.get_extends_recursive(configfiles, self.mainconfig)
15:28:12   File "/var/lib/jenkins/bin/jenkins-run.py", line 218, in get_extends_recursive
15:28:12     self.get_extends_recursive(configfiles, path)
15:28:12   File "/var/lib/jenkins/bin/jenkins-run.py", line 218, in get_extends_recursive
15:28:12     self.get_extends_recursive(configfiles, path)
15:28:12   File "/var/lib/jenkins/bin/jenkins-run.py", line 218, in get_extends_recursive
15:28:12     self.get_extends_recursive(configfiles, path)
15:28:12   File "/var/lib/jenkins/bin/jenkins-run.py", line 218, in get_extends_recursive
15:28:12     self.get_extends_recursive(configfiles, path)
15:28:12   File "/var/lib/jenkins/bin/jenkins-run.py", line 208, in get_extends_recursive
15:28:12     parser.read(path)
15:28:12   File "/usr/local/python/2.7.18/lib/python2.7/ConfigParser.py", line 305, in read
15:28:12     self._read(fp, filename)
15:28:12   File "/usr/local/python/2.7.18/lib/python2.7/ConfigParser.py", line 512, in _read
15:28:12     raise MissingSectionHeaderError(fpname, lineno, line)
15:28:12 ConfigParser.MissingSectionHeaderError: File contains no section headers.
15:28:12 file: /var/lib/jenkins/zope/extends-cache/a967378978144139cb02544677404a6c, line: 2
15:28:12 '<!DOCTYPE html>\n'
15:28:12 Build step 'Execute shell' marked build as failure
15:28:12 Recording test results
15:28:12 ERROR: Step ‘Publish JUnit test result report’ failed: No test report files were found. Configuration error?
15:28:13 [GitHub Checks] GitHub check (name: test-solr.cfg, status: completed) has been published.
15:28:13 Finished: FAILURE
```