### PR TITLE
Quickfix maxClauseCount error from solr

### DIFF
--- a/opengever/api/solrsearch.py
+++ b/opengever/api/solrsearch.py
@@ -17,7 +17,12 @@ from plone.restapi.services import Service
 from Products.CMFCore.utils import getToolByName
 from zExceptions import BadRequest
 from zExceptions import InternalError
+import logging
 
+
+logger = logging.getLogger('opengever.api')
+
+TOO_MANY_CLAUSES_ERROR = 'too many nested clauses'
 
 BLACKLISTED_ATTRIBUTES = set([
     'getDataOrigin',
@@ -283,6 +288,17 @@ class SolrSearchGet(SolrQueryBaseService):
             fl=field_list, **params)
 
         if not resp.is_ok():
+            # Quick-fix for https://4teamwork.atlassian.net/browse/TI-3679
+            if TOO_MANY_CLAUSES_ERROR in resp.error_msg().lower():
+                logger.error('Solr search failed: %s', resp.error_msg())
+                res = {
+                    "items": [],
+                    "start": start,
+                    "rows": rows,
+                    "facet_counts": {},
+                }
+                self.extend_with_batching(res, resp)
+                return res
             raise InternalError(resp.error_msg())
 
         res = {


### PR DESCRIPTION
Follow up of #8248 

This PR fixes an issue where solr raises a `maxClauseCount` since we use the `WordDelimiterGraphFilterFactory` for queries.

For [TI-3679]

## before
https://github.com/user-attachments/assets/fa4871b2-e304-47ee-abcd-221e4693e1c2


## after

https://github.com/user-attachments/assets/104da464-0714-4911-ac54-c206dcb9af8b

## Testing
I wasn't able to write a test for this case. I think it's ok to test it through the web.

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry ℹ️ no changelog beacuse the follow up is  within the same release
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

## Post-merge action

> [!IMPORTANT]
> After this PR is merged, Dev on Kubernetes must be updated.


[TI-3679]: https://4teamwork.atlassian.net/browse/TI-3679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ