### PR TITLE
Fix sharing group filter to match on group name instead of group id

### DIFF
--- a/changes/TI-3930.bugfix
+++ b/changes/TI-3930.bugfix
@@ -1,0 +1,1 @@
+Fix group white-/black-list prefix filter in sharing view to match on the group name instead of the group id  [elioschmutz]

--- a/opengever/sharing/browser/sharing.py
+++ b/opengever/sharing/browser/sharing.py
@@ -499,8 +499,8 @@ class OpengeverSharingView(SharingView):
                     results.append(principal)
 
             # groups
-            elif re.search(sharing_config.black_list_prefix, principal.get('id')):
-                if re.search(sharing_config.white_list_prefix, principal.get('id')):
+            elif re.search(sharing_config.black_list_prefix, principal.get('title')):
+                if re.search(sharing_config.white_list_prefix, principal.get('title')):
                     results.append(principal)
             else:
                 results.append(principal)

--- a/opengever/sharing/tests/test_sharing.py
+++ b/opengever/sharing/tests/test_sharing.py
@@ -10,6 +10,8 @@ from opengever.base.role_assignments import SharingRoleAssignment
 from opengever.base.role_assignments import TaskRoleAssignment
 from opengever.ogds.base.interfaces import IOGDSSyncConfiguration
 from opengever.ogds.models.group import Group
+from opengever.ogds.models.service import ogds_service
+from opengever.sharing.interfaces import ISharingConfiguration
 from opengever.testing import IntegrationTestCase
 from plone import api
 from urllib import urlencode
@@ -518,6 +520,35 @@ class TestOpengeverSharing(IntegrationTestCase):
         self.assertEquals(
             u'http://nohost/plone/@@list_groupmembers?group=group+with+spaces',
             entry['url'])
+
+    @browsing
+    def test_group_filter_matches_on_groupname_not_on_groupid(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        create(Builder('ogds_group')
+               .having(groupid='Meine Testgruppe',
+                       groupname='Meine Testgruppe',
+                       title='Meine Testgruppe'))
+        create(Builder('ogds_group')
+               .having(groupid='11111111-4368-1040-8650-4d25b64301d5',
+                       groupname='Meine Testgruppe 2',
+                       title='Meine Testgruppe 2'))
+
+        ogds_service().session.flush()
+
+        api.portal.set_registry_record(
+            name='black_list_prefix', value=u'^.', interface=ISharingConfiguration)
+        api.portal.set_registry_record(
+            name='white_list_prefix', value=u'^Meine', interface=ISharingConfiguration)
+
+        query = {'search': 'Testgruppe'}
+        browser.open(self.empty_dossier,
+                     view='@sharing?{}'.format(urlencode(query)),
+                     method='Get', headers={'Accept': 'application/json'})
+
+        ids = [item.get('id') for item in browser.json['items']]
+        self.assertIn('Meine Testgruppe', ids)
+        self.assertIn('11111111-4368-1040-8650-4d25b64301d5', ids)
 
     @browsing
     def test_sharing_view_handles_inactive_group(self, browser):


### PR DESCRIPTION
When searching for groups in the sharing view, the black-list/white-list filter was checking the wrong value. It compared the filter pattern against the group's internal ID instead of its name.

The fix changes the filter to check the group's actual name instead of its ID. This value was already being loaded elsewhere in the code for display purposes

## Before
https://github.com/user-attachments/assets/27b0e310-0866-4c6a-838a-e361222e6384


## After
https://github.com/user-attachments/assets/25357a3f-a8e6-483a-80fd-92ca560fa94e


For [TI-3930]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

## Post-merge action

> [!IMPORTANT]
> After this PR is merged, Dev on Kubernetes must be updated.


[TI-3930]: https://4teamwork.atlassian.net/browse/TI-3930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ