### PR TITLE
Fix purge trash feature flag

### DIFF
--- a/changes/TI-3813.bugfix
+++ b/changes/TI-3813.bugfix
@@ -1,0 +1,1 @@
+During after resolve dossiers nightly, trashed documents are correctly found  [ran]

--- a/opengever/dossier/resolve.py
+++ b/opengever/dossier/resolve.py
@@ -470,11 +470,14 @@ class AfterResolveJobs(object):
         if not self.get_property('purge_trash_enabled'):
             return
 
-        trashed_docs = api.content.find(
-            context=self.context,
-            depth=-1,
-            object_provides=[IBaseDocument],
-            trashed=True)
+        trashed_docs = self.catalog.unrestrictedSearchResults(
+            path={
+                'query': self.context.absolute_url_path(),
+                'depth': -1,
+            },
+            object_provides=IBaseDocument.__identifier__,
+            trashed=True,
+        )
 
         if trashed_docs:
             with elevated_privileges():


### PR DESCRIPTION
The api.content.find function in plone 4 doesnt have the 'unrestricted' flag, which means it can never find trashed documents. This is vital for the purge trash feature flag. The find function has now been replaced with a direct unrestrictedSearchResults function.


Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [TI-3813]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value

## Post-merge action

> [!IMPORTANT]
> After this PR is merged, Dev on Kubernetes must be updated.


[TI-3813]: https://4teamwork.atlassian.net/browse/TI-3813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ