### PR TITLE
Fix phrase queries

### DIFF
--- a/changes/TI-3679.bugfix
+++ b/changes/TI-3679.bugfix
@@ -1,0 +1,1 @@
+Fix searching with phrase queries containing tokens that are split by the word delimiter filter. [buchi]

--- a/solr-conf/managed-schema.xml
+++ b/solr-conf/managed-schema.xml
@@ -226,6 +226,9 @@
     <dynamicField name="*_custom_field_strings" type="string" indexed="true" stored="false" multiValued="true"/>
     <dynamicField name="*_custom_field_date" type="pdate" indexed="true" stored="false"/>
 
+    <!--In data import handler we prefix fields we want to ignore with ignored_ -->
+    <dynamicField name="ignored_*" type="ignored"/>
+
     <!-- Field to use to determine and enforce document uniqueness.
          Unless this field is marked with required="false", it will be a required field
      -->

--- a/solr-conf/managed-schema.xml
+++ b/solr-conf/managed-schema.xml
@@ -446,6 +446,17 @@
       </analyzer>
       <analyzer type="query">
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <filter class="solr.WordDelimiterGraphFilterFactory"
+                splitOnCaseChange="1"
+                splitOnNumerics="1"
+                stemEnglishPossessive="1"
+                generateWordParts="1"
+                generateNumberParts="1"
+                catenateWords="0"
+                catenateNumbers="0"
+                catenateAll="0"
+                preserveOriginal="1"/>
+        <filter class="solr.FlattenGraphFilterFactory"/>
         <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
 <!--         <filter class="solr.StopFilterFactory"
                 ignoreCase="true"
@@ -505,6 +516,17 @@
       </analyzer>
       <analyzer type="query">
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <filter class="solr.WordDelimiterGraphFilterFactory"
+                splitOnCaseChange="1"
+                splitOnNumerics="1"
+                stemEnglishPossessive="1"
+                generateWordParts="1"
+                generateNumberParts="1"
+                catenateWords="0"
+                catenateNumbers="0"
+                catenateAll="0"
+                preserveOriginal="1"/>
+        <filter class="solr.FlattenGraphFilterFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <!-- <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_de.txt" format="snowball" /> -->
         <filter class="solr.KeywordRepeatFilterFactory" />
@@ -558,6 +580,17 @@
       <analyzer type="query">
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
         <filter class="solr.KeywordRepeatFilterFactory" />
+        <filter class="solr.WordDelimiterGraphFilterFactory"
+                splitOnCaseChange="1"
+                splitOnNumerics="1"
+                stemEnglishPossessive="1"
+                generateWordParts="1"
+                generateNumberParts="1"
+                catenateWords="0"
+                catenateNumbers="0"
+                catenateAll="0"
+                preserveOriginal="1"/>
+        <filter class="solr.FlattenGraphFilterFactory"/>
         <!-- removes l', etc -->
         <filter class="solr.ElisionFilterFactory" ignoreCase="true" articles="lang/contractions_fr.txt"/>
         <filter class="solr.LowerCaseFilterFactory"/>


### PR DESCRIPTION
In order for phrase queries to work properly, the token position in index and query has to be the same.
Therefore the word delimiter filter needs to be in place in the query analyzer as well.

No Solr reindex is necessary as this is a query-only change.

Jira: [TI-3679](https://4teamwork.atlassian.net/browse/TI-3679)

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)



[TI-3679]: https://4teamwork.atlassian.net/browse/TI-3679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ