### PR TITLE
Set name_as_fallback to True for ActorLookUp

### DIFF
--- a/changes/TI-3700.bugfix
+++ b/changes/TI-3700.bugfix
@@ -1,0 +1,1 @@
+Allow ActorLookup with username in addition to userid  [ran]

--- a/opengever/api/actors.py
+++ b/opengever/api/actors.py
@@ -91,7 +91,7 @@ class ActorsGet(Service):
         actorid = self.read_params()
         full_representation = self.request.form.get(
             'full_representation', 'false').lower() in ("yes", "y", "true", "t", "1")
-        actor = ActorLookup(actorid).lookup()
+        actor = ActorLookup(actorid, name_as_fallback=True).lookup()
         serializer = queryMultiAdapter((actor, self.request), ISerializeToJson)
         return serializer(full_representation)
 
@@ -122,7 +122,7 @@ class ActorsGetListPOST(Service):
         full_representation = data.get('full_representation', False)
         items = []
         for actorid in actor_ids:
-            actor = ActorLookup(actorid).lookup()
+            actor = ActorLookup(actorid, name_as_fallback=True).lookup()
             serializer = queryMultiAdapter((actor, self.request), ISerializeToJson)
             items.append(serializer(full_representation))
 


### PR DESCRIPTION
After transitioning to uuid4 for userid, ActorLookup needs to have name_as_fallback option activated to properly find the actors for some actions. This PR sets it to true.


Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [TI-3700]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade-Steps:
  - [ ] SQL Operations do not use imported model (see [docs](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/994344994/Upgrade-Steps))
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
  - DB-Schema migration
    - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
    - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Bug fixed:
  - [ ] Resolved any Sentry issues caused by this bug
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Further improvements needed:
  - [ ] Create follow-up stories and link them in the PR and Jira issue
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value

## Post-merge action

> [!IMPORTANT]
> After this PR is merged, Dev on Kubernetes must be updated.


[TI-3700]: https://4teamwork.atlassian.net/browse/TI-3700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ