### PR TITLE
Add is_local is none to ogds plugin

### DIFF
--- a/changes/TI-3358.bugfix
+++ b/changes/TI-3358.bugfix
@@ -1,0 +1,1 @@
+OGDS Authentication Plugin returns only non-local groups  [ran]

--- a/opengever/ogds/auth/plugin.py
+++ b/opengever/ogds/auth/plugin.py
@@ -20,6 +20,7 @@ from Products.PluggableAuthService.interfaces.plugins import IRolesPlugin  # noq
 from Products.PluggableAuthService.interfaces.plugins import IUserEnumerationPlugin  # noqa
 from Products.PluggableAuthService.plugins.BasePlugin import BasePlugin
 from sqlalchemy import func
+from sqlalchemy import or_
 from sqlalchemy.sql import select
 from sqlalchemy.sql.expression import false
 from sqlalchemy.sql.expression import true
@@ -285,7 +286,7 @@ class OGDSAuthenticationPlugin(BasePlugin, Cacheable):
         query = (
             select([Group.groupid])
             .where(Group.active == true())
-            .where(Group.is_local == false())
+            .where(or_(Group.is_local == false(), Group.is_local.is_(None)))
             .order_by(Group.groupid)
         )
 
@@ -353,7 +354,7 @@ class OGDSAuthenticationPlugin(BasePlugin, Cacheable):
             .select_from(groups.join(groups_users))
             .where(func.lower(groups_users.c.userid) == principal_id.lower())
             .where(groups.c.active == true())
-            .where(groups.c.is_local == false())
+            .where(or_(groups.c.is_local == false(), groups.c.is_local.is_(None)))
         )
 
         # Omit groups with non-ASCII names
@@ -375,7 +376,7 @@ class OGDSAuthenticationPlugin(BasePlugin, Cacheable):
         query = (
             select([Group.groupname])
             .where(Group.active == true())
-            .where(Group.is_local == false())
+            .where(or_(Group.is_local == false(), Group.is_local.is_(None)))
             .where(func.lower(Group.groupid) == group_id.lower())
         )
         res = self.query_ogds(query).fetchone()
@@ -425,7 +426,7 @@ class OGDSAuthenticationPlugin(BasePlugin, Cacheable):
         query = (
             select([Group.groupid])
             .where(Group.active == true())
-            .where(Group.is_local == false())
+            .where(or_(Group.is_local == false(), Group.is_local.is_(None)))
             .order_by(Group.groupid)
         )
         return [self.to_ascii(value) for value, in self.query_ogds(query)]
@@ -475,7 +476,7 @@ class OGDSAuthenticationPlugin(BasePlugin, Cacheable):
         )
 
         if is_group:
-            query = query.where(Group.is_local == false())
+            query = query.where(or_(Group.is_local == false(), Group.is_local.is_(None)))
 
         match = self.query_ogds(query).fetchone()
 


### PR DESCRIPTION
Some ogds groups dont have false for is_local, but have None. These still have to be included. This PR fixes this issue.

For [TI-3358]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value

## Post-merge action

> [!IMPORTANT]
> After this PR is merged, Dev on Kubernetes must be updated.


[TI-3358]: https://4teamwork.atlassian.net/browse/TI-3358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ