### PR TITLE
Docuteam disposition api

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,7 +97,7 @@ with these contents:
 respective user in our development LDAP tree.
 
 For development a local LDAP server is used by default, that doesn't require a
-credentials file. 
+credentials file.
 
 
 Solr
@@ -321,6 +321,20 @@ defines these variables by default:
 
 To disable the use of a service, simply remove the according environment
 variable or set it to an empty value.
+
+
+SIP Archive Delivery
+~~~~~~~~~~~~~~~~~~~~
+
+Direct SIP delivery to an external archive system via the ``@deliver-sip-to-archive``
+API endpoint can be enabled with the ``disposition_sip_archive_delivery_enabled``
+feature flag and configured with the following environment variables:
+
+- ``DISPOSITION_SIP_TO_ARCHIVE_PROVIDER`` - Archive provider to use. Currently only ``docuteam``
+  is supported. This variable must be set when the feature flag is enabled.
+- ``DISPOSITION_DOCUTEAM_INGEST_URL`` - Base URL of the Docuteam ingest endpoint.
+- ``DISPOSITION_DOCUTEAM_INGEST_API_KEY`` - API key (token) for authenticating with the
+  Docuteam ingest endpoint.
 
 
 Development with local Ianus portal

--- a/changes/TI-3710.feature
+++ b/changes/TI-3710.feature
@@ -1,0 +1,1 @@
+Added support for sending SIPs directly to a docteam archive server. [elioschmutz]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -12,7 +12,7 @@ Breaking Changes
 
 Other Changes
 ^^^^^^^^^^^^^
-
+- ``@deliver-sip-to-archive``: New endpoint to send sip packages directly to an archive
 
 2026.3.0 (2026-05-28)
 ----------------------

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -1771,6 +1771,14 @@
       />
 
   <plone:service
+      method="POST"
+      name="@deliver-sip-to-archive"
+      for="opengever.disposition.disposition.IDispositionSchema"
+      factory=".disposition.DeliverSIPToArchivePost"
+      permission="opengever.disposition.DownloadSIPPackage"
+      />
+
+  <plone:service
       method="GET"
       name="@out-of-office"
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"

--- a/opengever/api/disposition.py
+++ b/opengever/api/disposition.py
@@ -6,6 +6,8 @@ from opengever.api.relationfield import relationfield_value_to_object
 from opengever.api.response import SerializeResponseToJson
 from opengever.api.serializer import GeverSerializeFolderToJson
 from opengever.base.behaviors.lifecycle import ILifeCycle
+from opengever.base.response import IResponseContainer
+from opengever.base.response import Response
 from opengever.base.utils import unrestrictedUuidToObject
 from opengever.disposition import is_sip_archive_delivery_enabled
 from opengever.disposition.archive_clients import get_archive_client
@@ -15,6 +17,7 @@ from opengever.disposition.interfaces import IDisposition
 from opengever.disposition.response import IDispositionResponse
 from opengever.disposition.validators import OfferedDossiersValidator
 from opengever.repository.interfaces import IRepositoryFolder
+from persistent.dict import PersistentDict
 from plone.protect.interfaces import IDisableCSRFProtection
 from plone.restapi.deserializer import json_body
 from plone.restapi.interfaces import IDeserializeFromJson
@@ -33,6 +36,9 @@ from zope.interface import alsoProvides
 from zope.interface import implementer
 from zope.interface import Interface
 from zope.interface import Invalid
+
+
+SIP_DELIVERED_TO_ARCHIVE_RESPONSE_TYPE = 'sip_delivered_to_archive'
 
 
 @implementer(IDeserializeFromJson)
@@ -182,5 +188,16 @@ class DeliverSIPToArchivePost(Service):
 
         alsoProvides(self.request, IDisableCSRFProtection)
         client = get_archive_client()
-        client.deliver(sip_package, filename)
+        response, submission_id = client.deliver(sip_package, filename)
+
+        self.create_response(submission_id)
+
         return self.reply_no_content()
+
+    def create_response(self, submission_id):
+        response = Response(SIP_DELIVERED_TO_ARCHIVE_RESPONSE_TYPE)
+        response.additional_data = PersistentDict({
+            'submission_id': submission_id
+        })
+        IResponseContainer(self.context).add(response)
+        return response

--- a/opengever/api/disposition.py
+++ b/opengever/api/disposition.py
@@ -1,17 +1,21 @@
 from opengever.api import _
 from opengever.api.deserializer import GeverDeserializeFromJson
 from opengever.api.not_reported_exceptions import BadRequest as NotReportedBadRequest
+from opengever.api.not_reported_exceptions import Forbidden as NotReportedForbidden
 from opengever.api.relationfield import relationfield_value_to_object
 from opengever.api.response import SerializeResponseToJson
 from opengever.api.serializer import GeverSerializeFolderToJson
 from opengever.base.behaviors.lifecycle import ILifeCycle
 from opengever.base.utils import unrestrictedUuidToObject
+from opengever.disposition import is_sip_archive_delivery_enabled
+from opengever.disposition.archive_clients import get_archive_client
 from opengever.disposition.disposition import IDispositionSchema
 from opengever.disposition.interfaces import IAppraisal
 from opengever.disposition.interfaces import IDisposition
 from opengever.disposition.response import IDispositionResponse
 from opengever.disposition.validators import OfferedDossiersValidator
 from opengever.repository.interfaces import IRepositoryFolder
+from plone.protect.interfaces import IDisableCSRFProtection
 from plone.restapi.deserializer import json_body
 from plone.restapi.interfaces import IDeserializeFromJson
 from plone.restapi.interfaces import IFieldSerializer
@@ -25,6 +29,7 @@ from zope.component import adapter
 from zope.component import getMultiAdapter
 from zope.component import queryMultiAdapter
 from zope.globalrequest import getRequest
+from zope.interface import alsoProvides
 from zope.interface import implementer
 from zope.interface import Interface
 from zope.interface import Invalid
@@ -161,3 +166,21 @@ class SerializeDispositionResponseToJson(SerializeResponseToJson):
 
         result['dossiers'] = json_compatible(self.context.dossiers)
         return result
+
+
+class DeliverSIPToArchivePost(Service):
+
+    def reply(self):
+        if not is_sip_archive_delivery_enabled():
+            raise NotReportedForbidden()
+
+        if not self.context.has_sip_package():
+            raise BadRequest(u'No SIP package available for delivery.')
+
+        sip_package = self.context.get_sip_package()
+        filename = self.context.get_sip_filename()
+
+        alsoProvides(self.request, IDisableCSRFProtection)
+        client = get_archive_client()
+        client.deliver(sip_package, filename)
+        return self.reply_no_content()

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -71,6 +71,7 @@ class TestConfig(IntegrationTestCase):
                 u'classic_ui_enabled': True,
                 u'contacts': 'plone',
                 u'disposition_disregard_retention_period': False,
+                u'disposition_sip_archive_delivery_enabled': False,
                 u'disposition_transport_filesystem': False,
                 u'disposition_transport_ftps': False,
                 u'doc_properties': False,
@@ -412,6 +413,19 @@ class TestConfig(IntegrationTestCase):
         with patch('opengever.base.configuration.count_available_dossier_types', return_value=2):
             browser.open(self.config_url, headers=self.api_headers)
             self.assertTrue(browser.json['features']['multiple_dossier_types'])
+
+    @browsing
+    def test_feature_disposition_sip_archive_delivery_enabled(self, browser):
+        self.login(self.regular_user, browser)
+
+        browser.open(self.config_url, headers=self.api_headers)
+
+        self.assertFalse(browser.json['features']['disposition_sip_archive_delivery_enabled'])
+
+        self.activate_feature('disposition_sip_archive_delivery_enabled')
+
+        browser.open(self.config_url, headers=self.api_headers)
+        self.assertTrue(browser.json['features']['disposition_sip_archive_delivery_enabled'])
 
     @browsing
     def test_contains_the_current_admin_unit(self, browser):

--- a/opengever/api/tests/test_disposition.py
+++ b/opengever/api/tests/test_disposition.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from ftw.testbrowser import browsing
 from ftw.testing import freeze
+from opengever.api.disposition import SIP_DELIVERED_TO_ARCHIVE_RESPONSE_TYPE
+from opengever.base.response import IResponseContainer
 from opengever.disposition.delivery import DeliveryScheduler
 from opengever.disposition.interfaces import IAppraisal
 from opengever.disposition.interfaces import IDisposition
@@ -610,3 +612,7 @@ class TestDeliverSIPToArchive(SolrIntegrationTestCase):
                 method='POST', headers=self.api_headers)
 
         self.assertEqual(204, browser.status_code)
+
+        last_response = IResponseContainer(self.disposition_with_sip).list().pop()
+        self.assertEqual(SIP_DELIVERED_TO_ARCHIVE_RESPONSE_TYPE, last_response.response_type)
+        self.assertEqual({'submission_id': '0'}, last_response.additional_data)

--- a/opengever/api/tests/test_disposition.py
+++ b/opengever/api/tests/test_disposition.py
@@ -1,6 +1,4 @@
 from datetime import datetime
-from ftw.builder.builder import Builder
-from ftw.builder.builder import create
 from ftw.testbrowser import browsing
 from ftw.testing import freeze
 from opengever.disposition.delivery import DeliveryScheduler
@@ -575,3 +573,40 @@ class TestTransferNumberPatch(SolrIntegrationTestCase):
             browser.open(u'{}/@transfer-number'.format(self.disposition.absolute_url()),
                          method='PATCH', headers=self.api_headers,
                          data=json.dumps(data))
+
+
+class TestDeliverSIPToArchive(SolrIntegrationTestCase):
+
+    @browsing
+    def test_raises_403_when_feature_is_disabled(self, browser):
+        self.login(self.records_manager, browser)
+
+        with browser.expect_http_error(code=403, reason='Forbidden'):
+            browser.open(
+                u'{}/@deliver-sip-to-archive'.format(
+                    self.disposition_with_sip.absolute_url()),
+                method='POST', headers=self.api_headers)
+
+    @browsing
+    def test_raises_400_when_no_sip_package(self, browser):
+        self.login(self.manager, browser)
+        self.activate_feature('disposition_sip_archive_delivery_enabled')
+
+        with browser.expect_http_error(code=400, reason='Bad Request'):
+            browser.open(
+                u'{}/@deliver-sip-to-archive'.format(
+                    self.disposition.absolute_url()),
+                method='POST', headers=self.api_headers)
+
+    @browsing
+    def test_delivers_sip_using_archive_client(self, browser):
+        self.login(self.records_manager, browser)
+        self.activate_feature('disposition_sip_archive_delivery_enabled')
+
+        with self.env(DISPOSITION_SIP_TO_ARCHIVE_PROVIDER='null_client'):
+            browser.open(
+                u'{}/@deliver-sip-to-archive'.format(
+                    self.disposition_with_sip.absolute_url()),
+                method='POST', headers=self.api_headers)
+
+        self.assertEqual(204, browser.status_code)

--- a/opengever/base/configuration.py
+++ b/opengever/base/configuration.py
@@ -14,6 +14,7 @@ from opengever.base.interfaces import IHubSpotSettings
 from opengever.base.interfaces import IRecentlyTouchedSettings
 from opengever.base.interfaces import ISearchSettings
 from opengever.bumblebee.interfaces import IGeverBumblebeeSettings
+from opengever.disposition import is_sip_archive_delivery_enabled
 from opengever.disposition.interfaces import IDispositionSettings
 from opengever.disposition.interfaces import IFilesystemTransportSettings
 from opengever.disposition.interfaces import IFTPSTransportSettings
@@ -147,6 +148,7 @@ class GeverSettingsAdpaterV1(object):
         features['classic_ui_enabled'] = api.portal.get_registry_record('is_classic_ui_enabled', interface=IGeverUI)
         features['contacts'] = self._get_contact_type()
         features['disposition_disregard_retention_period'] = api.portal.get_registry_record('disregard_retention_period', interface=IDispositionSettings)  # noqa
+        features['disposition_sip_archive_delivery_enabled'] = is_sip_archive_delivery_enabled()
         features['disposition_transport_filesystem'] = api.portal.get_registry_record('enabled', interface=IFilesystemTransportSettings)  # noqa
         features['disposition_transport_ftps'] = api.portal.get_registry_record('enabled', interface=IFTPSTransportSettings)  # noqa
         features['doc_properties'] = api.portal.get_registry_record('create_doc_properties', interface=ITemplateFolderProperties)  # noqa

--- a/opengever/base/tests/test_configuration_adapter.py
+++ b/opengever/base/tests/test_configuration_adapter.py
@@ -67,6 +67,7 @@ class TestConfigurationAdapter(IntegrationTestCase):
                 ('classic_ui_enabled', True),
                 ('contacts', 'plone'),
                 ('disposition_disregard_retention_period', False),
+                ('disposition_sip_archive_delivery_enabled', False),
                 ('disposition_transport_filesystem', False),
                 ('disposition_transport_ftps', False),
                 ('doc_properties', False),

--- a/opengever/core/upgrades/20260630112000_add_sip_archive_delivery_feature_flag/registry.xml
+++ b/opengever/core/upgrades/20260630112000_add_sip_archive_delivery_feature_flag/registry.xml
@@ -1,0 +1,4 @@
+<registry>
+  <record interface="opengever.disposition.interfaces.IDispositionSettings"
+          field="sip_archive_delivery" />
+</registry>

--- a/opengever/core/upgrades/20260630112000_add_sip_archive_delivery_feature_flag/upgrade.py
+++ b/opengever/core/upgrades/20260630112000_add_sip_archive_delivery_feature_flag/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddSIPArchiveDeliveryFeatureFlag(UpgradeStep):
+    """Add sip archive delivery feature flag.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/disposition/__init__.py
+++ b/opengever/disposition/__init__.py
@@ -15,6 +15,12 @@ def only_attach_original_enabled():
         interface=IDispositionSettings)
 
 
+def is_sip_archive_delivery_enabled():
+    return api.portal.get_registry_record(
+        'sip_archive_delivery',
+        interface=IDispositionSettings)
+
+
 DISPOSITION_ACTIVE_STATES = ["disposition-state-in-progress",
                              "disposition-state-appraised",
                              "disposition-state-archived",

--- a/opengever/disposition/actions.py
+++ b/opengever/disposition/actions.py
@@ -1,11 +1,18 @@
 from opengever.base.context_actions import BaseContextActions
 from opengever.base.interfaces import IOpengeverBaseLayer
+from opengever.disposition import is_sip_archive_delivery_enabled
 from opengever.disposition.interfaces import IDisposition
+from plone import api
 from zope.component import adapter
 
 
 @adapter(IDisposition, IOpengeverBaseLayer)
 class DispositionContextActions(BaseContextActions):
+
+    def get_actions(self):
+        super(DispositionContextActions, self).get_actions()
+        self.maybe_add_sip_archive_delivery()
+        return self.actions
 
     def is_download_appraisal_list_available(self):
         return True
@@ -15,3 +22,13 @@ class DispositionContextActions(BaseContextActions):
 
     def is_download_sip_available(self):
         return self.context.sip_download_available()
+
+    def maybe_add_sip_archive_delivery(self):
+        if not is_sip_archive_delivery_enabled():
+            return False
+        if not api.user.has_permission('opengever.disposition: Download SIP Package', obj=self.context):
+            return False
+        if not self.context.has_sip_package():
+            return False
+
+        self.add_action(u'sip-archive-delivery')

--- a/opengever/disposition/archive_clients.py
+++ b/opengever/disposition/archive_clients.py
@@ -1,0 +1,52 @@
+from os import environ
+import logging
+import requests
+
+
+logger = logging.getLogger('opengever.disposition.archive_clients')
+
+
+class NullClient(object):
+    """Client which does nothing and can be used for testing
+    """
+    def deliver(self, *args, **kwargs):
+        return None, '0'
+
+
+class DocuteamClient(object):
+    def __init__(self):
+        self.ingest_url = environ.get('DISPOSITION_DOCUTEAM_INGEST_URL')
+        if not self.ingest_url:
+            raise ValueError('Missing required environment variable: DISPOSITION_DOCUTEAM_INGEST_URL')
+
+        self.api_key = environ.get('DISPOSITION_DOCUTEAM_INGEST_API_KEY')
+        if not self.api_key:
+            raise ValueError('Missing required environment variable: DISPOSITION_DOCUTEAM_INGEST_API_KEY')
+
+    def deliver(self, sip_package, filename='package.zip'):
+        url = '{}?token={}&format=ech0160'.format(
+            self.ingest_url, self.api_key)
+        response = requests.post(
+            url,
+            files={'package': (filename, sip_package.data, 'application/zip')},
+        )
+        response.raise_for_status()
+        try:
+            submission_id = response.json()['response'][0]['id']
+        except (ValueError, KeyError, IndexError):
+            submission_id = u'<unavailable>'
+        logger.info('SIP delivered to docuteam archive. Submission ID: %s', submission_id)
+        return response, submission_id
+
+
+archive_client_registry = {
+    'null_client': NullClient,
+    'docuteam': DocuteamClient,
+}
+
+
+def get_archive_client():
+    provider_name = environ.get('DISPOSITION_SIP_TO_ARCHIVE_PROVIDER', '').strip().lower()
+    if not provider_name:
+        raise ValueError('Unknown disposition archive provider configured')
+    return archive_client_registry[provider_name]()

--- a/opengever/disposition/browser/ech0160.py
+++ b/opengever/disposition/browser/ech0160.py
@@ -1,3 +1,5 @@
+from opengever.base.response import IResponseContainer
+from opengever.base.response import Response
 from opengever.base.stream import TempfileStreamIterator
 from opengever.disposition import _
 from opengever.disposition.ech0160.sippackage import SIPPackage
@@ -9,6 +11,9 @@ from pyxb.utils.domutils import BindingDOMSupport
 from tempfile import TemporaryFile
 from zipfile import ZIP_DEFLATED
 from zipfile import ZipFile
+
+
+SIP_DOWNLOADED_RESPONSE_TYPE = 'sip_downloaded'
 
 
 class ECH0160ExportView(BrowserView):
@@ -67,4 +72,7 @@ class ECH0160DownloadView(BrowserView):
         sip_package = self.context.get_sip_package()
         filename = self.context.get_sip_filename()
         set_headers(sip_package, self.request.response, filename)
+
+        IResponseContainer(self.context).add(Response(SIP_DOWNLOADED_RESPONSE_TYPE))
+
         return stream_data(sip_package)

--- a/opengever/disposition/interfaces.py
+++ b/opengever/disposition/interfaces.py
@@ -73,6 +73,12 @@ class IDispositionSettings(Interface):
         'attached in the SIP package.',
         default=False)
 
+    sip_archive_delivery = schema.Bool(
+        title=u'Direct SIP delivery to archive system endpoint',
+        description=u'Enables a feature to directly transmit the generated '
+        u'SIP package to a configured archive system.',
+        default=False)
+
 
 class IFilesystemTransportSettings(Interface):
 

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -73,6 +73,7 @@ FEATURE_FLAGS = {
     'changed_for_end_date': 'opengever.dossier.interfaces.IDossierResolveProperties.use_changed_for_end_date',
     'automatically_set_end_date': 'opengever.dossier.interfaces.IDossierResolveProperties.automatically_set_end_date',
     'disposition-disregard-retention-period': 'opengever.disposition.interfaces.IDispositionSettings.disregard_retention_period',  # noqa
+    'disposition_sip_archive_delivery_enabled': 'opengever.disposition.interfaces.IDispositionSettings.sip_archive_delivery',  # noqa
     'doc-properties': 'opengever.dossier.interfaces.ITemplateFolderProperties.create_doc_properties',
     'docugate': 'opengever.docugate.interfaces.IDocugateSettings.is_feature_enabled',
     'dossier-checklist': 'opengever.dossier.interfaces.IDossierChecklistSettings.is_feature_enabled',


### PR DESCRIPTION
This PR implements a new ui action and endpoint to directly send an sip to a remote archive ingest server.

Currently we do only provide the docuteam ingest provider: https://docs.docuteam.ch/de/actions/ingest/ 

### Configuration

- ``DISPOSITION_SIP_TO_ARCHIVE_PROVIDER`` - Archive provider to use. Currently only ``docuteam``
  is supported. 
- ``DISPOSITION_DOCUTEAM_INGEST_URL`` - Base URL of the Docuteam ingest endpoint.
- ``DISPOSITION_DOCUTEAM_INGEST_API_KEY`` - API key (token) for authenticating with the
  Docuteam ingest endpoint.

### Permission

A user who can download an SIP is also allowed to send it to the archive.

### Journal

A new response-entry is created if an sip is downloaded or send to the archive.

For [TI-3710]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

## Post-merge action

> [!IMPORTANT]
> - [ ] After this PR is merged, Dev on Kubernetes must be updated.


[TI-3710]: https://4teamwork.atlassian.net/browse/TI-3710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ