### PR TITLE
CI: Migrate runner from self-hosted to lotus-arc

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: lotus-arc
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
_PR-Description: Migration der CI auf das neue Actions-Runner-Scale-Set.
runs-on: self-hosted -> lotus-arc. docker, docker build und docker compose laufen unverändert.


Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For [OPS-140]

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] Changelog entry
- [x] [Link to issue (Jira or GitHub) and backlink in issue (Jira)](https://4teamwork.atlassian.net/jira/software/c/projects/OPS/boards/48?selectedIssue=OPS-140)



## Post-merge action

> [!IMPORTANT]
> After this PR is merged, Dev on Kubernetes must be updated.


[OPS-140]: https://4teamwork.atlassian.net/browse/OPS-140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ